### PR TITLE
fix(harness): expose supported Claude permission modes

### DIFF
--- a/.changeset/quick-dogs-cycle.md
+++ b/.changeset/quick-dogs-cycle.md
@@ -3,5 +3,7 @@
 "@sapiom/harness-desktop": patch
 ---
 
-Start new and resumed interactive Claude Code sessions in Auto mode. Headless
-tasks keep their existing permission mode.
+Start new and resumed interactive Claude Code sessions in Auto mode when the
+account supports it. Bypass permissions is available as an explicit Shift+Tab
+choice for accounts without Auto mode; it is never activated silently.
+Headless tasks keep their existing permission mode.

--- a/.changeset/quick-dogs-cycle.md
+++ b/.changeset/quick-dogs-cycle.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/harness": patch
+"@sapiom/harness-desktop": patch
+---
+
+Start new and resumed interactive Claude Code sessions in Auto mode. Headless
+tasks keep their existing permission mode.

--- a/packages/harness/src/cli/doctor.test.ts
+++ b/packages/harness/src/cli/doctor.test.ts
@@ -53,12 +53,12 @@ import { MIN_CLAUDE_CODE_VERSION } from "../core/adapters/claude-code.js";
 describe("runDoctor", () => {
   it("passes when node, claude, and git are present and codex is absent", async () => {
     presentBinaries = new Set(["claude", "git"]);
-    claudeVersion = "2.1.4 (Claude Code)";
+    claudeVersion = "2.1.220 (Claude Code)";
     const report = await runDoctor();
     const byName = Object.fromEntries(report.checks.map((c) => [c.name, c]));
 
     expect(byName.node.ok).toBe(true);
-    expect(byName.claude).toEqual({ name: "claude", ok: true, detail: "2.1.4 (Claude Code)" });
+    expect(byName.claude).toEqual({ name: "claude", ok: true, detail: "2.1.220 (Claude Code)" });
     expect(byName.git).toEqual({ name: "git", ok: true, detail: "git version 2.43.0" });
     expect(byName.codex.ok).toBe(false);
 
@@ -70,7 +70,8 @@ describe("runDoctor", () => {
 
   it("marks a present-but-too-old claude unavailable, with an upgrade remedy", async () => {
     // Present on PATH and answers --version, but predates the flags every
-    // launch injects (notably --plugin-dir) — so it exit-1s each session
+    // launch relies on (Auto mode and, on older releases, --plugin-dir) — so
+    // it exit-1s each session
     // before establishing a session id. Doctor must report it NOT ok.
     presentBinaries = new Set(["claude", "git"]);
     claudeVersion = "1.9.9 (Claude Code)";
@@ -95,7 +96,7 @@ describe("runDoctor", () => {
 
   it("passes on codex alone, with claude's check carrying the exact install remedy", async () => {
     presentBinaries = new Set(["codex", "git"]);
-    claudeVersion = "2.1.4 (Claude Code)";
+    claudeVersion = "2.1.220 (Claude Code)";
     const report = await runDoctor();
     const byName = Object.fromEntries(report.checks.map((c) => [c.name, c]));
 
@@ -108,7 +109,7 @@ describe("runDoctor", () => {
 
   it("fails only when neither claude nor codex is present, surfacing both install remedies", async () => {
     presentBinaries = new Set(["git"]);
-    claudeVersion = "2.1.4 (Claude Code)";
+    claudeVersion = "2.1.220 (Claude Code)";
     const report = await runDoctor();
     const byName = Object.fromEntries(report.checks.map((c) => [c.name, c]));
 
@@ -120,7 +121,7 @@ describe("runDoctor", () => {
 
   it("prefers claude-code when both agents are present", async () => {
     presentBinaries = new Set(["claude", "codex", "git"]);
-    claudeVersion = "2.1.4 (Claude Code)";
+    claudeVersion = "2.1.220 (Claude Code)";
     const report = await runDoctor();
 
     expect(report.ok).toBe(true);

--- a/packages/harness/src/core/adapters/claude-code.test.ts
+++ b/packages/harness/src/core/adapters/claude-code.test.ts
@@ -88,6 +88,8 @@ describe("ClaudeCodeAdapter", () => {
         "/tmp/proj/.sapiom/settings.json",
         "--mcp-config",
         "/tmp/proj/.sapiom/mcp.json",
+        "--permission-mode",
+        "auto",
         "--append-system-prompt",
         DEFAULT_SYSTEM_PROMPT,
       ]);
@@ -100,6 +102,8 @@ describe("ClaudeCodeAdapter", () => {
       expect(resumed.args).toEqual([
         "--resume",
         "agent-uuid-123",
+        "--permission-mode",
+        "auto",
         "--append-system-prompt",
         DEFAULT_SYSTEM_PROMPT,
       ]);
@@ -112,7 +116,12 @@ describe("ClaudeCodeAdapter", () => {
       const spec = adapter.resume("agent-uuid-123", { harnessSessionId: "h1", cwd: "/tmp/proj" });
 
       expect(spec.command).toBe("fake-claude");
-      expect(spec.args).toEqual(["--resume", "agent-uuid-123"]);
+      expect(spec.args).toEqual([
+        "--resume",
+        "agent-uuid-123",
+        "--permission-mode",
+        "auto",
+      ]);
       expect(spec.env).toEqual({ CLAUDECODE: null });
     });
 
@@ -162,7 +171,6 @@ describe("ClaudeCodeAdapter", () => {
         "stream-json",
         "--verbose",
       ]);
-
       await rm(promptDir, { recursive: true, force: true });
     });
 
@@ -195,6 +203,7 @@ describe("ClaudeCodeAdapter", () => {
     it("rejects a version below the floor and accepts the floor and above", () => {
       expect(isClaudeVersionSupported("1.9.9 (Claude Code)")).toBe(false);
       expect(isClaudeVersionSupported("0.5.0")).toBe(false);
+      expect(isClaudeVersionSupported("2.1.82 (Claude Code)")).toBe(false);
       expect(isClaudeVersionSupported(`${MIN_CLAUDE_CODE_VERSION} (Claude Code)`)).toBe(true);
       expect(isClaudeVersionSupported("2.4.1 (Claude Code)")).toBe(true);
       expect(isClaudeVersionSupported("10.0.0")).toBe(true);

--- a/packages/harness/src/core/adapters/claude-code.test.ts
+++ b/packages/harness/src/core/adapters/claude-code.test.ts
@@ -90,6 +90,7 @@ describe("ClaudeCodeAdapter", () => {
         "/tmp/proj/.sapiom/mcp.json",
         "--permission-mode",
         "auto",
+        "--allow-dangerously-skip-permissions",
         "--append-system-prompt",
         DEFAULT_SYSTEM_PROMPT,
       ]);
@@ -104,6 +105,7 @@ describe("ClaudeCodeAdapter", () => {
         "agent-uuid-123",
         "--permission-mode",
         "auto",
+        "--allow-dangerously-skip-permissions",
         "--append-system-prompt",
         DEFAULT_SYSTEM_PROMPT,
       ]);
@@ -121,6 +123,7 @@ describe("ClaudeCodeAdapter", () => {
         "agent-uuid-123",
         "--permission-mode",
         "auto",
+        "--allow-dangerously-skip-permissions",
       ]);
       expect(spec.env).toEqual({ CLAUDECODE: null });
     });
@@ -171,6 +174,7 @@ describe("ClaudeCodeAdapter", () => {
         "stream-json",
         "--verbose",
       ]);
+      expect(spec.args).not.toContain("--allow-dangerously-skip-permissions");
       await rm(promptDir, { recursive: true, force: true });
     });
 

--- a/packages/harness/src/core/adapters/claude-code.ts
+++ b/packages/harness/src/core/adapters/claude-code.ts
@@ -364,7 +364,15 @@ function buildConfigArgs(opts: LaunchOpts): string[] {
 
 function buildInteractiveConfigArgs(opts: LaunchOpts): string[] {
   const args = buildConfigArgs(opts);
-  args.push("--permission-mode", "auto");
+  // Auto remains the safe, classifier-backed default for eligible accounts.
+  // Claude Code silently downgrades when the account/model cannot enter Auto;
+  // the allow flag only adds Bypass to the Shift+Tab cycle so the user can
+  // explicitly opt in. It does not activate Bypass or suppress its warning.
+  args.push(
+    "--permission-mode",
+    "auto",
+    "--allow-dangerously-skip-permissions",
+  );
   return args;
 }
 

--- a/packages/harness/src/core/adapters/claude-code.ts
+++ b/packages/harness/src/core/adapters/claude-code.ts
@@ -24,17 +24,19 @@ import { stripAnsi } from "../strip-ansi.js";
 /**
  * Minimum `claude` version the harness supports.
  *
- * Below this, the binary predates flags {@link ClaudeCodeAdapter.launch} /
- * `resume` inject on EVERY spawn — most importantly `--plugin-dir`. A
- * commander-style CLI aborts on an unknown option with a fast `exit 1`, BEFORE
- * it ever runs its SessionStart hook, so the session dies with no
- * `agentSessionId` and only an opaque exit code (the pty's stderr is discarded
- * on exit) — exactly the "exited before establishing a session id" failure
- * users report. `doctor()` reports a below-floor claude as NOT ok so the
- * desktop host installs a current one and the CLI surfaces an actionable
- * upgrade remedy, instead of every session crash-looping silently.
+ * Below this, the binary predates behavior {@link ClaudeCodeAdapter.launch} /
+ * `resume` rely on for EVERY spawn — Auto permission mode at this floor, and
+ * `--plugin-dir` on older releases. A commander-style CLI aborts on an unknown
+ * option or value with a fast `exit 1`, BEFORE it ever runs its SessionStart
+ * hook, so the session dies with no `agentSessionId` and only an opaque exit
+ * code (the pty's stderr is discarded on exit). `doctor()` reports a
+ * below-floor claude as NOT ok so the desktop host installs a current one and
+ * the CLI surfaces an actionable upgrade remedy instead.
  *
- * Why 2.1.0, from the Claude Code CHANGELOG:
+ * Why 2.1.83:
+ * - Claude's permission-mode documentation identifies 2.1.83 as the first
+ *   version that supports Auto mode, which interactive Harness sessions use as
+ *   their initial mode.
  * - The plugin system did not exist before the "Plugin System Released" entry
  *   in `2.0.12`, so no `1.x` or `2.0.0`–`2.0.11` build can recognize
  *   `--plugin-dir` — they reject it outright.
@@ -43,15 +45,10 @@ import { stripAnsi } from "../strip-ansi.js";
  *   against `2.1.x` (see core/inject/skills-plugin.ts). `2.1.x` is thus the
  *   earliest range we can GUARANTEE both recognizes the flag and loads our
  *   skills.
- * We floor at `2.1.0` — the earliest verified-safe version — rather than the
- * `2.0.12` plugin-system release, because we can't prove `--plugin-dir` is
- * present across the whole `2.0.x` line, and a spurious "please upgrade" for a
- * rare old-`2.0.x` install is far cheaper than the silent exit-1 crash-loop
- * this floor exists to prevent. This is the SINGLE source of truth — bump it
- * whenever the adapter starts sending a flag, or relying on behavior, a newer
- * `claude` introduced.
+ * This is the SINGLE source of truth — bump it whenever the adapter starts
+ * sending a flag, or relying on behavior, a newer `claude` introduced.
  */
-export const MIN_CLAUDE_CODE_VERSION = "2.1.0";
+export const MIN_CLAUDE_CODE_VERSION = "2.1.83";
 
 /**
  * Extract a leading `major.minor.patch` from a `claude --version` line such as
@@ -365,6 +362,12 @@ function buildConfigArgs(opts: LaunchOpts): string[] {
   return args;
 }
 
+function buildInteractiveConfigArgs(opts: LaunchOpts): string[] {
+  const args = buildConfigArgs(opts);
+  args.push("--permission-mode", "auto");
+  return args;
+}
+
 /**
  * Claude Code's known blocking startup screens, matched against stripped-ANSI
  * scrollback. Exported so the packaged smoke / e2e layers can pin the same
@@ -460,7 +463,7 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
   }
 
   launch(opts: LaunchOpts): SpawnSpec {
-    const args = buildConfigArgs(opts);
+    const args = buildInteractiveConfigArgs(opts);
     if (opts.systemPromptFile) {
       args.push("--append-system-prompt", readPromptFile(opts.systemPromptFile));
     }
@@ -476,7 +479,7 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
   }
 
   resume(agentSessionId: string, opts: LaunchOpts): SpawnSpec {
-    const args = ["--resume", agentSessionId, ...buildConfigArgs(opts)];
+    const args = ["--resume", agentSessionId, ...buildInteractiveConfigArgs(opts)];
     if (opts.systemPromptFile) {
       args.push("--append-system-prompt", readPromptFile(opts.systemPromptFile));
     }


### PR DESCRIPTION
<!--
Thank you for contributing to sapiom-js.
Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
-->

## Primary change type

<!-- Select exactly one primary type. -->

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Studio-launched Claude Code sessions only exposed Claude's default permission-mode cycle, so users could not select Auto or Bypass permissions when those optional modes were appropriate. Starting every session in Auto also requires a recent Claude Code binary and must not silently escalate users whose account or model cannot enter Auto.

## Summary and scope

Interactive Claude Code launches and resumes now request classifier-backed Auto mode and make Bypass permissions available as an explicit Shift+Tab option. Claude Code retains its own eligibility checks and warning/opt-in flow; Studio never activates Bypass silently. The minimum supported Claude Code version is now 2.1.83, the first release with Auto mode. Headless tasks remain on `acceptEdits` and do not expose Bypass.

## Related work

<!--
Link the issue or prior maintainer discussion when required by CONTRIBUTING.md.
Use N/A for a direct PR that does not need one.
-->

Related issue or discussion: N/A — direct fix for observed Studio session behavior.

## Validation

<!-- List the exact commands or manual checks you ran and their results. -->

```text
pnpm exec vitest run src/core/adapters/claude-code.test.ts src/cli/doctor.test.ts (from packages/harness) — 38 tests passed
pnpm --filter @sapiom/harness typecheck — passed
pnpm --filter @sapiom/harness lint — passed with one pre-existing warning in src/server/rest.test.ts
pnpm --filter @sapiom/harness build — passed
```

### Tests and documentation

Updated adapter argument-level tests for new, resumed, and headless Claude sessions, and updated doctor tests for the new minimum version. Added a Changeset describing the interactive behavior and explicit Bypass opt-in.

## Compatibility and release impact

- Breaking or externally visible changes: Interactive Claude sessions start in Auto when eligible and expose Bypass as an explicit mode-cycle option; unsupported accounts remain subject to Claude Code's safe downgrade and warnings. Headless tasks are unchanged.
- Changeset: Added `.changeset/quick-dogs-cycle.md` for patch releases of `@sapiom/harness` and `@sapiom/harness-desktop`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex updated the Claude adapter, regression assertions, and Changeset. I reviewed the exact spawned arguments and verified the change with focused tests, typechecking, linting, and a production build.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
