### PR TITLE
fix(harness): reveal the canvas pane on a real graph, not on scaffolding writes

### DIFF
--- a/.changeset/canvas-reveal-on-graph.md
+++ b/.changeset/canvas-reveal-on-graph.md
@@ -1,0 +1,19 @@
+---
+"@sapiom/harness": patch
+---
+
+Canvas: open the right pane when a real step graph renders, not when scaffolding is written
+
+A canvas WRITE is not a canvas RESULT. The pane revealed itself on every
+`canvas.reload`, and the "Preparing your agent — installing dependencies"
+placeholder written while npm runs is exactly such a write — so a fresh
+scaffold popped the pane open on setup state and presented it as the result
+(the server's "Rendering agent diagram…" pending document does the same to the
+mount probe).
+
+The reveal now waits for the document to post `sapiom-canvas:graph`, which only
+a real render embeds and the placeholders deliberately omit. Nothing is
+deferred but the reveal: a collapsed pane is hidden with `display:none`, never
+unmounted, so the iframe still loads and swaps its document in the background
+and the board is there the instant it is worth showing. Absence of content is
+still announced immediately, so an empty pane still hides itself.

--- a/packages/harness/web/e2e/canvas-reveal.spec.ts
+++ b/packages/harness/web/e2e/canvas-reveal.spec.ts
@@ -44,3 +44,42 @@ test("a live render re-opens a pane the user had collapsed", async ({ page }) =>
   await publishReload(page, "sess-boot");
   await expect(page.locator(".right-pane")).not.toHaveClass(/is-collapsed/);
 });
+
+/**
+ * …but a canvas WRITE is not a canvas RESULT. Scaffolding documents — the
+ * "Preparing your agent — installing dependencies" placeholder written while
+ * npm runs, and the server's "Rendering agent diagram…" pending doc — land in
+ * the same directory and broadcast the same reload. Revealing the pane for
+ * those presented setup state as if it were the finished graph.
+ *
+ * The discriminator is the document itself: a real render embeds the graph
+ * script that posts `sapiom-canvas:graph`; the placeholders deliberately post
+ * nothing. Served here by intercepting the canvas document, so no fixture
+ * session has to exist for a state that is transient by nature.
+ */
+const PREPARING_DOC = `<!doctype html><html><body>
+  <span class="canvas-badge">preparing</span>
+  <p>Preparing your agent — installing dependencies.</p>
+</body></html>`;
+
+test("a placeholder render does not open the pane — only a real graph does", async ({ page }) => {
+  await expect(page.locator(".right-pane")).not.toHaveClass(/is-collapsed/);
+  await page.getByTestId("right-collapse").click();
+  await expect(page.locator(".right-pane")).toHaveClass(/is-collapsed/);
+
+  // The scaffold's first write: a document with no graph in it.
+  await page.route("**/canvas/sess-boot/**", (route) =>
+    route.fulfill({ status: 200, contentType: "text/html", body: PREPARING_DOC }),
+  );
+  await publishReload(page, "sess-boot");
+
+  // Give the iframe time to load and post anything it was going to post: the
+  // assertion is the ABSENCE of a reveal, so it has to outlast the load.
+  await page.waitForTimeout(750);
+  await expect(page.locator(".right-pane")).toHaveClass(/is-collapsed/);
+
+  // Install finishes, the real render lands — now it opens, unprompted.
+  await page.unroute("**/canvas/sess-boot/**");
+  await publishReload(page, "sess-boot");
+  await expect(page.locator(".right-pane")).not.toHaveClass(/is-collapsed/);
+});

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -91,12 +91,21 @@ interface CanvasPaneProps {
    *  navigating to a launched workflow is an explicit act on it, so it
    *  rebinds, same as running a macro against it. */
   onOpenWorkflow: (path: string) => void;
-  /** Reports whether THIS session currently has a servable canvas board, so the
-   *  workbench can follow it: shown when it has one, hidden when it doesn't.
-   *  Fires on the mount probe, on every canvas.reload, and whenever the session
-   *  changes — the reload case is what opens the pane the moment an agent
-   *  renders a board (a fresh build, a switch to a populated agent), even one
-   *  the user had collapsed. */
+  /** Reports whether THIS session currently has a REAL rendered board, so the
+   *  workbench can follow it: shown when a step graph exists, hidden when it
+   *  doesn't.
+   *
+   *  "Real" means the document posted `sapiom-canvas:graph` — not merely that
+   *  a file exists. A canvas write also happens for the "Preparing your agent
+   *  — installing dependencies" placeholder (and the server answers an
+   *  unrendered bound session with a "Rendering agent diagram…" document), and
+   *  revealing the pane for those presented setup scaffolding as if it were
+   *  the result. Those documents deliberately post nothing, so waiting for the
+   *  graph message is what separates them.
+   *
+   *  Fires on the mount probe, whenever the session changes, and once a graph
+   *  arrives — the last case is what opens the pane the moment an agent
+   *  finishes rendering a board, even one the user had collapsed. */
   onCanvasState?: (hasContent: boolean) => void;
 }
 
@@ -493,6 +502,13 @@ export function CanvasPane({
         });
       } else if (data.type === "sapiom-canvas:graph") {
         setGraph(parseCanvasGraph((data as { graph?: unknown }).graph));
+        // THE reveal signal. Only a real render embeds the graph script that
+        // posts this; the "preparing"/"pending" placeholders post nothing, so
+        // this is what keeps the pane from opening on scaffolding. The
+        // document loads even while the pane is collapsed (it is hidden with
+        // `display:none`, never unmounted), so nothing is deferred — only the
+        // reveal waits.
+        onCanvasStateRef.current?.(true);
       } else if (data.type === "sapiom-canvas:node") {
         // A board pick: populate the bottom inspector, stay on the Canvas
         // tab. The Steps tab is the inspector's explicit "Open in Steps"
@@ -643,7 +659,11 @@ export function CanvasPane({
     if (isMockMode()) {
       const has = hasMockCanvasDoc(sessionId);
       setHasGeneratedContent(has);
-      onCanvasStateRef.current?.(has);
+      // Same rule as the live probe: absence is announced, presence waits for
+      // the graph message. The bundled fixture posts one (public/canvas/
+      // sess-boot/index.html), so the demo still opens on its seeded board —
+      // and the e2e suite exercises the real gate rather than a shortcut.
+      if (!has) onCanvasStateRef.current?.(false);
       return;
     }
     setHasGeneratedContent(false);
@@ -652,8 +672,13 @@ export function CanvasPane({
     fetch(`/canvas/${sessionId}/`, { method: "HEAD" })
       .then((res) => {
         if (cancelled) return;
+        // Mount the iframe when something is servable, but only ever announce
+        // the ABSENCE of content here. A 200 covers the real board, the
+        // "preparing" placeholder AND the server's "Rendering agent diagram…"
+        // pending document — indistinguishable to a HEAD probe. The reveal is
+        // the graph message's job; hiding an empty pane is still this one's.
         setHasGeneratedContent(res.ok);
-        onCanvasStateRef.current?.(res.ok);
+        if (!res.ok) onCanvasStateRef.current?.(false);
       })
       .catch(() => {})
       .finally(() => !cancelled && setProbing(false));
@@ -670,10 +695,11 @@ export function CanvasPane({
       // URL would be the static host's 404 page — never mount it; the pane
       // keeps its honest empty state instead.
       if (isMockMode() && !hasMockCanvasDoc(sessionId)) return;
+      // Mount and swap the document, but do NOT announce it: a canvas write is
+      // also how the "preparing" placeholder lands, and announcing here opened
+      // the pane on setup scaffolding. The reveal is announced from the graph
+      // message below, once the loaded document proves it has a board.
       setHasGeneratedContent(true);
-      // A live render just delivered a board — announce it so the workbench
-      // opens the pane, even one the user had collapsed.
-      onCanvasStateRef.current?.(true);
       setFrameLoading(true);
       setReloadKey((key) => key + 1);
     }


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Scaffolding a new agent pops the right pane open on a placeholder. The canvas
pane reveals itself on every `canvas.reload`, and the "Preparing your agent —
installing dependencies. The step graph appears here automatically once setup
finishes." document written while `npm install` runs *is* such a write. So the
pane opens on setup state and presents it as the result — precisely when the
user is waiting for a result and most likely to read whatever is on screen as
one. The server's "Rendering agent diagram…" pending document does the same
thing through the mount probe, which cannot distinguish a real board from
either placeholder (all answer 200).

A canvas WRITE is not a canvas RESULT, and today's reveal conflates them.

## Summary and scope

The reveal now waits for the loaded document to post `sapiom-canvas:graph` — a
message only a real render emits (its `#sapiom-graph` script), and which both
placeholders deliberately omit. Three edits in `CanvasPane.tsx`:

- `canvas.reload` still mounts and hot-swaps the document; it no longer
  announces content.
- The mount probe still mounts on a 200, and still announces **absence**
  immediately (an empty pane must keep hiding itself), but no longer announces
  presence.
- The `sapiom-canvas:graph` handler announces the reveal.

Only the reveal waits. A collapsed pane is hidden with `display:none` and never
unmounted, so the iframe still loads and swaps in the background — the board is
there the instant it is worth showing, and the existing "a live render re-opens
a pane the user had collapsed" contract is unchanged for real renders.

Mock mode follows the same rule rather than short-circuiting, because its
bundled fixture (`public/canvas/sess-boot/index.html`) posts a graph — so the
e2e suite exercises the real gate.

**Out of scope:** the failed-render path. When an install never finishes, the
180s install watchdog replaces the placeholder with the error panel, which
posts `sapiom-canvas:error`, not a graph — so the pane stays closed and the
error card is reached by opening the pane. That is the chosen behaviour
(graph-only reveal), not an oversight. Also unchanged: the empty/exited states,
the pending document itself, and the `canvas.reload` payload — it is published
by the content-blind file watcher, so teaching it to describe content would
mean reading the file in the watcher.

## Related work

Related issue or discussion: N/A — direct PR; follow-up to #618, agreed while
verifying that branch on Windows and macOS.

## Validation

```text
pnpm --filter @sapiom/harness test:ui — 314 passed (Playwright, chromium)
pnpm --filter @sapiom/harness test — full unit tier passed
pnpm --filter @sapiom/harness typecheck — clean (src + web)
pnpm --filter @sapiom/harness lint — clean
pnpm terminology:check — passed
pnpm provider-copy:check — passed
negative control: with the CanvasPane change stashed, the new spec FAILS
  ("a placeholder render does not open the pane — only a real graph does"),
  and passes with it — so the test pins the behaviour rather than the setup
```

### Tests and documentation

New spec in `web/e2e/canvas-reveal.spec.ts`: a graph-less document is served
through route interception (no fixture session needed for a state that is
transient by nature), a `canvas.reload` is published, and the pane must stay
collapsed across the iframe's load; then the real document lands and the pane
opens unprompted. Verified to fail without the source change.

Documentation: the `onCanvasState` contract comment now states what "has
content" means and why a file write is not enough.

## Compatibility and release impact

- Breaking or externally visible changes: One deliberate UX change — the right
  pane no longer auto-opens for a placeholder or a failed render. It still
  auto-opens for every real board (including a re-render into a pane the user
  had collapsed), still auto-hides when a session has no board, and is always
  manually openable.
- Changeset: Added — `.changeset/canvas-reveal-on-graph.md` (`@sapiom/harness`
  patch).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code (Fable 5) traced the reveal path end to end (which signals exist,
what the placeholders do and don't emit, and why the `canvas.reload` payload is
the wrong place to carry content state), then made the change and wrote the
spec. The load-bearing claim — that a collapsed, `display:none` pane still
loads its iframe, so gating the reveal costs nothing — was verified in a real
browser by the passing suite rather than assumed, and the new test was checked
against the pre-change source to confirm it fails there.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
