### PR TITLE
fix(ci): skip PR labels for trusted authors

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -35,13 +35,6 @@ jobs:
     name: Classify pull request
     runs-on: ubuntu-latest
     steps:
-      - name: Apply area labels
-        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
-        with:
-          configuration-path: .github/labeler.yml
-          pr-number: ${{ github.event.pull_request.number || inputs.pr_number }}
-          sync-labels: "true"
-
       # pull_request_target is privileged. Check out only the trusted base SHA;
       # never fetch or execute the contributor-controlled head ref in this job.
       - name: Check out trusted classifier
@@ -52,6 +45,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
 
       - name: Apply deterministic classification labels
+        id: classification
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           EVENT_ACTION: ${{ github.event.action || 'workflow_dispatch' }}
@@ -149,6 +143,10 @@ jobs:
               currentLabels,
               classification,
             );
+            core.setOutput(
+              "trusted",
+              classification.clearAutomationLabels ? "true" : "false",
+            );
 
             core.info(
               `PR #${pullNumber}: review size ${classification.reviewSize}; ` +
@@ -180,3 +178,11 @@ jobs:
                 labels: changes.add,
               });
             }
+
+      - name: Apply area labels to external pull requests
+        if: steps.classification.outputs.trusted == 'false'
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
+        with:
+          configuration-path: .github/labeler.yml
+          pr-number: ${{ github.event.pull_request.number || inputs.pr_number }}
+          sync-labels: "true"

--- a/scripts/pr-label-classifier.mjs
+++ b/scripts/pr-label-classifier.mjs
@@ -406,6 +406,7 @@ export function classifyPullRequest({
   const reportedFileCount = Number(pullRequest?.changed_files) || files.length;
   const opaque = files.some(isOpaqueFile) || reportedFileCount > files.length;
   const external = contributorLabel === "contributor: external";
+  const trusted = contributorLabel === "contributor: trusted";
   const manual =
     external &&
     (!repositoryPermissionResolved ||
@@ -415,20 +416,27 @@ export function classifyPullRequest({
       size.label === "size: xlarge" ||
       opaque);
 
-  const desiredLabels = new Set([contributorLabel, size.label]);
-  if (template.typeIsValid) desiredLabels.add(template.typeLabel);
-  if (!template.complete) desiredLabels.add("contribution: incomplete");
-  if (sensitive) desiredLabels.add("review: sensitive");
-  if (manual) desiredLabels.add("review: manual");
+  const desiredLabels = new Set();
+  // These labels route public contribution intake. Trusted authors are resolved
+  // from live repository access and remain outside the labeling pipeline.
+  if (!trusted) {
+    desiredLabels.add(contributorLabel);
+    desiredLabels.add(size.label);
+    if (template.typeIsValid) desiredLabels.add(template.typeLabel);
+    if (!template.complete) desiredLabels.add("contribution: incomplete");
+    if (sensitive) desiredLabels.add("review: sensitive");
+    if (manual) desiredLabels.add("review: manual");
+  }
 
   return {
     addNeedsTriage:
       external && shouldInitializeTriage(eventAction, initializeTriage),
+    clearAutomationLabels: trusted,
     desiredLabels: [...desiredLabels].sort((a, b) => a.localeCompare(b)),
     hasOpaqueFile: opaque,
     repositoryPermissionResolved,
     reviewSize: size.changedLines,
-    synchronizeTypeLabels: template.typeIsValid,
+    synchronizeTypeLabels: trusted || template.typeIsValid,
     templateReasons: template.reasons,
   };
 }
@@ -440,15 +448,20 @@ export function reconcilePullRequestLabels(currentLabels, classification) {
   if (classification.synchronizeTypeLabels) {
     for (const label of TYPE_LABELS) managed.add(label);
   }
+  if (classification.clearAutomationLabels) {
+    managed.add("needs-triage");
+  }
 
   const add = [...desired].filter((label) => !current.has(label));
   if (classification.addNeedsTriage && !current.has("needs-triage")) {
     add.push("needs-triage");
   }
 
-  const remove = [...current].filter(
-    (label) => managed.has(label) && !desired.has(label),
-  );
+  const remove = [...current].filter((label) => {
+    const automationArea =
+      classification.clearAutomationLabels && label.startsWith("area: ");
+    return (managed.has(label) || automationArea) && !desired.has(label);
+  });
 
   return {
     add: add.sort((a, b) => a.localeCompare(b)),

--- a/scripts/pr-label-classifier.test.mjs
+++ b/scripts/pr-label-classifier.test.mjs
@@ -360,6 +360,7 @@ test("external intake gets deterministic type, size, contributor, and triage lab
     "size: small",
   ]);
   assert.equal(classification.addNeedsTriage, true);
+  assert.equal(classification.clearAutomationLabels, false);
   assert.equal(classification.synchronizeTypeLabels, true);
 });
 
@@ -403,7 +404,7 @@ test("incomplete, sensitive, large, and opaque external PRs route to manual revi
   }
 });
 
-test("trusted PRs retain risk metadata without external manual routing", () => {
+test("trusted PRs receive no automation-managed labels", () => {
   const result = classifyPullRequest({
     pullRequest: {
       author_association: "NONE",
@@ -415,11 +416,9 @@ test("trusted PRs retain risk metadata without external manual routing", () => {
     eventAction: "opened",
   });
 
-  assert.ok(result.desiredLabels.includes("contributor: trusted"));
-  assert.ok(result.desiredLabels.includes("contribution: incomplete"));
-  assert.ok(result.desiredLabels.includes("review: sensitive"));
-  assert.ok(result.desiredLabels.includes("size: large"));
-  assert.ok(!result.desiredLabels.includes("review: manual"));
+  assert.deepEqual(result.desiredLabels, []);
+  assert.equal(result.clearAutomationLabels, true);
+  assert.equal(result.synchronizeTypeLabels, true);
   assert.equal(result.addNeedsTriage, false);
 });
 
@@ -480,7 +479,7 @@ test("needs-triage is initialized only on external intake or explicit backfill",
   );
 });
 
-test("reconciliation replaces managed labels and preserves maintainer state", () => {
+test("trusted reconciliation removes automation labels and preserves unrelated state", () => {
   const classification = classifyPullRequest({
     pullRequest: { body: pullRequestBody() },
     repositoryPermission: "write",
@@ -490,29 +489,41 @@ test("reconciliation replaces managed labels and preserves maintainer state", ()
   });
   const changes = reconcilePullRequestLabels(
     [
+      "bug",
+      "contributor: trusted",
       "contributor: external",
       "contributor: member",
       "size: large",
       "documentation",
+      "contribution: incomplete",
+      "review: sensitive",
       "review: manual",
       "needs-triage",
       "help wanted",
       "area: sdk",
+      "area: future-package",
+      "claude-code-assisted",
     ],
     classification,
   );
 
-  assert.deepEqual(changes.add, ["bug", "contributor: trusted", "size: small"]);
+  assert.deepEqual(changes.add, []);
   assert.deepEqual(changes.remove, [
+    "area: future-package",
+    "area: sdk",
+    "bug",
+    "contribution: incomplete",
     "contributor: external",
     "contributor: member",
+    "contributor: trusted",
     "documentation",
+    "needs-triage",
     "review: manual",
+    "review: sensitive",
     "size: large",
   ]);
-  assert.ok(!changes.remove.includes("needs-triage"));
   assert.ok(!changes.remove.includes("help wanted"));
-  assert.ok(!changes.remove.includes("area: sdk"));
+  assert.ok(!changes.remove.includes("claude-code-assisted"));
 });
 
 test("reconciliation removes stale trusted access after permission revocation", () => {
@@ -592,6 +603,16 @@ test("the privileged workflow stays pinned and never references PR head code or 
   assert.match(workflow, /contents: read/);
   assert.match(workflow, /pull-requests: write/);
   assert.match(workflow, /getCollaboratorPermissionLevel/);
+  assert.match(workflow, /id: classification/);
+  assert.match(workflow, /core\.setOutput\(\s*"trusted"/);
+  assert.match(
+    workflow,
+    /if: steps\.classification\.outputs\.trusted == 'false'/,
+  );
+  assert.ok(
+    workflow.indexOf("id: classification") <
+      workflow.indexOf("Apply area labels to external pull requests"),
+  );
   assert.doesNotMatch(workflow, /author_association/);
   assert.doesNotMatch(workflow, /pull_request\.head|head\.sha|secrets\./);
 


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The PR-labeling workflow applies contributor, size, type, risk, and area labels to trusted authors even though those labels exist to route external contribution intake. Internal team PRs should proceed directly to review without public-contribution metadata.

## Summary and scope

- Return no desired automation labels when the author has write-equivalent repository access.
- Remove stale contributor, size, type, risk, triage, and `area:*` labels from trusted PRs while preserving unrelated maintainer and app labels.
- Run the path labeler only for external PRs, after the trusted-permission classification succeeds.
- Keep external contributor classification, fail-closed permission handling, and triage behavior unchanged.

This does not change repository permission rules or enable automated code review.

## Related work

Related issue or discussion: N/A — this is a focused follow-up to the merged trusted-author classification change.

## Validation

```text
pnpm pr-labeler:check — passed (21/21 classifier and workflow-contract tests; formatting clean)
pnpm build — passed
pnpm typecheck — passed
pnpm lint — passed with existing warnings and no errors
pnpm test — passed
git diff --check — passed
```

### Tests and documentation

Updated classifier coverage for trusted-label suppression, stale-label cleanup, preservation of unrelated labels, unchanged external behavior, and the external-only workflow ordering. Documentation is N/A because this changes internal repository automation only.

## Compatibility and release impact

- Breaking or externally visible changes: Trusted PRs no longer receive labels managed by the contribution-intake workflow. External PR behavior is unchanged.
- Changeset: N/A — no published package or runtime behavior changes.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex helped inspect the existing classifier, implement the workflow and test changes, and run verification. I reviewed the diff and verified the result with the focused classifier checks and the complete repository build, typecheck, lint, and test suite.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
