### PR TITLE
chore(ci): harden external pull request checks

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -51,6 +51,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: harness-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Playwright mock-mode tier — harness web/e2e specs (VITE_MOCK=1, chromium only).
   # The live/real-pty tiers (e2e:live, sim) are opt-in local only; nothing here
@@ -61,12 +65,14 @@ jobs:
     # Single Node version is enough — the mock tier tests browser behaviour,
     # not Node version compat; that's covered by the matrix job in test.yml.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
           cache: "pnpm"
@@ -80,7 +86,7 @@ jobs:
       # Cache Playwright browser binaries keyed on the package.json devDependency
       # version so the cache invalidates on every @playwright/test bump.
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -106,7 +112,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: packages/harness/web/e2e/playwright-report/
@@ -130,12 +136,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           # NOT the dev box's Node 26, which breaks Electron's binary extraction.
           node-version: "22.x"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,21 +10,28 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: test-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       matrix:
         node-version: [20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
         # pnpm version comes from package.json `packageManager` (pnpm 10+)
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: "pnpm"
@@ -50,13 +57,16 @@ jobs:
   # and every co-located template.json manifest on a PR.
   examples:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22.x"
           cache: "pnpm"
@@ -79,6 +89,9 @@ jobs:
 
       - name: Test pull request classification
         run: pnpm pr-labeler:check
+
+      - name: Test pull request CI security
+        run: pnpm pr-ci-security:check
 
   # NOTE: the harness web-e2e (playwright-mock) and desktop packaging
   # (desktop-smoke) jobs moved to .github/workflows/harness.yml, which is

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "provider-copy:check": "node scripts/provider-neutral-copy-check.mjs",
     "provider-copy:check:test": "node --test scripts/provider-neutral-copy-check.test.mjs",
     "pr-labeler:check": "node --test scripts/pr-label-classifier.test.mjs && prettier --check .github/labeler.yml .github/workflows/pr-labeler.yml .github/workflows/test.yml .github/pull_request_template.md package.json scripts/pr-label-classifier.mjs scripts/pr-label-classifier.test.mjs",
+    "pr-ci-security:check": "node --test scripts/pr-ci-security.test.mjs && prettier --check .github/workflows/test.yml .github/workflows/harness.yml scripts/pr-ci-security.test.mjs",
     "examples:sort": "node scripts/examples-sort.mjs",
     "examples:sync-setup": "node scripts/examples-sync-setup.mjs"
   },

--- a/scripts/pr-ci-security.test.mjs
+++ b/scripts/pr-ci-security.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const PULL_REQUEST_WORKFLOWS = [
+  ".github/workflows/test.yml",
+  ".github/workflows/harness.yml",
+];
+
+function readWorkflow(relativePath) {
+  return readFileSync(path.join(ROOT, relativePath), "utf8");
+}
+
+function countMatches(source, pattern) {
+  return [...source.matchAll(pattern)].length;
+}
+
+test("pull request CI uses unprivileged fork-safe triggers", () => {
+  for (const relativePath of PULL_REQUEST_WORKFLOWS) {
+    const workflow = readWorkflow(relativePath);
+
+    assert.match(workflow, /^  pull_request:\s*$/m, relativePath);
+    assert.doesNotMatch(workflow, /pull_request_target:/, relativePath);
+    assert.match(
+      workflow,
+      /^permissions:\n  contents: read\s*$/m,
+      relativePath,
+    );
+    assert.doesNotMatch(
+      workflow,
+      /(?:^|\s)(?:write-all|[\w-]+: write)\s*$/m,
+      relativePath,
+    );
+    assert.doesNotMatch(workflow, /secrets\./, relativePath);
+    assert.doesNotMatch(
+      workflow,
+      /\b(?:GITHUB_TOKEN|github\.token)\b/,
+      relativePath,
+    );
+  }
+});
+
+test("pull request CI cancels superseded revisions and bounds every job", () => {
+  for (const relativePath of PULL_REQUEST_WORKFLOWS) {
+    const workflow = readWorkflow(relativePath);
+    const jobCount = countMatches(workflow, /^    runs-on:/gm);
+    const runners = [...workflow.matchAll(/^    runs-on:\s*(.+)\s*$/gm)].map(
+      ([, runner]) => runner.trim(),
+    );
+    const timeouts = [
+      ...workflow.matchAll(/^    timeout-minutes:\s*(\d+)\s*$/gm),
+    ].map(([, timeout]) => Number.parseInt(timeout, 10));
+
+    assert.match(
+      workflow,
+      /group: [^\n]*github\.event\.pull_request\.number[^\n]*github\.ref/,
+      relativePath,
+    );
+    assert.match(workflow, /cancel-in-progress: true/, relativePath);
+    assert.deepEqual(
+      [...new Set(runners)],
+      ["ubuntu-latest"],
+      `${relativePath}: only standard ephemeral runners are allowed`,
+    );
+    assert.equal(
+      timeouts.length,
+      jobCount,
+      `${relativePath}: every job needs a timeout`,
+    );
+    assert.ok(
+      timeouts.every((timeout) => timeout <= 20),
+      `${relativePath}: job timeouts must remain at most 20 minutes`,
+    );
+  }
+});
+
+test("pull request CI pins actions and disables checkout credentials", () => {
+  for (const relativePath of PULL_REQUEST_WORKFLOWS) {
+    const workflow = readWorkflow(relativePath);
+    const actionUses = [
+      ...workflow.matchAll(/^\s*-?\s*uses:\s*([^\s#]+)/gm),
+    ].map(([, action]) => action);
+    const checkoutCount = actionUses.filter((action) =>
+      action.startsWith("actions/checkout@"),
+    ).length;
+
+    assert.ok(actionUses.length > 0, `${relativePath}: expected actions`);
+    for (const action of actionUses) {
+      assert.match(
+        action,
+        /^[^@\s]+@[0-9a-f]{40}$/,
+        `${relativePath}: ${action}`,
+      );
+    }
+    assert.equal(
+      countMatches(workflow, /^\s+persist-credentials: false\s*$/gm),
+      checkoutCount,
+      `${relativePath}: every checkout must disable persisted credentials`,
+    );
+  }
+});


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [x] Maintenance or refactor

## Problem and motivation

The repository now allows established GitHub users to run public-fork CI automatically. The workflows that execute pull-request code should therefore have explicit least-privilege defaults, bounded execution, supply-chain pins, and regression coverage.

## Summary and scope

- Cancel superseded Test and Harness runs per pull request.
- Add 10–20 minute job timeouts and retain standard ephemeral Ubuntu runners.
- Disable persisted checkout credentials and pin every third-party action to a reviewed commit SHA.
- Add a repository test that enforces the unprivileged trigger, token, runner, timeout, action-pin, and checkout-credential contract.

The GitHub fork-approval setting was changed separately to `first_time_contributors_new_to_github`; this PR contains only the supporting workflow hardening and regression checks. It does not add Claude review or alter merge authority.

## Related work

Related issue or discussion: N/A — focused repository-automation follow-up.

## Validation

```text
pnpm pr-ci-security:check — passed (3/3 security-contract tests; formatting clean)
pnpm pr-labeler:check — passed (21/21 classifier tests; formatting clean)
pnpm examples:check:test — passed (150/150 repository script tests)
pnpm build — passed
pnpm typecheck — passed after build, matching CI order
pnpm lint — passed with existing warnings and no errors
pnpm test — passed
git diff --check — passed
GitHub fork approval API readback — first_time_contributors_new_to_github
```

### Tests and documentation

Added `scripts/pr-ci-security.test.mjs` and wired its dedicated check into the Test workflow. The external strategy document is maintained outside this repository; no public SDK documentation changes are required.

## Compatibility and release impact

- Breaking or externally visible changes: Superseded PR CI runs are cancelled; jobs time out after 10–20 minutes. SDK behavior is unchanged.
- Changeset: N/A — no published package changes.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex inspected the live GitHub Actions policy and workflows, implemented the workflow hardening and regression test, and ran the verification commands listed above. I reviewed the resulting diff and the live repository-setting readback.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
