### PR TITLE
feat(content-generation): route video verbs through the capability router (SAP-2575)

### DIFF
--- a/.changeset/route-video-through-capability.md
+++ b/.changeset/route-video-through-capability.md
@@ -5,3 +5,8 @@
 content-generation: route `video.create` / `video.launch` through the `/v1/capabilities/content.generation.video` router (SAP-2575)
 
 Video verbs now submit through the shared capability router (like images), so the SDK no longer builds the gateway-direct `/run/<model>` URL: `model` is a request-body field the router's adapter resolves server-side (a semantic alias like `"veo3-fast"`, or a raw provider id, defaulted when omitted), and authentication rides the `/v1` guard's `x-api-key` header. The public `video.create` / `video.launch` surface and the submit-then-poll-to-completion behavior are unchanged.
+
+**Breaking — video's base URL moves to Core.** Video now resolves its base URL from Core like every other routed capability (`resolveCoreBaseUrl()` → `SAPIOM_BASE_URL` ?? `SAPIOM_API_URL` ?? `https://api.sapiom.ai`):
+
+- The content-generation-specific `SAPIOM_CONTENT_GENERATION_URL` override is **no longer read** for video — set **`SAPIOM_BASE_URL` / `SAPIOM_API_URL`** instead.
+- Any explicit `baseUrl` passed to `video.create` / `video.launch` must now point to **Core** (e.g. `https://api.sapiom.ai`), **not the Fal gateway**. A Fal-gateway URL here will now hit the wrong host.

--- a/.changeset/route-video-through-capability.md
+++ b/.changeset/route-video-through-capability.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/tools": minor
+---
+
+content-generation: route `video.create` / `video.launch` through the `/v1/capabilities/content.generation.video` router (SAP-2575)
+
+Video verbs now submit through the shared capability router (like images), so the SDK no longer builds the gateway-direct `/run/<model>` URL: `model` is a request-body field the router's adapter resolves server-side (a semantic alias like `"veo3-fast"`, or a raw provider id, defaulted when omitted), and authentication rides the `/v1` guard's `x-api-key` header. The public `video.create` / `video.launch` surface and the submit-then-poll-to-completion behavior are unchanged.

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -282,6 +282,14 @@ describe("contentGeneration.video.create()", () => {
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
+              requestId: "req-merge",
+              statusUrl: `${BASE}/queue/req-merge/status`,
+              responseUrl: `${BASE}/queue/req-merge`,
+            })
+          : null,
+      (c) =>
+        c.init.method === "GET"
+          ? jsonResponse({
               video: {
                 url: "https://media/merged.mp4",
                 content_type: "video/mp4",
@@ -290,17 +298,22 @@ describe("contentGeneration.video.create()", () => {
           : null,
     ]);
 
-    const out = await createVideo({ prompt: "merge" }, transport, BASE);
+    const out = await createVideo(
+      { prompt: "merge", pollIntervalMs: 1 },
+      transport,
+      BASE,
+    );
 
-    // The router returns the sync-completion `video` object (some fal ops, notably
-    // ffmpeg merge, complete inline) — mapped snake → camelCase.
+    // The submit always returns a queue handle (the video adapter's
+    // `fromGatewayResponse` throws without one) — the poll target still returns
+    // fal's raw snake_case result, mapped to camelCase here.
     expect(out).toEqual({
       video: {
         url: "https://media/merged.mp4",
         contentType: "video/mp4",
       },
     });
-    expect(calls).toHaveLength(1);
+    expect(calls).toHaveLength(2);
     expect(calls[0]!.url).toBe(
       `${BASE}/v1/capabilities/content.generation.video`,
     );
@@ -319,12 +332,19 @@ describe("contentGeneration.video.create()", () => {
     const { transport, calls } = makeTransport([
       (c) =>
         c.init.method === "POST"
+          ? jsonResponse({
+              requestId: "req-alias",
+              responseUrl: `${BASE}/queue/req-alias`,
+            })
+          : null,
+      (c) =>
+        c.init.method === "GET"
           ? jsonResponse({ video: { url: "https://media/v.mp4" } })
           : null,
     ]);
 
     await createVideo(
-      { prompt: "a wave", model: "veo3-fast" },
+      { prompt: "a wave", model: "veo3-fast", pollIntervalMs: 1 },
       transport,
       BASE,
     );
@@ -338,6 +358,45 @@ describe("contentGeneration.video.create()", () => {
     });
     // The alias never gets turned into a URL path — the adapter resolves it server-side.
     expect(calls.some((c) => c.url.includes("/run/"))).toBe(false);
+  });
+
+  it("forwards `params` as a nested field, an explicit model verbatim, and `storage`", async () => {
+    const { transport, calls } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({
+              requestId: "req-body-shape",
+              responseUrl: `${BASE}/queue/req-body-shape`,
+            })
+          : null,
+      (c) =>
+        c.init.method === "GET"
+          ? jsonResponse({ video: { url: "https://media/v.mp4" } })
+          : null,
+    ]);
+
+    await createVideo(
+      {
+        prompt: "x",
+        model: "veo3-fast",
+        params: { duration: 8, seed: 42 },
+        storage: { visibility: "private" },
+        pollIntervalMs: 1,
+      },
+      transport,
+      BASE,
+    );
+
+    // model rides as a top-level body field (the caller's semantic alias, not a raw
+    // provider id — the adapter resolves it server-side), and params is nested — not
+    // spread to the top level — so the adapter forwards it verbatim. Mirrors
+    // createImage's identically-named body-shape test.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      model: "veo3-fast",
+      params: { duration: 8, seed: 42 },
+      storage: { visibility: "private" },
+    });
   });
 
   it("derives the result URL when the router returns only statusUrl", async () => {
@@ -549,10 +608,20 @@ describe("contentGeneration.video.create()", () => {
 
   it("`video.create` is the same operation as `createVideo`", async () => {
     const { transport, calls } = makeTransport([
-      () => jsonResponse({ video: { url: "u" } }),
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({
+              requestId: "req-ns2",
+              responseUrl: `${BASE}/queue/req-ns2`,
+            })
+          : null,
+      (c) =>
+        c.init.method === "GET"
+          ? jsonResponse({ video: { url: "u" } })
+          : null,
     ]);
 
-    await video.create({ prompt: "x" }, transport, BASE);
+    await video.create({ prompt: "x", pollIntervalMs: 1 }, transport, BASE);
     expect(calls[0]!.url).toBe(
       `${BASE}/v1/capabilities/content.generation.video`,
     );

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -2,6 +2,7 @@ import { createClient } from "../index.js";
 import { Transport } from "../_client/index.js";
 import {
   images,
+  video,
   createImage,
   launchImage,
   createVideo,
@@ -272,11 +273,11 @@ describe("createClient().contentGeneration.images.create", () => {
 });
 
 // ---------------------------------------------------------------------------
-// contentGeneration.video.create()  — async: submit, then poll until ready
+// contentGeneration.video.create()  — routed submit, then poll until ready
 // ---------------------------------------------------------------------------
 
 describe("contentGeneration.video.create()", () => {
-  it("returns a synchronous video result without trying to poll", async () => {
+  it("POSTs to /v1/capabilities/content.generation.video with x-api-key and the prompt (model omitted → router default)", async () => {
     const { transport, calls } = makeTransport([
       (c) =>
         c.init.method === "POST"
@@ -291,6 +292,8 @@ describe("contentGeneration.video.create()", () => {
 
     const out = await createVideo({ prompt: "merge" }, transport, BASE);
 
+    // The router returns the sync-completion `video` object (some fal ops, notably
+    // ffmpeg merge, complete inline) — mapped snake → camelCase.
     expect(out).toEqual({
       video: {
         url: "https://media/merged.mp4",
@@ -298,15 +301,52 @@ describe("contentGeneration.video.create()", () => {
       },
     });
     expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/capabilities/content.generation.video`,
+    );
+    expect(calls[0]!.init.method).toBe("POST");
+    // Routed verbs authenticate via x-api-key (the /v1 guard's header), NOT the
+    // gateway-direct x-sapiom-api-key — wrong header = silent 401.
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
+    // model omitted → the router's video adapter defaults it; no /run/<model> URL building here.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "merge",
+    });
   });
 
-  it("derives the result URL when Fal returns only status_url", async () => {
+  it("sends a semantic alias verbatim in the body — no /run/<model> URL, no raw provider id in caller code", async () => {
+    const { transport, calls } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({ video: { url: "https://media/v.mp4" } })
+          : null,
+    ]);
+
+    await createVideo(
+      { prompt: "a wave", model: "veo3-fast" },
+      transport,
+      BASE,
+    );
+
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/capabilities/content.generation.video`,
+    );
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "a wave",
+      model: "veo3-fast",
+    });
+    // The alias never gets turned into a URL path — the adapter resolves it server-side.
+    expect(calls.some((c) => c.url.includes("/run/"))).toBe(false);
+  });
+
+  it("derives the result URL when the router returns only statusUrl", async () => {
     const { transport, calls } = makeTransport([
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
-              request_id: "req-status-only",
-              status_url: `${BASE}/queue/fal-ai/ffmpeg-api/requests/req-status-only/status`,
+              requestId: "req-status-only",
+              statusUrl: `${BASE}/queue/fal-ai/ffmpeg-api/requests/req-status-only/status`,
             })
           : null,
       (c) =>
@@ -327,21 +367,22 @@ describe("contentGeneration.video.create()", () => {
     );
   });
 
-  it("submits the default video model, polls until ready, and maps the result to camelCase", async () => {
+  it("polls until ready and maps the raw snake poll result to camelCase", async () => {
     let polls = 0;
     const { transport, calls } = makeTransport([
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
-              request_id: "req-1",
-              response_url: `${BASE}/queue/fal-ai/veo3/requests/req-1`,
-              status_url: `${BASE}/queue/fal-ai/veo3/requests/req-1/status`,
+              requestId: "req-1",
+              responseUrl: `${BASE}/queue/fal-ai/veo3/requests/req-1`,
+              statusUrl: `${BASE}/queue/fal-ai/veo3/requests/req-1/status`,
             })
           : null,
       (c) => {
         if (c.init.method !== "GET") return null;
         polls += 1;
-        // pending first, completed result second
+        // pending first, completed result second — the poll target still returns
+        // fal's RAW snake_case result (the gateway's queue passthrough).
         return polls < 2
           ? jsonResponse({ status: "IN_PROGRESS" })
           : jsonResponse({
@@ -362,12 +403,6 @@ describe("contentGeneration.video.create()", () => {
       video: { url: "https://media/v.mp4", contentType: "video/mp4" },
       seed: 9,
     });
-    // submit: default model, prompt only (no provider named, no storage).
-    expect(calls[0]!.url).toBe(`${BASE}/run/fal-ai/veo3/fast`);
-    expect(calls[0]!.init.method).toBe("POST");
-    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
-      prompt: "a wave",
-    });
     // polled the rewritten result URL until it carried output.
     expect(
       calls.filter(
@@ -383,8 +418,8 @@ describe("contentGeneration.video.create()", () => {
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
-              request_id: "req-2",
-              response_url: `${BASE}/queue/req-2`,
+              requestId: "req-2",
+              responseUrl: `${BASE}/queue/req-2`,
             })
           : null,
       (c) =>
@@ -425,8 +460,8 @@ describe("contentGeneration.video.create()", () => {
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
-              request_id: "req-4",
-              response_url: `${BASE}/queue/req-4`,
+              requestId: "req-4",
+              responseUrl: `${BASE}/queue/req-4`,
             })
           : null,
       (c) =>
@@ -465,8 +500,8 @@ describe("contentGeneration.video.create()", () => {
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
-              request_id: "req-3",
-              response_url: `${BASE}/queue/req-3`,
+              requestId: "req-3",
+              responseUrl: `${BASE}/queue/req-3`,
             })
           : null,
       (c) =>
@@ -490,8 +525,8 @@ describe("contentGeneration.video.create()", () => {
       (c) =>
         c.init.method === "POST"
           ? jsonResponse({
-              request_id: "req-5",
-              response_url: `${BASE}/queue/req-5`,
+              requestId: "req-5",
+              responseUrl: `${BASE}/queue/req-5`,
             })
           : null,
       (c) => {
@@ -511,6 +546,17 @@ describe("contentGeneration.video.create()", () => {
 
     expect(out.video?.url).toBe("https://media/v5.mp4");
   });
+
+  it("`video.create` is the same operation as `createVideo`", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ video: { url: "u" } }),
+    ]);
+
+    await video.create({ prompt: "x" }, transport, BASE);
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/capabilities/content.generation.video`,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -518,7 +564,7 @@ describe("contentGeneration.video.create()", () => {
 // ---------------------------------------------------------------------------
 
 describe("createClient().contentGeneration.video.create", () => {
-  it("binds to the client credential + default host, submits then polls to the result", async () => {
+  it("binds to the client credential + the Core base URL, sending x-api-key, submits then polls to the result", async () => {
     let polls = 0;
     const calls: FetchCall[] = [];
     const fetchMock = (async (
@@ -528,8 +574,8 @@ describe("createClient().contentGeneration.video.create", () => {
       calls.push({ url: String(input), init });
       if (init.method === "POST") {
         return jsonResponse({
-          request_id: "r",
-          response_url: "https://fal.services.sapiom.ai/queue/r",
+          requestId: "r",
+          responseUrl: "https://api.sapiom.ai/queue/r",
         });
       }
       polls += 1;
@@ -547,14 +593,15 @@ describe("createClient().contentGeneration.video.create", () => {
 
     expect(out.video?.fileId).toBe("f");
     expect(calls[0]!.url).toBe(
-      "https://fal.services.sapiom.ai/run/fal-ai/veo3/fast",
+      "https://api.sapiom.ai/v1/capabilities/content.generation.video",
     );
-    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("client-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
   });
 });
 
 // ---------------------------------------------------------------------------
-// contentGeneration.video.launch() — dispatch handle + workflow resume token
+// contentGeneration.video.launch() — routed async dispatch + resume token
 // ---------------------------------------------------------------------------
 
 function makeLaunchTransport(
@@ -588,11 +635,11 @@ function makeLaunchTransport(
 }
 
 describe("contentGeneration.video.launch()", () => {
-  it("accepts a status_url-only submit handle", async () => {
+  it("accepts a statusUrl-only submit handle, deriving the poll URL by stripping /status", async () => {
     const { transport } = makeLaunchTransport(
       {
-        request_id: "req-status-only",
-        status_url: `${BASE}/queue/fal-ai/ffmpeg-api/requests/req-status-only/status`,
+        requestId: "req-status-only",
+        statusUrl: `${BASE}/queue/fal-ai/ffmpeg-api/requests/req-status-only/status`,
       },
       { video: { url: "https://media/merged.mp4" } },
     );
@@ -605,27 +652,43 @@ describe("contentGeneration.video.launch()", () => {
     });
   });
 
-  it("submits to the right URL and method, returns a handle with requestId and dispatch", async () => {
+  it("POSTs the routed capability with x-api-key, model as a body field, and returns a handle", async () => {
     const { transport, calls } = makeLaunchTransport(
       {
-        request_id: "req-launch-1",
-        response_url: `${BASE}/queue/req-launch-1`,
+        requestId: "req-launch-1",
+        responseUrl: `${BASE}/queue/req-launch-1`,
       },
       { video: { url: "https://media/v.mp4" } },
     );
 
-    const handle = await launchVideo({ prompt: "a wave" }, transport, BASE);
+    const handle = await launchVideo(
+      { prompt: "a wave", model: "veo3-fast" },
+      transport,
+      BASE,
+    );
 
-    expect(calls[0]!.url).toBe(`${BASE}/run/fal-ai/veo3/fast`);
+    // Routed URL (Core capability route), NOT a fal-direct /run/<model> path.
+    expect(calls[0]!.url).toBe(
+      `${BASE}/v1/capabilities/content.generation.video`,
+    );
     expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-api-key")).toBe("test-key");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
+    // Video is async-only (no sync/async choice, unlike images), so the body carries
+    // no `dispatch` field — `model` rides as a body field (a semantic alias here) and
+    // the adapter resolves it server-side.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "a wave",
+      model: "veo3-fast",
+    });
     expect(handle.requestId).toBe("req-launch-1");
   });
 
   it("dispatch.correlationId equals requestId and dispatch.resultSignal equals VIDEO_RESULT_SIGNAL", async () => {
     const { transport } = makeLaunchTransport(
       {
-        request_id: "req-dispatch",
-        response_url: `${BASE}/queue/req-dispatch`,
+        requestId: "req-dispatch",
+        responseUrl: `${BASE}/queue/req-dispatch`,
       },
       { video: { url: "https://media/v.mp4" } },
     );
@@ -642,7 +705,7 @@ describe("contentGeneration.video.launch()", () => {
 
   it("includes x-sapiom-workflow-token when transport.resumeToken is set", async () => {
     const { transport, calls } = makeLaunchTransport(
-      { request_id: "req-tok", response_url: `${BASE}/queue/req-tok` },
+      { requestId: "req-tok", responseUrl: `${BASE}/queue/req-tok` },
       { video: { url: "u" } },
       "tok-workflow-abc",
     );
@@ -656,7 +719,7 @@ describe("contentGeneration.video.launch()", () => {
 
   it("omits x-sapiom-workflow-token when resumeToken is not set", async () => {
     const { transport, calls } = makeLaunchTransport(
-      { request_id: "req-notok", response_url: `${BASE}/queue/req-notok` },
+      { requestId: "req-notok", responseUrl: `${BASE}/queue/req-notok` },
       { video: { url: "u" } },
     );
 
@@ -676,8 +739,8 @@ describe("contentGeneration.video.launch()", () => {
       ): Promise<Response> => {
         calls.push({ url: String(input), init });
         return jsonResponse({
-          request_id: "req-env",
-          response_url: `${BASE}/queue/req-env`,
+          requestId: "req-env",
+          responseUrl: `${BASE}/queue/req-env`,
         });
       }) as typeof globalThis.fetch;
       // Transport reads env var when resumeToken is not explicitly set
@@ -691,7 +754,7 @@ describe("contentGeneration.video.launch()", () => {
     }
   });
 
-  it("wait() polls the response_url and returns the mapped result", async () => {
+  it("wait() polls the responseUrl and returns the mapped result", async () => {
     let polls = 0;
     const calls: FetchCall[] = [];
     const fetchMock = (async (
@@ -702,8 +765,8 @@ describe("contentGeneration.video.launch()", () => {
       calls.push({ url, init });
       if (init.method === "POST") {
         return jsonResponse({
-          request_id: "req-wait",
-          response_url: `${BASE}/queue/req-wait`,
+          requestId: "req-wait",
+          responseUrl: `${BASE}/queue/req-wait`,
         });
       }
       polls += 1;
@@ -731,7 +794,7 @@ describe("contentGeneration.video.launch()", () => {
 
   it("wait() maps fileId and passes storage on submit", async () => {
     const { transport, calls } = makeLaunchTransport(
-      { request_id: "req-store", response_url: `${BASE}/queue/req-store` },
+      { requestId: "req-store", responseUrl: `${BASE}/queue/req-store` },
       { video: { url: "https://media/v.mp4", file_id: "f-store" } },
     );
 
@@ -762,7 +825,7 @@ describe("contentGeneration.video.launch()", () => {
 
   it("wait() throws if the result isn't ready before the timeout", async () => {
     const { transport } = makeLaunchTransport(
-      { request_id: "req-timeout", response_url: `${BASE}/queue/req-timeout` },
+      { requestId: "req-timeout", responseUrl: `${BASE}/queue/req-timeout` },
       { status: "IN_PROGRESS" },
     );
 
@@ -783,8 +846,8 @@ describe("contentGeneration.video.launch()", () => {
       ): Promise<Response> => {
         calls.push({ url: String(input), init });
         return jsonResponse({
-          request_id: "req-explicit",
-          response_url: `${BASE}/queue/req-explicit`,
+          requestId: "req-explicit",
+          responseUrl: `${BASE}/queue/req-explicit`,
         });
       }) as typeof globalThis.fetch;
       const transport = new Transport({
@@ -799,6 +862,17 @@ describe("contentGeneration.video.launch()", () => {
     } finally {
       delete process.env[KEY];
     }
+  });
+
+  it("`video.launch` is the same operation as `launchVideo`", async () => {
+    const { transport } = makeLaunchTransport(
+      { requestId: "req-ns", responseUrl: `${BASE}/queue/req-ns` },
+      { video: { url: "u" } },
+    );
+
+    const handle = await video.launch({ prompt: "x" }, transport, BASE);
+    expect(handle.requestId).toBe("req-ns");
+    expect(handle.dispatch.resultSignal).toBe(VIDEO_RESULT_SIGNAL);
   });
 });
 
@@ -818,8 +892,8 @@ describe("createClient().contentGeneration.video.launch", () => {
       ): Promise<Response> => {
         calls.push({ url: String(input), init });
         return jsonResponse({
-          request_id: "r-client",
-          response_url: "https://fal.services.sapiom.ai/queue/r-client",
+          requestId: "r-client",
+          responseUrl: "https://api.sapiom.ai/queue/r-client",
         });
       }) as typeof globalThis.fetch;
 
@@ -831,9 +905,10 @@ describe("createClient().contentGeneration.video.launch", () => {
       expect(handle.requestId).toBe("r-client");
       expect(handle.dispatch.resultSignal).toBe(VIDEO_RESULT_SIGNAL);
       expect(calls[0]!.url).toBe(
-        "https://fal.services.sapiom.ai/run/fal-ai/veo3/fast",
+        "https://api.sapiom.ai/v1/capabilities/content.generation.video",
       );
-      expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("client-key");
+      expect(headerOf(calls[0]!, "x-api-key")).toBe("client-key");
+      expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBeUndefined();
       expect(headerOf(calls[0]!, "x-sapiom-workflow-token")).toBe(
         "tok-client-bind",
       );
@@ -856,7 +931,7 @@ describe("contentGeneration.images.launch()", () => {
 
     const handle = await launchImage({ prompt: "a red bike" }, transport, BASE);
 
-    // Routed URL (Core), NOT the fal-direct /run/<model> path video uses.
+    // Routed URL (Core capability route), NOT a fal-direct /run/<model> path.
     expect(calls[0]!.url).toBe(
       `${BASE}/v1/capabilities/content.generation.images`,
     );

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -25,21 +25,10 @@ import {
   defaultTransport,
   resolveCoreBaseUrl,
 } from "../_client/index.js";
-import { resolveServiceUrl } from "../_client/service-url.js";
-import { ensureOk, ContentGenerationHttpError } from "./errors.js";
+import { ContentGenerationHttpError } from "./errors.js";
 import type { DispatchHandle } from "../dispatch.js";
 
 export { ContentGenerationHttpError };
-
-/**
- * Base URL for the still-provider-direct video ops (deferred — async/poll, SAP-1117).
- * The routed `images.create` verb does NOT use this; it resolves the single Core
- * base URL at call time via {@link resolveCoreBaseUrl} (SAP-1116).
- */
-const DEFAULT_BASE_URL = resolveServiceUrl(
-  "fal",
-  process.env.SAPIOM_CONTENT_GENERATION_URL,
-);
 
 /**
  * Capability-stable signal a video launch fires when the video reaches a terminal
@@ -177,11 +166,6 @@ function mapResult(raw: RawImageResult): ImageGenerationResult {
 }
 
 // ----- Capability operations -----
-
-/** Encode a model id into a URL path, preserving its `/` separators. */
-function modelToPath(model: string): string {
-  return model.split("/").filter(Boolean).map(encodeURIComponent).join("/");
-}
 
 /**
  * Guard a prompt value: throw a clear error before a paid job is submitted when
@@ -462,15 +446,15 @@ export const images = { create: createImage, launch: launchImage };
 type LiteralUnion<T extends string> = T | (string & Record<never, never>);
 
 /**
- * The concrete video models the Sapiom video gateway serves today, ready to pass as
- * {@link VideoCreateInput.model} — e.g. `VIDEO_MODELS.veo3Fast`. Omit `model` to use the
- * default (`veo3Fast`).
+ * The concrete provider video model ids the Sapiom video gateway serves, ready to pass as
+ * {@link VideoCreateInput.model} — e.g. `VIDEO_MODELS.veo3Fast`.
  *
- * These are raw *provider* model ids. They are deliberately NOT the Sapiom backend's
- * semantic aliases (`"veo3-fast"`, `"kling-standard"`, …): those aliases resolve server-side
- * ONLY on the `content.generation.video` capability route. This SDK forwards `model` verbatim
- * to the video gateway, so passing a semantic alias here fails upstream with a 404. When in
- * doubt, use a value from this object.
+ * @deprecated Raw provider ids are no longer required. `video.create`/`video.launch` route
+ * through the `content.generation.video` capability (SAP-2575), and that capability's adapter
+ * resolves Sapiom's semantic aliases (`"veo3-fast"`, `"kling-standard"`, …) server-side — pass
+ * one of those directly to {@link VideoCreateInput.model} instead. Kept exported for
+ * back-compat: a raw provider id from this object still works, the adapter passes an
+ * already-resolved id straight through.
  */
 export const VIDEO_MODELS = {
   /** Google Veo 3 Fast — fast text-to-video. The default. */
@@ -488,8 +472,6 @@ export const VIDEO_MODELS = {
 /** A known video model id — one of the values of {@link VIDEO_MODELS}. */
 export type KnownVideoModel = (typeof VIDEO_MODELS)[keyof typeof VIDEO_MODELS];
 
-/** Default video model when the caller doesn't pick one. */
-const DEFAULT_VIDEO_MODEL: KnownVideoModel = VIDEO_MODELS.veo3Fast;
 /** How often to poll for the async result, and when to give up. Caller-overridable. */
 const DEFAULT_VIDEO_POLL_INTERVAL_MS = 5_000;
 const DEFAULT_VIDEO_TIMEOUT_MS = 5 * 60_000;
@@ -498,14 +480,14 @@ export interface VideoCreateInput {
   /** Text prompt describing the video to generate. */
   prompt: string;
   /**
-   * Optional video model. Omit to use the default ({@link VIDEO_MODELS.veo3Fast}).
+   * Optional video model. Omit to use the router's default (currently Veo 3 Fast).
    *
-   * Pass a value from {@link VIDEO_MODELS} — a raw *provider* model id. The Sapiom backend's
-   * semantic aliases (`"veo3-fast"`, `"kling-standard"`, …) are NOT accepted here: they resolve
-   * only on the server-side `content.generation.video` capability route, whereas this SDK
-   * forwards `model` verbatim to the gateway, so an alias fails upstream with a 404.
+   * Pass a Sapiom semantic alias (`"veo3-fast"`, `"kling-standard"`, …) or a raw *provider*
+   * model id from {@link VIDEO_MODELS} — both resolve: the request routes through the
+   * `content.generation.video` capability, whose adapter resolves an alias to its provider
+   * id server-side (SAP-2575).
    *
-   * @example VIDEO_MODELS.veo3Fast
+   * @example "veo3-fast"
    */
   model?: LiteralUnion<KnownVideoModel>;
   /**
@@ -570,23 +552,30 @@ interface RawVideoResult {
   [key: string]: unknown;
 }
 
-/** The async submit handle: a queue id + the Sapiom URL to poll for the result. */
-interface QueueHandle {
-  request_id?: string;
-  response_url?: string;
-  status_url?: string;
+/**
+ * The routed async-submit handle the Core capability router returns for the video
+ * capability — camelCase (the router normalizes fal's snake_case), with `servedBy`
+ * stripped at the public `/v1` boundary. Mirrors {@link ImageDispatchResponse}.
+ *
+ * NOTE: this is only the SUBMIT envelope's shape. The URL it carries
+ * (`responseUrl`/`statusUrl`) points at the gateway's queue passthrough, which still
+ * returns fal's RAW snake_case result — see {@link RawVideoResult} and {@link mapVideo}.
+ */
+interface VideoDispatchResponse {
+  requestId: string;
+  statusUrl: string;
+  responseUrl?: string;
 }
 
 /**
- * The upstream service occasionally omits `response_url` while still returning the canonical
- * `.../requests/:id/status` URL. The result endpoint is the same URL without
- * the final `/status` segment, so keep async video launches usable in that
- * valid response shape.
+ * The result endpoint to poll. Prefer `responseUrl`; fall back to `statusUrl` with a
+ * trailing `/status` removed — the same convention as {@link imageResultUrl} — so an
+ * async video launch stays usable when only `statusUrl` comes back.
  */
-function queueResultUrl(handle: QueueHandle): string | undefined {
-  if (handle.response_url) return handle.response_url;
-  if (!handle.status_url) return undefined;
-  const url = new URL(handle.status_url);
+function videoResultUrl(handle: VideoDispatchResponse): string | undefined {
+  if (handle.responseUrl) return handle.responseUrl;
+  if (!handle.statusUrl) return undefined;
+  const url = new URL(handle.statusUrl);
   if (!url.pathname.endsWith("/status")) return undefined;
   url.pathname = url.pathname.slice(0, -"/status".length);
   return url.toString();
@@ -622,37 +611,49 @@ const sleep = (ms: number): Promise<void> =>
  * persist the output (the returned `video` then carries `fileId`). Throws
  * {@link ContentGenerationHttpError} on a failed submit, or an `Error` if the result
  * isn't ready within `timeoutMs`.
+ *
+ * Routed (SAP-2575): the submit goes through the shared {@link capabilityCall} seam to
+ * `POST /v1/capabilities/content.generation.video` on the single Core base URL — the
+ * same seam {@link createImage} uses. `model` is a request-body field the router's video
+ * adapter resolves (a semantic alias like `"veo3-fast"`, or a raw provider id, and
+ * defaults when omitted); the SDK no longer builds a `/run/<model>` URL itself. The poll
+ * loop is unchanged: the submit response's `responseUrl`/`statusUrl` point at the
+ * gateway's queue passthrough, which still returns fal's raw snake_case result.
  */
 export async function createVideo(
   input: VideoCreateInput,
   transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_BASE_URL,
+  baseUrl: string = resolveCoreBaseUrl(),
 ): Promise<VideoGenerationResult> {
   assertPrompt(input.prompt);
-  const path = modelToPath(input.model || DEFAULT_VIDEO_MODEL);
 
-  const body: Record<string, unknown> = {
-    prompt: input.prompt,
-    ...input.params,
-  };
+  // Map to the router's camelCase video request. `params` rides as a nested field
+  // (not spread) so the adapter forwards it verbatim; `model` is a body field the
+  // adapter resolves — mirrors createImage's body byte-for-byte.
+  const body: Record<string, unknown> = { prompt: input.prompt };
+  if (input.model != null) body.model = input.model;
   // Truthy check (not `!== undefined`) so `storage: null` is treated as "no storage".
   if (input.storage) body.storage = input.storage;
+  if (input.params != null) body.params = input.params;
 
-  // Submit — for an async model Sapiom returns a queue handle, not the result.
-  const submitRes = await ensureOk(
-    await transport.fetch(`${baseUrl}/run/${path}`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
-    }),
-    "Failed to submit video generation",
+  // Submit through the capability router — for an async model this returns a queue
+  // handle (camelCase requestId/statusUrl/responseUrl), not the result.
+  const submitted = await capabilityCall<VideoDispatchResponse & RawVideoResult>(
+    "content.generation.video",
+    body,
+    {
+      transport,
+      baseUrl,
+      makeError: (message, status, errorBody) =>
+        new ContentGenerationHttpError(message, status, errorBody),
+      errorPrefix: "Failed to submit video generation",
+    },
   );
-  const submitted = (await submitRes.json()) as QueueHandle & RawVideoResult;
   // Some Fal video operations (notably ffmpeg merge) complete synchronously and
   // return the final `video` object instead of a queue handle.
   if (submitted.video?.url) return mapVideoResult(submitted);
   const handle = submitted;
-  const responseUrl = queueResultUrl(handle);
+  const responseUrl = videoResultUrl(handle);
   if (!responseUrl) {
     throw new Error("Video submit did not return a result URL to poll");
   }
@@ -680,7 +681,7 @@ export async function createVideo(
     await sleep(intervalMs);
   }
   throw new Error(
-    `Video generation did not complete within ${timeoutMs}ms (request id: ${handle.request_id ?? "unknown"})`,
+    `Video generation did not complete within ${timeoutMs}ms (request id: ${handle.requestId ?? "unknown"})`,
   );
 }
 
@@ -770,41 +771,56 @@ export function toVideoResumePayload(
  *
  * Pass `storage` to persist the output (the result then carries `fileId`).
  * Throws {@link ContentGenerationHttpError} when the submit fails.
+ *
+ * Routed (SAP-2575): the submit is identical to {@link createVideo}'s — same body,
+ * same `POST /v1/capabilities/content.generation.video` call through the shared
+ * {@link capabilityCall} seam. Unlike images, video has no sync/async choice (it's
+ * the first capability that is ASYNC-dispatch only), so there's no `dispatch` field
+ * to set here; `launchVideo` differs from `createVideo` only in returning the
+ * dispatch handle (for workflow pause/resume) instead of polling to completion
+ * itself. Workflow resume is driven by forwarding the engine's resume token via
+ * {@link workflowResumeHeaders} so the service resumes the paused step on
+ * completion. `model` resolves the same way as `createVideo` (semantic alias or
+ * raw provider id, defaulted when omitted). The poll stays unchanged: `wait()`
+ * reads the gateway's queue passthrough, which still returns fal's raw
+ * snake_case result.
  */
 export async function launchVideo(
   input: VideoCreateInput,
   transport: Transport = defaultTransport(),
-  baseUrl = DEFAULT_BASE_URL,
+  baseUrl: string = resolveCoreBaseUrl(),
 ): Promise<VideoLaunchHandle> {
   assertPrompt(input.prompt);
-  const path = modelToPath(input.model || DEFAULT_VIDEO_MODEL);
 
-  const body: Record<string, unknown> = {
-    prompt: input.prompt,
-    ...input.params,
-  };
+  // Mirror createVideo's body byte-for-byte — video is async-only, so there's no
+  // `dispatch` field to add (unlike launchImage, which sets `dispatch: 'async'` to
+  // pick the queue path over images' sync default).
+  const body: Record<string, unknown> = { prompt: input.prompt };
+  if (input.model != null) body.model = input.model;
   if (input.storage) body.storage = input.storage;
+  if (input.params != null) body.params = input.params;
 
-  // Submit — includes the workflow resume token header so the service can resume
-  // the paused step when the job completes (no-op outside a workflow context).
-  const submitRes = await ensureOk(
-    await transport.fetch(`${baseUrl}/run/${path}`, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        ...workflowResumeHeaders(transport.resumeToken),
-      },
-      body: JSON.stringify(body),
-    }),
-    "Failed to submit video generation",
+  const handle = await capabilityCall<VideoDispatchResponse>(
+    "content.generation.video",
+    body,
+    {
+      transport,
+      baseUrl,
+      // Forward the resume token so the service resumes a paused workflow step when the
+      // job completes (no header, no behavior change outside a workflow context).
+      headers: workflowResumeHeaders(transport.resumeToken),
+      makeError: (message, status, errorBody) =>
+        new ContentGenerationHttpError(message, status, errorBody),
+      errorPrefix: "Failed to submit video generation",
+    },
   );
-  const handle = (await submitRes.json()) as QueueHandle;
-  const responseUrl = queueResultUrl(handle);
+
+  const responseUrl = videoResultUrl(handle);
   if (!responseUrl) {
     throw new Error("Video submit did not return a result URL to poll");
   }
 
-  const requestId = handle.request_id ?? "unknown";
+  const requestId = handle.requestId ?? "unknown";
 
   const wait = async ({
     timeoutMs = input.timeoutMs ?? DEFAULT_VIDEO_TIMEOUT_MS,

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -636,9 +636,10 @@ export async function createVideo(
   if (input.storage) body.storage = input.storage;
   if (input.params != null) body.params = input.params;
 
-  // Submit through the capability router — for an async model this returns a queue
-  // handle (camelCase requestId/statusUrl/responseUrl), not the result.
-  const submitted = await capabilityCall<VideoDispatchResponse & RawVideoResult>(
+  // Submit through the capability router — the video capability's adapter always
+  // returns a queue handle (camelCase requestId/statusUrl/responseUrl), never the
+  // finished result inline (its `fromGatewayResponse` throws without a handle).
+  const handle = await capabilityCall<VideoDispatchResponse>(
     "content.generation.video",
     body,
     {
@@ -649,10 +650,6 @@ export async function createVideo(
       errorPrefix: "Failed to submit video generation",
     },
   );
-  // Some Fal video operations (notably ffmpeg merge) complete synchronously and
-  // return the final `video` object instead of a queue handle.
-  if (submitted.video?.url) return mapVideoResult(submitted);
-  const handle = submitted;
   const responseUrl = videoResultUrl(handle);
   if (!responseUrl) {
     throw new Error("Video submit did not return a result URL to poll");

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -554,12 +554,12 @@ interface RawVideoResult {
 
 /**
  * The routed async-submit handle the Core capability router returns for the video
- * capability — camelCase (the router normalizes fal's snake_case), with `servedBy`
+ * capability — camelCase (the router normalizes the provider's snake_case), with `servedBy`
  * stripped at the public `/v1` boundary. Mirrors {@link ImageDispatchResponse}.
  *
  * NOTE: this is only the SUBMIT envelope's shape. The URL it carries
  * (`responseUrl`/`statusUrl`) points at the gateway's queue passthrough, which still
- * returns fal's RAW snake_case result — see {@link RawVideoResult} and {@link mapVideo}.
+ * returns the provider's RAW snake_case result — see {@link RawVideoResult} and {@link mapVideo}.
  */
 interface VideoDispatchResponse {
   requestId: string;
@@ -618,7 +618,7 @@ const sleep = (ms: number): Promise<void> =>
  * adapter resolves (a semantic alias like `"veo3-fast"`, or a raw provider id, and
  * defaults when omitted); the SDK no longer builds a `/run/<model>` URL itself. The poll
  * loop is unchanged: the submit response's `responseUrl`/`statusUrl` point at the
- * gateway's queue passthrough, which still returns fal's raw snake_case result.
+ * gateway's queue passthrough, which still returns the provider's raw snake_case result.
  */
 export async function createVideo(
   input: VideoCreateInput,
@@ -779,7 +779,7 @@ export function toVideoResumePayload(
  * {@link workflowResumeHeaders} so the service resumes the paused step on
  * completion. `model` resolves the same way as `createVideo` (semantic alias or
  * raw provider id, defaulted when omitted). The poll stays unchanged: `wait()`
- * reads the gateway's queue passthrough, which still returns fal's raw
+ * reads the gateway's queue passthrough, which still returns the provider's raw
  * snake_case result.
  */
 export async function launchVideo(


### PR DESCRIPTION
## E1 — Video transport consolidation (SAP-2575) · SDK half

Repoint `contentGeneration.video.*` from **provider-direct** (`POST ${falGateway}/run/<model>` + self-poll) onto the **capability router** — the same `capabilityCall` seam `contentGeneration.images` already uses. A clean swap: the backend `content.generation.video` capability is already registered and built for it (SAP-1666).

### What changed — `packages/tools/src/content-generation/`
- `createVideo` / `launchVideo` submit via `capabilityCall("content.generation.video", …)` on the single Core base URL (`resolveCoreBaseUrl()`) instead of building a `/run/<model>` URL against the fal gateway.
- `model` is now a request-body field the router's adapter resolves → **semantic aliases (`veo3-fast`, …) resolve from the SDK, no raw provider id required** (the literal fix). `params` ride nested (the adapter re-spreads them), matching the image path.
- Submit handle is camelCase (`{ requestId, statusUrl, responseUrl? }`); the polled result stays fal's raw shape (`mapVideo`). Public handle `{ requestId, dispatch, wait }` is **byte-identical**.
- `VIDEO_MODELS` `@deprecated`; dead code removed (`DEFAULT_BASE_URL`, `modelToPath`, `DEFAULT_VIDEO_MODEL`); the stale "aliases 404" docs corrected.
- `launchVideo` no longer sends `dispatch: 'async'` — `VideoCreateRequest` has no such field (video is async-only, unlike images).

### Acceptance
- [x] `video.launch({ model: 'veo3-fast' })` succeeds with no provider id in caller code — **verified live** against a local backend (handle returned, alias resolved, no 404).
- [x] Public handle shape byte-identical; `servedBy` stripped at the backend boundary (unchanged).
- [x] 522 unit tests green (content-generation 79/79), typecheck + lint clean.

### Follow-ups (not here)
- Backend: workflow pause/resume regression test through the routed path (the riskiest surface).
- SDK release + migration note; submit→asset-ready p50/p95 per model on the shared media-generation board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)