### PR TITLE
fix(sandbox): bound execStream's post-stream status poll by the exec timeout

### DIFF
--- a/.changeset/sandbox-execstream-poll-deadline.md
+++ b/.changeset/sandbox-execstream-poll-deadline.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/sandbox": patch
+---
+
+Bound `execStream`'s post-stream status reconciliation by the exec timeout.
+
+When a log stream ends before its process reaches a terminal status, `execStream` re-polls `GET /process/:pid` to resolve the real exit code. That loop had no deadline, so a process that never reported a terminal status left the caller awaiting the output iterable forever. Every other poll path (`exec`, `waitForProcess`) already stops at the 60s exec timeout and throws `Process <pid> timed out after 60000ms`; the reconciliation loop now does the same, turning a silent hang into the loud, debuggable failure the polling contract already documented.

--- a/packages/sandbox/src/sandbox.test.ts
+++ b/packages/sandbox/src/sandbox.test.ts
@@ -107,6 +107,21 @@ function execHandlers(
   ];
 }
 
+/**
+ * {@link execHandlers} plus the log-stream endpoint, so an `execStream` call
+ * gets past the stream and into the post-stream status reconciliation.
+ */
+function execStreamHandlers(
+  pollStatuses: ProcessBody[],
+  logBody = "stdout:hello\n",
+): Array<(call: FetchCall) => Response | null> {
+  return [
+    (call: FetchCall) =>
+      /\/logs\/stream$/.test(call.url) ? new Response(logBody) : null,
+    ...execHandlers(pollStatuses),
+  ];
+}
+
 describe("SapiomSandbox — multipart methods", () => {
   describe("initiateMultipartUpload", () => {
     it("POSTs to the correct URL with permissions in the body", async () => {
@@ -789,5 +804,56 @@ describe("SapiomSandbox — exec process polling", () => {
     ]);
     // The log stream endpoint was never opened for an already-finished process.
     expect(calls.some((c) => c.url.includes("/logs/stream"))).toBe(false);
+  });
+
+  it("execStream reconciles an exit code reported after the log stream ends", async () => {
+    jest.useFakeTimers();
+    try {
+      const { sandbox } = await makeSandbox(
+        execStreamHandlers([
+          { status: "running" },
+          { status: "failed", exitCode: 3 },
+        ]),
+      );
+
+      const stream = await sandbox.execStream("false");
+      const drained = (async () => {
+        const seen: Array<{ stream: string; data: string }> = [];
+        for await (const line of stream.output) seen.push(line);
+        return seen;
+      })();
+
+      await jest.advanceTimersByTimeAsync(1_000);
+
+      expect(await drained).toEqual([{ stream: "stdout", data: "hello" }]);
+      expect(stream.exitCode).toBe(3);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  // Regression: the reconciliation poll above ran with no deadline, so a
+  // process that never reports a terminal status hung the consumer forever
+  // instead of failing with the exec timeout every other poll path applies.
+  it("execStream times out when the process never reaches a terminal status", async () => {
+    jest.useFakeTimers();
+    try {
+      const { sandbox } = await makeSandbox(
+        execStreamHandlers([{ status: "running" }]),
+      );
+
+      const stream = await sandbox.execStream("sleep 999");
+      const drained = (async () => {
+        for await (const line of stream.output) void line;
+      })();
+      const rejection = expect(drained).rejects.toThrow(
+        "Process p1 timed out after 60000ms",
+      );
+
+      await jest.advanceTimersByTimeAsync(60_000);
+      await rejection;
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/packages/sandbox/src/sandbox.ts
+++ b/packages/sandbox/src/sandbox.ts
@@ -620,9 +620,19 @@ export class SapiomSandbox {
         (await statusResponse.json()) as ProcessStatusResponse;
 
       // If the process hasn't finished yet (e.g. stream disconnected
-      // before the process finished), poll until it does.
+      // before the process finished), poll until it does — bounded by the same
+      // exec timeout `_pollProcess` applies, so a process that never reports a
+      // terminal status fails loudly instead of polling forever.
+      const deadline = Date.now() + DEFAULT_EXEC_TIMEOUT;
       while (!isProcessTerminal(status.status)) {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
+        if (Date.now() >= deadline) {
+          throw new Error(
+            `Process ${proc.pid} timed out after ${DEFAULT_EXEC_TIMEOUT}ms`,
+          );
+        }
+        await new Promise((resolve) =>
+          setTimeout(resolve, DEFAULT_POLL_INTERVAL),
+        );
         const retry = await fetchFn(
           `${baseUrl}/v1/sandboxes/${encodeURIComponent(sandboxName)}/process/${proc.pid}`,
           { signal },


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

`execStream` resolves a process's real exit code after its log stream ends. If the
stream disconnects before the process finishes, it re-polls `GET /process/:pid`
until the status is terminal. That loop had no deadline, so a process that never
reports a terminal status left the caller awaiting the output iterable forever —
the exit code getter never settles and the consumer hangs with no error.

Every other poll path already bounds itself: `exec` and `waitForProcess` both go
through `_pollProcess`, which stops at the 60s exec timeout and throws
`Process <pid> timed out after 60000ms`. The invariant is stated in the file
itself, above `TERMINAL_PROCESS_STATUSES`:

> Any unrecognized status keeps polling and ultimately hits the exec timeout,
> which is a loud, debuggable failure rather than a silent wrong result.

The reconciliation loop was the one path that did not honour it. #63 established
that invariant and covered `exec`/`waitForProcess`, but this loop was left
unbounded, so the guarantee has a hole.

## Summary and scope

- `execStream`'s post-stream reconciliation loop now stops at the same
  `DEFAULT_EXEC_TIMEOUT` (60s) and throws the same error text `_pollProcess`
  throws, so both poll paths fail identically.
- The loop's hardcoded `1000` sleep now uses the existing `DEFAULT_POLL_INTERVAL`
  constant, matching `_pollProcess`.
- Two tests, covering the previously untested reconciliation loop: no test opened
  the log-stream endpoint before this PR.

Intentionally out of scope:

- **No public API change.** `ExecStreamOptions` was *not* given `timeout` /
  `pollInterval` fields. Adding them would be an API addition needing an issue
  first, and the bug is fixable with the internal defaults already in the file.
- **`@sapiom/tools` carries the same duplicated loop**
  (`packages/tools/src/sandboxes/index.ts`, same two constants). Left out to keep
  this PR to one package; happy to follow up, or fold it in here if you prefer.

## Related work

Related issue or discussion: N/A — direct PR, per CONTRIBUTING's "focused bug
fixes with a clear reproduction". Prior art: #63, which introduced the
timeout invariant this loop was missing.

## Validation

```text
# command — result
pnpm build                               — pass (18/18 packages)
pnpm typecheck                           — pass (18/18 packages)
pnpm lint                                — pass (18/18 packages)
pnpm --filter @sapiom/sandbox test       — pass, 60/60 (58 before this PR)
pnpm test                                — @sapiom/sandbox 60/60 pass; 3 packages fail locally for environment reasons, detailed below
```

Local-only failures, all pre-existing and unrelated to this change (it touches
only `packages/sandbox`, which no workspace package depends on):

- `@sapiom/langchain-classic` — 25 failures from `tiktoken not available`,
  `Unknown model`, and `fetch failed`; network- and tokenizer-dependent tests.
- `@sapiom/harness` — 36 of 1813 failures, all `Test timed out in 5000ms` in the
  canvas/esbuild and pty suites. My checkout is on a Windows drive mounted into
  WSL, where those suites run 10-15x slower.
- `@sapiom/cli` — 1 failure: a bounded-exit assertion expecting `< 12000ms` got
  `12707ms`, same slow-filesystem cause.

### Tests and documentation

Two tests in `packages/sandbox/src/sandbox.test.ts`, plus an `execStreamHandlers`
helper that mocks the log-stream endpoint so the reconciliation loop is reachable:

- `execStream reconciles an exit code reported after the log stream ends` — the
  loop's happy path, proving the new deadline does not break normal
  reconciliation.
- `execStream times out when the process never reaches a terminal status` — the
  regression. Verified it is not vacuous: with the deadline reverted, this test
  hangs and fails on the 5s jest limit.

Both use fake timers, so they assert the 60s budget without taking 60s.

Documentation: N/A — no public API or documented behavior changes; the reasoning
lives in the code comment on the loop and in the changeset.

## Compatibility and release impact

- Breaking or externally visible changes: No API surface change. One externally
  visible behavior change, which is the point of the fix: a call that previously
  hung forever now rejects after 60s with
  `Process <pid> timed out after 60000ms`, the same error `exec` and
  `waitForProcess` already throw. No caller that completes today is affected.
- Changeset: Added — `patch` for `@sapiom/sandbox`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Cursor was used to survey the repository, locate this bug, and draft the fix,
the two tests, and the changeset. I verified the result myself: I confirmed the
unbounded loop against the invariant documented above `TERMINAL_PROCESS_STATUSES`
and against `_pollProcess`, checked that no open issue or PR already covered it,
and validated the regression test by reverting the deadline and confirming the
test hangs and fails without it. I ran the build, typecheck, lint, and test
commands listed above and can explain and maintain every line of the diff.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.