### PR TITLE
fix(core): setHeader/removeHeader no longer coerce undefined headers to empty string

### DIFF
--- a/.changeset/header-utils-undefined-values.md
+++ b/.changeset/header-utils-undefined-values.md
@@ -1,0 +1,16 @@
+---
+"@sapiom/core": patch
+---
+
+Fix `setHeader` and `removeHeader` coercing unrelated `undefined`-valued
+headers into empty strings
+
+Both helpers accept `Record<string, string | string[] | undefined>`, where
+`undefined` represents an omitted header in Node/HTTP-style maps. When copying
+unrelated headers, the previous `val || ""` fallback turned any `undefined`
+value into `""`, so an absent header (e.g. `Authorization: undefined`) came
+back as a present-but-empty header. Downstream HTTP clients could then send an
+empty header instead of omitting it.
+
+Unrelated headers with an `undefined` value are now skipped while copying, so
+they stay omitted in the returned header map, matching the documented type.

--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -71,6 +71,20 @@ describe("Header Utilities", () => {
       expect(result["Authorization"]).toBe("old"); // Other headers preserved
     });
 
+    it("should keep unrelated undefined-valued headers omitted, not coerce to empty string", () => {
+      const headers = {
+        Authorization: undefined,
+        "Content-Type": "text/plain",
+      };
+
+      const result = setHeader(headers, "X-Sapiom-Transaction-Id", "tx_123");
+
+      expect(result["Authorization"]).toBeUndefined();
+      expect("Authorization" in result).toBe(false);
+      expect(result["Content-Type"]).toBe("text/plain");
+      expect(result["X-Sapiom-Transaction-Id"]).toBe("tx_123");
+    });
+
     it("should remove all case variants when setting same header", () => {
       const headers = {
         "x-custom": "value1",
@@ -102,6 +116,18 @@ describe("Header Utilities", () => {
 
       expect(result["Content-Type"]).toBeUndefined();
       expect(result["Authorization"]).toBe("Bearer token");
+    });
+
+    it("should keep unrelated undefined-valued headers omitted, not coerce to empty string", () => {
+      const headers = {
+        Authorization: undefined,
+        "Content-Type": "text/plain",
+      };
+
+      const result = removeHeader(headers, "Content-Type");
+
+      expect(result["Authorization"]).toBeUndefined();
+      expect("Authorization" in result).toBe(false);
     });
 
     it("should remove all case variants", () => {

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -55,10 +55,12 @@ export function setHeader(
   const lowerHeaderName = headerName.toLowerCase();
   const newHeaders: Record<string, string> = {};
 
-  // Copy all headers except case variants of the one we're setting
+  // Copy all headers except case variants of the one we're setting.
+  // Headers with an `undefined` value represent an omitted header
+  // (Node/HTTP-style maps) and must stay omitted, not become "".
   for (const [key, val] of Object.entries(headers)) {
-    if (key.toLowerCase() !== lowerHeaderName) {
-      newHeaders[key] = Array.isArray(val) ? val[0] || "" : val || "";
+    if (key.toLowerCase() !== lowerHeaderName && val !== undefined) {
+      newHeaders[key] = Array.isArray(val) ? val[0] || "" : val;
     }
   }
 
@@ -82,9 +84,11 @@ export function removeHeader(
   const lowerHeaderName = headerName.toLowerCase();
   const newHeaders: Record<string, string> = {};
 
+  // Headers with an `undefined` value represent an omitted header
+  // (Node/HTTP-style maps) and must stay omitted, not become "".
   for (const [key, val] of Object.entries(headers)) {
-    if (key.toLowerCase() !== lowerHeaderName) {
-      newHeaders[key] = Array.isArray(val) ? val[0] || "" : val || "";
+    if (key.toLowerCase() !== lowerHeaderName && val !== undefined) {
+      newHeaders[key] = Array.isArray(val) ? val[0] || "" : val;
     }
   }
 


### PR DESCRIPTION
Fixes #625

Both `setHeader` and `removeHeader` accept `Record<string, string | string[] | undefined>`, where `undefined` represents an omitted header in Node/HTTP-style maps. The copy loop used `val || ""` as a fallback, which turned any `undefined` value into an empty string, so an absent header (e.g. `Authorization: undefined`) came back as present-but-empty. Downstream HTTP clients could then send an empty header instead of omitting it.

**Fix:** unrelated headers with an `undefined` value are now skipped while copying, keeping them omitted in the returned map, matching the documented type.

**Tests:** added regression tests for both `setHeader` and `removeHeader`, per the issue's suggested fix (`packages/core/src/utils/utils.test.ts`).

**Changeset:** added (`@sapiom/core`, patch).

Verified locally: `pnpm --filter @sapiom/core test` (134/134 passing), `pnpm --filter @sapiom/core typecheck` clean, `eslint` clean on both changed files.