### PR TITLE
fix(core): omit undefined copied headers

### DIFF
--- a/.changeset/skip-undefined-headers.md
+++ b/.changeset/skip-undefined-headers.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/core": patch
+---
+
+Omit undefined header values when copying header maps in the core header helpers.

--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -90,6 +90,24 @@ describe("Header Utilities", () => {
       expect(result["X-Custom"]).toBe("final");
       expect(result["Other"]).toBe("keep");
     });
+
+    it("should omit unrelated headers with undefined values", () => {
+      const headers = {
+        Authorization: undefined,
+        "Content-Type": "text/plain",
+      };
+
+      const result = setHeader(
+        headers,
+        "X-Sapiom-Transaction-Id",
+        "tx_123",
+      );
+
+      expect(result["Authorization"]).toBeUndefined();
+      expect(Object.keys(result)).not.toContain("Authorization");
+      expect(result["Content-Type"]).toBe("text/plain");
+      expect(result["X-Sapiom-Transaction-Id"]).toBe("tx_123");
+    });
   });
 
   describe("removeHeader", () => {
@@ -116,6 +134,19 @@ describe("Header Utilities", () => {
       expect(result["x-custom"]).toBeUndefined();
       expect(result["X-Custom"]).toBeUndefined();
       expect(result["Other-Header"]).toBe("keep");
+    });
+
+    it("should omit unrelated headers with undefined values", () => {
+      const headers = {
+        Authorization: undefined,
+        "Content-Type": "application/json",
+      };
+
+      const result = removeHeader(headers, "Content-Type");
+
+      expect(result["Authorization"]).toBeUndefined();
+      expect(Object.keys(result)).not.toContain("Authorization");
+      expect(result["Content-Type"]).toBeUndefined();
     });
   });
 

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -58,7 +58,8 @@ export function setHeader(
   // Copy all headers except case variants of the one we're setting
   for (const [key, val] of Object.entries(headers)) {
     if (key.toLowerCase() !== lowerHeaderName) {
-      newHeaders[key] = Array.isArray(val) ? val[0] || "" : val || "";
+      const headerValue = normalizeHeaderValue(val);
+      if (headerValue !== undefined) newHeaders[key] = headerValue;
     }
   }
 
@@ -84,9 +85,17 @@ export function removeHeader(
 
   for (const [key, val] of Object.entries(headers)) {
     if (key.toLowerCase() !== lowerHeaderName) {
-      newHeaders[key] = Array.isArray(val) ? val[0] || "" : val || "";
+      const headerValue = normalizeHeaderValue(val);
+      if (headerValue !== undefined) newHeaders[key] = headerValue;
     }
   }
 
   return newHeaders;
+}
+
+function normalizeHeaderValue(
+  value: string | string[] | undefined,
+): string | undefined {
+  if (value === undefined) return undefined;
+  return Array.isArray(value) ? value[0] || "" : value;
 }


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The core header helpers accept header maps where individual values may be `undefined`, which is the usual representation for an omitted header in Node/HTTP-style objects. While copying unrelated headers, `setHeader` and `removeHeader` currently coerce those `undefined` values to `""`, turning an absent header into a present-but-empty header.

## Summary and scope

- Skip `undefined` header values when copying non-target headers in `setHeader` and `removeHeader`.
- Keep the existing string and string-array behavior, including preserving empty string values and using the first array value.
- Add regression coverage for both helpers.

## Related work

Related issue or discussion: Fixes #625

## Validation

```text
corepack pnpm --filter @sapiom/core test -- --runTestsByPath src/utils/utils.test.ts — passed, 17 tests
corepack pnpm --filter @sapiom/core typecheck — passed
corepack pnpm --filter @sapiom/core lint — passed with existing warnings only:
  packages/core/src/client/TransactionAPI.ts: ListTransactionsParams unused
  packages/core/src/types/config.ts: SapiomClientConfig unused
  packages/core/src/utils/TransactionAuthorizer.ts: CreateTransactionRequest unused
```

### Tests and documentation

Added regression tests in `packages/core/src/utils/utils.test.ts`. Documentation update is N/A because this is an internal helper behavior fix.

## Compatibility and release impact

- Breaking or externally visible changes: none expected; `undefined` values are omitted instead of being serialized as empty headers.
- Changeset: added for `@sapiom/core` patch.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the Security Policy for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex helped inspect the helper behavior, add the focused regression tests, and run the validation commands. I reviewed the resulting diff and test output.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.