### PR TITLE
fix(agent-core): scaffold no longer overwrites a template-authored .npmrc

### DIFF
--- a/.changeset/scaffold-npmrc-overwrite.md
+++ b/.changeset/scaffold-npmrc-overwrite.md
@@ -1,0 +1,16 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Fix `scaffold` overwriting a template-authored `.npmrc`
+
+`scaffold` renames a template's `_npmrc` to `.npmrc` via `copyTemplate`, then
+— when the resolved package versions came from a non-default registry (a
+local Verdaccio dev loop) — unconditionally overwrote that `.npmrc` with a
+single `@sapiom:registry=...` line. Any content the template had shipped in
+`_npmrc` (auth tokens, other registry config) was silently lost.
+
+The registry line is now appended to an existing template-authored `.npmrc`
+instead of overwriting it (and skipped if the line is already present), so
+template-provided `.npmrc` content survives alongside the dev-loop registry
+config. Behavior is unchanged when no template `.npmrc` exists.

--- a/packages/agent-core/src/__tests__/scaffold.test.ts
+++ b/packages/agent-core/src/__tests__/scaffold.test.ts
@@ -348,6 +348,53 @@ describe("scaffold .npmrc (local registry)", () => {
       rmSync(base, { recursive: true, force: true });
     }
   });
+
+  it("appends to (not overwrites) a template-authored .npmrc", async () => {
+    process.env.npm_config_registry = "http://localhost:4873";
+    global.fetch = (async () => ({
+      ok: true,
+      json: async () => ({ version: "9.9.9" }),
+    })) as unknown as typeof fetch;
+
+    const templatesRoot = makeTmp();
+    const templateDir = path.join(templatesRoot, "with-npmrc");
+    mkdirSync(templateDir, { recursive: true });
+    writeFileSync(
+      path.join(templateDir, "package.json"),
+      JSON.stringify({
+        name: "__PROJECT_NAME__",
+        version: "0.1.0",
+        dependencies: {
+          "@sapiom/agent": "__AGENT_VERSION__",
+          "@sapiom/tools": "__TOOLS_VERSION__",
+          zod: "__ZOD_VERSION__",
+        },
+      }),
+    );
+    writeFileSync(path.join(templateDir, "index.ts"), "export {};\n");
+    writeFileSync(
+      path.join(templateDir, "_npmrc"),
+      "auth-token=template-provided-token\n",
+    );
+
+    const base = makeTmp();
+    const targetDir = path.join(base, "template-npmrc");
+    try {
+      await scaffold({
+        targetDir,
+        template: "with-npmrc",
+        templatesDir: templatesRoot,
+      });
+      const npmrc = readFileSync(path.join(targetDir, ".npmrc"), "utf8");
+      expect(npmrc).toContain("auth-token=template-provided-token");
+      expect(npmrc).toContain(
+        "@sapiom:registry=http://localhost:4873",
+      );
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+      rmSync(templatesRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("resolveVersions offline fallback", () => {

--- a/packages/agent-core/src/scaffold.ts
+++ b/packages/agent-core/src/scaffold.ts
@@ -356,13 +356,22 @@ export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
   // public npm. Skipped for the default registry so a real customer's project
   // stays clean. Only meaningful when scaffold itself resolved the versions;
   // an explicit `opts.versions` caller manages its own registry.
+  //
+  // Appends to (rather than overwrites) any .npmrc the template already
+  // produced from a `_npmrc` file, so template-authored registry config,
+  // auth tokens, etc. survive alongside the dev-loop registry line.
   if (!opts.versions) {
     const sapiomRegistry = registryFor("@sapiom/tools");
     if (sapiomRegistry !== DEFAULT_REGISTRY) {
-      writeFileSync(
-        path.join(targetDir, ".npmrc"),
-        `@sapiom:registry=${sapiomRegistry}\n`,
-      );
+      const npmrcPath = path.join(targetDir, ".npmrc");
+      const registryLine = `@sapiom:registry=${sapiomRegistry}\n`;
+      const existing = existsSync(npmrcPath)
+        ? readFileSync(npmrcPath, "utf8")
+        : "";
+      if (!existing.includes("@sapiom:registry=")) {
+        const separator = existing && !existing.endsWith("\n") ? "\n" : "";
+        writeFileSync(npmrcPath, existing + separator + registryLine);
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #573

`scaffold` renames a template's `_npmrc` to `.npmrc` via `copyTemplate`, then — when resolved package versions came from a non-default registry (a local Verdaccio dev loop) — unconditionally overwrote that `.npmrc` with a single `@sapiom:registry=...` line, silently dropping any content the template had shipped in `_npmrc` (auth tokens, other registry config).

**Fix:** the registry line is now appended to an existing template-authored `.npmrc` instead of overwriting it (and skipped if the line is already present), so template-provided `.npmrc` content survives alongside the dev-loop registry line. Behavior is unchanged when no template `.npmrc` exists.

**Tests:** added a regression test that exercises the same `_npmrc` → `.npmrc` restore path a real template uses, with a fixture template shipping its own `_npmrc`.

**Changeset:** added (`@sapiom/agent-core`, patch).

Verified locally: `pnpm --filter @sapiom/agent-core exec jest src/__tests__/scaffold.test.ts` — 20/20 passing (including the 3 `.npmrc`-focused tests).