### PR TITLE
chore: add .gitattributes to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Summary

The repository ships no `.gitattributes`, so on Windows (git `core.autocrlf=true`, the default) a fresh clone checks out text files with CRLF. `pnpm test` then fails out of the box: the `skill-sync` drift guard in `packages/agent-core` asserts `content.startsWith("---\nname: ...")`, which is `false` when the `SKILL.md` files are CRLF.

Adding a standard `.gitattributes` normalizes text files to LF on checkout, so a Windows contributor's working tree matches what the tests (and the Linux CI) already expect.

## Change

- `.gitattributes` — `* text=auto eol=lf`

A single line. `git add --renormalize .` stages nothing else (the index is already LF), so there is no mass line-ending churn. No `.bat` / `.cmd` / `.ps1` files exist that would need a `eol=crlf` exception, and no committed fixtures or snapshots depend on CRLF.

## Testing

- Before: on Windows, `pnpm --filter @sapiom/agent-core test` fails two `skill-sync` assertions (`has a canonical source with the … trigger frontmatter`).
- After renormalizing the working tree to honor the new attribute, the `SKILL.md` files check out as LF and `skill-sync` passes 7/7.
- No published package changes, so no changeset is included.
