### PR TITLE
feat(content-generation): surface SAP-2576 cost envelope on SDK media results

### DIFF
--- a/.changeset/content-generation-cost-envelope.md
+++ b/.changeset/content-generation-cost-envelope.md
@@ -2,11 +2,13 @@
 "@sapiom/tools": minor
 ---
 
-content-generation: surface the SAP-2576 per-generation cost envelope on image & video results
+content-generation: surface the SAP-2576 per-generation cost envelope + `resolvedModel` across every media-result path
 
-`ImageGenerationResult` / `VideoGenerationResult` — and the `images.launch` / `video.launch`
-handles — now carry `cost?: MediaCostEnvelope` (`estimateUsd` inline plus the settled charge
-out-of-band via `cost.reference`) and `resolvedModel?`, mirroring the backend capability
-contract (SAP-2576). For video the envelope resolves at submit, so it is threaded from the
-dispatch handle onto the polled result (the gateway's queue passthrough carries neither). A
-reseller can now price a generation without a second API call.
+Consumers (e.g. Polsia ads re-billing its customers' wallets) can now price a generation without a second API call, consistently across synchronous image calls, polled results, launch handles, AND durable workflow resumes:
+
+- New `MediaCostEnvelope` (`estimateUsd` inline + the settled charge out-of-band via `cost.reference`) and `resolvedModel` on `ImageGenerationResult` / `VideoGenerationResult` and the `images.launch` / `video.launch` handles.
+- `resolvedModel` is **required** (the routed backend always echoes it — a cataloged raw id reverse-maps to its alias, an uncataloged one is echoed verbatim), matching the backend SAP-2576 contract. `cost` stays optional (quote/reference are best-effort).
+- The durable resume payload (`VideoResultPayload` / `ImageResultPayload`, via `toVideoResumePayload` / `toImageResumePayload`) now carries `resolvedModel` + `cost` (new shared `MediaResumeFields`), so a workflow step that bills in the **resumed** step — after generation — can still read `cost.reference`.
+- For video the envelope resolves at submit and is threaded from the dispatch handle onto the polled result (the gateway's queue passthrough carries neither).
+
+> Companion (backend, chengdu): the Fal workflow-resume producer must emit `resolvedModel` + `cost` in the resume payload JSON for real webhook-driven resumes to carry them; the SDK mapper covers local stubs/tests only.

--- a/.changeset/content-generation-cost-envelope.md
+++ b/.changeset/content-generation-cost-envelope.md
@@ -1,0 +1,12 @@
+---
+"@sapiom/tools": minor
+---
+
+content-generation: surface the SAP-2576 per-generation cost envelope on image & video results
+
+`ImageGenerationResult` / `VideoGenerationResult` — and the `images.launch` / `video.launch`
+handles — now carry `cost?: MediaCostEnvelope` (`estimateUsd` inline plus the settled charge
+out-of-band via `cost.reference`) and `resolvedModel?`, mirroring the backend capability
+contract (SAP-2576). For video the envelope resolves at submit, so it is threaded from the
+dispatch handle onto the polled result (the gateway's queue passthrough carries neither). A
+reseller can now price a generation without a second API call.

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -1217,11 +1217,16 @@ describe("cost envelope (SAP-2576)", () => {
     expect(out.video?.url).toBe("https://media/v.mp4");
   });
 
-  it("createVideo leaves the result untouched when the submit handle carries no cost", async () => {
+  it("createVideo surfaces resolvedModel with no cost when the quote was unavailable", async () => {
     const { transport } = makeTransport([
       (c) =>
         c.init.method === "POST"
-          ? jsonResponse({ requestId: "r", responseUrl: `${BASE}/queue/r` })
+          ? jsonResponse({
+              requestId: "r",
+              responseUrl: `${BASE}/queue/r`,
+              // Contract: the router always echoes resolvedModel, even when the price join is down.
+              resolvedModel: "veo3-fast",
+            })
           : null,
       (c) =>
         c.init.method === "GET"
@@ -1235,9 +1240,34 @@ describe("cost envelope (SAP-2576)", () => {
       BASE,
     );
 
-    expect(out).toEqual({ video: { url: "https://media/v.mp4" } });
+    expect(out.resolvedModel).toBe("veo3-fast");
     expect(out.cost).toBeUndefined();
-    expect(out.resolvedModel).toBeUndefined();
+    expect(out.video?.url).toBe("https://media/v.mp4");
+  });
+
+  it("createVideo echoes a legacy raw provider id as resolvedModel", async () => {
+    const { transport } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({
+              requestId: "r-raw",
+              responseUrl: `${BASE}/queue/r-raw`,
+              resolvedModel: "fal-ai/veo3/fast",
+            })
+          : null,
+      (c) =>
+        c.init.method === "GET"
+          ? jsonResponse({ video: { url: "https://media/v.mp4" } })
+          : null,
+    ]);
+
+    const out = await createVideo(
+      { prompt: "x", model: "fal-ai/veo3/fast", pollIntervalMs: 1 },
+      transport,
+      BASE,
+    );
+
+    expect(out.resolvedModel).toBe("fal-ai/veo3/fast");
   });
 
   it("launchVideo exposes cost + resolvedModel on the handle AND on the wait() result", async () => {
@@ -1297,37 +1327,76 @@ describe("cost envelope (SAP-2576)", () => {
 // ---------------------------------------------------------------------------
 
 describe("toVideoResumePayload()", () => {
+  const M = "veo3-fast";
+
+  // SAP-2576: the durable resume payload MUST carry resolvedModel + cost, so a step that bills
+  // in the resumed step (after generation) can still read cost.reference / resolvedModel.
+  it("carries resolvedModel + cost onto the resume payload (the Polsia rebilling case)", () => {
+    const payload = toVideoResumePayload({
+      video: { url: "https://media/v.mp4", fileId: "f-1" },
+      resolvedModel: M,
+      cost: {
+        estimateUsd: 0.4,
+        currency: "USD",
+        isEstimate: true,
+        source: "quote",
+        reference: "txn_abc123",
+      },
+    });
+    expect(payload.resolvedModel).toBe(M);
+    expect(payload.cost?.reference).toBe("txn_abc123");
+    expect(payload.outputs).toEqual([{ fileId: "f-1" }]);
+  });
+
+  it("carries a reference-only cost envelope (quote unavailable, transaction still created)", () => {
+    const payload = toVideoResumePayload({
+      video: { url: "u" },
+      resolvedModel: M,
+      cost: { reference: "txn_only" },
+    });
+    expect(payload.cost).toEqual({ reference: "txn_only" });
+    expect(payload.resolvedModel).toBe(M);
+  });
+
   it("maps a video with fileId to outputs[0].fileId", () => {
     const payload = toVideoResumePayload({
       video: { url: "https://media/v.mp4", fileId: "f-1" },
+      resolvedModel: M,
     });
-    expect(payload).toEqual({ outputs: [{ fileId: "f-1" }] });
+    expect(payload).toEqual({ resolvedModel: M, outputs: [{ fileId: "f-1" }] });
   });
 
   it("maps a video with storageError to outputs[0].storageError", () => {
     const payload = toVideoResumePayload({
       video: { url: "https://media/v.mp4", storageError: "quota exceeded" },
+      resolvedModel: M,
     });
-    expect(payload).toEqual({ outputs: [{ storageError: "quota exceeded" }] });
+    expect(payload).toEqual({
+      resolvedModel: M,
+      outputs: [{ storageError: "quota exceeded" }],
+    });
   });
 
   it("maps a video with neither fileId nor storageError to an empty-field outputs[0]", () => {
     const payload = toVideoResumePayload({
       video: { url: "https://media/v.mp4" },
+      resolvedModel: M,
     });
-    expect(payload).toEqual({ outputs: [{}] });
+    expect(payload).toEqual({ resolvedModel: M, outputs: [{}] });
   });
 
-  it("returns empty outputs when there is no video", () => {
-    const payload = toVideoResumePayload({});
-    expect(payload).toEqual({ outputs: [] });
+  it("returns empty outputs when there is no video (metadata still present)", () => {
+    const payload = toVideoResumePayload({ resolvedModel: M });
+    expect(payload).toEqual({ resolvedModel: M, outputs: [] });
   });
 
   it("includes both fileId and storageError when both are present", () => {
     const payload = toVideoResumePayload({
       video: { url: "u", fileId: "f-2", storageError: "partial" },
+      resolvedModel: M,
     });
     expect(payload).toEqual({
+      resolvedModel: M,
       outputs: [{ fileId: "f-2", storageError: "partial" }],
     });
   });
@@ -1340,8 +1409,10 @@ describe("toVideoResumePayload()", () => {
         downloadUrl: "https://dl/f-3",
         downloadUrlExpiresAt: "2026-03-03T00:00:00Z",
       },
+      resolvedModel: M,
     });
     expect(payload).toEqual({
+      resolvedModel: M,
       outputs: [
         {
           fileId: "f-3",
@@ -1358,21 +1429,58 @@ describe("toVideoResumePayload()", () => {
 // ---------------------------------------------------------------------------
 
 describe("toImageResumePayload()", () => {
+  const M = "flux-fast";
+
+  it("carries resolvedModel + cost onto the resume payload (the Polsia rebilling case)", () => {
+    const payload = toImageResumePayload({
+      images: [{ url: "u1", fileId: "f-1" }],
+      resolvedModel: M,
+      cost: {
+        estimateUsd: 0.02,
+        currency: "USD",
+        isEstimate: true,
+        source: "quote",
+        reference: "txn_img",
+      },
+    });
+    expect(payload.resolvedModel).toBe(M);
+    expect(payload.cost?.reference).toBe("txn_img");
+    expect(payload.outputs).toEqual([{ fileId: "f-1" }]);
+  });
+
+  it("carries a reference-only cost envelope (quote unavailable, transaction still created)", () => {
+    const payload = toImageResumePayload({
+      images: [{ url: "u" }],
+      resolvedModel: M,
+      cost: { reference: "txn_only" },
+    });
+    expect(payload.cost).toEqual({ reference: "txn_only" });
+    expect(payload.resolvedModel).toBe(M);
+  });
+
   it("maps each image to an outputs[] entry (one per image, order preserved)", () => {
     const payload = toImageResumePayload({
       images: [
         { url: "u1", fileId: "f-1" },
         { url: "u2", fileId: "f-2", storageError: "partial" },
       ],
+      resolvedModel: M,
     });
     expect(payload).toEqual({
+      resolvedModel: M,
       outputs: [{ fileId: "f-1" }, { fileId: "f-2", storageError: "partial" }],
     });
   });
 
-  it("returns empty outputs when there are no images", () => {
-    expect(toImageResumePayload({})).toEqual({ outputs: [] });
-    expect(toImageResumePayload({ images: [] })).toEqual({ outputs: [] });
+  it("returns empty outputs when there are no images (metadata still present)", () => {
+    expect(toImageResumePayload({ resolvedModel: M })).toEqual({
+      resolvedModel: M,
+      outputs: [],
+    });
+    expect(toImageResumePayload({ images: [], resolvedModel: M })).toEqual({
+      resolvedModel: M,
+      outputs: [],
+    });
   });
 
   it("carries the convenience downloadUrl + its expiry alongside fileId", () => {
@@ -1385,8 +1493,10 @@ describe("toImageResumePayload()", () => {
           downloadUrlExpiresAt: "2026-03-03T00:00:00Z",
         },
       ],
+      resolvedModel: M,
     });
     expect(payload).toEqual({
+      resolvedModel: M,
       outputs: [
         {
           fileId: "f-3",
@@ -1398,8 +1508,11 @@ describe("toImageResumePayload()", () => {
   });
 
   it("emits an empty-field entry for an image with no storage annotations", () => {
-    const payload = toImageResumePayload({ images: [{ url: "u" }] });
-    expect(payload).toEqual({ outputs: [{}] });
+    const payload = toImageResumePayload({
+      images: [{ url: "u" }],
+      resolvedModel: M,
+    });
+    expect(payload).toEqual({ resolvedModel: M, outputs: [{}] });
   });
 });
 

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -616,9 +616,7 @@ describe("contentGeneration.video.create()", () => {
             })
           : null,
       (c) =>
-        c.init.method === "GET"
-          ? jsonResponse({ video: { url: "u" } })
-          : null,
+        c.init.method === "GET" ? jsonResponse({ video: { url: "u" } }) : null,
     ]);
 
     await video.create({ prompt: "x", pollIntervalMs: 1 }, transport, BASE);
@@ -1172,6 +1170,125 @@ describe("contentGeneration.images.launch()", () => {
     const handle = await images.launch({ prompt: "x" }, transport, BASE);
     expect(handle.requestId).toBe("img-ns");
     expect(handle.dispatch.resultSignal).toBe(IMAGE_RESULT_SIGNAL);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SAP-2576 — per-generation cost envelope surfaced on results + launch handles
+// ---------------------------------------------------------------------------
+
+describe("cost envelope (SAP-2576)", () => {
+  const COST = {
+    estimateUsd: 0.4,
+    currency: "USD",
+    isEstimate: true,
+    source: "quote",
+    reference: "txn_abc123",
+  } as const;
+
+  it("createVideo threads the submit handle's cost + resolvedModel onto the polled result", async () => {
+    const { transport } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({
+              requestId: "req-cost",
+              responseUrl: `${BASE}/queue/req-cost`,
+              resolvedModel: "seedance-fast",
+              cost: COST,
+            })
+          : null,
+      (c) =>
+        c.init.method === "GET"
+          ? jsonResponse({ video: { url: "https://media/v.mp4" } })
+          : null,
+    ]);
+
+    const out = await createVideo(
+      { prompt: "a wave", pollIntervalMs: 1 },
+      transport,
+      BASE,
+    );
+
+    // The queue passthrough (the GET poll) carries neither cost nor resolvedModel — both are
+    // threaded from the submit handle, so a reseller can price without a second API call.
+    expect(out.resolvedModel).toBe("seedance-fast");
+    expect(out.cost).toEqual(COST);
+    expect(out.cost?.reference).toBe("txn_abc123");
+    expect(out.video?.url).toBe("https://media/v.mp4");
+  });
+
+  it("createVideo leaves the result untouched when the submit handle carries no cost", async () => {
+    const { transport } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({ requestId: "r", responseUrl: `${BASE}/queue/r` })
+          : null,
+      (c) =>
+        c.init.method === "GET"
+          ? jsonResponse({ video: { url: "https://media/v.mp4" } })
+          : null,
+    ]);
+
+    const out = await createVideo(
+      { prompt: "x", pollIntervalMs: 1 },
+      transport,
+      BASE,
+    );
+
+    expect(out).toEqual({ video: { url: "https://media/v.mp4" } });
+    expect(out.cost).toBeUndefined();
+    expect(out.resolvedModel).toBeUndefined();
+  });
+
+  it("launchVideo exposes cost + resolvedModel on the handle AND on the wait() result", async () => {
+    const { transport } = makeLaunchTransport(
+      {
+        requestId: "req-lc",
+        responseUrl: `${BASE}/queue/req-lc`,
+        resolvedModel: "veo3-fast",
+        cost: COST,
+      },
+      { video: { url: "https://media/v.mp4" } },
+    );
+
+    const handle = await launchVideo({ prompt: "x" }, transport, BASE);
+    expect(handle.resolvedModel).toBe("veo3-fast");
+    expect(handle.cost).toEqual(COST);
+
+    const result = await handle.wait({ pollMs: 1 });
+    expect(result.cost?.reference).toBe("txn_abc123");
+    expect(result.resolvedModel).toBe("veo3-fast");
+  });
+
+  it("createImage surfaces the response body's cost + resolvedModel", async () => {
+    const { transport } = makeTransport([
+      () =>
+        jsonResponse({
+          images: [{ url: "https://media/x.png" }],
+          resolvedModel: "flux-fast",
+          cost: COST,
+        }),
+    ]);
+
+    const out = await createImage({ prompt: "x" }, transport, BASE);
+    expect(out.resolvedModel).toBe("flux-fast");
+    expect(out.cost).toEqual(COST);
+  });
+
+  it("launchImage exposes cost + resolvedModel on the handle", async () => {
+    const { transport } = makeLaunchTransport(
+      {
+        requestId: "img-c",
+        responseUrl: `${BASE}/queue/img-c`,
+        resolvedModel: "flux-fast",
+        cost: COST,
+      },
+      { images: [{ url: "u" }] },
+    );
+
+    const handle = await launchImage({ prompt: "x" }, transport, BASE);
+    expect(handle.resolvedModel).toBe("flux-fast");
+    expect(handle.cost?.reference).toBe("txn_abc123");
   });
 });
 

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -161,9 +161,10 @@ export interface ImageGenerationResult {
   images?: GeneratedImage[];
   /**
    * The public semantic model alias that served this generation (SAP-2576) — the grouping
-   * dimension for per-model cost/failure slicing. Absent on a legacy uncataloged raw id.
+   * dimension for per-model cost/failure slicing. Always present: a cataloged raw id is
+   * reverse-mapped to its alias, an uncataloged one is echoed verbatim (never omitted).
    */
-  resolvedModel?: string;
+  resolvedModel: string;
   /** Per-generation cost (SAP-2576); omitted when the price join was unavailable. */
   cost?: MediaCostEnvelope;
   /** Additional model-specific fields (e.g. `seed`, `timings`), returned as-is. */
@@ -190,7 +191,7 @@ interface RawImage {
 
 interface RawImageResult {
   images?: RawImage[];
-  resolvedModel?: string;
+  resolvedModel: string;
   cost?: MediaCostEnvelope;
   [key: string]: unknown;
 }
@@ -218,23 +219,22 @@ function mapResult(raw: RawImageResult): ImageGenerationResult {
 }
 
 /**
- * Thread a dispatch handle's SAP-2576 cost envelope (`cost`) + `resolvedModel` onto a polled
- * result. For video (and async image) the price quote + transaction `reference` resolve at
- * SUBMIT, so they ride the dispatch handle — but the result is polled from the gateway's queue
- * passthrough, which carries neither. Merge them here, conditionally: a handle with no cost
- * envelope leaves the result untouched (omit-don't-fabricate). The `as T` narrows the generic
- * object spread back to the caller's concrete result type.
+ * Thread a dispatch handle's SAP-2576 `resolvedModel` (always present) + optional `cost`
+ * envelope onto a polled result. For video (and async image) the resolved model, price quote,
+ * and transaction `reference` resolve at SUBMIT, so they ride the dispatch handle — but the
+ * result is polled from the gateway's queue passthrough, which carries none of them. Merge them
+ * here: `resolvedModel` unconditionally (the contract guarantees it), `cost` only when the
+ * quote/reference resolved (omit-don't-fabricate). The `as` narrows the generic object spread.
  */
-function withDispatchCost<
-  T extends ImageGenerationResult | VideoGenerationResult,
->(result: T, handle: { cost?: MediaCostEnvelope; resolvedModel?: string }): T {
+function withDispatchCost<TBody extends Record<string, unknown>>(
+  body: TBody,
+  handle: { cost?: MediaCostEnvelope; resolvedModel: string },
+): TBody & { resolvedModel: string; cost?: MediaCostEnvelope } {
   return {
-    ...result,
-    ...(handle.resolvedModel !== undefined && {
-      resolvedModel: handle.resolvedModel,
-    }),
+    ...body,
+    resolvedModel: handle.resolvedModel,
     ...(handle.cost !== undefined && { cost: handle.cost }),
-  } as T;
+  } as TBody & { resolvedModel: string; cost?: MediaCostEnvelope };
 }
 
 // ----- Capability operations -----
@@ -326,8 +326,8 @@ interface ImageDispatchResponse {
   requestId: string;
   statusUrl: string;
   responseUrl?: string;
-  /** The semantic model alias this job was submitted to (SAP-2576). */
-  resolvedModel?: string;
+  /** The semantic model alias this job was submitted to (SAP-2576). Always present. */
+  resolvedModel: string;
   /** Per-generation cost estimate (SAP-2576), resolved at submit; omitted when the quote was unavailable. */
   cost?: MediaCostEnvelope;
 }
@@ -356,11 +356,8 @@ function imageResultUrl(handle: ImageDispatchResponse): string | undefined {
 export interface ImageLaunchHandle extends DispatchHandle {
   /** The queue request id for this job (also the correlation id a workflow resumes on). */
   requestId: string;
-  /**
-   * The semantic model alias this job was submitted to (SAP-2576), from the submit handle.
-   * Absent when the router didn't echo one.
-   */
-  resolvedModel?: string;
+  /** The semantic model alias this job was submitted to (SAP-2576), from the submit handle. */
+  resolvedModel: string;
   /**
    * Per-generation cost envelope (SAP-2576), resolved at submit — `estimateUsd` inline and the
    * settled charge out-of-band via `cost.reference`. Also merged onto the {@link wait} result.
@@ -380,7 +377,20 @@ export interface ImageLaunchHandle extends DispatchHandle {
  * the identical shape a resumed video step receives. Annotate a resumed step's input
  * with this type instead of hand-rolling the shape.
  */
-export interface ImageResultPayload {
+/**
+ * The SAP-2576 generation metadata a resumed step needs alongside its `outputs`. Carried on the
+ * durable pause/resume payload so a workflow step that bills AFTER the generation (the Polsia
+ * rebilling case) can still read `cost.reference` / `resolvedModel` — the launch handle is gone
+ * by then (`pauseUntilSignal` reduces it to its signal + `correlationId`).
+ */
+export interface MediaResumeFields {
+  /** The semantic model alias that served this generation (SAP-2576). Always present. */
+  resolvedModel: string;
+  /** Per-generation cost (SAP-2576) — `estimateUsd` inline, settled charge via `cost.reference`. */
+  cost?: MediaCostEnvelope;
+}
+
+export interface ImageResultPayload extends MediaResumeFields {
   outputs: Array<{
     /** Present when the output was persisted to file storage — the durable reference. */
     fileId?: string;
@@ -412,6 +422,10 @@ export function toImageResumePayload(
   result: ImageGenerationResult,
 ): ImageResultPayload {
   return {
+    // SAP-2576: preserve the generation metadata across the durable pause/resume boundary, so a
+    // resumed step (which never sees the launch handle) can still bill against `cost.reference`.
+    resolvedModel: result.resolvedModel,
+    ...(result.cost !== undefined && { cost: result.cost }),
     outputs: (result.images ?? []).map((img) => ({
       ...(img.fileId !== undefined && { fileId: img.fileId }),
       ...(img.downloadUrl !== undefined && { downloadUrl: img.downloadUrl }),
@@ -512,11 +526,9 @@ export async function launchImage(
 
   return {
     requestId,
-    // SAP-2576: surface the submit handle's cost envelope + resolvedModel on the handle too,
+    // SAP-2576: surface the submit handle's resolvedModel + cost envelope on the handle too,
     // so a caller reading them off `launch()` needn't await `wait()`.
-    ...(handle.resolvedModel !== undefined && {
-      resolvedModel: handle.resolvedModel,
-    }),
+    resolvedModel: handle.resolvedModel,
     ...(handle.cost !== undefined && { cost: handle.cost }),
     dispatch: { correlationId: requestId, resultSignal: IMAGE_RESULT_SIGNAL },
     wait,
@@ -628,9 +640,10 @@ export interface VideoGenerationResult {
   video?: GeneratedVideo;
   /**
    * The public semantic model alias that served this generation (SAP-2576) — from the submit
-   * handle (the polled queue passthrough doesn't carry it). Absent on a legacy uncataloged id.
+   * handle (the polled queue passthrough doesn't carry it). Always present: cataloged raw ids
+   * reverse-map to their alias, uncataloged ones are echoed verbatim.
    */
-  resolvedModel?: string;
+  resolvedModel: string;
   /**
    * Per-generation cost (SAP-2576), threaded from the submit handle: `estimateUsd` inline and
    * the settled charge out-of-band via `cost.reference`. Omitted when the price join was
@@ -670,8 +683,8 @@ interface VideoDispatchResponse {
   requestId: string;
   statusUrl: string;
   responseUrl?: string;
-  /** The semantic model alias this job was submitted to (SAP-2576). */
-  resolvedModel?: string;
+  /** The semantic model alias this job was submitted to (SAP-2576). Always present. */
+  resolvedModel: string;
   /**
    * Per-generation cost envelope (SAP-2576), resolved at submit. Carries the `estimateUsd`
    * quote and the transaction `reference` for the settled charge — the poll target (the
@@ -707,7 +720,12 @@ function mapVideo(raw: RawMedia): GeneratedVideo {
   };
 }
 
-function mapVideoResult(raw: RawVideoResult): VideoGenerationResult {
+// Returns the camelCase video BODY only — the submit-only metadata (`resolvedModel`, `cost`) is
+// threaded on separately by `withDispatchCost`, since the queue passthrough omits it.
+function mapVideoResult(raw: RawVideoResult): {
+  video?: GeneratedVideo;
+  [key: string]: unknown;
+} {
   const { video, ...rest } = raw;
   return video === undefined
     ? { ...rest }
@@ -806,11 +824,8 @@ export async function createVideo(
 export interface VideoLaunchHandle extends DispatchHandle {
   /** The queue request id for this job. */
   requestId: string;
-  /**
-   * The semantic model alias this job was submitted to (SAP-2576), from the submit handle.
-   * Absent when the router didn't echo one.
-   */
-  resolvedModel?: string;
+  /** The semantic model alias this job was submitted to (SAP-2576), from the submit handle. */
+  resolvedModel: string;
   /**
    * Per-generation cost envelope (SAP-2576), resolved at submit — `estimateUsd` inline and the
    * settled charge out-of-band via `cost.reference`. Also merged onto the {@link wait} result.
@@ -833,7 +848,7 @@ export interface VideoLaunchHandle extends DispatchHandle {
  *     async run(result: VideoResultPayload, ctx) { … },
  *   });
  */
-export interface VideoResultPayload {
+export interface VideoResultPayload extends MediaResumeFields {
   outputs: Array<{
     /** Present when the output was persisted to file storage — the durable reference. */
     fileId?: string;
@@ -864,8 +879,15 @@ export interface VideoResultPayload {
 export function toVideoResumePayload(
   result: VideoGenerationResult,
 ): VideoResultPayload {
-  if (!result.video) return { outputs: [] };
+  // SAP-2576: preserve the generation metadata across the durable pause/resume boundary, so a
+  // resumed step (which never sees the launch handle) can still bill against `cost.reference`.
+  const metadata = {
+    resolvedModel: result.resolvedModel,
+    ...(result.cost !== undefined && { cost: result.cost }),
+  };
+  if (!result.video) return { outputs: [], ...metadata };
   return {
+    ...metadata,
     outputs: [
       {
         ...(result.video.fileId !== undefined && {
@@ -975,11 +997,9 @@ export async function launchVideo(
 
   return {
     requestId,
-    // SAP-2576: surface the submit handle's cost envelope + resolvedModel on the handle too,
+    // SAP-2576: surface the submit handle's resolvedModel + cost envelope on the handle too,
     // so a caller reading them off `launch()` needn't await `wait()`.
-    ...(handle.resolvedModel !== undefined && {
-      resolvedModel: handle.resolvedModel,
-    }),
+    resolvedModel: handle.resolvedModel,
     ...(handle.cost !== undefined && { cost: handle.cost }),
     dispatch: { correlationId: requestId, resultSignal: VIDEO_RESULT_SIGNAL },
     wait,

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -58,6 +58,49 @@ export interface StorageOptions {
   visibility?: "private" | "public";
 }
 
+/**
+ * Per-generation cost visibility (SAP-2576) — the SDK mirror of the backend capability
+ * envelope (`content-generation/content-generation.types.ts`). Two INDEPENDENTLY-available
+ * halves; the envelope ships when at least one resolved, and neither half is ever fabricated
+ * to satisfy the other (omit-don't-fabricate):
+ *
+ *  - the ESTIMATE quartet (`estimateUsd`, `currency`, `isEstimate`, `source`) — present
+ *    together exactly when the price quote resolved;
+ *  - the `reference` — the Sapiom transaction id the charge lands on; present when the gateway
+ *    echoed it. The authoritative SETTLED amount lives out-of-band at
+ *    `GET /v1/transactions/:id/costs` (design D1 option C — estimate inline, settled out-of-band).
+ *
+ * The shape is stable from this epic onward: the E6 metering migration flips `source` (adding
+ * `'metered'`) and nothing else, so a reseller can build credit pricing against it today.
+ */
+export interface MediaCostEnvelope {
+  /**
+   * Estimated cost of THIS generation in `currency`, quoted from the provider's ungated price
+   * route. For an `upto`-priced video model this is the authorized CEILING — the settled amount
+   * can be lower. Absent when the quote didn't resolve (never `0`).
+   */
+  estimateUsd?: number;
+  /** ISO 4217 code of `estimateUsd`; present exactly when it is. Always `"USD"` today. */
+  currency?: string;
+  /**
+   * `true` while `source` is `"quote"`: the authoritative settled number lives out-of-band at
+   * `GET /v1/transactions/:id/costs`, reachable via `reference`. Travels with `estimateUsd`.
+   */
+  isEstimate?: boolean;
+  /**
+   * Provenance of `estimateUsd`: `"quote"` (the ungated gateway price inquiry — today's only
+   * value) or `"authorized"` (the payment-authorized amount). E6 adds `"metered"`.
+   */
+  source?: "quote" | "authorized";
+  /**
+   * The Sapiom transaction id this generation's charge lands on — resolves at
+   * `GET /v1/transactions/:id/costs`. Captured from the gateway's `x-sapiom-transaction-id`
+   * response header (set by the x402 collapsed flow at authorization time, so async submits
+   * carry it too); omitted when the gateway didn't echo one.
+   */
+  reference?: string;
+}
+
 export interface ImageCreateInput {
   /** Text prompt describing the image to generate. */
   prompt: string;
@@ -116,6 +159,13 @@ export interface GeneratedImage {
 export interface ImageGenerationResult {
   /** Generated images. */
   images?: GeneratedImage[];
+  /**
+   * The public semantic model alias that served this generation (SAP-2576) — the grouping
+   * dimension for per-model cost/failure slicing. Absent on a legacy uncataloged raw id.
+   */
+  resolvedModel?: string;
+  /** Per-generation cost (SAP-2576); omitted when the price join was unavailable. */
+  cost?: MediaCostEnvelope;
   /** Additional model-specific fields (e.g. `seed`, `timings`), returned as-is. */
   [key: string]: unknown;
 }
@@ -140,6 +190,8 @@ interface RawImage {
 
 interface RawImageResult {
   images?: RawImage[];
+  resolvedModel?: string;
+  cost?: MediaCostEnvelope;
   [key: string]: unknown;
 }
 
@@ -163,6 +215,26 @@ function mapResult(raw: RawImageResult): ImageGenerationResult {
   return images === undefined
     ? { ...rest }
     : { ...rest, images: images.map(mapImage) };
+}
+
+/**
+ * Thread a dispatch handle's SAP-2576 cost envelope (`cost`) + `resolvedModel` onto a polled
+ * result. For video (and async image) the price quote + transaction `reference` resolve at
+ * SUBMIT, so they ride the dispatch handle — but the result is polled from the gateway's queue
+ * passthrough, which carries neither. Merge them here, conditionally: a handle with no cost
+ * envelope leaves the result untouched (omit-don't-fabricate). The `as T` narrows the generic
+ * object spread back to the caller's concrete result type.
+ */
+function withDispatchCost<
+  T extends ImageGenerationResult | VideoGenerationResult,
+>(result: T, handle: { cost?: MediaCostEnvelope; resolvedModel?: string }): T {
+  return {
+    ...result,
+    ...(handle.resolvedModel !== undefined && {
+      resolvedModel: handle.resolvedModel,
+    }),
+    ...(handle.cost !== undefined && { cost: handle.cost }),
+  } as T;
 }
 
 // ----- Capability operations -----
@@ -254,6 +326,10 @@ interface ImageDispatchResponse {
   requestId: string;
   statusUrl: string;
   responseUrl?: string;
+  /** The semantic model alias this job was submitted to (SAP-2576). */
+  resolvedModel?: string;
+  /** Per-generation cost estimate (SAP-2576), resolved at submit; omitted when the quote was unavailable. */
+  cost?: MediaCostEnvelope;
 }
 
 /**
@@ -280,6 +356,16 @@ function imageResultUrl(handle: ImageDispatchResponse): string | undefined {
 export interface ImageLaunchHandle extends DispatchHandle {
   /** The queue request id for this job (also the correlation id a workflow resumes on). */
   requestId: string;
+  /**
+   * The semantic model alias this job was submitted to (SAP-2576), from the submit handle.
+   * Absent when the router didn't echo one.
+   */
+  resolvedModel?: string;
+  /**
+   * Per-generation cost envelope (SAP-2576), resolved at submit — `estimateUsd` inline and the
+   * settled charge out-of-band via `cost.reference`. Also merged onto the {@link wait} result.
+   */
+  cost?: MediaCostEnvelope;
   /** Poll to completion and resolve the full result. */
   wait(opts?: {
     timeoutMs?: number;
@@ -405,7 +491,9 @@ export async function launchImage(
       const res = await transport.fetch(responseUrl, { method: "GET" });
       if (res.ok) {
         const raw = (await res.json()) as RawImageResult;
-        if (Array.isArray(raw.images)) return mapResult(raw);
+        // Thread the submit handle's SAP-2576 cost + resolvedModel onto the polled result.
+        if (Array.isArray(raw.images))
+          return withDispatchCost(mapResult(raw), handle);
       } else {
         // Still generating, or a transient error. Drain the unread body so the
         // connection can be reused, then keep polling — `timeoutMs` is the backstop.
@@ -424,6 +512,12 @@ export async function launchImage(
 
   return {
     requestId,
+    // SAP-2576: surface the submit handle's cost envelope + resolvedModel on the handle too,
+    // so a caller reading them off `launch()` needn't await `wait()`.
+    ...(handle.resolvedModel !== undefined && {
+      resolvedModel: handle.resolvedModel,
+    }),
+    ...(handle.cost !== undefined && { cost: handle.cost }),
     dispatch: { correlationId: requestId, resultSignal: IMAGE_RESULT_SIGNAL },
     wait,
   };
@@ -532,6 +626,17 @@ export interface GeneratedVideo {
 export interface VideoGenerationResult {
   /** The generated video. */
   video?: GeneratedVideo;
+  /**
+   * The public semantic model alias that served this generation (SAP-2576) — from the submit
+   * handle (the polled queue passthrough doesn't carry it). Absent on a legacy uncataloged id.
+   */
+  resolvedModel?: string;
+  /**
+   * Per-generation cost (SAP-2576), threaded from the submit handle: `estimateUsd` inline and
+   * the settled charge out-of-band via `cost.reference`. Omitted when the price join was
+   * unavailable at submit.
+   */
+  cost?: MediaCostEnvelope;
   /** Additional model-specific fields (e.g. `seed`, `timings`), returned as-is. */
   [key: string]: unknown;
 }
@@ -565,6 +670,14 @@ interface VideoDispatchResponse {
   requestId: string;
   statusUrl: string;
   responseUrl?: string;
+  /** The semantic model alias this job was submitted to (SAP-2576). */
+  resolvedModel?: string;
+  /**
+   * Per-generation cost envelope (SAP-2576), resolved at submit. Carries the `estimateUsd`
+   * quote and the transaction `reference` for the settled charge — the poll target (the
+   * gateway's queue passthrough) carries neither, so this is the only place they ride.
+   */
+  cost?: MediaCostEnvelope;
 }
 
 /**
@@ -664,7 +777,9 @@ export async function createVideo(
     const res = await transport.fetch(responseUrl, { method: "GET" });
     if (res.ok) {
       const raw = (await res.json()) as RawVideoResult;
-      if (raw.video?.url) return mapVideoResult(raw);
+      // Thread the submit handle's SAP-2576 cost + resolvedModel onto the polled result —
+      // the queue passthrough (this `raw`) carries neither.
+      if (raw.video?.url) return withDispatchCost(mapVideoResult(raw), handle);
     } else {
       // Still generating, or a transient error. Drain the unread body so the
       // connection can be reused, then keep polling — `timeoutMs` is the backstop
@@ -691,6 +806,16 @@ export async function createVideo(
 export interface VideoLaunchHandle extends DispatchHandle {
   /** The queue request id for this job. */
   requestId: string;
+  /**
+   * The semantic model alias this job was submitted to (SAP-2576), from the submit handle.
+   * Absent when the router didn't echo one.
+   */
+  resolvedModel?: string;
+  /**
+   * Per-generation cost envelope (SAP-2576), resolved at submit — `estimateUsd` inline and the
+   * settled charge out-of-band via `cost.reference`. Also merged onto the {@link wait} result.
+   */
+  cost?: MediaCostEnvelope;
   /** Poll to completion and resolve the full result. */
   wait(opts?: {
     timeoutMs?: number;
@@ -831,7 +956,9 @@ export async function launchVideo(
       const res = await transport.fetch(responseUrl, { method: "GET" });
       if (res.ok) {
         const raw = (await res.json()) as RawVideoResult;
-        if (raw.video?.url) return mapVideoResult(raw);
+        // Thread the submit handle's SAP-2576 cost + resolvedModel onto the polled result.
+        if (raw.video?.url)
+          return withDispatchCost(mapVideoResult(raw), handle);
       } else {
         try {
           await res.body?.cancel();
@@ -848,6 +975,12 @@ export async function launchVideo(
 
   return {
     requestId,
+    // SAP-2576: surface the submit handle's cost envelope + resolvedModel on the handle too,
+    // so a caller reading them off `launch()` needn't await `wait()`.
+    ...(handle.resolvedModel !== undefined && {
+      resolvedModel: handle.resolvedModel,
+    }),
+    ...(handle.cost !== undefined && { cost: handle.cost }),
     dispatch: { correlationId: requestId, resultSignal: VIDEO_RESULT_SIGNAL },
     wait,
   };

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -1084,9 +1084,12 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
               ],
             }),
           ) as ImageGenerationResult;
+          // SAP-2576: the routed backend always echoes a resolvedModel; mirror that in the stub.
+          result.resolvedModel = input.model ?? "stub-model";
 
           const handle: ImageLaunchHandle = {
             requestId,
+            resolvedModel: result.resolvedModel,
             dispatch: {
               correlationId: requestId,
               resultSignal: IMAGE_RESULT_SIGNAL,
@@ -1138,9 +1141,12 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
               },
             }),
           ) as VideoGenerationResult;
+          // SAP-2576: the routed backend always echoes a resolvedModel; mirror that in the stub.
+          result.resolvedModel = input.model ?? "stub-model";
 
           const handle: VideoLaunchHandle = {
             requestId,
+            resolvedModel: result.resolvedModel,
             dispatch: {
               correlationId: requestId,
               resultSignal: VIDEO_RESULT_SIGNAL,


### PR DESCRIPTION
## Summary

The E2 backend (SAP-2576) already puts a per-generation cost envelope on every media capability response, but its **SDK half was deferred** (#4289) — so a typed `@sapiom/tools` consumer (e.g. Polsia ads re-billing its customers' wallets) could not read `cost.estimateUsd` / `cost.reference`. The settled-cost track was blocked at the SDK, not at the caller. This surfaces that envelope on the SDK results.

> **Stacked on #633** (SAP-2575 / E1 — video verbs → capability router). Base is that branch, so this diff is E2-SDK only. Rebase onto `main` once #633 merges.

## Changes

- Add `MediaCostEnvelope` — the SDK mirror of the backend envelope (`estimateUsd`, `currency`, `isEstimate`, `source`, `reference`).
- `cost?` + `resolvedModel?` on `ImageGenerationResult` / `VideoGenerationResult` and the `ImageDispatchResponse` / `VideoDispatchResponse` submit handles.
- Expose `cost` / `resolvedModel` on the `images.launch` / `video.launch` handles (readable without awaiting `wait()`).
- Thread the submit handle's cost onto the **polled** result for video + async image — the gateway's queue passthrough carries neither cost nor `resolvedModel`. Sync image passes it through the existing response-body spread.
- 5 new tests; `.changeset` (minor → `0.27.0`).

## Motivation

Polsia's ads video re-bills its own customers' ad wallets by the per-generation cost. It calls the media capability but can't read the cost back without this. Design **D1 option C**: `estimateUsd` inline, settled amount out-of-band via `cost.reference` → `GET /v1/transactions/:id/costs`. Envelope shape is stable from E2 onward (E6 only flips `source` → `'metered'`).

## Testing

- [x] `pnpm --filter @sapiom/tools typecheck` — clean
- [x] `pnpm --filter @sapiom/tools test` (content-generation) — 85/85 (5 new)
- [x] prettier + eslint clean

## Related

- Refs: SAP-2576 — fulfills the epic's "SDK types updated and released" deliverable.
- Stacked on #633 (SAP-2575).

## Checklist

- [x] Code follows project guidelines
- [x] Commits follow conventions
- [x] All tests passing
- [x] No hardcoded secrets
- [x] Self-reviewed
