### PR TITLE
fix(agent-core): use pathToFileURL for dynamic import on Windows

### DIFF
--- a/packages/agent-core/src/check.ts
+++ b/packages/agent-core/src/check.ts
@@ -6,6 +6,7 @@
  * the bundle, being type-stripped, cannot).
  */
 import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
 import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -198,7 +199,7 @@ export async function check(opts: CheckOptions): Promise<CheckResult> {
     // definition shape is identical, so everything downstream (buildManifest,
     // graph validation) works unchanged on either.
     const mod: Record<string, unknown> = await import(
-      `file://${bundlePath}?t=${Date.now()}`
+      `${pathToFileURL(bundlePath).href}?t=${Date.now()}`
     );
     const defs: unknown[] = [];
     for (const value of Object.values(mod)) {

--- a/packages/agent-core/src/local/load.ts
+++ b/packages/agent-core/src/local/load.ts
@@ -8,6 +8,7 @@ import { createHash } from "node:crypto";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import {
   type AgentDefinition,
@@ -67,7 +68,7 @@ export async function loadDefinition(
     }
 
     const mod: Record<string, unknown> = await import(
-      `file://${bundlePath}?t=${Date.now()}`
+      `${pathToFileURL(bundlePath).href}?t=${Date.now()}`
     );
     const defs = Object.values(mod).filter(isAgentDefinition);
     if (defs.length === 0) {


### PR DESCRIPTION
## Summary

Fixes #612

`loadDefinition` (load.ts) and `check` (check.ts) both used raw string interpolation to build a `file://` URL for dynamic import:

```ts
await import(`file://${bundlePath}?t=${Date.now()}`);
```

On Windows, `path.join` produces backslash-separated paths, making this an invalid URL. This fix uses `pathToFileURL` from `node:url` which correctly handles both POSIX and Windows paths.

## Changes

- `packages/agent-core/src/local/load.ts` added `pathToFileURL` import, fixed URL construction
- `packages/agent-core/src/check.ts` same fix