### PR TITLE
fix(agent): normalize array form type in skeletonFromJsonSchema

### DIFF
--- a/packages/agent/src/introspection.ts
+++ b/packages/agent/src/introspection.ts
@@ -105,7 +105,10 @@ function skeletonFromJsonSchema(schema: Record<string, unknown>): unknown {
     return skeletonFromJsonSchema(branches[0]);
   }
 
-  switch (schema.type) {
+  const type = Array.isArray(schema.type)
+    ? (schema.type as string[]).find((t) => t !== 'null') ?? 'null'
+    : schema.type;
+  switch (type) {
     case 'object': {
       const props = (schema.properties ?? {}) as Record<string, Record<string, unknown>>;
       const out: Record<string, unknown> = {};


### PR DESCRIPTION
## Summary

Fixes #614

`skeletonFromJsonSchema` passed `schema.type` directly to a `switch` statement. JSON Schema allows `type` to be an array (e.g. `["string", "null"]` for `z.string().nullable()`). When an array is passed, no `case` matches and the function always returns `null` instead of a type-appropriate skeleton value.

## Fix

Normalize `schema.type` before the switch extract the first non-`"null"` entry from the array:

```ts
const type = Array.isArray(schema.type)
  ? (schema.type as string[]).find((t) => t !== 'null') ?? 'null'
  : schema.type;
switch (type) { ... }
```

## Changes

- `packages/agent/src/introspection.ts` 4 lines added before the switch