### PR TITLE
fix(axios): reauthorize existing transactions that still require payment

### DIFF
--- a/packages/axios/src/http-client.integration.test.ts
+++ b/packages/axios/src/http-client.integration.test.ts
@@ -448,6 +448,74 @@ describe("Axios HTTP Client Integration Tests", () => {
       expect(mocks.reauthorizeWithPayment).toHaveBeenCalled();
     });
 
+    it("should reauthorize with payment when the existing transaction genuinely requires it (status: pending)", async () => {
+      mocks.create.mockResolvedValue({
+        id: "tx-needs-payment",
+        status: TransactionStatus.AUTHORIZED,
+      } as any);
+
+      // This is the realistic shape returned for a transaction that actually
+      // needs payment: requiresPayment is true and status is not yet
+      // AUTHORIZED (unlike the mock above, which — misleadingly — has
+      // requiresPayment: false alongside status: AUTHORIZED).
+      mocks.get.mockResolvedValue({
+        id: "tx-needs-payment",
+        status: TransactionStatus.PENDING,
+        requiresPayment: true,
+      } as any);
+
+      mocks.reauthorizeWithPayment.mockResolvedValue({
+        id: "tx-needs-payment",
+        status: TransactionStatus.AUTHORIZED,
+        payment: {
+          authorizationPayload: "payment-token-xyz",
+        },
+      } as any);
+
+      mocks.complete.mockResolvedValue({
+        transaction: { id: "tx-needs-payment", status: "completed" },
+      } as any);
+
+      let requestCount = 0;
+      mockAxios.onGet("/paid").reply(() => {
+        requestCount++;
+        if (requestCount === 1) {
+          return [
+            402,
+            {
+              x402Version: 1,
+              accepts: [
+                {
+                  scheme: "exact",
+                  network: "base",
+                  maxAmountRequired: "1000000",
+                  resource: "https://api.example.com/paid",
+                  payTo: "0x123",
+                  asset: "0xUSDC",
+                },
+              ],
+            },
+          ];
+        } else {
+          return [200, { paid: true }];
+        }
+      });
+
+      const client = withSapiom(axiosInstance, {
+        sapiomClient: mockSapiomClient,
+      });
+      const response = await client.get("/paid");
+      await flushPromises();
+
+      expect(response.status).toBe(200);
+      expect(response.data).toEqual({ paid: true });
+      expect(requestCount).toBe(2);
+      expect(mocks.reauthorizeWithPayment).toHaveBeenCalledWith(
+        "tx-needs-payment",
+        expect.objectContaining({ x402: expect.anything() }),
+      );
+    });
+
     it("should return original 402 if payment reauthorization is denied", async () => {
       mocks.create.mockResolvedValue({
         id: "tx-auth",

--- a/packages/axios/src/interceptors.ts
+++ b/packages/axios/src/interceptors.ts
@@ -614,26 +614,28 @@ export function addPaymentInterceptor(
             existingTransactionId,
           );
 
-          if (
-            !transaction.requiresPayment &&
-            transaction.status === TransactionStatus.AUTHORIZED
-          ) {
-            transaction =
-              await config.sapiomClient.transactions.reauthorizeWithPayment(
-                existingTransactionId,
-                {
-                  x402: x402Response,
-                  metadata: {
-                    originalRequest: {
-                      url: originalConfig.url,
-                      method: originalConfig.method,
-                    },
-                    responseHeaders: error.response?.headers,
-                    httpStatusCode: 402,
+          // Submit the payment proof for this existing transaction, the same
+          // way @sapiom/fetch and @sapiom/node-http do unconditionally. The
+          // previous `!transaction.requiresPayment && status === AUTHORIZED`
+          // guard skipped this call in exactly the case it's needed — a
+          // transaction that genuinely still requires payment — leaving
+          // `transaction` without payment data and causing the flow below to
+          // poll a transaction that can never become authorized.
+          transaction =
+            await config.sapiomClient.transactions.reauthorizeWithPayment(
+              existingTransactionId,
+              {
+                x402: x402Response,
+                metadata: {
+                  originalRequest: {
+                    url: originalConfig.url,
+                    method: originalConfig.method,
                   },
+                  responseHeaders: error.response?.headers,
+                  httpStatusCode: 402,
                 },
-              );
-          }
+              },
+            );
         } catch (apiError) {
           // Clear payment handling flag so completion interceptor fires
           (originalConfig as any).__sapiomPaymentHandling = false;


### PR DESCRIPTION
## Bug

`addPaymentInterceptor` in `packages/axios/src/interceptors.ts` gates the
reauthorize-with-payment call behind:

    if (!transaction.requiresPayment && transaction.status === AUTHORIZED)

This calls `reauthorizeWithPayment` exactly when it's *not* needed (payment
not required, already authorized), and skips it in the realistic case that
triggered this whole flow — an existing transaction that genuinely requires
payment. When skipped, `transaction` keeps its stale value and the code
falls through to polling a transaction that was never given payment data,
so it can never become authorized. In production this hangs until the
poller's own timeout.

`@sapiom/fetch` and `@sapiom/node-http` don't have this guard at all — they
call `reauthorizeWithPayment` unconditionally whenever there's an existing
transaction. This appears to be an axios-specific regression.

The existing test suite didn't catch this because every payment-flow mock
in `http-client.integration.test.ts` uses `requiresPayment: false` with
`status: AUTHORIZED` — a combination that happens to satisfy the buggy
condition, masking the fact that the realistic combination
(`requiresPayment: true`) was never exercised.

## Fix

Removed the condition; `reauthorizeWithPayment` is now called unconditionally
whenever there's an existing transaction ID, matching `@sapiom/fetch` and
`@sapiom/node-http`.

## Testing

Added a test with the realistic mock shape
(`requiresPayment: true, status: PENDING`). Confirmed it times out on
unpatched `main` (the hang described above) and passes in ~15ms with the
fix. Full package suite: 34/34 passing. `tsc --noEmit` clean. `eslint`
clean (pre-existing unrelated warnings only).

## Changeset

N/A — bug fix to existing behavior, no public API change. Happy to add one
if maintainers prefer a changeset for behavior-affecting fixes.