### PR TITLE
feat(harness): rebuild the command palette as Command Search

### DIFF
--- a/.changeset/palette-command-search.md
+++ b/.changeset/palette-command-search.md
@@ -1,0 +1,32 @@
+---
+"@sapiom/harness": minor
+---
+
+Command palette: a proper fuzzy finder, redesigned as Command Search
+
+The Cmd+K palette is rebuilt around the reported search failures ("cannot find
+this simple agent"): short queries no longer "match" characters scattered
+across absolute paths, duplicate past sessions no longer flood the list, and
+what you search is what the rail shows.
+
+- **Boundary-gated matcher** (`web/src/lib/fuzzy.ts`): every matched character
+  must be contiguous with the previous one or sit at a word/segment boundary,
+  with a substring fallback for mid-word fragments. Scattered-noise matches are
+  rejected outright, not merely down-ranked. Multi-term queries AND across
+  whitespace.
+- **Ranking model** (`web/src/lib/palette.ts`, new): rows carry display names
+  (`displayAgentName`, `sessionDisplayName` — user renames are searchable);
+  same-title same-folder past sessions collapse to the newest; sections order
+  by their best hit with per-section caps (lifted when only one kind matches);
+  recency is a bounded score bonus that never lifts a path-only match over a
+  name match.
+- **Command Search surface** (per the design-eng widget): a search bar with a
+  clear button, filter tabs — All / Sessions / Agents / Templates / Docs /
+  Files / Actions — cycled with Tab/Shift+Tab, and a shortcut-bar footer. App
+  verbs (browse templates, toggle theme, panel toggles, new session here) are
+  injected actions; the Templates tab lists the catalog and opens the gallery
+  focused on a template; the Docs tab searches a short list of docs pages with
+  the docs site as the footer destination.
+- The active session is badged "current", demoted from the unqueried top spot,
+  and never the default selection; matched characters render on an
+  accent-tinted cap that stays legible on selected rows in both themes.

--- a/packages/harness/web/e2e/palette-search.spec.ts
+++ b/packages/harness/web/e2e/palette-search.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * Command-palette search quality — the fixes for the 2026-08-11 report
+ * ("cannot find this simple agent"). Runs against `?mockFixtures=search`,
+ * which additively seeds the reported shapes: a scoped agent name, an agent
+ * whose PATH carries the query's letters scattered across segments,
+ * duplicate same-title history rows, and a raw-first-prompt title.
+ */
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/?mockFixtures=search");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+});
+
+test("an agent is found by its display name, not its raw scoped package name", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+  await page.getByTestId("command-palette-input").fill("slack");
+
+  // "@sapiom/example-slack-notifier" surfaces as "slack-notifier", with the
+  // match highlighted in the NAME, and ranks first.
+  const first = page.getByTestId("command-palette-item-0");
+  await expect(first.locator(".command-palette-item-label")).toHaveText("slack-notifier");
+  await expect(first.locator(".command-palette-item-label .palette-match").first()).toBeVisible();
+
+  // The scatter-path foil (s…l…a…c…k strewn across "social…analytics-stack")
+  // no longer matches at all.
+  await expect(page.getByTestId("command-palette-list")).not.toContainText("daily-activity-analyst");
+});
+
+test("an agent name outranks history noise instead of drowning under it", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+  await page.getByTestId("command-palette-input").fill("daily");
+
+  const first = page.getByTestId("command-palette-item-0");
+  await expect(first).toContainText("daily-activity-analyst");
+  // And the raw-prompt noise rows ("You are annotating…") stay out entirely.
+  await expect(page.getByTestId("command-palette-list")).not.toContainText("You are annotating");
+});
+
+test("indistinguishable past sessions collapse to a single row", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+  await page.getByTestId("command-palette-input").fill("Standup");
+
+  const list = page.getByTestId("command-palette-list");
+  await expect(list.getByText("Standup summary for #eng")).toHaveCount(1);
+});
+
+test("a renamed session is searchable by its new name", async ({ page }) => {
+  // Same rename flow the header test uses (client-side ui-prefs persistence).
+  await page.getByTestId("session-menu").click();
+  await page.getByTestId("session-rename").click();
+  const input = page.getByTestId("session-rename-input");
+  await input.fill("Leasing revamp");
+  await input.press("Enter");
+  await expect(page.getByTestId("session-context-title")).toHaveText("Leasing revamp");
+
+  await page.getByTestId("palette-trigger").click();
+  await page.getByTestId("command-palette-input").fill("revamp");
+  const first = page.getByTestId("command-palette-item-0");
+  await expect(first).toContainText("Leasing revamp");
+  await expect(first.locator(".command-palette-item-label .palette-match").first()).toBeVisible();
+});
+
+test("the current session is badged, and never the default selection", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+  const list = page.getByTestId("command-palette-list");
+
+  // The active (boot) session carries the "current" pill…
+  const currentRow = list.locator(".command-palette-item.is-current");
+  await expect(currentRow).toHaveCount(1);
+  await expect(currentRow.locator(".command-palette-current")).toHaveText("current");
+
+  // …and the default-selected row is the first ranked item that is NOT it.
+  const selected = list.locator(".command-palette-item.is-selected");
+  await expect(selected).toHaveCount(1);
+  await expect(selected).not.toHaveClass(/is-current/);
+});
+
+test("jump targets show their raw path as monospace meta", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+
+  const first = page.getByTestId("command-palette-item-0");
+  const meta = first.locator(".command-palette-item-meta");
+  await expect(meta).toContainText("/Users/demo/acme-app");
+  await expect(meta).toHaveAttribute("data-code", "true");
+});
+
+test("the Actions tab lists the app's verbs, and Enter runs one", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+  await page.getByTestId("command-palette-filter-actions").click();
+
+  const list = page.getByTestId("command-palette-list");
+  for (const label of [
+    "Browse templates",
+    "Toggle theme",
+    "Hide workspace panel",
+    "Hide canvas panel",
+    "New session in this folder",
+  ]) {
+    await expect(list.getByText(label)).toBeVisible();
+  }
+
+  // Running "Hide workspace panel" collapses the rail.
+  await list.getByText("Hide workspace panel").click();
+  await expect(page.locator(".rail-workflows")).toBeHidden();
+});
+
+test("the Docs tab searches the doc links and offers the docs site in the footer", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+  await page.getByTestId("command-palette-filter-docs").click();
+
+  const list = page.getByTestId("command-palette-list");
+  await expect(list.getByText("Agents quick start")).toBeVisible();
+  await expect(page.getByTestId("command-palette-destination")).toContainText("Open documentation");
+
+  await page.getByTestId("command-palette-input").fill("mcp");
+  await expect(list.getByText("MCP servers: setup")).toBeVisible();
+  await expect(list.getByText("Agents quick start")).toBeHidden();
+});
+
+test("a scoped tab never leaks other kinds into the results", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+  await page.getByTestId("command-palette-filter-files").click();
+
+  const sections = page.getByTestId("command-palette-section");
+  await expect(sections).toHaveCount(1);
+  await expect(sections.first()).toHaveText("Folders");
+});
+
+test("Escape clears a typed query first and closes only when empty", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+  const input = page.getByTestId("command-palette-input");
+  await input.fill("leasing");
+
+  await page.keyboard.press("Escape");
+  await expect(input).toHaveValue("");
+  await expect(page.getByTestId("command-palette-list")).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("command-palette-list")).toBeHidden();
+});
+
+test("the Templates tab lists the catalog and its footer link opens the gallery", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+  await page.getByTestId("command-palette-filter-templates").click();
+
+  // The catalog itself is listed (gallery fixtures + bundled starters) …
+  const list = page.getByTestId("command-palette-list");
+  await expect(list.getByText("Hello Agent")).toBeVisible();
+
+  // … and the browse link lives in the footer, not as a lone action row.
+  await expect(list.getByText("Browse templates")).toHaveCount(0);
+  const destination = page.getByTestId("command-palette-destination");
+  await expect(destination).toContainText("Browse templates");
+  await destination.click();
+  await expect(page.locator(".templates-panel")).toBeVisible();
+});
+
+test("activating a template opens the gallery focused on it", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+  await page.getByTestId("command-palette-input").fill("Hello Agent");
+  await expect(page.getByTestId("command-palette-item-0")).toContainText("Hello Agent");
+  await page.keyboard.press("Enter");
+
+  await expect(page.locator(".templates-panel")).toBeVisible();
+  await expect(page.locator(".template-detail")).toContainText("Hello Agent");
+});
+
+test("Tab and Shift+Tab cycle the category tabs", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+
+  await page.keyboard.press("Tab");
+  await expect(page.getByTestId("command-palette-filter-sessions")).toHaveAttribute("aria-selected", "true");
+  await page.keyboard.press("Shift+Tab");
+  await expect(page.getByTestId("command-palette-filter-all")).toHaveAttribute("aria-selected", "true");
+  await page.keyboard.press("Shift+Tab");
+  await expect(page.getByTestId("command-palette-filter-actions")).toHaveAttribute("aria-selected", "true");
+
+  // A typed query never blocks it, and focus stays in the input.
+  await page.getByTestId("command-palette-filter-all").click();
+  await page.getByTestId("command-palette-input").fill("leasing");
+  await page.keyboard.press("Tab");
+  await expect(page.getByTestId("command-palette-filter-sessions")).toHaveAttribute("aria-selected", "true");
+  await expect(page.getByTestId("command-palette-input")).toBeFocused();
+
+  // The footer hints the binding.
+  await expect(page.getByTestId("command-palette-footer")).toContainText("category");
+});
+
+test("the Sessions and Agents tabs scope their kinds", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+
+  await page.getByTestId("command-palette-filter-sessions").click();
+  const sections = page.getByTestId("command-palette-section");
+  await expect(sections.first()).toHaveText("Sessions");
+  await expect(sections.filter({ hasText: "Agents" })).toHaveCount(0);
+
+  await page.getByTestId("command-palette-filter-agents").click();
+  await expect(sections).toHaveCount(1);
+  await expect(sections.first()).toHaveText("Agents");
+  await expect(page.getByTestId("command-palette-list")).toContainText("slack-notifier");
+});
+
+test("the filter row hides in path mode and the footer shows the shortcut hint", async ({ page }) => {
+  await page.getByTestId("palette-trigger").click();
+  await expect(page.getByTestId("command-palette-filter-all")).toBeVisible();
+  await expect(page.getByTestId("command-palette-footer")).toContainText("navigate");
+
+  await page.getByTestId("command-palette-input").fill("/Users/demo");
+  await expect(page.getByTestId("command-palette-filter-all")).toBeHidden();
+  await expect(page.getByText("Open this path")).toBeVisible();
+});

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -69,6 +69,8 @@ import { resolveMacroUrl } from "./lib/macro-gating";
 import { directActionKind } from "./lib/macro-actions";
 import { describeWorkflowPrompt } from "./lib/describe-prompt";
 import { sessionDisplayName } from "./lib/session-name";
+import type { PaletteAction } from "./lib/palette";
+import { toggleTheme } from "./lib/theme";
 import { loadUiPrefs, saveUiPrefs } from "./lib/ui-prefs";
 import { useNavigationHistory, type NavigationVisit } from "./lib/navigation-history";
 import { CANVAS_MIN, RAIL_MIN, isMobileShell, useMobileShell, usePaneWidths } from "./lib/use-pane-widths";
@@ -1767,14 +1769,62 @@ export const App = (): JSX.Element => {
           workflows={state.workflows}
           recentDirs={harness.settings?.recentDirs ?? []}
           history={harness.history}
+          sessionNames={sessionNames}
+          activeSessionId={harness.activeSessionId}
           listDir={harness.listDir}
+          listTemplates={harness.listTemplates}
           onSelectSession={openSession}
           onReviewSummary={reviewPastSession}
           onOpenPath={(cwd) => void handleCreateSession(cwd, "claude-code")}
-          onBrowseTemplates={() => {
+          onOpenTemplate={(templateId) => {
+            setDeepLinkTemplateId(templateId);
             setTemplatesOpen(true);
             setOverviewOpen(false);
           }}
+          actions={[
+            {
+              id: "browse-templates",
+              label: "Browse templates",
+              meta: "Gallery and starters",
+              icon: "LayoutTemplate",
+              run: () => {
+                setTemplatesOpen(true);
+                setOverviewOpen(false);
+              },
+            },
+            {
+              id: "toggle-theme",
+              label: "Toggle theme",
+              meta: "Light and dark",
+              icon: "Sun",
+              run: toggleTheme,
+            },
+            {
+              id: "toggle-rail",
+              label: railCollapsed ? "Show workspace panel" : "Hide workspace panel",
+              meta: "Left pane",
+              icon: "Menu",
+              run: () => setRailCollapsed((collapsed) => !collapsed),
+            },
+            {
+              id: "toggle-right",
+              label: rightCollapsed ? "Show canvas panel" : "Hide canvas panel",
+              meta: "Right pane",
+              icon: rightCollapsed ? "PanelRightOpen" : "PanelRightClose",
+              run: () => setRightCollapsed((collapsed) => !collapsed),
+            },
+            ...(activeSession
+              ? [
+                  {
+                    id: "new-session-here",
+                    label: "New session in this folder",
+                    meta: activeSession.cwd,
+                    icon: "Plus",
+                    run: () => void handleCreateSession(activeSession.cwd, "claude-code"),
+                  },
+                ]
+              : []),
+          ] satisfies PaletteAction[]}
           onClose={() => setPaletteOpen(false)}
         />
       )}

--- a/packages/harness/web/src/components/CommandPalette.tsx
+++ b/packages/harness/web/src/components/CommandPalette.tsx
@@ -1,23 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { JSX, KeyboardEvent, ReactNode } from "react";
-import type { HarnessSession, SessionSummary, WorkflowInfo } from "@shared/types";
+import type { HarnessSession, SessionSummary, TemplateListResponse, WorkflowInfo } from "@shared/types";
 
 import type { FsDirEntry, FsListResponse } from "../lib/api";
-import { fuzzyMatch } from "../lib/fuzzy";
+import {
+  buildPaletteItems,
+  buildPathItems,
+  FILTER_DESTINATION,
+  PALETTE_FILTERS,
+  paletteActivation,
+  rankPaletteItems,
+} from "../lib/palette";
+import type { PaletteAction, PaletteFilter, PaletteItem, PaletteTemplate } from "../lib/palette";
+import type { SessionNameOverrides } from "../lib/session-name";
+import { STARTER_TEMPLATES } from "../lib/templates";
+import { useTabIndicator } from "../lib/use-tab-indicator";
 import { Icon } from "./Icon";
-
-interface PaletteItem {
-  id: string;
-  kind: "command" | "session" | "past" | "workflow" | "recent" | "path";
-  label: string;
-  meta: string;
-  sessionId?: string;
-  summary?: SessionSummary;
-  path?: string;
-  /** Matched character positions — set on the field the query hit. */
-  labelIndices?: number[];
-  metaIndices?: number[];
-}
 
 interface CommandPaletteProps {
   sessions: HarnessSession[];
@@ -26,41 +24,55 @@ interface CommandPaletteProps {
   /** Past sessions from the transcript/registry history fan-out —
    *  loaded by the opener, so the palette can jump to any past session too. */
   history: SessionSummary[];
+  /** User renames from ui-prefs — the palette searches and shows the same
+   *  names the rail and header render. */
+  sessionNames: SessionNameOverrides;
+  /** The session on screen — badged "current", demoted from the top spot. */
+  activeSessionId: string | null;
+  /** App verbs the palette can run. Supplied by the caller rather than
+   *  hard-coded here: the palette knows how to FIND things, the app knows
+   *  what it can do, and threading one prop per verb would have grown a
+   *  parameter for every button in the product. */
+  actions: PaletteAction[];
   listDir: (path?: string) => Promise<FsListResponse>;
+  /** Feeds the Templates tab (gallery + bundled starters). */
+  listTemplates: () => Promise<TemplateListResponse>;
   onSelectSession: (id: string) => void;
   /** Opens the review pane for a transcript-only history entry (never
    *  silently spawns — resuming is the pane's explicit action). */
   onReviewSummary: (summary: SessionSummary) => void;
   onOpenPath: (cwd: string) => void;
-  /** Opens the template gallery (browse -> preview -> use) — the palette is
-   *  a first-class browse entry, not just the add dialog's branch. */
-  onBrowseTemplates: () => void;
+  /** Opens the templates browser focused on one template. */
+  onOpenTemplate: (templateId: string) => void;
   onClose: () => void;
 }
 
 const ICON_FOR_KIND: Record<PaletteItem["kind"], string> = {
-  command: "LayoutTemplate",
+  command: "Zap",
+  doc: "BookOpen",
   session: "Radio",
   past: "History",
-  workflow: "Workflow",
+  agent: "Workflow",
   recent: "Folder",
   path: "Folder",
+  template: "LayoutTemplate",
 };
 
 /** Section headers keep mixed result types tellable apart: a session
  *  row and a folder row can share a name, so the group says which is which. */
 const SECTION_LABELS: Record<PaletteItem["kind"], string> = {
   command: "Actions",
+  doc: "Documentation",
   session: "Sessions",
   past: "Past sessions",
-  workflow: "Agents",
+  agent: "Agents",
   recent: "Folders",
   path: "Folders",
+  template: "Templates",
 };
 
-/** How many past sessions the empty-query list shows — the full history
- *  stays reachable by typing; unqueried it would otherwise drown the rest. */
-const PAST_UNQUERIED_CAP = 6;
+const IS_MAC = typeof navigator !== "undefined" && navigator.platform.toUpperCase().includes("MAC");
+const MOD_LABEL = IS_MAC ? "⌘" : "Ctrl";
 
 /** Wraps the characters at `indices` in <b> so the fuzzy hit is visible. */
 function highlightText(text: string, indices: number[] | undefined): ReactNode {
@@ -86,47 +98,65 @@ function highlightText(text: string, indices: number[] | undefined): ReactNode {
   return parts;
 }
 
-/** Name matches outrank path matches: a query that hits the label scores in
- *  a band strictly above any meta-only hit, so "se" can never float a row
- *  whose visible name doesn't contain it over one whose name does. */
-function scoreItem(query: string, item: PaletteItem): { item: PaletteItem; score: number } | null {
-  const label = fuzzyMatch(query, item.label);
-  if (label) return { item: { ...item, labelIndices: label.indices }, score: 1000 + label.score };
-  const meta = fuzzyMatch(query, item.meta);
-  if (meta) return { item: { ...item, metaIndices: meta.indices }, score: meta.score };
-  return null;
-}
-
 /**
- * Cmd+K / Cmd+P quick-jump: fuzzy match over running sessions, past
- * sessions, workflow paths, and recent directories — grouped under section
- * headers with the matched characters bolded. When the query looks like a
- * path, GET /api/fs/list drives live directory completion instead. Enter
- * switches to a session hit, opens a past session for review, or starts a
- * fresh session at a path hit.
+ * Cmd+K / Cmd+P quick-jump (the Command Search widget): a search bar, a
+ * filter-tab row (All / Templates / Docs / Files / Actions), the ranked
+ * result list, and a shortcut bar. Matching and ranking live in
+ * lib/palette.ts (display-name matching, past-session dedup, best-hit
+ * section order, recency boost). When the query looks like a path,
+ * GET /api/fs/list drives live directory completion instead. Enter switches
+ * to a session hit, opens a past session for review, runs an action, opens
+ * a doc, or starts a fresh session at a path hit.
  */
 export function CommandPalette({
   sessions,
   workflows,
   recentDirs,
   history,
+  sessionNames,
+  activeSessionId,
+  actions,
   listDir,
+  listTemplates,
   onSelectSession,
   onReviewSummary,
   onOpenPath,
-  onBrowseTemplates,
+  onOpenTemplate,
   onClose,
 }: CommandPaletteProps): JSX.Element {
   const [query, setQuery] = useState("");
+  const [filter, setFilter] = useState<PaletteFilter>("all");
+  const [templates, setTemplates] = useState<PaletteTemplate[]>([]);
   const [pathDirs, setPathDirs] = useState<FsDirEntry[]>([]);
   const [pathLoading, setPathLoading] = useState(false);
   const [pathError, setPathError] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const filterTabs = useTabIndicator(filter);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     inputRef.current?.focus();
   }, []);
+
+  // The catalog is small and cached server-side; one fetch per open keeps
+  // the Templates tab live without a loading state — until it lands (or if
+  // it fails), the bundled starters are still listed.
+  useEffect(() => {
+    let cancelled = false;
+    setTemplates(STARTER_TEMPLATES.map(({ id, name, description }) => ({ id, name, description })));
+    listTemplates()
+      .then((res) => {
+        if (cancelled) return;
+        setTemplates([
+          ...res.templates.map(({ id, name, description }) => ({ id, name, description })),
+          ...STARTER_TEMPLATES.map(({ id, name, description }) => ({ id, name, description })),
+        ]);
+      })
+      .catch(() => undefined);
+    return () => {
+      cancelled = true;
+    };
+  }, [listTemplates]);
 
   const looksLikePath = query.startsWith("/") || query.startsWith("~");
 
@@ -159,128 +189,82 @@ export function CommandPalette({
   }, [query, looksLikePath, listDir]);
 
   const items = useMemo<PaletteItem[]>(() => {
-    if (looksLikePath) {
-      const trimmed = query.trim();
-      const confirmItem: PaletteItem[] = trimmed
-        ? [{ id: `confirm:${trimmed}`, kind: "path", label: trimmed, meta: "Open this path", path: trimmed }]
-        : [];
-      const dirItems: PaletteItem[] = pathDirs.map((dir) => ({
-        id: `dir:${dir.path}`,
-        kind: "path",
-        label: dir.name,
-        meta: dir.path,
-        path: dir.path,
-      }));
-      return [...confirmItem, ...dirItems];
-    }
-
-    const sessionItems: PaletteItem[] = sessions
-      .filter((session) => session.status !== "exited")
-      .map((session) => ({
-        id: `session:${session.id}`,
-        kind: "session",
-        label: session.title,
-        meta: session.cwd,
-        sessionId: session.id,
-      }));
-
-    // Past sessions (the palette source): exited registry sessions
-    // plus history entries — deduped the same way the rail's list is, so a
-    // registry-mirrored transcript never renders twice.
-    const registryIds = new Set(sessions.map((session) => session.id));
-    const registryAgentIds = new Set(
-      sessions.map((session) => session.agentSessionId).filter((id): id is string => id != null),
+    if (looksLikePath) return buildPathItems(query, pathDirs);
+    return rankPaletteItems(
+      query,
+      buildPaletteItems({
+        sessions,
+        workflows,
+        history,
+        recentDirs,
+        sessionNames,
+        actions,
+        templates,
+        activeSessionId,
+      }),
+      { filter },
     );
-    const pastItems: PaletteItem[] = [
-      ...sessions
-        .filter((session) => session.status === "exited")
-        .map((session) => ({
-          id: `past:${session.id}`,
-          kind: "past" as const,
-          label: session.title,
-          meta: session.cwd,
-          sessionId: session.id,
-        })),
-      ...history
-        .filter(
-          (summary) =>
-            !(summary.harnessSessionId != null && registryIds.has(summary.harnessSessionId)) &&
-            !registryAgentIds.has(summary.agentSessionId),
-        )
-        .map((summary) => ({
-          id: `summary:${summary.agentSessionId}`,
-          kind: "past" as const,
-          label: summary.title,
-          meta: summary.cwd,
-          summary,
-        })),
-    ];
+  }, [
+    query,
+    looksLikePath,
+    pathDirs,
+    sessions,
+    workflows,
+    recentDirs,
+    history,
+    sessionNames,
+    activeSessionId,
+    actions,
+    templates,
+    filter,
+  ]);
 
-    const workflowItems: PaletteItem[] = workflows.map((workflow) => ({
-      id: `workflow:${workflow.path}`,
-      kind: "workflow",
-      label: workflow.name,
-      meta: workflow.path,
-      path: workflow.path,
-    }));
+  useEffect(() => {
+    // Default selection = the first ranked row that ISN'T the session the
+    // user is already looking at (jumping there is a no-op).
+    const first = items.findIndex((item) => !item.current);
+    setSelectedIndex(first === -1 ? 0 : first);
+  }, [items, query, filter]);
 
-    // Palette actions: template browsing is reachable from anywhere, not
-    // only the add dialog's "I don't have a project yet" branch.
-    const commandItems: PaletteItem[] = [
-      {
-        id: "command:browse-templates",
-        kind: "command",
-        label: "Browse templates",
-        meta: "Gallery and starters",
-      },
-    ];
-
-    const workflowPaths = new Set(workflows.map((workflow) => workflow.path));
-    const recentItems: PaletteItem[] = recentDirs
-      .filter((dir) => !workflowPaths.has(dir))
-      .map((dir) => ({
-        id: `recent:${dir}`,
-        kind: "recent",
-        label: dir.split("/").filter(Boolean).pop() ?? dir,
-        meta: dir,
-        path: dir,
-      }));
-
-    if (!query) {
-      // Actions ride below the jump targets but are never crowded out of
-      // the unqueried list — the cap applies to the target rows only.
-      return [...sessionItems, ...pastItems.slice(0, PAST_UNQUERIED_CAP), ...workflowItems, ...recentItems]
-        .slice(0, 20 - commandItems.length)
-        .concat(commandItems);
-    }
-
-    // Filter and rank WITHIN each section, then keep the fixed section order:
-    // grouping is what makes two same-named rows of different types readable,
-    // so scores never interleave the groups.
-    return [sessionItems, pastItems, workflowItems, recentItems, commandItems]
-      .flatMap((section) =>
-        section
-          .map((item) => scoreItem(query, item))
-          .filter((entry): entry is { item: PaletteItem; score: number } => entry !== null)
-          .sort((a, b) => b.score - a.score)
-          .map((entry) => entry.item),
-      )
-      .slice(0, 20);
-  }, [query, looksLikePath, pathDirs, sessions, workflows, recentDirs, history]);
-
-  useEffect(() => setSelectedIndex(0), [items.length, query]);
+  // Where this tab continues, if it continues anywhere. Path mode has no
+  // tabs, so it has no destination either.
+  const destination = looksLikePath ? undefined : FILTER_DESTINATION[filter];
 
   const activate = (item: PaletteItem): void => {
-    if (item.kind === "command") {
-      onBrowseTemplates();
-    } else if ((item.kind === "session" || item.kind === "past") && item.sessionId) {
-      onSelectSession(item.sessionId);
-    } else if (item.kind === "past" && item.summary) {
-      onReviewSummary(item.summary);
-    } else if (item.path) {
-      onOpenPath(item.path);
+    const activation = paletteActivation(item);
+    switch (activation.type) {
+      case "run":
+        activation.run();
+        break;
+      case "open-href":
+        window.open(activation.href, "_blank", "noopener,noreferrer");
+        break;
+      case "open-template":
+        onOpenTemplate(activation.templateId);
+        break;
+      case "select-session":
+        onSelectSession(activation.sessionId);
+        break;
+      case "review-summary":
+        onReviewSummary(activation.summary);
+        break;
+      case "open-path":
+        onOpenPath(activation.path);
+        break;
+      case "none":
+        break;
     }
     onClose();
+  };
+
+  // Tab / Shift+Tab cycle the category tabs — the palette is a single-field
+  // dialog, so Tab has no focus to move and can carry navigation instead.
+  const cycleFilter = (delta: number): void => {
+    setFilter((current) => {
+      const index = PALETTE_FILTERS.findIndex((option) => option.id === current);
+      const next = (index + delta + PALETTE_FILTERS.length) % PALETTE_FILTERS.length;
+      return PALETTE_FILTERS[next].id;
+    });
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>): void => {
@@ -290,27 +274,78 @@ export function CommandPalette({
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setSelectedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Tab" && !looksLikePath) {
+      e.preventDefault();
+      cycleFilter(e.shiftKey ? -1 : 1);
     } else if (e.key === "Enter") {
       e.preventDefault();
       const item = items[selectedIndex];
       if (item) activate(item);
     } else if (e.key === "Escape") {
-      onClose();
+      // A typed query is the nearer state to undo — clear it first, close on
+      // the second press.
+      if (query) setQuery("");
+      else onClose();
     }
   };
 
   return (
     <div className="modal-backdrop" onClick={onClose}>
       <div className="modal command-palette" onClick={(e) => e.stopPropagation()}>
-        <input
-          ref={inputRef}
-          className="command-palette-input"
-          data-testid="command-palette-input"
-          placeholder="Jump to a session, agent, or path…"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={handleKeyDown}
-        />
+        <div className="command-palette-search">
+          <Icon name="Search" size={16} />
+          <input
+            ref={inputRef}
+            className="command-palette-input"
+            data-testid="command-palette-input"
+            aria-label="Jump to a session, agent, or path"
+            placeholder="Jump to a session, agent, or path…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+          />
+          {query && (
+            <button
+              type="button"
+              className="command-palette-clear"
+              data-testid="command-palette-clear"
+              aria-label="Clear search"
+              onClick={() => {
+                setQuery("");
+                inputRef.current?.focus();
+              }}
+            >
+              <Icon name="X" size={14} />
+            </button>
+          )}
+        </div>
+        {!looksLikePath && (
+          <div
+            ref={filterTabs.trackRef}
+            className="command-palette-filters tab-track"
+            role="tablist"
+            aria-label="Search filter"
+          >
+            <span className="tab-indicator" style={filterTabs.style} aria-hidden="true" />
+            {PALETTE_FILTERS.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                role="tab"
+                aria-selected={filter === option.id}
+                className={"command-palette-filter" + (filter === option.id ? " is-active" : "")}
+                data-testid={`command-palette-filter-${option.id}`}
+                onClick={() => {
+                  setFilter(option.id);
+                  inputRef.current?.focus();
+                }}
+              >
+                <Icon name={option.icon} size={14} />
+                {option.label}
+              </button>
+            ))}
+          </div>
+        )}
         <div className="command-palette-list" data-testid="command-palette-list">
           {looksLikePath && pathLoading && <div className="command-palette-empty">Loading…</div>}
           {looksLikePath && pathError && !pathLoading && (
@@ -330,17 +365,70 @@ export function CommandPalette({
               )}
               <button
                 type="button"
-                className={"command-palette-item" + (index === selectedIndex ? " is-selected" : "")}
+                className={
+                  "command-palette-item" +
+                  (index === selectedIndex ? " is-selected" : "") +
+                  (item.current ? " is-current" : "")
+                }
                 data-testid={`command-palette-item-${index}`}
                 onMouseEnter={() => setSelectedIndex(index)}
                 onClick={() => activate(item)}
               >
-                <Icon name={ICON_FOR_KIND[item.kind]} size={14} />
+                <Icon name={item.icon ?? ICON_FOR_KIND[item.kind]} size={14} />
                 <span className="command-palette-item-label">{highlightText(item.label, item.labelIndices)}</span>
-                <span className="command-palette-item-meta">{highlightText(item.meta, item.metaIndices)}</span>
+                {item.current && <span className="command-palette-current">current</span>}
+                <span
+                  className="command-palette-item-meta"
+                  data-code={item.path != null || item.kind === "session" || item.kind === "past" || undefined}
+                >
+                  {item.meta ? highlightText(item.meta, item.metaIndices) : null}
+                </span>
               </button>
             </div>
           ))}
+        </div>
+        <div className="command-palette-footer" data-testid="command-palette-footer">
+          <span>
+            <kbd>↑</kbd>
+            <kbd>↓</kbd> navigate
+          </span>
+          {!looksLikePath && (
+            <span>
+              <kbd>tab</kbd> category
+            </span>
+          )}
+          <span>
+            <kbd>↵</kbd> open
+          </span>
+          <span>
+            <kbd>esc</kbd> close
+          </span>
+          {destination ? (
+            <button
+              type="button"
+              className="btn-ghost command-palette-footer-cta"
+              data-testid="command-palette-destination"
+              onClick={() => {
+                if (destination.href) {
+                  window.open(destination.href, "_blank", "noopener,noreferrer");
+                } else if (destination.actionId) {
+                  const verb = actions.find((action) => action.id === destination.actionId);
+                  if (verb) {
+                    verb.run();
+                    onClose();
+                  }
+                }
+              }}
+            >
+              {destination.label}
+              <Icon name={destination.href ? "ExternalLink" : "ArrowRight"} size={14} />
+            </button>
+          ) : (
+            <span className="command-palette-footer-mod">
+              <kbd>{MOD_LABEL}</kbd>
+              <kbd>K</kbd> anytime
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -39,6 +39,8 @@ import {
   MOCK_HISTORY,
   MOCK_LAUNCH_DIR,
   MOCK_MACROS,
+  MOCK_SEARCH_HISTORY,
+  MOCK_SEARCH_WORKFLOWS,
   MOCK_SESSION_RECORDS,
   MOCK_SESSIONS,
   MOCK_SETTINGS,
@@ -133,6 +135,19 @@ export function isFreshMockState(): boolean {
   return (
     isMockMode() &&
     new URLSearchParams(window.location.search).get("mockState") === "fresh"
+  );
+}
+
+/**
+ * Mock mode only: `?mockFixtures=search` additionally seeds the shapes from
+ * the search bug report (a scoped agent name, a scatter-path agent, duplicate
+ * and raw-prompt history titles) so Playwright can exercise the palette's
+ * ranking. Additive-only, so every fixture-count assertion elsewhere holds.
+ */
+export function isSearchFixturesEnabled(): boolean {
+  return (
+    isMockMode() &&
+    new URLSearchParams(window.location.search).get("mockFixtures") === "search"
   );
 }
 
@@ -858,7 +873,10 @@ class MockApi implements HarnessApi {
     : MOCK_SESSIONS.map((session) => ({ ...session }));
   private workflows = this.fresh
     ? []
-    : MOCK_WORKFLOWS.map((workflow) => ({ ...workflow }));
+    : [
+        ...MOCK_WORKFLOWS,
+        ...(isSearchFixturesEnabled() ? MOCK_SEARCH_WORKFLOWS : []),
+      ].map((workflow) => ({ ...workflow }));
   private settings: HarnessSettings = this.fresh
     ? { ...MOCK_SETTINGS, recentDirs: [] }
     : {
@@ -1022,7 +1040,8 @@ class MockApi implements HarnessApi {
 
   async sessionHistory(cwd: string): Promise<SessionSummary[]> {
     await delay();
-    return MOCK_HISTORY[cwd] ?? [];
+    const searchExtras = isSearchFixturesEnabled() ? (MOCK_SEARCH_HISTORY[cwd] ?? []) : [];
+    return [...(MOCK_HISTORY[cwd] ?? []), ...searchExtras];
   }
 
   async sessionRecord(id: string): Promise<SessionRecord | null> {

--- a/packages/harness/web/src/lib/docs.ts
+++ b/packages/harness/web/src/lib/docs.ts
@@ -1,0 +1,46 @@
+/**
+ * The documentation the finder can reach.
+ *
+ * Five pages, not a mirror of the site's nav: these are the ones someone
+ * reaches for from inside the product — how to start an agent, how to start a
+ * workflow, which models a capability can call, and the two halves of MCP
+ * setup. Everything else is one click away behind the footer link, which is
+ * why this list gets to stay short instead of growing a page per release.
+ */
+export const DOCS_SITE = "https://docs.sapiom.ai/";
+
+export interface DocLink {
+  /** Page title as the docs site names it. */
+  label: string;
+  /** The one line that says who the page is for. */
+  meta: string;
+  href: string;
+}
+
+export const DOC_LINKS: readonly DocLink[] = [
+  {
+    label: "Agents quick start",
+    meta: "Run your first agent",
+    href: "https://docs.sapiom.ai/agents/quick-start",
+  },
+  {
+    label: "Workflows quick start",
+    meta: "Typed steps, gates and exits",
+    href: "https://docs.sapiom.ai/workflows/quick-start",
+  },
+  {
+    label: "AI models",
+    meta: "Which models a capability can call",
+    href: "https://docs.sapiom.ai/capabilities/ai-models",
+  },
+  {
+    label: "MCP servers: setup",
+    meta: "Connect a server to a workspace",
+    href: "https://docs.sapiom.ai/integration/mcp-servers/setup",
+  },
+  {
+    label: "MCP servers: remote",
+    meta: "Reach a server you do not host",
+    href: "https://docs.sapiom.ai/integration/mcp-servers/remote",
+  },
+];

--- a/packages/harness/web/src/lib/fuzzy.test.ts
+++ b/packages/harness/web/src/lib/fuzzy.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { fuzzyMatch, fuzzyScore } from "./fuzzy";
+
+// The two production failures this matcher exists to prevent (from the
+// 2026-08-11 Slack report): a short query "matching" characters scattered
+// across an absolute path, and matching strewn across a raw-prompt title.
+describe("fuzzyMatch rejects scattered-noise subsequences", () => {
+  it("does not match a query strewn across an absolute path", () => {
+    expect(fuzzyMatch("slack", "/Users/gwitwer/sapiom/hackathon-local/workflows/backlog-nudge")).toBeNull();
+    expect(fuzzyMatch("daily", "/Users/gwitwer/sapiom/hackathon-local/workflows/backlog-nudge")).toBeNull();
+  });
+
+  it("does not match a query strewn across a raw-prompt title", () => {
+    expect(fuzzyMatch("daily", "You are annotating an already-generated draft")).toBeNull();
+  });
+
+  it("rejects in-order but off-boundary scatter inside a single word", () => {
+    // The old greedy matcher accepted this ("l…s…g" inside "leasing").
+    expect(fuzzyScore("lsg", "leasing")).toBeNull();
+    expect(fuzzyScore("xyz", "leasing")).toBeNull();
+  });
+});
+
+describe("fuzzyMatch accepts the useful match shapes", () => {
+  it("prefix", () => {
+    expect(fuzzyMatch("slack", "slack-notifier")?.indices).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("mid-word substring (the only legal off-boundary start)", () => {
+    expect(fuzzyMatch("otif", "slack-notifier")?.indices).toEqual([7, 8, 9, 10]);
+  });
+
+  it("word initials across separators", () => {
+    expect(fuzzyMatch("daa", "daily-activity-analyst")).not.toBeNull();
+  });
+
+  it("camelCase humps", () => {
+    expect(fuzzyMatch("fb", "FooBar")?.indices).toEqual([0, 3]);
+  });
+
+  it("separator skip (query omits the dash)", () => {
+    expect(fuzzyMatch("slacknot", "slack-notifier")).not.toBeNull();
+  });
+
+  it("multi-term AND", () => {
+    expect(fuzzyMatch("daily analyst", "daily-activity-analyst")).not.toBeNull();
+    expect(fuzzyMatch("daily xyz", "daily-activity-analyst")).toBeNull();
+  });
+
+  it("a repeated term scores once, not once per repetition", () => {
+    expect(fuzzyScore("slack slack", "slack-notifier")).toBe(fuzzyScore("slack", "slack-notifier"));
+  });
+
+  it("length-changing lowercase never desyncs highlight indices", () => {
+    // U+0130 lowercases to two code units; alignment must survive.
+    const match = fuzzyMatch("app", "İstanbul-app");
+    expect(match?.indices).toEqual([9, 10, 11]);
+  });
+
+  it("ignores surrounding whitespace instead of matching it literally", () => {
+    expect(fuzzyMatch("  slack ", "slack-notifier")).not.toBeNull();
+  });
+
+  it("empty query matches everything with a zero score", () => {
+    expect(fuzzyMatch("", "anything")).toEqual({ score: 0, indices: [] });
+    expect(fuzzyMatch("   ", "anything")).toEqual({ score: 0, indices: [] });
+  });
+});
+
+describe("fuzzyMatch scoring order", () => {
+  const score = (q: string, t: string): number => {
+    const s = fuzzyScore(q, t);
+    if (s === null) throw new Error(`expected "${q}" to match "${t}"`);
+    return s;
+  };
+
+  it("pins the canonical scores so constant drift is visible", () => {
+    // start 20 + boundary char 13 + four consecutive chars at 11 each
+    expect(score("daily", "daily-activity-analyst")).toBe(77);
+    // start 20 + boundary char 13 + six consecutive at 11 + exact 25
+    expect(score("leasing", "leasing")).toBe(124);
+  });
+
+  it("exact beats prefix", () => {
+    expect(score("leasing", "leasing")).toBeGreaterThan(score("leas", "leasing"));
+  });
+
+  it("match at the start beats the same match mid-target", () => {
+    expect(score("not", "notifier")).toBeGreaterThan(score("not", "slack-notifier"));
+  });
+
+  it("contiguous beats boundary-hopping", () => {
+    expect(score("act", "activity")).toBeGreaterThan(score("act", "a-c-tools"));
+  });
+
+  it("boundary-anchored beats mid-word", () => {
+    expect(score("daa", "daily-activity-analyst")).toBeGreaterThan(score("daa", "xdaa"));
+  });
+});

--- a/packages/harness/web/src/lib/fuzzy.ts
+++ b/packages/harness/web/src/lib/fuzzy.ts
@@ -1,8 +1,19 @@
 /**
- * Minimal subsequence fuzzy matcher for the command palette — not a library,
- * just enough to rank "characters of the query appear in order in the
- * target" matches, favoring contiguous runs and matches near the start.
- * Returns null when the query isn't a subsequence of the target at all.
+ * Boundary-gated fuzzy matcher for the command palette.
+ *
+ * The old matcher accepted any in-order subsequence, so a short query would
+ * "match" characters scattered across a long absolute path ("slack" inside
+ * /Users/…/hackathon-local/workflows/backlog-nudge) and flood the palette
+ * with noise. This one only accepts a match when every matched character is
+ * contiguous with the previous one OR sits at a word/segment boundary
+ * (start, after a separator, digit transition, camelCase hump), plus a
+ * plain-substring pass so mid-word fragments ("otif" → slack-noTIFier)
+ * still land. Scattered subsequences are rejected outright — not merely
+ * down-ranked.
+ *
+ * Multi-term: the query splits on whitespace and every term must match the
+ * target independently (AND); the score is the sum, the highlight indices
+ * the union.
  */
 
 export interface FuzzyMatch {
@@ -11,33 +22,185 @@ export interface FuzzyMatch {
   indices: number[];
 }
 
+const CHAR_BASE = 1; // every matched character
+const BONUS_BOUNDARY = 12; // character matched at a word/segment boundary
+const BONUS_CONSECUTIVE = 10; // character adjacent to the previous match
+const BONUS_START = 20; // term starts at the very beginning of the target
+const BONUS_EXACT = 25; // the whole query IS the whole target
+
+/** Skipping characters costs, so tighter placements win; capped because a
+ *  20-char gap is not meaningfully worse than a 10-char one. */
+const gapPenalty = (gap: number): number => -(3 + Math.min(gap, 9));
+
+const SEPARATORS = new Set(["/", "\\", "-", "_", ".", ":", " "]);
+const isDigit = (ch: string): boolean => ch >= "0" && ch <= "9";
+const isLower = (ch: string): boolean => ch !== ch.toUpperCase() && ch === ch.toLowerCase();
+const isUpper = (ch: string): boolean => ch !== ch.toLowerCase() && ch === ch.toUpperCase();
+
+/** Word/segment starts, computed on the ORIGINAL casing (matching itself is
+ *  case-insensitive, but the camelCase hump only exists pre-lowering). */
+function computeBoundaries(target: string): boolean[] {
+  const out = new Array<boolean>(target.length);
+  for (let j = 0; j < target.length; j++) {
+    if (j === 0) {
+      out[j] = true;
+      continue;
+    }
+    const prev = target[j - 1];
+    const cur = target[j];
+    out[j] =
+      SEPARATORS.has(prev) ||
+      isDigit(cur) !== isDigit(prev) ||
+      (isUpper(cur) && isLower(prev));
+  }
+  return out;
+}
+
+interface TermMatch {
+  score: number;
+  indices: number[];
+}
+
+/** Gated-subsequence pass: first char at a boundary, every next char at
+ *  prev+1 or a later boundary. Memoized best-score search over the small
+ *  (term × target) state space; `next` pointers reconstruct the indices. */
+function gatedPass(
+  term: string,
+  targetLower: string,
+  boundaries: boolean[],
+  boundaryPos: ReadonlyMap<string, number[]>,
+): TermMatch | null {
+  const n = term.length;
+  const m = targetLower.length;
+
+  const stepScore = (p: number, p2: number): number => {
+    let s = CHAR_BASE;
+    if (boundaries[p2]) s += BONUS_BOUNDARY;
+    if (p2 === p + 1) s += BONUS_CONSECUTIVE;
+    const gap = p2 - p - 1;
+    if (gap >= 1) s += gapPenalty(gap);
+    return s;
+  };
+
+  // memo[(i, p)] = best score matching term[i+1..] given term[i] sits at p,
+  // with the chosen position for term[i+1] (-1 = dead end / last char).
+  const memo = new Map<number, { score: number; next: number }>();
+  const g = (i: number, p: number): number => {
+    if (i === n - 1) return 0;
+    const key = i * m + p;
+    const hit = memo.get(key);
+    if (hit !== undefined) return hit.score;
+    const want = term[i + 1];
+    let best = Number.NEGATIVE_INFINITY;
+    let bestNext = -1;
+    if (p + 1 < m && targetLower[p + 1] === want) {
+      const s = stepScore(p, p + 1) + g(i + 1, p + 1);
+      if (s > best) {
+        best = s;
+        bestNext = p + 1;
+      }
+    }
+    for (const b of boundaryPos.get(want) ?? []) {
+      if (b <= p + 1) continue; // p+1 already tried; earlier positions illegal
+      const s = stepScore(p, b) + g(i + 1, b);
+      if (s > best) {
+        best = s;
+        bestNext = b;
+      }
+    }
+    memo.set(key, { score: best, next: bestNext });
+    return best;
+  };
+
+  let bestTotal = Number.NEGATIVE_INFINITY;
+  let bestStart = -1;
+  for (const p0 of boundaryPos.get(term[0]) ?? []) {
+    const startScore = CHAR_BASE + BONUS_BOUNDARY + (p0 === 0 ? BONUS_START : 0);
+    const total = startScore + g(0, p0);
+    if (total > bestTotal) {
+      bestTotal = total;
+      bestStart = p0;
+    }
+  }
+  if (bestStart === -1 || !Number.isFinite(bestTotal)) return null;
+
+  const indices = [bestStart];
+  for (let i = 0, p = bestStart; i < n - 1; i++) {
+    const next = memo.get(i * m + p)?.next ?? -1;
+    indices.push(next);
+    p = next;
+  }
+  return { score: bestTotal, indices };
+}
+
+/** Substring pass: the term occurs contiguously anywhere — the only way a
+ *  match may START off-boundary. Best occurrence wins (a boundary-aligned
+ *  one outscores a mid-word one). */
+function substringPass(term: string, targetLower: string, boundaries: boolean[]): TermMatch | null {
+  let best: { score: number; start: number } | null = null;
+  for (let from = 0; ; ) {
+    const at = targetLower.indexOf(term, from);
+    if (at === -1) break;
+    let s = at === 0 ? BONUS_START : 0;
+    for (let k = 0; k < term.length; k++) {
+      s += CHAR_BASE;
+      if (boundaries[at + k]) s += BONUS_BOUNDARY;
+      if (k > 0) s += BONUS_CONSECUTIVE;
+    }
+    if (best === null || s > best.score) best = { score: s, start: at };
+    from = at + 1;
+  }
+  if (best === null) return null;
+  const start = best.start;
+  return { score: best.score, indices: Array.from({ length: term.length }, (_, k) => start + k) };
+}
+
 /** Full match info (score + matched character positions) — the palette
  *  bolds the matched characters, so it needs the indices, not just a rank. */
+/** Per-code-unit lowering that PRESERVES LENGTH: a character whose lowercase
+ *  expands (e.g. İ → i̇) stays as-is, so match indices computed against the
+ *  lowered string always line up with the original for highlighting. */
+function lowerAligned(s: string): string {
+  let out = "";
+  for (let i = 0; i < s.length; i++) {
+    const lower = s[i].toLowerCase();
+    out += lower.length === 1 ? lower : s[i];
+  }
+  return out;
+}
+
 export function fuzzyMatch(query: string, target: string): FuzzyMatch | null {
-  if (!query) return { score: 0, indices: [] };
-  const q = query.toLowerCase();
-  const t = target.toLowerCase();
+  // Dedupe repeated terms: "slack slack" must not score a single occurrence
+  // twice against targets that contain it once.
+  const terms = [...new Set(lowerAligned(query).split(/\s+/).filter(Boolean))];
+  if (terms.length === 0) return { score: 0, indices: [] };
+  if (!target) return null;
 
-  let score = 0;
-  let targetIndex = 0;
-  let consecutiveRun = 0;
-  const indices: number[] = [];
-
-  for (let i = 0; i < q.length; i++) {
-    const char = q[i];
-    const foundAt = t.indexOf(char, targetIndex);
-    if (foundAt === -1) return null;
-
-    consecutiveRun = foundAt === targetIndex ? consecutiveRun + 1 : 0;
-    score += 10 - Math.min(foundAt - targetIndex, 8); // reward proximity to the previous match
-    score += consecutiveRun * 3; // reward contiguous runs
-    if (foundAt === 0) score += 5; // reward matching right at the start
-
-    indices.push(foundAt);
-    targetIndex = foundAt + 1;
+  const targetLower = lowerAligned(target);
+  const boundaries = computeBoundaries(target);
+  const boundaryPos = new Map<string, number[]>();
+  for (let j = 0; j < target.length; j++) {
+    if (!boundaries[j]) continue;
+    const ch = targetLower[j];
+    const list = boundaryPos.get(ch);
+    if (list) list.push(j);
+    else boundaryPos.set(ch, [j]);
   }
 
-  return { score, indices };
+  let score = 0;
+  const indexSet = new Set<number>();
+  for (const term of terms) {
+    if (term.length > targetLower.length) return null;
+    const gated = gatedPass(term, targetLower, boundaries, boundaryPos);
+    const substr = substringPass(term, targetLower, boundaries);
+    const match = gated && substr ? (gated.score >= substr.score ? gated : substr) : (gated ?? substr);
+    if (!match) return null;
+    score += match.score;
+    for (const idx of match.indices) indexSet.add(idx);
+  }
+  if (lowerAligned(query.trim()) === targetLower) score += BONUS_EXACT;
+
+  return { score, indices: [...indexSet].sort((a, b) => a - b) };
 }
 
 export function fuzzyScore(query: string, target: string): number | null {

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -900,6 +900,88 @@ export const MOCK_WORKFLOWS: WorkflowInfo[] = [
   },
 ];
 
+/**
+ * `?mockFixtures=search` only — the shapes from the 2026-08-11 search bug
+ * report, kept out of the default fixtures so every fixture-count assertion
+ * elsewhere holds verbatim. Their paths deliberately stay out of
+ * MOCK_FS_TREE and MOCK_SETTINGS.recentDirs so directory-picker badges and
+ * bulk-scan counts never see them either.
+ */
+export const MOCK_SEARCH_WORKFLOWS: WorkflowInfo[] = [
+  // Raw scoped package name vs the rail's display name "slack-notifier" —
+  // the palette must search and show the short form.
+  {
+    name: "@sapiom/example-slack-notifier",
+    path: "/Users/demo/team-tools/slack-notifier",
+    definitionId: null,
+    definitionSlug: null,
+    source: "scan",
+  },
+  // Its PATH carries s…l…a…c…k scattered across segments ("social…stack"),
+  // which the old matcher accepted — a "slack" query must NOT surface it.
+  {
+    name: "daily-activity-analyst",
+    path: "/Users/demo/social-marketing/analytics-stack/daily-activity-analyst",
+    definitionId: null,
+    definitionSlug: null,
+    source: "scan",
+  },
+];
+
+export const MOCK_SEARCH_HISTORY: Record<string, SessionSummary[]> = {
+  // Under the boot session's cwd so the palette-open history fan-out already
+  // covers this directory — no recentDirs change needed.
+  "/Users/demo/acme-app": [
+    // Three transcript rows the user cannot tell apart (same title, same
+    // folder) — the palette collapses them to the newest.
+    ...[2, 4, 5].map((age, index) => ({
+      agentSessionId: `search-standup-${index + 1}`,
+      harness: "claude-code" as const,
+      cwd: "/Users/demo/acme-app",
+      title: "Standup summary for #eng",
+      lastActiveAt: daysAgo(age),
+      source: "transcript" as const,
+      resumeMode: "rehydrate" as const,
+      turnCount: 6 - index,
+    })),
+    // A raw first-prompt title — the old matcher let short queries land on
+    // characters scattered through strings like this.
+    {
+      agentSessionId: "search-annotate",
+      harness: "claude-code" as const,
+      cwd: "/Users/demo/acme-app",
+      title: "You are annotating an already-generated draft of the leasing docs",
+      lastActiveAt: daysAgo(3),
+      source: "transcript" as const,
+      resumeMode: "rehydrate" as const,
+      turnCount: 2,
+    },
+    // Noise rows for the "daily" query: titles that share letters with it
+    // (the old matcher scattered across them) but carry no boundary hit, so
+    // the agent must be the only match.
+    {
+      agentSessionId: "search-digest",
+      harness: "claude-code" as const,
+      cwd: "/Users/demo/acme-app",
+      title: "Digest and activity rollup",
+      lastActiveAt: daysAgo(1),
+      source: "transcript" as const,
+      resumeMode: "rehydrate" as const,
+      turnCount: 4,
+    },
+    {
+      agentSessionId: "search-activity-log",
+      harness: "claude-code" as const,
+      cwd: "/Users/demo/acme-app",
+      title: "Check the activity log",
+      lastActiveAt: daysAgo(6),
+      source: "transcript" as const,
+      resumeMode: "rehydrate" as const,
+      turnCount: 3,
+    },
+  ],
+};
+
 export const MOCK_MACROS: MacroDef[] = [
   {
     id: "run_local",

--- a/packages/harness/web/src/lib/palette.test.ts
+++ b/packages/harness/web/src/lib/palette.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it } from "vitest";
+import type { HarnessSession, SessionSummary, WorkflowInfo } from "@shared/types";
+
+import {
+  buildPaletteItems,
+  buildPathItems,
+  GLOBAL_CAP,
+  type PaletteAction,
+  paletteActivation,
+  type PaletteFilter,
+  type PaletteItem,
+  type PaletteSources,
+  rankPaletteItems,
+  recencyBonus,
+  SECTION_QUERIED_CAP,
+} from "./palette";
+
+const NOW = Date.parse("2026-08-11T12:00:00.000Z");
+const minutesAgo = (m: number): string => new Date(NOW - m * 60_000).toISOString();
+const daysAgo = (d: number): string => new Date(NOW - d * 86_400_000).toISOString();
+
+const session = (over: Partial<HarnessSession> & { id: string }): HarnessSession => ({
+  agentSessionId: null,
+  boundWorkflowPath: null,
+  harness: "claude-code",
+  cwd: "/Users/demo/acme-app",
+  title: "acme-app",
+  status: "running",
+  createdAt: minutesAgo(60),
+  lastActiveAt: minutesAgo(30),
+  ready: true,
+  ...over,
+});
+
+const summary = (over: Partial<SessionSummary> & { agentSessionId: string }): SessionSummary => ({
+  harness: "claude-code",
+  cwd: "/Users/demo/acme-app",
+  title: "Untitled",
+  lastActiveAt: minutesAgo(30),
+  source: "transcript",
+  resumeMode: "rehydrate",
+  ...over,
+});
+
+const workflow = (over: Partial<WorkflowInfo> & { name: string; path: string }): WorkflowInfo => ({
+  definitionId: null,
+  definitionSlug: null,
+  source: "scan",
+  ...over,
+});
+
+const action = (over: Partial<PaletteAction> & { id: string; label: string }): PaletteAction => ({
+  run: () => undefined,
+  ...over,
+});
+
+const sources = (over: Partial<PaletteSources>): PaletteSources => ({
+  sessions: [],
+  workflows: [],
+  history: [],
+  recentDirs: [],
+  sessionNames: {},
+  actions: [],
+  templates: [],
+  ...over,
+});
+
+const rank = (query: string, over: Partial<PaletteSources>, filter: PaletteFilter = "all"): PaletteItem[] =>
+  rankPaletteItems(query, buildPaletteItems(sources(over)), { filter, now: NOW });
+
+describe("buildPaletteItems display names", () => {
+  it("agents carry the rail's display name, not the raw scoped package name", () => {
+    const items = buildPaletteItems(
+      sources({
+        workflows: [workflow({ name: "@sapiom/example-slack-notifier", path: "/Users/demo/team-tools/slack-notifier" })],
+      }),
+    );
+    const agent = items.find((item) => item.kind === "agent");
+    expect(agent?.label).toBe("slack-notifier");
+    expect(agent?.path).toBe("/Users/demo/team-tools/slack-notifier");
+    expect(agent?.meta).toBe("/Users/demo/team-tools/slack-notifier");
+  });
+
+  it("live sessions get the rail's numbered default names", () => {
+    const first = session({ id: "s1", createdAt: minutesAgo(90) });
+    const second = session({ id: "s2", createdAt: minutesAgo(10) });
+    const items = buildPaletteItems(sources({ sessions: [first, second] }));
+    expect(items.filter((item) => item.kind === "session").map((item) => item.label)).toEqual([
+      "acme-app",
+      "acme-app 2",
+    ]);
+  });
+
+  it("session renames apply to registry rows and to their history summaries", () => {
+    const renamed = session({ id: "s1" });
+    const items = buildPaletteItems(
+      sources({
+        sessions: [renamed],
+        history: [summary({ agentSessionId: "a9", harnessSessionId: "h9", title: "raw prompt text" })],
+        sessionNames: { s1: "Leasing revamp", h9: "Digest tuning" },
+      }),
+    );
+    expect(items.find((item) => item.kind === "session")?.label).toBe("Leasing revamp");
+    expect(items.find((item) => item.kind === "past")?.label).toBe("Digest tuning");
+  });
+
+  it("actions and docs become searchable rows with their own icons and metas", () => {
+    const items = buildPaletteItems(
+      sources({ actions: [action({ id: "toggle-theme", label: "Toggle theme", meta: "Light and dark", icon: "Sun" })] }),
+    );
+    const command = items.find((item) => item.kind === "command");
+    expect(command).toMatchObject({ id: "command:toggle-theme", label: "Toggle theme", icon: "Sun" });
+    expect(command?.run).toBeTypeOf("function");
+    const docs = items.filter((item) => item.kind === "doc");
+    expect(docs.length).toBeGreaterThan(0);
+    expect(docs[0].href).toMatch(/^https:\/\/docs\.sapiom\.ai\//);
+  });
+});
+
+describe("past-session dedup", () => {
+  it("collapses same-title same-folder rows to the newest", () => {
+    const items = buildPaletteItems(
+      sources({
+        history: [
+          summary({ agentSessionId: "a1", title: "Standup summary for #eng", lastActiveAt: daysAgo(4) }),
+          summary({ agentSessionId: "a2", title: "Standup summary for #eng", lastActiveAt: daysAgo(2) }),
+          summary({ agentSessionId: "a3", title: "Standup summary for #eng", lastActiveAt: daysAgo(5) }),
+        ],
+      }),
+    );
+    const past = items.filter((item) => item.kind === "past");
+    expect(past).toHaveLength(1);
+    expect(past[0].summary?.agentSessionId).toBe("a2");
+  });
+
+  it("keeps same-title rows apart when they live in different folders", () => {
+    const items = buildPaletteItems(
+      sources({
+        history: [
+          summary({ agentSessionId: "a1", title: "Standup", cwd: "/Users/demo/one" }),
+          summary({ agentSessionId: "a2", title: "Standup", cwd: "/Users/demo/two" }),
+        ],
+      }),
+    );
+    expect(items.filter((item) => item.kind === "past")).toHaveLength(2);
+  });
+
+  it("on a recency tie the resumable registry row beats the transcript row", () => {
+    const at = daysAgo(1);
+    const items = buildPaletteItems(
+      sources({
+        sessions: [session({ id: "r1", status: "exited", title: "Old run", lastActiveAt: at })],
+        history: [summary({ agentSessionId: "a1", title: "Old run", lastActiveAt: at, turnCount: 3 })],
+      }),
+    );
+    const past = items.filter((item) => item.kind === "past");
+    expect(past).toHaveLength(1);
+    // Enter must resume the session, not downgrade to the review pane.
+    expect(past[0].sessionId).toBe("r1");
+  });
+
+  it("between two transcripts on a recency tie the better-kept one wins", () => {
+    const at = daysAgo(1);
+    const items = buildPaletteItems(
+      sources({
+        history: [
+          summary({ agentSessionId: "thin", title: "Old run", lastActiveAt: at, turnCount: 1 }),
+          summary({ agentSessionId: "rich", title: "Old run", lastActiveAt: at, turnCount: 9 }),
+        ],
+      }),
+    );
+    const past = items.filter((item) => item.kind === "past");
+    expect(past).toHaveLength(1);
+    expect(past[0].summary?.agentSessionId).toBe("rich");
+  });
+});
+
+describe("rankPaletteItems — the reported failures", () => {
+  it('"daily" surfaces the agent, never rows matched via scattered path characters', () => {
+    const results = rank("daily", {
+      workflows: [
+        workflow({
+          name: "daily-activity-analyst",
+          path: "/Users/demo/social-marketing/analytics-stack/daily-activity-analyst",
+        }),
+      ],
+      history: [1, 2, 3, 4, 5].map((n) =>
+        summary({
+          agentSessionId: `noise-${n}`,
+          title: "You are annotating an already-generated draft",
+          cwd: `/Users/gwitwer/sapiom/hackathon-${n}`,
+          lastActiveAt: minutesAgo(n),
+        }),
+      ),
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].kind).toBe("agent");
+    expect(results[0].label).toBe("daily-activity-analyst");
+    expect(results[0].labelIndices).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('"slack" dedups the session flood and drops path-scatter junk agents', () => {
+    const results = rank("slack", {
+      workflows: [
+        workflow({ name: "@sapiom/example-slack-notifier", path: "/Users/demo/team-tools/slack-notifier" }),
+        workflow({ name: "backlog-nudge", path: "/Users/gwitwer/sapiom/hackathon-local/workflows/backlog-nudge" }),
+      ],
+      history: [1, 2, 3, 4, 5, 6].map((n) =>
+        summary({
+          agentSessionId: `sb-${n}`,
+          title: "slacksummarybot",
+          cwd: "/Users/demo/wf-demo-testing/slacksummarybot",
+          lastActiveAt: minutesAgo(n * 10),
+        }),
+      ),
+    });
+    expect(results.filter((item) => item.label === "slacksummarybot")).toHaveLength(1);
+    const agent = results.find((item) => item.kind === "agent");
+    expect(agent?.label).toBe("slack-notifier");
+    expect(agent?.labelIndices).toEqual([0, 1, 2, 3, 4]);
+    expect(results.some((item) => item.label === "backlog-nudge")).toBe(false);
+  });
+});
+
+describe("rankPaletteItems ordering", () => {
+  it("a name match can never rank below a path-only match, even a maximally fresh one", () => {
+    const results = rank("acme", {
+      history: [
+        summary({ agentSessionId: "label-hit", title: "acme rollout", cwd: "/Users/demo/misc", lastActiveAt: daysAgo(60) }),
+        summary({ agentSessionId: "meta-hit", title: "Something else", cwd: "/Users/demo/acme-app", lastActiveAt: minutesAgo(1) }),
+      ],
+    });
+    expect(results.map((item) => item.summary?.agentSessionId)).toEqual(["label-hit", "meta-hit"]);
+    expect(results[0].labelIndices).toBeDefined();
+    expect(results[1].metaIndices).toBeDefined();
+  });
+
+  it("home-prefix path segments are searchable (metas are the raw cwd)", () => {
+    const results = rank("demo", {
+      history: [summary({ agentSessionId: "a1", title: "Something", cwd: "/Users/demo/acme-app" })],
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].metaIndices).toBeDefined();
+  });
+
+  it("recency boost lifts a fresh near-exact match over a stale exact match", () => {
+    const results = rank("leasing", {
+      history: [
+        summary({ agentSessionId: "stale-exact", title: "leasing", cwd: "/Users/demo/one", lastActiveAt: daysAgo(60) }),
+        summary({ agentSessionId: "fresh-prefix", title: "leasing-v2", cwd: "/Users/demo/two", lastActiveAt: minutesAgo(5) }),
+      ],
+    });
+    expect(results.map((item) => item.summary?.agentSessionId)).toEqual(["fresh-prefix", "stale-exact"]);
+  });
+
+  it("equal matches order newest-first", () => {
+    const results = rank("digest", {
+      history: [
+        summary({ agentSessionId: "older", title: "digest run", cwd: "/Users/demo/one", lastActiveAt: daysAgo(3) }),
+        summary({ agentSessionId: "newer", title: "digest run", cwd: "/Users/demo/two", lastActiveAt: daysAgo(2) }),
+      ],
+    });
+    expect(results.map((item) => item.summary?.agentSessionId)).toEqual(["newer", "older"]);
+  });
+
+  it("on a dead-even best hit, Agents rank above Past sessions", () => {
+    const results = rank("slack", {
+      workflows: [workflow({ name: "slack-notifier", path: "/Users/demo/team-tools/slack-notifier" })],
+      history: [
+        summary({
+          agentSessionId: "old",
+          title: "slacksummarybot",
+          cwd: "/Users/demo/wf-demo-testing/slacksummarybot",
+          lastActiveAt: daysAgo(60),
+        }),
+      ],
+    });
+    expect(results.map((item) => item.kind)).toEqual(["agent", "past"]);
+  });
+
+  it("caps each section when several kinds match, but a lone section fills the window", () => {
+    const many = (count: number): SessionSummary[] =>
+      Array.from({ length: count }, (_, n) =>
+        summary({
+          agentSessionId: `m-${n}`,
+          title: `meeting notes ${n}`,
+          cwd: `/Users/demo/dir-${n}`,
+          lastActiveAt: daysAgo(n + 1),
+        }),
+      );
+    // Only past sessions match: the per-section cap lifts.
+    expect(rank("meeting", { history: many(10) })).toHaveLength(10);
+
+    // Two kinds match: each is capped so neither starves the other.
+    const mixed = rank("dir", {
+      history: many(10),
+      workflows: Array.from({ length: 10 }, (_, n) =>
+        workflow({ name: `dir-agent-${n}`, path: `/opt/agents/dir-agent-${n}` }),
+      ),
+    });
+    expect(mixed.length).toBeLessThanOrEqual(GLOBAL_CAP);
+    expect(mixed.filter((item) => item.kind === "agent")).toHaveLength(SECTION_QUERIED_CAP);
+    expect(mixed.filter((item) => item.kind === "past")).toHaveLength(SECTION_QUERIED_CAP);
+  });
+});
+
+describe("rankPaletteItems filters", () => {
+  const filterSources: Partial<PaletteSources> = {
+    sessions: [session({ id: "s1" }), session({ id: "s2", status: "exited", title: "Old run" })],
+    workflows: [workflow({ name: "leasing", path: "/Users/demo/acme-app/leasing" })],
+    recentDirs: ["/Users/demo/somewhere"],
+    actions: [
+      action({ id: "browse-templates", label: "Browse templates", meta: "Gallery and starters" }),
+      action({ id: "toggle-theme", label: "Toggle theme", meta: "Light and dark" }),
+    ],
+    templates: [
+      { id: "hello-agent", name: "Hello Agent", description: "The minimal single-step agent." },
+      { id: "webhook-router", name: "Webhook Router", description: "Route inbound webhooks." },
+    ],
+  };
+
+  it("the Actions tab lists every injected verb and nothing else", () => {
+    const results = rank("", filterSources, "actions");
+    expect(results.map((item) => item.kind)).toEqual(["command", "command"]);
+    expect(results.map((item) => item.label)).toEqual(["Browse templates", "Toggle theme"]);
+  });
+
+  it("the Templates tab lists the catalog and matches within it", () => {
+    const unqueried = rank("", filterSources, "templates");
+    expect(unqueried.map((item) => item.label)).toEqual(["Hello Agent", "Webhook Router"]);
+    const queried = rank("webhook", filterSources, "templates");
+    expect(queried.map((item) => item.templateId)).toEqual(["webhook-router"]);
+  });
+
+  it("the Sessions tab scopes to live and past sessions", () => {
+    const results = rank("", filterSources, "sessions");
+    expect(results.map((item) => item.kind)).toEqual(["session", "past"]);
+  });
+
+  it("the Agents tab scopes to agents", () => {
+    const results = rank("", filterSources, "agents");
+    expect(results.map((item) => item.kind)).toEqual(["agent"]);
+  });
+
+  it("the Docs tab lists the doc links and matches within them", () => {
+    const unqueried = rank("", filterSources, "docs");
+    expect(unqueried.every((item) => item.kind === "doc")).toBe(true);
+    const queried = rank("mcp", filterSources, "docs");
+    expect(queried.length).toBeGreaterThan(0);
+    expect(queried.every((item) => item.kind === "doc")).toBe(true);
+  });
+
+  it("the Files tab lists folders only", () => {
+    const results = rank("", filterSources, "files");
+    expect(results.map((item) => item.kind)).toEqual(["recent"]);
+  });
+
+  it("a scoped tab never leaks other kinds for a broad query", () => {
+    const results = rank("e", filterSources, "actions");
+    expect(results.every((item) => item.kind === "command")).toBe(true);
+  });
+
+  it("template matches join the All tab's ranked results", () => {
+    const results = rank("webhook", filterSources, "all");
+    expect(results.some((item) => item.kind === "template")).toBe(true);
+  });
+});
+
+describe("current session", () => {
+  it("is badged and sorts last among live sessions unqueried, despite being the freshest", () => {
+    const current = session({ id: "s-active", cwd: "/Users/demo/one", lastActiveAt: minutesAgo(0), createdAt: minutesAgo(10) });
+    const other = session({ id: "s-other", cwd: "/Users/demo/two", lastActiveAt: minutesAgo(20), createdAt: minutesAgo(60) });
+    const results = rank("", { sessions: [current, other], activeSessionId: "s-active" });
+    const sessionRows = results.filter((item) => item.kind === "session");
+    expect(sessionRows.map((item) => item.sessionId)).toEqual(["s-other", "s-active"]);
+    expect(sessionRows[1].current).toBe(true);
+    expect(sessionRows[0].current).toBeUndefined();
+  });
+
+  it("keeps its earned rank when queried — identification is the badge's job", () => {
+    const current = session({ id: "s-active", title: "leasing pipeline", cwd: "/Users/demo/one", lastActiveAt: minutesAgo(0) });
+    const results = rank("leasing pipeline", { sessions: [current], activeSessionId: "s-active" });
+    expect(results[0].sessionId).toBe("s-active");
+    expect(results[0].current).toBe(true);
+  });
+});
+
+describe("rankPaletteItems empty query (All tab)", () => {
+  it("keeps the fixed section order with recency-sorted groups and the action rows pinned last", () => {
+    const older = session({ id: "s1", cwd: "/Users/demo/one", lastActiveAt: minutesAgo(50), createdAt: minutesAgo(60) });
+    const newer = session({ id: "s2", cwd: "/Users/demo/two", lastActiveAt: minutesAgo(5), createdAt: minutesAgo(10) });
+    const results = rank("", {
+      sessions: [older, newer],
+      workflows: [workflow({ name: "leasing", path: "/Users/demo/two/leasing" })],
+      history: Array.from({ length: 8 }, (_, n) =>
+        summary({ agentSessionId: `p-${n}`, title: `run ${n}`, lastActiveAt: daysAgo(n + 1) }),
+      ),
+      recentDirs: ["/Users/demo/one"],
+      actions: [action({ id: "browse-templates", label: "Browse templates" })],
+    });
+    expect(results[0].sessionId).toBe("s2");
+    expect(results[1].sessionId).toBe("s1");
+    expect(results.filter((item) => item.kind === "past")).toHaveLength(6);
+    expect(results.at(-1)?.label).toBe("Browse templates");
+    const kinds = results.map((item) => item.kind);
+    expect(kinds.indexOf("past")).toBeGreaterThan(kinds.lastIndexOf("session"));
+    expect(kinds.indexOf("agent")).toBeGreaterThan(kinds.lastIndexOf("past"));
+  });
+});
+
+describe("recencyBonus", () => {
+  it("tiers by age and ignores pseudo-recency", () => {
+    expect(recencyBonus(NOW, NOW - 10 * 60_000)).toBe(30);
+    expect(recencyBonus(NOW, NOW - 5 * 3_600_000)).toBe(20);
+    expect(recencyBonus(NOW, NOW - 3 * 86_400_000)).toBe(12);
+    expect(recencyBonus(NOW, NOW - 20 * 86_400_000)).toBe(6);
+    expect(recencyBonus(NOW, NOW - 90 * 86_400_000)).toBe(0);
+    expect(recencyBonus(NOW, 5)).toBe(0); // MRU rank, not a timestamp
+    expect(recencyBonus(NOW, 0)).toBe(0);
+  });
+});
+
+describe("paletteActivation", () => {
+  const base: PaletteItem = { id: "x", kind: "past", label: "x", meta: "", recency: 0 };
+
+  it("a past row prefers its live/registry id over the transcript summary", () => {
+    const both = { ...base, sessionId: "s1", summary: summary({ agentSessionId: "a1" }) };
+    expect(paletteActivation(both)).toEqual({ type: "select-session", sessionId: "s1" });
+  });
+
+  it("a transcript-only past row opens the review pane", () => {
+    const only = { ...base, summary: summary({ agentSessionId: "a1" }) };
+    expect(paletteActivation(only)).toEqual({ type: "review-summary", summary: only.summary });
+  });
+
+  it("a past row never falls through to open-path", () => {
+    expect(paletteActivation({ ...base, path: "/Users/demo/x" })).toEqual({ type: "none" });
+  });
+
+  it("actions run their verb; docs open their page; paths open raw", () => {
+    const run = (): void => undefined;
+    expect(paletteActivation({ ...base, kind: "command", run })).toEqual({ type: "run", run });
+    expect(paletteActivation({ ...base, kind: "doc", href: "https://docs.sapiom.ai/" })).toEqual({
+      type: "open-href",
+      href: "https://docs.sapiom.ai/",
+    });
+    expect(paletteActivation({ ...base, kind: "agent", path: "/p" })).toEqual({ type: "open-path", path: "/p" });
+  });
+
+  it("a template row opens the templates browser focused on it", () => {
+    expect(paletteActivation({ ...base, kind: "template", templateId: "hello-agent" })).toEqual({
+      type: "open-template",
+      templateId: "hello-agent",
+    });
+  });
+});
+
+describe("buildPathItems", () => {
+  it("offers the literal input first, then the listed dirs with raw metas", () => {
+    const items = buildPathItems("/Users/demo", [
+      { name: "acme-app", path: "/Users/demo/acme-app", hasAgentProject: false },
+    ]);
+    expect(items[0]).toMatchObject({ label: "/Users/demo", meta: "Open this path", path: "/Users/demo" });
+    expect(items[1]).toMatchObject({ label: "acme-app", meta: "/Users/demo/acme-app" });
+  });
+
+  it("omits the confirm row for a blank query", () => {
+    expect(buildPathItems("  ", [])).toEqual([]);
+  });
+});

--- a/packages/harness/web/src/lib/palette.ts
+++ b/packages/harness/web/src/lib/palette.ts
@@ -1,0 +1,523 @@
+/**
+ * Pure command-palette model: which rows exist, what they say, and how a
+ * query ranks them. No React, no fetch — CommandPalette.tsx renders this.
+ *
+ * The load-bearing choices (each one undoes a reported search failure):
+ *   - Rows carry DISPLAY names (displayAgentName / sessionDisplayName), so
+ *     what's searchable is what the rail shows, and user renames are findable.
+ *   - Near-identical past sessions (same visible title, same folder) collapse
+ *     to the newest — the history fan-out otherwise floods the list.
+ *   - When querying, sections are ordered by their best hit instead of a
+ *     fixed order, so an agent whose NAME matches is never buried under a
+ *     pile of path-matched sessions; per-section caps keep every matching
+ *     kind reachable, and they lift when only one kind matched at all.
+ *   - Recency is a bounded score bonus: the thing you touched an hour ago
+ *     outranks a stale row of comparable match quality, but a path-only
+ *     match can never climb above a name match.
+ *
+ * The finder's surface (per the Command Search design): a filter-tab row
+ * scopes the search to Templates / Docs / Files / Actions, app verbs arrive
+ * as injected PaletteActions rather than hard-coded rows, and a short list
+ * of documentation pages is searchable in place.
+ */
+import type { HarnessSession, SessionSummary, WorkflowInfo } from "@shared/types";
+
+import { displayAgentName } from "./agent-name";
+import type { FsDirEntry } from "./api";
+import { DOC_LINKS, DOCS_SITE } from "./docs";
+import { fuzzyMatch } from "./fuzzy";
+import { sessionDisplayName, type SessionNameOverrides } from "./session-name";
+import { isUnder } from "./workspace-tree";
+
+export type PaletteKind = "command" | "session" | "past" | "agent" | "recent" | "path" | "doc" | "template";
+
+export interface PaletteItem {
+  id: string;
+  kind: PaletteKind;
+  /** Display name — matching runs on this exact string, so the highlight
+   *  indices align with what's rendered. */
+  label: string;
+  /** Display meta: the raw path for jump targets (rendered monospace), a
+   *  one-line description for actions and docs. */
+  meta: string;
+  /** Per-item icon override (actions carry their own); falls back to the
+   *  kind's icon. */
+  icon?: string;
+  /** The injected verb an action row executes. */
+  run?: () => void;
+  /** External page a doc row opens. */
+  href?: string;
+  /** Gallery/starter id a template row opens in the templates browser. */
+  templateId?: string;
+  sessionId?: string;
+  summary?: SessionSummary;
+  /** The session the user is looking at right now — badged in the list, and
+   *  never the default selection (jumping to it is a no-op). */
+  current?: boolean;
+  /** RAW absolute path for activation. */
+  path?: string;
+  /** Epoch ms, or a small MRU pseudo-recency (always below any timestamp,
+   *  and too old for a recency bonus), or 0 for "no signal". */
+  recency: number;
+  labelIndices?: number[];
+  metaIndices?: number[];
+}
+
+/** An app verb the palette can run. Supplied by the caller rather than
+ *  hard-coded here: the palette knows how to FIND things, the app knows
+ *  what it can do. */
+export interface PaletteAction {
+  id: string;
+  label: string;
+  meta?: string;
+  icon?: string;
+  run: () => void;
+}
+
+export type PaletteFilter = "all" | "sessions" | "agents" | "templates" | "docs" | "files" | "actions";
+
+export const PALETTE_FILTERS: { id: PaletteFilter; label: string; icon: string }[] = [
+  { id: "all", label: "All", icon: "Search" },
+  { id: "sessions", label: "Sessions", icon: "Radio" },
+  { id: "agents", label: "Agents", icon: "Workflow" },
+  { id: "templates", label: "Templates", icon: "LayoutTemplate" },
+  { id: "docs", label: "Docs", icon: "BookOpen" },
+  { id: "files", label: "Files", icon: "Folder" },
+  { id: "actions", label: "Actions", icon: "Zap" },
+];
+
+/** Where a tab continues, if it continues anywhere — the footer's CTA.
+ *  `href` opens an external page; `actionId` runs one of the injected verbs. */
+export const FILTER_DESTINATION: Partial<
+  Record<PaletteFilter, { label: string; href?: string; actionId?: string }>
+> = {
+  templates: { label: "Browse templates", actionId: "browse-templates" },
+  docs: { label: "Open documentation", href: DOCS_SITE },
+};
+
+/** A catalog entry the Templates tab lists — the minimal slice of a gallery
+ *  or bundled-starter template the finder needs. */
+export interface PaletteTemplate {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface PaletteSources {
+  sessions: HarnessSession[];
+  workflows: WorkflowInfo[];
+  history: SessionSummary[];
+  recentDirs: string[];
+  /** User renames from ui-prefs — the palette must search the same names
+   *  the rail and header render. */
+  sessionNames: SessionNameOverrides;
+  /** App verbs, in the order the Actions tab lists them. */
+  actions: PaletteAction[];
+  /** Template catalog (gallery + bundled starters), in gallery order. */
+  templates: PaletteTemplate[];
+  /** The session currently on screen — its row is badged and demoted. */
+  activeSessionId?: string | null;
+}
+
+/** How many past sessions the empty-query list shows — the full history
+ *  stays reachable by typing; unqueried it would otherwise drown the rest. */
+export const PAST_UNQUERIED_CAP = 6;
+/** Per-section cap while querying: one prolific kind (usually past sessions)
+ *  must not starve the others out of the global window. Lifted when only a
+ *  single section matched — there is nothing left to starve. */
+export const SECTION_QUERIED_CAP = 6;
+export const GLOBAL_CAP = 20;
+const AGENTS_UNQUERIED_CAP = 6;
+
+const HOUR = 3_600_000;
+const DAY = 24 * HOUR;
+
+/** Bounded bonus so fresh rows outrank stale rows of comparable match
+ *  quality. Tiers, not a curve, so ranking stays explainable; pseudo-recency
+ *  values (tiny numbers) age out to 0 by construction. */
+export function recencyBonus(now: number, recency: number): number {
+  if (recency <= 0) return 0;
+  const age = now - recency;
+  if (age <= HOUR) return 30;
+  if (age <= DAY) return 20;
+  if (age <= 7 * DAY) return 12;
+  if (age <= 30 * DAY) return 6;
+  return 0;
+}
+
+const basenameOf = (path: string): string => path.split("/").filter(Boolean).pop() ?? path;
+const parseTime = (iso: string): number => {
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? 0 : t;
+};
+
+interface PastCandidate {
+  item: PaletteItem;
+  cwd: string;
+  /** Turn/message count — the better-kept row between two transcripts. */
+  count: number;
+  fromRegistry: boolean;
+}
+
+const keepsOver = (a: PastCandidate, b: PastCandidate): boolean => {
+  if (a.item.recency !== b.item.recency) return a.item.recency > b.item.recency;
+  // Registry rows resolve to a directly selectable session; on a dead-even
+  // tie the resumable row must win, or Enter silently downgrades from
+  // "switch to session" to "open review pane".
+  if (a.fromRegistry !== b.fromRegistry) return a.fromRegistry;
+  return a.count > b.count;
+};
+
+/**
+ * Builds the display-ready rows: registry-mirror filtering, past-session
+ * dedup, display names, recency, injected actions, doc links. No query
+ * involved — rankPaletteItems does the matching.
+ */
+export function buildPaletteItems(src: PaletteSources): PaletteItem[] {
+  const { sessions, workflows, history, recentDirs, sessionNames, actions, templates, activeSessionId } = src;
+
+  const sessionItems: PaletteItem[] = sessions
+    .filter((session) => session.status !== "exited")
+    .map((session) => ({
+      id: `session:${session.id}`,
+      kind: "session" as const,
+      label: sessionDisplayName(session, sessions, sessionNames),
+      meta: session.cwd,
+      sessionId: session.id,
+      current: session.id === activeSessionId || undefined,
+      recency: parseTime(session.lastActiveAt),
+    }));
+
+  // Past sessions: exited registry sessions plus history entries, minus the
+  // history rows the registry already mirrors (same filter the rail uses).
+  const registryIds = new Set(sessions.map((session) => session.id));
+  const registryAgentIds = new Set(
+    sessions.map((session) => session.agentSessionId).filter((id): id is string => id != null),
+  );
+  const pastCandidates: PastCandidate[] = [
+    ...sessions
+      .filter((session) => session.status === "exited")
+      .map((session) => ({
+        item: {
+          id: `past:${session.id}`,
+          kind: "past" as const,
+          label: sessionDisplayName(session, sessions, sessionNames),
+          meta: session.cwd,
+          sessionId: session.id,
+          recency: parseTime(session.lastActiveAt),
+        },
+        cwd: session.cwd,
+        count: 0,
+        fromRegistry: true,
+      })),
+    ...history
+      .filter(
+        (summary) =>
+          !(summary.harnessSessionId != null && registryIds.has(summary.harnessSessionId)) &&
+          !registryAgentIds.has(summary.agentSessionId),
+      )
+      .map((summary) => ({
+        item: {
+          id: `summary:${summary.agentSessionId}`,
+          kind: "past" as const,
+          label: sessionNames[summary.harnessSessionId ?? ""]?.trim() || summary.title,
+          meta: summary.cwd,
+          summary,
+          recency: parseTime(summary.lastActiveAt),
+        },
+        cwd: summary.cwd,
+        count: summary.turnCount ?? summary.messageCount ?? 0,
+        fromRegistry: false,
+      })),
+  ];
+  // Collapse rows the user cannot tell apart (same visible title in the same
+  // folder) to the newest — the specific ones stay reachable via the rail's
+  // history popover, which this dedup deliberately does not touch.
+  const byTitleAndCwd = new Map<string, PastCandidate>();
+  for (const candidate of pastCandidates) {
+    const key = `${candidate.item.label.trim()}\u0000${candidate.cwd}`;
+    const kept = byTitleAndCwd.get(key);
+    if (!kept || keepsOver(candidate, kept)) byTitleAndCwd.set(key, candidate);
+  }
+  const pastItems = [...byTitleAndCwd.values()]
+    .map((candidate) => candidate.item)
+    .sort((a, b) => b.recency - a.recency);
+
+  // WorkflowInfo has no timestamp — derive agent recency from the sessions
+  // working in/on it, falling back to a small recentDirs MRU rank (orders
+  // agents among themselves but never earns a recency bonus).
+  const agentRecency = (workflow: WorkflowInfo): number => {
+    let latest = 0;
+    for (const session of sessions) {
+      if (session.boundWorkflowPath !== workflow.path && !isUnder(session.cwd, workflow.path)) continue;
+      const at = parseTime(session.lastActiveAt);
+      if (at > latest) latest = at;
+    }
+    if (latest > 0) return latest;
+    const mru = recentDirs.findIndex((dir) => isUnder(workflow.path, dir) || isUnder(dir, workflow.path));
+    return mru === -1 ? 0 : recentDirs.length - mru;
+  };
+  const agentItems: PaletteItem[] = workflows.map((workflow) => ({
+    id: `agent:${workflow.path}`,
+    kind: "agent" as const,
+    label: displayAgentName(workflow.name),
+    meta: workflow.path,
+    path: workflow.path,
+    recency: agentRecency(workflow),
+  }));
+
+  const agentPaths = new Set(workflows.map((workflow) => workflow.path));
+  const recentItems: PaletteItem[] = recentDirs
+    .filter((dir) => !agentPaths.has(dir))
+    .map((dir) => ({
+      id: `recent:${dir}`,
+      kind: "recent" as const,
+      label: basenameOf(dir),
+      meta: dir,
+      path: dir,
+      recency: recentDirs.length - recentDirs.indexOf(dir),
+    }));
+
+  const commandItems: PaletteItem[] = actions.map((action) => ({
+    id: `command:${action.id}`,
+    kind: "command" as const,
+    label: action.label,
+    meta: action.meta ?? "",
+    icon: action.icon,
+    run: action.run,
+    recency: 0,
+  }));
+
+  const docItems: PaletteItem[] = DOC_LINKS.map((doc) => ({
+    id: `doc:${doc.href}`,
+    kind: "doc" as const,
+    label: doc.label,
+    meta: doc.meta,
+    href: doc.href,
+    recency: 0,
+  }));
+
+  const templateItems: PaletteItem[] = templates.map((template) => ({
+    id: `template:${template.id}`,
+    kind: "template" as const,
+    label: template.name,
+    meta: template.description,
+    templateId: template.id,
+    recency: 0,
+  }));
+
+  return [
+    ...sessionItems,
+    ...pastItems,
+    ...agentItems,
+    ...recentItems,
+    ...templateItems,
+    ...docItems,
+    ...commandItems,
+  ];
+}
+
+interface ScoredItem {
+  item: PaletteItem;
+  /** 0 = the visible name matched, 1 = only the meta did. Sorts before any
+   *  score, so a meta-only hit can never float above a name hit. */
+  fieldRank: number;
+  /** Match score + recency bonus. */
+  boosted: number;
+  matchedLength: number;
+}
+
+/** Tie order between sections whose best hits are equal — deliberately puts
+ *  Agents above Past sessions: agents are the durable things users reach
+ *  for; history is the long tail. */
+const SECTION_PRIORITY: Record<PaletteKind, number> = {
+  session: 0,
+  agent: 1,
+  past: 2,
+  recent: 3,
+  template: 4,
+  doc: 5,
+  command: 6,
+  path: 7,
+};
+
+/** Which kinds each filter tab searches. */
+const FILTER_KINDS: Record<PaletteFilter, PaletteKind[]> = {
+  all: ["session", "agent", "past", "recent", "template", "doc", "command"],
+  sessions: ["session", "past"],
+  agents: ["agent"],
+  templates: ["template"],
+  docs: ["doc"],
+  files: ["recent"],
+  actions: ["command"],
+};
+
+const byKind = (items: PaletteItem[], kind: PaletteKind): PaletteItem[] =>
+  items.filter((item) => item.kind === kind);
+
+/** Unqueried order within one kind: activity groups sort newest-first, the
+ *  rest keep their build order (MRU for folders, list order for templates,
+ *  docs, and actions). The CURRENT session sorts last among the live ones —
+ *  it is always the most recently active, but jumping to it is a no-op, so
+ *  it must never be the default-selected first row. */
+function unqueriedGroup(items: PaletteItem[], kind: PaletteKind): PaletteItem[] {
+  const group = byKind(items, kind);
+  if (kind === "session") {
+    return group.sort(
+      (a, b) => (a.current ? 1 : 0) - (b.current ? 1 : 0) || b.recency - a.recency,
+    );
+  }
+  if (kind === "past") return group.sort((a, b) => b.recency - a.recency);
+  if (kind === "agent") return group.sort((a, b) => b.recency - a.recency || a.label.localeCompare(b.label));
+  if (kind === "recent") return group.sort((a, b) => b.recency - a.recency);
+  return group;
+}
+
+export interface RankOptions {
+  filter?: PaletteFilter;
+  /** Injectable clock so recency ranking is deterministic under test. */
+  now?: number;
+}
+
+/**
+ * "" → the unqueried composition (fixed section order, recency-sorted
+ * groups, actions pinned last on the All tab). Otherwise: match both fields
+ * (label preferred), band label over meta, add the recency bonus, rank
+ * within sections, order sections by their best hit, cap per section and
+ * globally.
+ */
+export function rankPaletteItems(query: string, items: PaletteItem[], options: RankOptions = {}): PaletteItem[] {
+  const filter = options.filter ?? "all";
+  const now = options.now ?? Date.now();
+  const kinds = FILTER_KINDS[filter];
+  const trimmed = query.trim();
+
+  if (!trimmed) {
+    if (filter !== "all") {
+      return kinds.flatMap((kind) => unqueriedGroup(items, kind)).slice(0, GLOBAL_CAP);
+    }
+    const commandItems = byKind(items, "command");
+    // Jump targets first; templates and docs fill leftover space; actions are
+    // pinned at the end so the Actions section is always reachable without
+    // typing.
+    return [
+      ...unqueriedGroup(items, "session"),
+      ...unqueriedGroup(items, "past").slice(0, PAST_UNQUERIED_CAP),
+      ...unqueriedGroup(items, "agent").slice(0, AGENTS_UNQUERIED_CAP),
+      ...unqueriedGroup(items, "recent"),
+      ...unqueriedGroup(items, "template"),
+      ...unqueriedGroup(items, "doc"),
+    ]
+      .slice(0, Math.max(0, GLOBAL_CAP - commandItems.length))
+      .concat(commandItems);
+  }
+
+  const scoreItem = (item: PaletteItem): ScoredItem | null => {
+    const label = fuzzyMatch(trimmed, item.label);
+    if (label) {
+      return {
+        item: { ...item, labelIndices: label.indices },
+        fieldRank: 0,
+        boosted: label.score + recencyBonus(now, item.recency),
+        matchedLength: item.label.length,
+      };
+    }
+    const meta = item.meta ? fuzzyMatch(trimmed, item.meta) : null;
+    if (meta) {
+      return {
+        item: { ...item, metaIndices: meta.indices },
+        fieldRank: 1,
+        boosted: meta.score + recencyBonus(now, item.recency),
+        matchedLength: item.meta.length,
+      };
+    }
+    return null;
+  };
+
+  const sections = kinds
+    .map((kind) => ({
+      kind,
+      scored: byKind(items, kind)
+        .map(scoreItem)
+        .filter((scored): scored is ScoredItem => scored !== null)
+        .sort(
+          (a, b) =>
+            a.fieldRank - b.fieldRank ||
+            b.boosted - a.boosted ||
+            b.item.recency - a.item.recency ||
+            a.matchedLength - b.matchedLength ||
+            a.item.label.localeCompare(b.item.label),
+        ),
+    }))
+    .filter((section) => section.scored.length > 0);
+
+  // The per-section cap exists so no kind can starve the others; with a lone
+  // matching section there is nothing to starve, so the window is its own cap.
+  const sectionCap = sections.length > 1 ? SECTION_QUERIED_CAP : GLOBAL_CAP;
+
+  return sections
+    .sort((a, b) => {
+      const bestA = a.scored[0];
+      const bestB = b.scored[0];
+      return (
+        bestA.fieldRank - bestB.fieldRank ||
+        bestB.boosted - bestA.boosted ||
+        SECTION_PRIORITY[a.kind] - SECTION_PRIORITY[b.kind]
+      );
+    })
+    .flatMap((section) => section.scored.slice(0, sectionCap).map((scored) => scored.item))
+    .slice(0, GLOBAL_CAP);
+}
+
+/** Path-completion rows (query starts with / or ~): a confirm row for the
+ *  literal input, then the listed directories. */
+export function buildPathItems(query: string, dirs: FsDirEntry[]): PaletteItem[] {
+  const trimmed = query.trim();
+  const confirmItem: PaletteItem[] = trimmed
+    ? [{ id: `confirm:${trimmed}`, kind: "path", label: trimmed, meta: "Open this path", path: trimmed, recency: 0 }]
+    : [];
+  return [
+    ...confirmItem,
+    ...dirs.map((dir) => ({
+      id: `dir:${dir.path}`,
+      kind: "path" as const,
+      label: dir.name,
+      meta: dir.path,
+      path: dir.path,
+      recency: 0,
+    })),
+  ];
+}
+
+export type PaletteActivation =
+  | { type: "run"; run: () => void }
+  | { type: "open-href"; href: string }
+  | { type: "open-template"; templateId: string }
+  | { type: "select-session"; sessionId: string }
+  | { type: "review-summary"; summary: SessionSummary }
+  | { type: "open-path"; path: string }
+  | { type: "none" };
+
+/** What activating a row does. A past row resolves its live/registry id
+ *  first, then falls back to the transcript summary (review pane) — and
+ *  never to open-path, so a stray `path` can't silently spawn a session. */
+export function paletteActivation(item: PaletteItem): PaletteActivation {
+  switch (item.kind) {
+    case "command":
+      return item.run ? { type: "run", run: item.run } : { type: "none" };
+    case "doc":
+      return item.href ? { type: "open-href", href: item.href } : { type: "none" };
+    case "template":
+      return item.templateId ? { type: "open-template", templateId: item.templateId } : { type: "none" };
+    case "session":
+      return item.sessionId ? { type: "select-session", sessionId: item.sessionId } : { type: "none" };
+    case "past":
+      if (item.sessionId) return { type: "select-session", sessionId: item.sessionId };
+      if (item.summary) return { type: "review-summary", summary: item.summary };
+      return { type: "none" };
+    case "agent":
+    case "recent":
+    case "path":
+      return item.path ? { type: "open-path", path: item.path } : { type: "none" };
+  }
+}

--- a/packages/harness/web/src/lib/use-tab-indicator.ts
+++ b/packages/harness/web/src/lib/use-tab-indicator.ts
@@ -1,0 +1,69 @@
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import type { CSSProperties, RefCallback } from "react";
+
+/**
+ * The moving pill behind a tab row.
+ *
+ * A tab row that signals its selection by turning a background on under one
+ * tab and off under another reads as a blink: two tabs change at once and
+ * nothing connects them, so the eye has to re-find the selection after every
+ * toggle instead of following it. One pill that travels says the same thing
+ * as a continuous movement, and movement is the one channel that survives
+ * not being looked at directly.
+ *
+ * Measured rather than declared, because a tab's width is its label's and only
+ * the browser knows that. The row is observed too, so the pill keeps its place
+ * when the pane is resized or a label is hidden at a narrow width — a stale
+ * pill under the wrong tab is worse than none.
+ *
+ * The active tab is found by aria-selected, which a tablist has to set anyway:
+ * nothing to remember to pass, and nothing to keep in sync with the styling.
+ */
+export function useTabIndicator(activeKey: string): {
+  trackRef: RefCallback<HTMLElement>;
+  style: CSSProperties;
+} {
+  const nodeRef = useRef<HTMLElement | null>(null);
+  const [box, setBox] = useState<{ x: number; w: number } | null>(null);
+
+  const measure = useCallback(() => {
+    const track = nodeRef.current;
+    if (!track) return;
+    const active = track.querySelector<HTMLElement>('[aria-selected="true"]');
+    if (!active) {
+      setBox(null);
+      return;
+    }
+    const t = track.getBoundingClientRect();
+    const a = active.getBoundingClientRect();
+    setBox({ x: a.left - t.left + track.scrollLeft, w: a.width });
+  }, []);
+
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const trackRef = useCallback<RefCallback<HTMLElement>>(
+    (node) => {
+      observerRef.current?.disconnect();
+      nodeRef.current = node;
+      if (!node) return;
+      measure();
+      if (typeof ResizeObserver === "undefined") return;
+      observerRef.current = new ResizeObserver(measure);
+      observerRef.current.observe(node);
+    },
+    [measure],
+  );
+
+  useLayoutEffect(() => {
+    measure();
+  }, [activeKey, measure]);
+
+  useLayoutEffect(() => () => observerRef.current?.disconnect(), []);
+
+  return {
+    trackRef,
+    style: box
+      ? { transform: `translateX(${box.x}px)`, width: `${box.w}px`, opacity: 1 }
+      : // No measurement yet: stay invisible rather than slide in from zero.
+        { opacity: 0 },
+  };
+}

--- a/packages/harness/web/src/lib/workspace-logic.test.ts
+++ b/packages/harness/web/src/lib/workspace-logic.test.ts
@@ -33,9 +33,13 @@ const workflow = (overrides: Partial<WorkflowInfo>): WorkflowInfo => ({
   ...overrides,
 });
 
+// The matcher's own behavior (boundary gating, scoring order, the Slack
+// regressions) is pinned in fuzzy.test.ts — this keeps only the palette-visible
+// contract this file always asserted: tighter matches rank higher, absent
+// characters don't match at all.
 describe("fuzzyScore", () => {
-  it("matches subsequences and prefers tighter matches", () => {
-    const loose = fuzzyScore("lsg", "leasing");
+  it("prefers tighter matches", () => {
+    const loose = fuzzyScore("leas", "leasing");
     const exact = fuzzyScore("leasing", "leasing");
     expect(loose).not.toBeNull();
     expect(exact).not.toBeNull();
@@ -44,6 +48,10 @@ describe("fuzzyScore", () => {
 
   it("returns null when characters are missing", () => {
     expect(fuzzyScore("xyz", "leasing")).toBeNull();
+  });
+
+  it("no longer accepts off-boundary scatter (the old matcher did)", () => {
+    expect(fuzzyScore("lsg", "leasing")).toBeNull();
   });
 });
 

--- a/packages/harness/web/src/lib/workspace-tree.ts
+++ b/packages/harness/web/src/lib/workspace-tree.ts
@@ -69,7 +69,9 @@ export interface WorkspaceTree {
 }
 
 const basename = (path: string): string => path.split("/").filter(Boolean).pop() ?? path;
-const isUnder = (childPath: string, cwd: string): boolean =>
+/** Segment-aware containment — a bare prefix check would put /a/scratch-2
+ *  under /a/scratch. Exported for the palette's agent-recency derivation. */
+export const isUnder = (childPath: string, cwd: string): boolean =>
   childPath === cwd || childPath.startsWith(`${cwd}/`);
 
 // Agent rows have no recency signal (WorkflowInfo carries no timestamp), so

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -6488,26 +6488,156 @@ button.rail-footer-card:hover {
 }
 
 .command-palette {
-  width: 480px;
+  width: min(640px, calc(100vw - 32px));
   padding: 0;
   overflow: hidden;
 }
 
-.command-palette-input {
-  width: 100%;
+/* THREE BARS: a search bar on top, a tab row under it, a shortcut bar at the
+   bottom — the result list scrolls between them. */
+.command-palette-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   height: var(--pane-header-h);
   padding: 0 var(--pane-pad-x);
-  border: none;
   border-bottom: 1px solid var(--border);
+  color: var(--text-faint);
+}
+
+.command-palette-input {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  padding: 0;
+  border: none;
   background: transparent;
   color: var(--text);
   font-size: var(--type-body);
-  transition: border-color var(--transition-fast);
 }
 
 .command-palette-input:focus {
   outline: none;
-  border-bottom-color: var(--focus);
+}
+
+.command-palette-clear {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: var(--radius-full);
+  background: var(--surface-hover);
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.command-palette-clear:hover {
+  color: var(--text);
+  background: var(--active-shade);
+}
+
+/* The filter tabs, with one pill that TRAVELS behind the active tab instead
+   of two backgrounds blinking on and off. */
+.tab-track {
+  position: relative;
+}
+
+.tab-indicator {
+  position: absolute;
+  z-index: 0;
+  top: 50%;
+  left: 0;
+  height: var(--control-h);
+  margin-top: calc(var(--control-h) / -2);
+  border-radius: var(--radius);
+  background: var(--active-shade);
+  pointer-events: none;
+  transition:
+    transform 0.18s ease,
+    width 0.18s ease,
+    opacity var(--transition-fast);
+}
+
+.tab-track > [role="tab"] {
+  position: relative;
+  z-index: 1;
+  border-radius: var(--radius);
+}
+
+.command-palette-filters {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  height: 40px;
+  flex: 0 0 auto;
+  padding: 0 var(--sp2);
+  border-bottom: 1px solid var(--border);
+}
+
+.command-palette-filter {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: var(--control-h);
+  padding: 0 10px;
+  border: none;
+  background: transparent;
+  color: var(--text-faint);
+  font-size: var(--type-label);
+}
+
+.command-palette-filter:hover {
+  color: var(--text-dim);
+  background: var(--surface-hover);
+}
+
+.command-palette-filter.is-active {
+  background: transparent;
+  color: var(--text);
+}
+
+.command-palette-footer {
+  display: flex;
+  align-items: center;
+  gap: var(--sp3);
+  height: 40px;
+  flex: 0 0 auto;
+  padding: 0 var(--sp2) 0 var(--sp3);
+  overflow: hidden;
+  border-top: 1px solid var(--border);
+  color: var(--text-faint);
+  font-size: var(--type-meta);
+}
+
+.command-palette-footer kbd {
+  margin-right: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-inset);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  line-height: 1;
+  color: var(--text-dim);
+}
+
+.command-palette-footer-mod {
+  margin-left: auto;
+}
+
+/* The tab's destination, anchored to the bar's right edge and sized to sit
+   INSIDE the 40px bar rather than growing it. */
+.command-palette-footer-cta {
+  margin-left: auto;
+  height: var(--control-h);
+  font-size: var(--type-meta);
 }
 
 .command-palette-list {
@@ -6558,21 +6688,40 @@ button.rail-footer-card:hover {
 .command-palette-item-meta {
   font-size: var(--type-meta);
   color: var(--text-faint);
-  font-family: var(--font-mono);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   flex: 1;
 }
 
-.command-palette-item.is-selected .command-palette-item-label,
+/* Paths read as code; action and doc one-liners read as prose. */
+.command-palette-item-meta[data-code] {
+  font-family: var(--font-mono);
+}
+
+/* Selection is the row WASH alone — the text keeps its reading colors, so
+   the match highlight (an accent-tinted cap behind the hit characters) stays
+   the one colored signal on any row. Accent-colored text on the selected row
+   fought that cap and read as murk in dark mode. */
+.command-palette-item.is-selected .command-palette-item-label {
+  color: var(--text);
+}
+
 .command-palette-item.is-selected .command-palette-item-meta {
-  /* The selected row is the palette's one sanctioned accent use. Colour the text
-     with the accent ITSELF (--accent = brand green), which is legible on the
-     neutral --nested-shade highlight in both themes. --accent-foreground was
-     wrong here: it is the ink FOR a green fill (--brand-ink, a near-black green
-     in dark mode), so on the neutral highlight the text all but vanished. */
+  color: var(--text-dim);
+}
+
+/* The active session's row: identifiable at a glance, but NEVER the same
+   affordance as keyboard selection — a quiet accent pill after the name. */
+.command-palette-current {
+  flex-shrink: 0;
+  padding: 1px 7px;
+  border-radius: var(--radius-full);
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
   color: var(--accent);
+  font-size: var(--type-micro);
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 /* DialogHeader recipe: a hairline separator under the title. */
@@ -7361,18 +7510,19 @@ button.rail-footer-card:hover {
   margin-top: 0;
 }
 
-/* The fuzzy-matched characters, bolded in place. */
+/* The fuzzy-matched characters: a soft accent-tinted cap behind the hit, the
+   way an editor marks find results — legible on the plain row AND on the
+   selected wash in both themes, where color-only bolding disappeared. */
 .palette-match {
   font-weight: 700;
   color: var(--text);
+  background: color-mix(in srgb, var(--accent) 26%, transparent);
+  border-radius: 3px;
 }
 
 .command-palette-item-meta .palette-match {
   color: var(--text-dim);
-}
-
-.command-palette-item.is-selected .palette-match {
-  color: var(--accent-foreground);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 .command-palette-error {

--- a/scripts/agent-studio-terminology-allowlist.json
+++ b/scripts/agent-studio-terminology-allowlist.json
@@ -227,8 +227,22 @@
     "id": "command-palette-private-identifiers",
     "path": "packages/harness/web/src/components/CommandPalette.tsx",
     "pattern": "^workflow:?$",
-    "occurrences": 3,
-    "reason": "The private palette discriminator, item prefix, and icon identifier remain stable."
+    "occurrences": 1,
+    "reason": "The icon-name identifier remains stable; the palette's discriminator and item prefix now say agent."
+  },
+  {
+    "id": "palette-docs-page-titles",
+    "path": "packages/harness/web/src/lib/docs.ts",
+    "pattern": "Workflows quick start|/workflows/",
+    "occurrences": 2,
+    "reason": "Docs-site page title and its URL, quoted verbatim — the platform SDK concept keeps its own name."
+  },
+  {
+    "id": "palette-model-icon-identifier",
+    "path": "packages/harness/web/src/lib/palette.ts",
+    "pattern": "^workflow$",
+    "occurrences": 1,
+    "reason": "The Agents filter tab reuses the agent rows' icon identifier."
   },
   {
     "id": "session-bar-private-css-and-test-id",


### PR DESCRIPTION
<!--
Thank you for contributing to sapiom-js.
Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
-->

## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Studio's Cmd+K search could not reliably find the thing the user wanted (reported in #studio on 2026-08-11: "Cannot find this simple agent"). Four compounding causes: the fuzzy matcher accepted any in-order subsequence, so short queries "matched" characters scattered across absolute paths; results ranked only within fixed section order with no per-section cap, so junk path-matched past sessions buried perfect agent-name matches; nothing collapsed duplicate past sessions sharing a title and folder; and the palette searched raw `workflow.name` / `session.title` instead of the display names the rail renders, so renames were unsearchable and visible names didn't match searchable ones.

Separately, design shipped the new Command Search widget for this surface (design-eng Storybook: `projects-sapiom-studio-04-widgets--command-search`), and review feedback asked for category tabs, a searchable template catalog, Tab-key category cycling, and a distinct current-session affordance.

## Summary and scope

Search engine, rewritten:

- `web/src/lib/fuzzy.ts`: boundary-gated subsequence matcher — every matched character must be contiguous with the previous one or sit at a word/segment boundary (start, after separators, digit transitions, camelCase humps), plus a substring fallback pass for mid-word fragments. Scattered-noise matches return null instead of a low score. Multi-term queries AND across whitespace; repeated terms score once; lowercase is length-preserving so highlight indices never desync.
- `web/src/lib/palette.ts` (new, pure model): rows carry display names (`displayAgentName`, `sessionDisplayName` — user renames searchable); same-title same-folder past sessions collapse to the newest (registry row preferred on ties, so Enter resumes rather than opening the review pane); sections order by their best hit with per-section caps that lift when only one kind matches; recency is a bounded score bonus banded strictly under label-over-path.

Command Search surface (ported from the design-eng `sapiom-studio` sources onto the new engine):

- Search bar with icon and clear button; Escape clears the query first, closes when empty.
- Filter tabs (All / Sessions / Agents / Templates / Docs / Files / Actions) with an animated indicator pill, cycled with Tab / Shift+Tab; hidden in path mode.
- App verbs are injected `PaletteAction`s (browse templates, toggle theme, panel toggles, new session in the active folder) instead of hard-coded rows.
- The Templates tab lists the catalog (gallery + bundled starters); activating one opens the gallery focused on it; "Browse templates" is the tab's footer destination. The Docs tab searches five docs pages with the docs site as its destination.
- The active session is badged "current", demoted from the unqueried top spot, and never the default selection; matched characters render on an accent-tinted cap that stays legible on selected rows in both themes.

Out of scope (known follow-ups): the rail's past-sessions popover still renders raw titles and keeps its own copy of the registry-mirror history filter; agent recency derivation is palette-local rather than shared with `workspace-tree.ts`.

## Related work

Related issue or discussion: N/A — direct PR from the #studio search-quality report (Slack thread 2026-08-11) and the design-eng Command Search spec.

## Validation

```text
pnpm --filter @sapiom/harness exec tsc --noEmit -p web/tsconfig.json — clean
pnpm --filter @sapiom/harness test — pass (unit + perf configs)
pnpm --filter @sapiom/harness exec vitest run web — 503 passed (36 files)
pnpm --filter @sapiom/harness test:ui — 313 passed / 0 failed (full Playwright suite, mock mode)
pnpm --filter @sapiom/harness build — clean
pnpm terminology:check — passed (404 files, no stale allowlist entries)
pnpm provider-copy:check — passed (74 audited files)
Manual: desktop app (pnpm --filter @sapiom/harness-desktop dev) against real ~/.sapiom data across
three review rounds; dark/light screenshots compared against the design mock for the empty, queried,
Actions, Docs, and Templates states.
```

### Tests and documentation

New unit suites: `web/src/lib/fuzzy.test.ts` (18 tests — pins the two reported regression queries, acceptance shapes, scoring order) and `web/src/lib/palette.test.ts` (33 tests — display names, dedup, ranking, recency, filters, activation). New e2e spec `web/e2e/palette-search.spec.ts` (15 tests) against additive `?mockFixtures=search` fixtures reproducing the reported shapes; existing palette e2e in `smoke.spec.ts`/`wave5.spec.ts` pass unchanged. Documentation: changeset describes the user-facing change; no docs-site pages cover the palette.

## Compatibility and release impact

- Breaking or externally visible changes: None outside the Studio UI — no server, API, or CLI changes; the palette's props/model are internal to the SPA.
- Changeset: Added `.changeset/palette-command-search.md` (`@sapiom/harness` minor).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code (Claude Fable 5) implemented the matcher, palette model, component port, tests, and fixtures under direction, working from the design-eng Command Search sources and iterating over three human review rounds in the running desktop app. Verified by the human reviewer in the app against real data, plus the full unit (503) and Playwright (313) suites, terminology/provider-copy gates, and screenshot comparison against the design mock.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
