### PR TITLE
fix(agent-core): use pathToFileURL for the bundle import URL (Windows fix)

### DIFF
--- a/.changeset/windows-bundle-file-url.md
+++ b/.changeset/windows-bundle-file-url.md
@@ -1,0 +1,19 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Fix invalid `file://` URL on Windows when dynamically importing a bundled
+agent
+
+`check` and `local/load` both bundle an agent to a temp file, then
+`import()` it via a hand-built `` `file://${bundlePath}?t=${Date.now()}` ``
+template. `path.join`/esbuild's output path use the platform's own
+separator, so on Windows this produced an invalid URL (backslashes, and a
+missing leading `/` before the drive letter), breaking `sapiom check` and
+`sapiom run` for every Windows user.
+
+Both call sites now build the URL with `pathToFileURL` (via a new shared
+`bundleFileUrl` helper), which percent-encodes the path and handles both
+platforms correctly. This also fixes the same class of bug for any
+POSIX path containing characters a raw template leaves unencoded (e.g.
+spaces), which the added regression tests cover directly.

--- a/packages/agent-core/src/bundle-url.spec.ts
+++ b/packages/agent-core/src/bundle-url.spec.ts
@@ -1,0 +1,35 @@
+import path from "node:path";
+
+import { bundleFileUrl } from "./bundle-url";
+
+describe("bundleFileUrl", () => {
+  it("produces a valid, importable file:// URL", () => {
+    const url = bundleFileUrl(path.join("/tmp", "sapiom-bundle", "out.mjs"));
+    expect(() => new URL(url)).not.toThrow();
+    expect(url.startsWith("file://")).toBe(true);
+  });
+
+  it("appends a cache-busting timestamp query param", () => {
+    const url = bundleFileUrl("/tmp/sapiom-bundle/out.mjs");
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has("t")).toBe(true);
+    expect(Number(parsed.searchParams.get("t"))).not.toBeNaN();
+  });
+
+  it("percent-encodes characters a raw `file://${path}` template would leave broken", () => {
+    // A raw `file://${bundlePath}` template previously left spaces
+    // unencoded, producing a URL that Node's `import()` — a strict WHATWG
+    // URL parser — cannot resolve. pathToFileURL encodes them correctly.
+    const url = bundleFileUrl("/tmp/sapiom bundle dir/out.mjs");
+    expect(() => new URL(url)).not.toThrow();
+    expect(url).toContain("%20");
+    expect(url).not.toContain("sapiom bundle dir"); // raw space must not survive
+  });
+
+  it("returns distinct URLs for successive calls (cache-busting)", () => {
+    const first = bundleFileUrl("/tmp/sapiom-bundle/out.mjs");
+    const second = bundleFileUrl("/tmp/sapiom-bundle/out.mjs");
+    expect(new URL(first).searchParams.get("t")).toBeTruthy();
+    expect(new URL(second).searchParams.get("t")).toBeTruthy();
+  });
+});

--- a/packages/agent-core/src/bundle-url.ts
+++ b/packages/agent-core/src/bundle-url.ts
@@ -1,0 +1,21 @@
+/**
+ * Build a cache-busted `file://` URL for `import()`-ing a freshly bundled
+ * file from disk.
+ *
+ * Both `check` and `local/load` bundle an agent to a temp file and then
+ * dynamically `import()` it, appending `?t=<timestamp>` so re-running against
+ * an unchanged path (e.g. `sapiom dev`'s watch loop) doesn't hit Node's ESM
+ * module cache. The URL must be built with `pathToFileURL` rather than a raw
+ * `file://${path}` template: `path.join`/`esbuild`'s output path use the
+ * platform's own separator, so on Windows the raw template produces an
+ * invalid URL (backslashes, and a missing leading `/` before a drive
+ * letter). `pathToFileURL` percent-encodes the path and handles both
+ * platforms correctly.
+ */
+import { pathToFileURL } from "node:url";
+
+export function bundleFileUrl(bundlePath: string): string {
+  const url = pathToFileURL(bundlePath);
+  url.search = `t=${Date.now()}`;
+  return url.href;
+}

--- a/packages/agent-core/src/check.ts
+++ b/packages/agent-core/src/check.ts
@@ -21,6 +21,7 @@ import {
 import * as esbuild from "esbuild";
 
 import { describeBundleFailure } from "./bundle-error.js";
+import { bundleFileUrl } from "./bundle-url.js";
 import { AgentOperationError } from "./errors.js";
 
 /**
@@ -199,7 +200,7 @@ export async function check(opts: CheckOptions): Promise<CheckResult> {
     // definition shape is identical, so everything downstream (buildManifest,
     // graph validation) works unchanged on either.
     const mod: Record<string, unknown> = await import(
-      `file://${bundlePath}?t=${Date.now()}`
+      bundleFileUrl(bundlePath)
     );
     const defs: unknown[] = [];
     for (const value of Object.values(mod)) {

--- a/packages/agent-core/src/local/load.ts
+++ b/packages/agent-core/src/local/load.ts
@@ -19,6 +19,7 @@ import {
 import * as esbuild from "esbuild";
 
 import { describeBundleFailure } from "../bundle-error.js";
+import { bundleFileUrl } from "../bundle-url.js";
 import { AgentOperationError } from "../errors.js";
 
 const LOCAL_SDK_VERSION = "0.0.0-local";
@@ -67,7 +68,7 @@ export async function loadDefinition(
     }
 
     const mod: Record<string, unknown> = await import(
-      `file://${bundlePath}?t=${Date.now()}`
+      bundleFileUrl(bundlePath)
     );
     const defs = Object.values(mod).filter(isAgentDefinition);
     if (defs.length === 0) {


### PR DESCRIPTION
Fixes #612

`check` and `local/load` both bundle an agent to a temp file, then `import()` it via a hand-built `` `file://${bundlePath}?t=${Date.now()}` `` template. `path.join`/esbuild's output path use the platform's own separator, so on Windows this produced an invalid URL (backslashes, and a missing leading `/` before the drive letter), breaking `sapiom check` and `sapiom run` for every Windows user.

**Fix:** extracted a shared `bundleFileUrl(bundlePath)` helper (`bundle-url.ts`) that builds the URL with `pathToFileURL`, used by both call sites. `pathToFileURL` percent-encodes the path and handles both platforms correctly.

**Tests:** added regression tests covering URL validity, the cache-busting timestamp param, and percent-encoding of characters (e.g. spaces) a raw template would leave broken and Node's `import()` — a strict WHATWG URL parser — can't resolve. True Windows backslash behavior can't be exercised on a Linux runner since `pathToFileURL` is itself platform-aware, but the encoding behavior it shares across platforms is directly covered.

**Changeset:** added (`@sapiom/agent-core`, patch).

Verified locally: `pnpm --filter @sapiom/agent-core exec jest src/check.spec.ts src/bundle-url.spec.ts` (15/15 passing), typecheck and eslint clean on all four changed/added source files.