### PR TITLE
feat(harness): attach files when creating sessions

### DIFF
--- a/.changeset/new-session-file-uploads.md
+++ b/.changeset/new-session-file-uploads.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Allow files to be picked, dropped, or pasted into the create-new composer so they arrive with the agent's first request.

--- a/docs/plans/new-session-file-uploads/00-status.md
+++ b/docs/plans/new-session-file-uploads/00-status.md
@@ -1,0 +1,33 @@
+# Status: New-session file uploads
+
+- Gate 1 — Product: APPROVED 2026-08-14
+- Gate 2 — Architecture: APPROVED 2026-08-14
+- Gate 3 — Program Design: APPROVED 2026-08-14
+- Gate 4 — Slice plan: APPROVED 2026-08-14
+
+## Slices
+
+- [x] Slice 1 — tracer bullet: one queued file travels from the create-new composer through session creation into the mock agent's first request.
+- [x] Slice 2 — real happy path: picker, Finder-style drop, clipboard file/image, zero-copy paths, and local inline materialization work end to end.
+- [x] Slice 3 — safety and recovery: validation, limits, path confinement, deduplication, removal, busy state, and rollback keep incomplete prompts from sending.
+- [x] Slice 4 — proof and polish: accessibility/responsive states, cross-platform path cases, full regression suites, macOS packaged smoke, and release note.
+
+## Notes for a fresh session
+
+- Source request: Slack thread `C09SDAQS3T3`, parent `1786728554.835109`.
+- Users can already give files to an agent from a live session, but the create-new screen has no corresponding interaction or QA coverage.
+- Worktree: `/Users/ewan/projects/sapiom/sapiom-js-worktree-new-session-file-uploads`.
+- Branch: `codex/new-session-file-uploads`, based on `origin/main` at `90d4fa7`.
+- The current checkout at `/Users/ewan/projects/sapiom/sapiom-js` has unrelated user work and must not be modified.
+- Gate 1 approved by the user on 2026-08-14.
+- Gate 1 reopened on 2026-08-14 to add clipboard image/file paste requested during Gate 2 review; normal text paste must remain unchanged.
+- Revised Gate 1, including clipboard attachments, approved by the user on 2026-08-14.
+- Gate 2 approved by the user on 2026-08-14. Live-session terminal drag/drop and copy/paste are an explicit regression boundary and remain unchanged.
+- Gate 3 approved by the user on 2026-08-14, including the macOS/Windows/Linux verification matrix.
+- Gate 4 approved by the user on 2026-08-14.
+- Slice 1 completed on 2026-08-14: production build, harness typecheck, 15 focused unit/regression tests, and the focused Chromium tracer test all pass.
+- Slice 2 completed on 2026-08-14: path-backed files stay zero-copy; picker, drag/drop, pathless clipboard files, the boot-token local materialization client/route, mixed ordering, and ordinary text paste are wired end to end. Harness typecheck and production build pass; 83 focused unit/server regressions and all 10 create-new Chromium tests pass. `Terminal.tsx` and `terminal-drop.ts` remain unchanged.
+- Slice 3 completed on 2026-08-14: 10 MiB per-file and 50 MiB aggregate inline limits, linear base64 validation, server-owned filenames, realpath/symlink confinement, 30/min client rate limiting, SHA-256 inline deduplication, removal, serialized queueing, synchronous submit locking, and provisional-session rollback are implemented. A failed materialization kills the blank session, retains the exact queue, sends no prompt, and retries cleanly. Full typecheck and production build pass; 100 focused unit/server regressions and all 13 create-new Chromium tests pass. Harness lint reports zero errors and one pre-existing warning from `origin/main`.
+- Slice 4 completed on 2026-08-14: tokenized dragging/queued/busy states, live ARIA status, filename-safe analytics redaction, reduced motion, visible keyboard focus, and 44 px narrow-screen controls are implemented. Harness typecheck/build pass; 2,095 unit/integration tests, 4 performance tests, all 319 Chromium tests (including 15 create-new cases), and all 152 desktop tests pass. Lint has zero errors and the same pre-existing warning from `origin/main`.
+- The unsigned macOS arm64 package builds under Node 22/Python 3.11 and its isolated packaged smoke reports 13 passed, 1 intentionally skipped Windows-only check. Packaged UI validation proved real Finder copy/paste, ordinary text paste, removal, and the exact zero-copy macOS path returned by `pathForFile`; a packaged DevTools probe also proved drag/drop and clipboard-file queueing for pathless files. The system picker itself is native OS UI and the ScreenCaptureKit driver could not snapshot its modal, so its product callback remains covered by Playwright rather than a recorded pointer interaction.
+- macOS is the only packaged OS exercised locally. Fast tests cover explicit POSIX and Windows quoting/path cases; Linux and Windows packaged smoke remain evidence for their existing CI runners and must not be claimed until that CI runs on a pushed PR.

--- a/docs/plans/new-session-file-uploads/01-product.md
+++ b/docs/plans/new-session-file-uploads/01-product.md
@@ -1,0 +1,17 @@
+# Product: New-session file uploads
+
+## Problem
+
+When someone is describing a new agent, important context often already exists in screenshots, documents, data files, or examples on their computer. The create-new screen only accepts typed text today, forcing them to start a session first and then add the files again. This makes the first request incomplete and makes Studio feel less capable precisely at the moment a user is explaining what they want to build.
+
+## Success metric
+
+At least 95% of new-agent starts that include files deliver every selected file with the user's first request, measured from attachment selection through receipt by the agent.
+
+## Announcement — the blog post before the feature
+
+You can now give a new agent the files it needs before starting the session. Paste an image or copied file directly into the create-new composer, drop files from Finder, or choose them with the attachment button. Ordinary copied text still pastes into the description normally. Selected files stay visible and removable so you always know what will be sent. When you start the session, the agent receives your description and every attached file together as its first request.
+
+## Screens
+
+- `mockups/new-session-with-files.html` — the create-new composer with clipboard paste, an attachment button, selected-file tray, remove actions, and a full-composer drag target.

--- a/docs/plans/new-session-file-uploads/02-architecture.md
+++ b/docs/plans/new-session-file-uploads/02-architecture.md
@@ -1,0 +1,61 @@
+# Architecture: New-session file uploads
+
+## Fit
+
+- `NewSessionComposer` owns a temporary attachment queue, picker, composer-scoped clipboard listener, drag state, removal controls, and accessible announcements. The listener is attached to the create-new composer rather than `window`, so it cannot intercept a live terminal paste. Ordinary clipboard text is ignored by attachment handling and continues into the textarea normally.
+- Queue entries use two sources:
+  - `path`: a dropped, picked, or copied file that Electron can resolve to an existing absolute path through the current desktop bridge.
+  - `inline`: a clipboard `File` with no path (most importantly a pasted screenshot), retained in renderer memory until the session exists.
+- This split follows Electron's contract: `webUtils.getPathForFile` returns an empty string for a JavaScript-created `File` that is not backed by a file on disk. Path-backed files therefore stay zero-copy, while clipboard-only bytes take a bounded fallback route.
+- A small pure attachment module normalizes/deduplicates queue entries and formats resolved paths as first-request context. It shares the existing terminal path-quoting rule instead of defining a second escaping format.
+- `App` continues to own session creation. It uses only the user's text to choose the project name, creates the session, materializes any inline attachments, and then passes the complete text-plus-file request through the existing held-first-prompt path.
+- The existing live-terminal drag/drop and copy/paste behavior remains untouched; `Terminal.tsx` and `terminal-drop.ts` are not part of this feature's implementation surface.
+
+## Endpoints
+
+- `POST /api/sessions/:id/attachments` — accepts one base64 data URL plus a display filename for a clipboard-only file, writes it under the session's `.sapiom/uploads/` directory, and returns its absolute path without injecting terminal input.
+
+The endpoint is behind the existing boot-token middleware. It validates the session, payload shape, decoded size, media type syntax, and filename; generates the stored filename server-side; confines writes to the session working directory; and uses a per-client rate limit. A single inline attachment is capped at 10 MiB and the renderer caps one new session's aggregate inline queue at 50 MiB. Path-backed desktop files do not traverse this endpoint and have no Studio-imposed size limit.
+
+## Data
+
+No database or settings changes.
+
+Renderer-only queue entries:
+
+- Path-backed: display name + absolute path.
+- Clipboard-only: display name + media type + byte size + data URL + SHA-256 content fingerprint for deduplication.
+
+Clipboard-only files are written to `.sapiom/uploads/` inside the new project after session creation. That directory is already covered by the scaffold's `.sapiom/` ignore rule. Queue state is discarded when an item is removed or the completed create flow leaves the composer.
+
+Primary operations:
+
+- Inspect only file-bearing clipboard items; never intercept a text-only paste.
+- Prefer a bridge-resolved local path.
+- Fall back to reading unresolved clipboard files into bounded inline entries.
+- Reject unreadable or oversized inline entries with user-visible feedback.
+- Deduplicate while preserving user order.
+- Materialize inline entries and combine all resulting paths into one first request.
+
+## Flow
+
+1. The user pastes a file/image while the composer is focused, drops files over the composer, or chooses files with the attachment button.
+2. `NewSessionComposer` checks each `File` with the existing desktop bridge.
+3. Path-backed files queue by absolute path. Unresolved clipboard files are read into the bounded inline form. Selected files appear in one removable tray.
+4. The user starts the session with text, files, or both.
+5. `App` derives the project folder from the user's text only and creates the session.
+6. `App` sends each inline entry to the attachment endpoint and replaces it with the returned project-local path. If any materialization fails, it does not send an incomplete first request and surfaces the named failure.
+7. `App` formats the user's text plus every resolved path and registers that complete request with the existing readiness hold.
+8. Once Claude Code or Codex is ready, the existing bracketed-paste submission delivers the request as one turn.
+
+## External
+
+No third-party APIs, environment variables, storage services, permissions, or new Electron IPC channels. The existing `pathForFile` bridge is reused; clipboard-only bytes travel only to Studio's boot-token-protected local server.
+
+## Portability
+
+- The renderer uses standard `File`, `DataTransfer`, and `ClipboardEvent` APIs already provided by Electron's Chromium runtime on macOS, Windows, and Linux.
+- The desktop bridge uses Electron's cross-platform `webUtils.getPathForFile` implementation.
+- Server writes use Node path utilities and byte APIs, never shell commands or hand-built separators.
+- Existing quoting covers POSIX paths, Windows drive paths, spaces, quotes, and backslashes.
+- Native macOS behavior is verified locally. Shared browser/server tests exercise platform-neutral behavior and explicit POSIX/Windows paths; packaged Linux and Windows evidence comes from the repository's OS-specific CI/release jobs and is reported separately rather than inferred from a macOS run.

--- a/docs/plans/new-session-file-uploads/03-program-design.md
+++ b/docs/plans/new-session-file-uploads/03-program-design.md
@@ -1,0 +1,233 @@
+# Program Design: New-session file uploads
+
+## Files
+
+- `.changeset/new-session-file-uploads.md` — patch release note for `@sapiom/harness`.
+- `packages/harness/src/shared/types.ts` — attachment directory, inline-size limit, and REST request/response contracts shared by server and SPA.
+- `packages/harness/src/server/rest.ts` — boot-token-gated attachment materialization route, validation, safe filename generation, rate limiting, and session lookup.
+- `packages/harness/src/server/rest.test.ts` — HTTP contract, size/error cases, path confinement, and proof that materialization never injects terminal input.
+- `packages/harness/web/src/lib/api.ts` — real and mock attachment clients; mock call/failure instrumentation for Playwright.
+- `packages/harness/web/src/lib/use-harness-state.ts` — stable attachment callback exposed to `App` through the existing harness state facade.
+- `packages/harness/web/src/lib/new-session-attachments.ts` — queue model, file conversion, deduplication, materialization orchestration, and first-request formatting.
+- `packages/harness/web/src/lib/new-session-attachments.test.ts` — fast tests for queue behavior, rollback-safe failure propagation, prompt composition, and POSIX/Windows paths.
+- `packages/harness/web/src/components/NewSessionComposer.tsx` — scoped paste/drop/picker interactions, attachment tray, remove controls, progress state, and accessible announcements.
+- `packages/harness/web/src/App.tsx` — derive the project name from text alone, keep the composer mounted during creation/materialization, close the provisional session on materialization failure, and register the complete held first prompt.
+- `packages/harness/web/src/styles.css` — attachment tray, drag target, busy state, responsive wrapping, and focus/hover treatments using existing tokens.
+- `packages/harness/web/e2e/new-session-composer.spec.ts` — user-path and regression tests for picker, drag, clipboard file, ordinary text paste, removal, attach-only start, delivery, and failure recovery.
+- `docs/plans/new-session-file-uploads/*` — durable gate decisions, mockup, and slice status.
+
+Explicitly unchanged implementation files:
+
+- `packages/harness/web/src/components/Terminal.tsx`
+- `packages/harness/web/src/lib/terminal-drop.ts`
+
+Their existing tests still run as regression coverage.
+
+## Types & signatures
+
+```ts
+export const HARNESS_UPLOADS_DIR = ".sapiom/uploads";
+export const MAX_INLINE_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+export const MAX_INLINE_ATTACHMENTS_TOTAL_BYTES = 50 * 1024 * 1024;
+
+export interface AttachFileRequest {
+  dataUrl: string;
+  filename: string;
+}
+
+export interface AttachFileResponse {
+  path: string;
+  mediaType: string;
+  bytes: number;
+}
+```
+
+```ts
+export type NewSessionAttachment =
+  | {
+      id: string;
+      kind: "path";
+      name: string;
+      path: string;
+    }
+  | {
+      id: string;
+      kind: "inline";
+      name: string;
+      mediaType: string;
+      bytes: number;
+      dataUrl: string;
+      fingerprint: string;
+    };
+
+export interface ResolvedNewSessionAttachment {
+  name: string;
+  path: string;
+}
+
+export interface QueueFilesResult {
+  attachments: NewSessionAttachment[];
+  errors: string[];
+}
+
+export async function filesToAttachments(
+  files: readonly File[],
+  pathForFile?: (file: File) => string,
+): Promise<QueueFilesResult>;
+
+export function mergeAttachments(
+  current: readonly NewSessionAttachment[],
+  incoming: readonly NewSessionAttachment[],
+): NewSessionAttachment[];
+
+export async function materializeAttachments(
+  sessionId: string,
+  attachments: readonly NewSessionAttachment[],
+  upload: (
+    sessionId: string,
+    request: AttachFileRequest,
+  ) => Promise<AttachFileResponse>,
+): Promise<ResolvedNewSessionAttachment[]>;
+
+export function buildIdeaWithAttachments(
+  idea: string,
+  attachments: readonly ResolvedNewSessionAttachment[],
+): string | undefined;
+```
+
+```ts
+interface HarnessApi {
+  attachFile(
+    id: string,
+    request: AttachFileRequest,
+  ): Promise<AttachFileResponse>;
+}
+
+interface NewSessionComposerProps {
+  onSubmitIdea: (
+    idea: string,
+    harness: HarnessKind,
+    attachments: readonly NewSessionAttachment[],
+  ) => Promise<void>;
+  onAttachmentError: (message: string) => void;
+  // existing props unchanged
+}
+```
+
+```ts
+// App-local extension of the existing creation choke point.
+interface CreateSessionAtOptions {
+  keepComposerOpen?: boolean;
+}
+
+async function createSessionAt(
+  cwd: string,
+  harness: HarnessKind,
+  options?: CreateSessionAtOptions,
+): Promise<HarnessSession>;
+```
+
+Server route contract:
+
+```text
+POST /api/sessions/:id/attachments
+AttachFileRequest -> AttachFileResponse
+```
+
+## Call stack
+
+### Queue by paste, drag, or picker
+
+1. Composer-scoped `paste`, `drop`, or file-input `change` handler receives browser `File` objects.
+2. The paste handler exits without `preventDefault()` when there are no file items.
+3. `filesToAttachments` tries the optional desktop `pathForFile` capability.
+4. A real path becomes a zero-copy path entry; an unresolved file is read into a capped inline entry.
+5. `mergeAttachments` deduplicates and preserves order.
+6. `NewSessionComposer` renders the tray and announces the new count; errors go through the existing toast surface.
+
+### Start the new session
+
+1. `NewSessionComposer.submit` guards against duplicate submits and awaits `App.handleComposerSubmitIdea`.
+2. `App` derives `cwd` from the original text only.
+3. `createSessionAt(..., { keepComposerOpen: true })` creates/selects a provisional session while the composer and its queue remain mounted.
+4. `materializeAttachments` passes path entries through and sends inline entries through `harness.attachFile`.
+5. On success, `buildIdeaWithAttachments` appends one quoted path per attachment and `sendPromptWhenReady` registers the complete scaffold request.
+6. `App` closes the composer; the existing readiness effect submits the request once the agent is ready.
+7. On materialization failure, `App` closes the provisional session, leaves the composer/queue intact, surfaces the named error, and sends no prompt.
+
+### Inline materialization
+
+1. `RealApi.attachFile` POSTs the data URL and display filename with the boot token.
+2. `createRestRouter` rate-limits, validates the request and live session, decodes/caps bytes, and derives a server-owned safe filename.
+3. The route resolves `.sapiom/uploads/` within the session cwd, creates it, writes the bytes, and returns the absolute path.
+4. The route never calls `SessionManager.submitInput`; first-request submission remains one operation owned by `App`.
+
+## Test plan
+
+### Fast unit tests
+
+- `filesToAttachments uses a desktop path without reading or copying bytes`.
+- `filesToAttachments falls back to inline bytes for a pathless clipboard image`.
+- `filesToAttachments rejects an inline file over 10 MiB with its filename`.
+- `mergeAttachments deduplicates repeated disk paths and repeated inline identities while preserving order`.
+- `buildIdeaWithAttachments preserves user text and quotes POSIX paths with spaces`.
+- `buildIdeaWithAttachments handles Windows drive paths/backslashes without corrupting them`.
+- `buildIdeaWithAttachments supports attachments with no typed text`.
+- `materializeAttachments preserves mixed path/inline order and propagates a named upload failure`.
+- Existing `terminal-drop.test.ts` remains green unchanged.
+
+### Server integration tests
+
+- `POST attachment writes decoded bytes below the session cwd and returns the path`.
+- `uses a server-owned filename even when the display filename contains traversal segments`.
+- `accepts representative image, PDF, text, and generic binary media types`.
+- `rejects malformed/empty base64, an oversized decoded payload, an unknown session, and a missing filename`.
+- `rate limits a runaway attachment client`.
+- `never calls submitInput while materializing a file`.
+
+### Browser interaction tests
+
+- Attachment button opens the hidden multi-file picker; selected filenames render with remove controls.
+- Finder-style drag shows the drop state and queues every file.
+- Clipboard image paste queues an inline file and prevents binary content entering the textarea.
+- Copied file paste queues the file.
+- Text-only paste edits the textarea and creates no attachment.
+- Re-adding the same file does not duplicate it.
+- Removing a file excludes it from the first request.
+- Text plus mixed attachments reaches the mock agent in one first request and keeps the text-derived project slug.
+- Attachments without text use the fallback project name and still reach the mock agent.
+- Materialization failure leaves the composer and attachment queue intact and sends no partial prompt.
+- Submit controls expose a busy state and prevent double session creation.
+- Existing new-session and terminal-related browser tests remain green.
+
+### Cross-platform and packaged verification
+
+- Typecheck and build the harness plus desktop host.
+- Run all harness unit/integration tests and the full Playwright mock suite.
+- Exercise explicit POSIX and Windows path cases in fast tests.
+- Package the macOS desktop app, run its smoke suite, then manually verify picker, Finder drag, pasted screenshot, ordinary text paste, removal, and first-request receipt with a real agent.
+- Linux packaged smoke is covered by the harness PR workflow.
+- Windows packaging/smoke is covered by the existing `windows-2022` desktop release matrix; report it as CI evidence, not local evidence.
+
+## Design-system extension
+
+### Existing patterns
+
+- The attachment button reuses the composer's existing square ghost-control recipe beside the folder button.
+- Attachment rows reuse raised-surface, hairline, tokenized text, and existing `Paperclip`/`X` icons.
+- Errors use the current toast; no new feedback surface is introduced.
+
+### States and accessibility
+
+- Default: attachment button is keyboard focusable and labelled “Attach files”.
+- Dragging: the composer border/drop overlay changes with existing brand and surface tokens; no layout shift.
+- Queued: a labelled list exposes each filename and a per-file “Remove &lt;name&gt;” button.
+- Busy: send, picker, removal, and repeat submission are disabled; an `aria-live` status reports attachment processing.
+- Error: the tray remains intact and focus stays in the composer so the user can retry.
+- Text paste: native textarea behavior is preserved because file handling does not cancel a file-free paste.
+
+## Least confident decisions
+
+1. Clipboard file representation differs by OS/application. The design handles both disk-backed and pathless `File` objects, but native pasted-screenshot proof is only possible on the OS being run; Windows/Linux native evidence must come from their packaged jobs or hands-on QA.
+2. A 10 MiB cap applies only to clipboard-only bytes. It is intentionally aligned with the repo's former image composer and current 15 MiB JSON parser ceiling; path-backed Finder files remain zero-copy and uncapped.
+3. Materialization happens after a provisional session exists because that safely scopes the write to an established cwd. Keeping the composer mounted and closing that provisional session on failure prevents a duplicate retry or a silently incomplete first prompt, at the cost of a little orchestration in `App`.

--- a/docs/plans/new-session-file-uploads/04-slices.md
+++ b/docs/plans/new-session-file-uploads/04-slices.md
@@ -1,0 +1,8 @@
+# Vertical Slices: New-session file uploads
+
+1. **Tracer bullet — one file reaches the first request.** Add the minimal queue contract and attachment row/button, wire one path-backed file through `NewSessionComposer` → `App` → the existing readiness hold, and prove in the mock browser that the agent's first request contains the path while the project name still comes from typed text.
+2. **Real happy path — every ingest surface and clipboard fallback.** Implement picker, Finder-style drop, composer-scoped file paste, path resolution, pathless-file conversion, the local materialization endpoint/client, and mixed-attachment ordering; prove path-backed and clipboard-only files arrive together while text-only paste stays native.
+3. **Safety and recovery — never lose context or send a partial request.** Add decoded/aggregate size validation, rate limiting, safe server-owned filenames, cwd confinement, queue deduplication/removal, submit locking, and provisional-session rollback; prove failures retain the queue and send no prompt.
+4. **Proof and polish — shippable across Studio hosts.** Finish tokenized drag/queued/busy/responsive states and ARIA behavior, add the changeset, run focused-to-full unit/integration/Playwright/desktop checks, package and smoke the macOS app, manually exercise the real Finder/paste flow, and record Linux/Windows evidence boundaries.
+
+Every slice ends with a running UI path and its own focused automated proof. Existing `Terminal.tsx` and `terminal-drop.ts` remain unchanged through all four slices, and their regression tests run before completion.

--- a/docs/plans/new-session-file-uploads/mockups/new-session-with-files.html
+++ b/docs/plans/new-session-file-uploads/mockups/new-session-with-files.html
@@ -1,0 +1,289 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>New session with files — product mockup</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0b0e13;
+        --surface: #151920;
+        --surface-hover: #1c222b;
+        --line: #313844;
+        --text: #f3f3f5;
+        --muted: #9aa3af;
+        --faint: #697380;
+        --brand: #6be195;
+        --brand-ink: #07140c;
+        --danger: #f4a7a1;
+        --radius: 9px;
+        font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: var(--bg);
+        color: var(--text);
+      }
+      main {
+        width: min(640px, calc(100vw - 40px));
+        text-align: center;
+      }
+      .greeting {
+        margin: 0 0 8px;
+        color: var(--muted);
+        font-size: 14px;
+      }
+      h1 {
+        margin: 0 0 24px;
+        font-size: 26px;
+        letter-spacing: -0.02em;
+      }
+      .chips {
+        display: flex;
+        justify-content: center;
+        gap: 8px;
+        margin-bottom: 18px;
+      }
+      .chip,
+      .icon-button,
+      .agent-select {
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: transparent;
+        color: var(--muted);
+        height: 30px;
+      }
+      .chip {
+        padding: 0 12px;
+        background: var(--surface);
+      }
+      .composer {
+        position: relative;
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        padding: 12px;
+        background: var(--surface);
+        box-shadow: 0 14px 36px rgb(0 0 0 / 0.22);
+        text-align: left;
+      }
+      textarea {
+        width: 100%;
+        min-height: 68px;
+        resize: none;
+        border: 0;
+        outline: 0;
+        background: transparent;
+        color: var(--text);
+        font: inherit;
+        line-height: 1.5;
+      }
+      textarea::placeholder {
+        color: var(--faint);
+      }
+      .files {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        margin: 6px 0 12px;
+        padding: 0;
+        list-style: none;
+      }
+      .file {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        min-width: 0;
+        max-width: 250px;
+        height: 34px;
+        padding: 0 7px 0 9px;
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        background: var(--surface-hover);
+        color: var(--text);
+      }
+      .file-icon {
+        color: var(--brand);
+      }
+      .file-name {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-size: 12px;
+      }
+      .remove {
+        border: 0;
+        background: transparent;
+        color: var(--faint);
+        font-size: 18px;
+        cursor: pointer;
+      }
+      .remove:hover {
+        color: var(--danger);
+      }
+      .actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .icon-button {
+        width: 30px;
+        cursor: pointer;
+        font-size: 16px;
+      }
+      .icon-button:hover,
+      .agent-select:hover {
+        background: var(--surface-hover);
+        color: var(--text);
+      }
+      .right {
+        margin-left: auto;
+        display: flex;
+        gap: 8px;
+      }
+      .agent-select {
+        padding: 0 10px;
+      }
+      .send {
+        width: 30px;
+        height: 30px;
+        border: 0;
+        border-radius: var(--radius);
+        background: var(--brand);
+        color: var(--brand-ink);
+        font-size: 18px;
+        cursor: pointer;
+      }
+      .drop-overlay {
+        position: absolute;
+        inset: 6px;
+        display: none;
+        place-items: center;
+        border: 1px dashed var(--brand);
+        border-radius: 11px;
+        background: color-mix(in srgb, var(--bg) 86%, var(--brand));
+        color: var(--brand);
+        font-size: 14px;
+        font-weight: 600;
+        pointer-events: none;
+      }
+      .composer.is-dragging .drop-overlay {
+        display: grid;
+      }
+      .hint {
+        margin: 10px 0 0;
+        color: var(--faint);
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p class="greeting">Good evening. Let's build a new agent.</p>
+      <h1>What should your agent do?</h1>
+      <div class="chips" aria-label="Suggestions">
+        <button class="chip">sales outreach</button>
+        <button class="chip">support triage</button>
+        <button class="chip">research digest</button>
+        <button class="chip">code review</button>
+      </div>
+      <section class="composer" id="composer" aria-label="Describe a new agent">
+        <textarea placeholder="Describe the outcome you want">
+Turn the attached sketches and requirements into a working onboarding flow.</textarea
+        >
+        <ul class="files" id="files" aria-label="Attached files">
+          <li class="file">
+            <span class="file-icon">▧</span
+            ><span class="file-name">onboarding-sketch.png</span
+            ><button class="remove" aria-label="Remove onboarding-sketch.png">
+              ×
+            </button>
+          </li>
+          <li class="file">
+            <span class="file-icon">▤</span
+            ><span class="file-name">requirements.pdf</span
+            ><button class="remove" aria-label="Remove requirements.pdf">
+              ×
+            </button>
+          </li>
+        </ul>
+        <div class="actions">
+          <button
+            class="icon-button"
+            aria-label="Open a folder"
+            title="Open a folder"
+          >
+            ＋
+          </button>
+          <button
+            class="icon-button"
+            id="attach"
+            aria-label="Attach files"
+            title="Attach files"
+          >
+            ⌕
+          </button>
+          <input id="picker" type="file" multiple hidden />
+          <div class="right">
+            <button class="agent-select">Claude Code⌄</button>
+            <button class="send" aria-label="Start session">↑</button>
+          </div>
+        </div>
+        <div class="drop-overlay">Drop files to attach</div>
+      </section>
+      <p class="hint">
+        Paste, drop, or choose files. Ordinary text paste still edits the
+        description. Files can be removed before starting.
+      </p>
+    </main>
+    <script>
+      const composer = document.querySelector("#composer");
+      const picker = document.querySelector("#picker");
+      const files = document.querySelector("#files");
+      const addFiles = (items) => {
+        for (const item of items) {
+          const row = document.createElement("li");
+          row.className = "file";
+          row.innerHTML = `<span class="file-icon">▧</span><span class="file-name"></span><button class="remove" aria-label="Remove file">×</button>`;
+          row.querySelector(".file-name").textContent = item.name;
+          row
+            .querySelector(".remove")
+            .addEventListener("click", () => row.remove());
+          files.append(row);
+        }
+      };
+      document
+        .querySelector("#attach")
+        .addEventListener("click", () => picker.click());
+      picker.addEventListener("change", () => addFiles(picker.files));
+      composer.addEventListener("paste", (event) => {
+        const pastedFiles = Array.from(event.clipboardData?.files ?? []);
+        if (pastedFiles.length === 0) return;
+        event.preventDefault();
+        addFiles(pastedFiles);
+      });
+      files.addEventListener("click", (event) => {
+        if (event.target.classList.contains("remove"))
+          event.target.closest(".file").remove();
+      });
+      composer.addEventListener("dragover", (event) => {
+        event.preventDefault();
+        composer.classList.add("is-dragging");
+      });
+      composer.addEventListener("dragleave", () =>
+        composer.classList.remove("is-dragging"),
+      );
+      composer.addEventListener("drop", (event) => {
+        event.preventDefault();
+        composer.classList.remove("is-dragging");
+        addFiles(event.dataTransfer.files);
+      });
+    </script>
+  </body>
+</html>

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -481,6 +481,148 @@ describe("createRestRouter", () => {
     });
   });
 
+  describe("POST /sessions/:id/attachments", () => {
+    let projectRoot: string;
+    let sessionManager: RestRouterOptions["sessionManager"];
+
+    beforeEach(async () => {
+      projectRoot = path.join(tmpHome, "project");
+      await fs.mkdir(projectRoot, { recursive: true });
+      projectRoot = await fs.realpath(projectRoot);
+      sessionManager = fakeSessionManager([
+        exitedSession({
+          id: "sess-upload",
+          cwd: projectRoot,
+          status: "running",
+          exitCode: null,
+        }),
+      ]);
+      start({ sessionManager });
+    });
+
+    const postAttachment = (
+      body: unknown,
+      sessionId = "sess-upload",
+    ): Promise<Response> =>
+      fetch(`${baseUrl}/sessions/${sessionId}/attachments`, {
+        method: "POST",
+        headers: { ...TOKEN_HEADER, "content-type": "application/json" },
+        body: JSON.stringify(body),
+      });
+
+    it("materializes clipboard bytes under the session cwd without injecting input", async () => {
+      const res = await postAttachment({
+        filename: "screenshot.png",
+        dataUrl: "data:image/png;base64,cGl4ZWxz",
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        path: string;
+        mediaType: string;
+        bytes: number;
+      };
+      expect(body.mediaType).toBe("image/png");
+      expect(body.bytes).toBe(6);
+      const relativePath = path.relative(projectRoot, body.path);
+      const relativeParts = relativePath.split(path.sep);
+      expect(relativeParts.slice(0, 2)).toEqual([".sapiom", "uploads"]);
+      expect(relativeParts[2]).toMatch(/^[0-9a-f-]+\.png$/);
+      await expect(fs.readFile(body.path, "utf8")).resolves.toBe("pixels");
+      expect(sessionManager.submitInput).not.toHaveBeenCalled();
+    });
+
+    it("uses a server-owned filename for a traversal-shaped display name", async () => {
+      const res = await postAttachment({
+        filename: "../../outside/escape.pdf",
+        dataUrl: "data:application/pdf;base64,UERG",
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { path: string };
+      expect(path.dirname(body.path)).toBe(
+        path.join(projectRoot, ".sapiom", "uploads"),
+      );
+      expect(path.basename(body.path)).toMatch(/^[0-9a-f-]+\.pdf$/);
+      expect(path.basename(body.path)).not.toBe("escape.pdf");
+    });
+
+    it.each([
+      ["image/png", "image.png"],
+      ["application/pdf", "document.pdf"],
+      ["text/plain", "notes.txt"],
+      ["application/octet-stream", "data.bin"],
+    ])("accepts %s clipboard data", async (mediaType, filename) => {
+      const res = await postAttachment({
+        filename,
+        dataUrl: `data:${mediaType};base64,YQ==`,
+      });
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({ mediaType, bytes: 1 });
+    });
+
+    it.each([
+      [{ filename: "bad.bin", dataUrl: "not-a-data-url" }, 400],
+      [{ filename: "bad.bin", dataUrl: "data:text/plain;base64,%%%" }, 400],
+      [{ filename: "empty.bin", dataUrl: "data:text/plain;base64," }, 400],
+      [{ dataUrl: "data:text/plain;base64,YQ==" }, 400],
+    ])("rejects an invalid attachment request", async (body, status) => {
+      const res = await postAttachment(body);
+      expect(res.status).toBe(status);
+    });
+
+    it("rejects a decoded payload over 10 MiB", async () => {
+      const encoded = Buffer.alloc(10 * 1024 * 1024 + 1).toString("base64");
+      const res = await postAttachment({
+        filename: "too-large.bin",
+        dataUrl: `data:application/octet-stream;base64,${encoded}`,
+      });
+      expect(res.status).toBe(413);
+    });
+
+    it("rejects an unknown session", async () => {
+      const res = await postAttachment(
+        { filename: "note.txt", dataUrl: "data:text/plain;base64,YQ==" },
+        "missing",
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it.skipIf(process.platform === "win32")(
+      "rejects an uploads symlink that escapes the session cwd",
+      async () => {
+        const outside = path.join(tmpHome, "outside");
+        await fs.mkdir(path.join(projectRoot, ".sapiom"), { recursive: true });
+        await fs.mkdir(outside, { recursive: true });
+        await fs.symlink(outside, path.join(projectRoot, ".sapiom", "uploads"));
+
+        const res = await postAttachment({
+          filename: "escape.txt",
+          dataUrl: "data:text/plain;base64,YQ==",
+        });
+
+        expect(res.status).toBe(400);
+        await expect(fs.readdir(outside)).resolves.toEqual([]);
+      },
+    );
+
+    it("rate limits a runaway attachment client", async () => {
+      for (let index = 0; index < 30; index += 1) {
+        const res = await postAttachment({
+          filename: `note-${index}.txt`,
+          dataUrl: "data:text/plain;base64,YQ==",
+        });
+        expect(res.status).toBe(200);
+      }
+      const limited = await postAttachment({
+        filename: "one-too-many.txt",
+        dataUrl: "data:text/plain;base64,YQ==",
+      });
+      expect(limited.status).toBe(429);
+    });
+  });
+
   describe("POST /sessions/:id/input", () => {
     it("submits input and returns ok:true", async () => {
       const sessionManager = fakeSessionManager();

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -5,13 +5,18 @@
  */
 
 import express, { Router } from "express";
+import rateLimit from "express-rate-limit";
 import { z } from "zod";
 
 import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import type {
   AdoptSessionRequest,
   AnalyticsEvent,
   AppState,
+  AttachFileRequest,
+  AttachFileResponse,
   BackgroundTask,
   BindWorkflowRequest,
   CreateSessionRequest,
@@ -28,7 +33,9 @@ import type {
   WorkflowInfo,
 } from "../shared/types.js";
 import {
+  HARNESS_UPLOADS_DIR,
   JSON_BODY_LIMIT_BYTES,
+  MAX_INLINE_ATTACHMENT_BYTES,
   SPAWNABLE_HARNESS_KINDS,
   EDITOR_KINDS,
 } from "../shared/types.js";
@@ -37,7 +44,28 @@ import { SessionNotReadyError, UnknownSessionError, type SessionManager } from "
 import { normalizeCwd } from "./cwd-normalize.js";
 import type { SessionRecordReader } from "../core/session-record.js";
 import { getHarnessAdapter, listHarnessAdapters } from "../core/adapters/registry.js";
+import { resolveWithinRoot } from "../core/path-safety.js";
 import { loadSettings, saveSettings } from "../cli/settings.js";
+
+const DATA_URL_RE = /^data:([a-z0-9.+/-]+);base64,([\s\S]+)$/i;
+
+/** Validate standard padded base64 in one pass and return decoded size. */
+function decodedBase64Size(encoded: string): number | null {
+  if (encoded.length === 0 || encoded.length % 4 !== 0) return null;
+  const padding = encoded.endsWith("==") ? 2 : encoded.endsWith("=") ? 1 : 0;
+  const contentLength = encoded.length - padding;
+  for (let index = 0; index < encoded.length; index += 1) {
+    const code = encoded.charCodeAt(index);
+    const isDataCharacter =
+      (code >= 65 && code <= 90) ||
+      (code >= 97 && code <= 122) ||
+      (code >= 48 && code <= 57) ||
+      code === 43 ||
+      code === 47;
+    if (index < contentLength ? !isDataCharacter : code !== 61) return null;
+  }
+  return (encoded.length / 4) * 3 - padding;
+}
 
 // Derived from SPAWNABLE_HARNESS_KINDS (shared/types.ts) so the zod
 // validation and the TypeScript type can never drift from each other.
@@ -55,6 +83,11 @@ const injectInputSchema = z.object({
   text: z.string(),
   submit: z.boolean().optional(),
 }) satisfies z.ZodType<InjectInputRequest>;
+
+const attachFileSchema = z.object({
+  dataUrl: z.string().min(1),
+  filename: z.string().trim().min(1).max(255),
+}) satisfies z.ZodType<AttachFileRequest>;
 
 const bindWorkflowSchema = z.object({
   workflowPath: z.string().min(1).nullable(),
@@ -248,6 +281,12 @@ export function createRestRouter(options: RestRouterOptions): Router {
     listMacros,
   } = options;
   const router = Router();
+  const attachmentUploadRateLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
   router.use(express.json({ limit: JSON_BODY_LIMIT_BYTES }));
 
   router.get("/state", async (_req, res, next) => {
@@ -385,6 +424,91 @@ export function createRestRouter(options: RestRouterOptions): Router {
       next(err);
     }
   });
+
+  router.post(
+    "/sessions/:id/attachments",
+    attachmentUploadRateLimiter,
+    async (req, res, next) => {
+      const parsed = attachFileSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json({ error: parsed.error.message });
+        return;
+      }
+
+      const session = sessionManager.get(req.params.id);
+      if (!session) {
+        res.status(404).json({ error: "session not found" });
+        return;
+      }
+
+      const match = DATA_URL_RE.exec(parsed.data.dataUrl);
+      if (!match) {
+        res.status(400).json({ error: "dataUrl must be a base64 data: URL" });
+        return;
+      }
+
+      const mediaType = match[1]!.toLowerCase();
+      const encoded = match[2]!;
+      const decodedSize = decodedBase64Size(encoded);
+      if (decodedSize === null) {
+        res
+          .status(400)
+          .json({ error: "attachment payload is not valid base64" });
+        return;
+      }
+      if (decodedSize === 0) {
+        res.status(400).json({ error: "attachment payload is empty" });
+        return;
+      }
+      if (decodedSize > MAX_INLINE_ATTACHMENT_BYTES) {
+        res.status(413).json({
+          error: `Attachment is ${decodedSize} bytes; the limit is ${MAX_INLINE_ATTACHMENT_BYTES} bytes`,
+        });
+        return;
+      }
+      const buffer = Buffer.from(encoded, "base64");
+
+      const uploadsDir = resolveWithinRoot(session.cwd, HARNESS_UPLOADS_DIR);
+      if (!uploadsDir) {
+        res
+          .status(500)
+          .json({ error: "could not resolve the uploads directory" });
+        return;
+      }
+      const requestedExtension = path.extname(
+        path.basename(parsed.data.filename),
+      );
+      const extension = /^\.[a-z0-9]{1,12}$/i.test(requestedExtension)
+        ? requestedExtension.toLowerCase()
+        : ".bin";
+      try {
+        await fs.mkdir(uploadsDir, { recursive: true });
+        const [realCwd, realUploadsDir] = await Promise.all([
+          fs.realpath(session.cwd),
+          fs.realpath(uploadsDir),
+        ]);
+        if (!resolveWithinRoot(realCwd, realUploadsDir)) {
+          res.status(400).json({
+            error: "uploads directory escapes the session cwd",
+          });
+          return;
+        }
+        const filePath = path.join(
+          realUploadsDir,
+          `${randomUUID()}${extension}`,
+        );
+        await fs.writeFile(filePath, buffer);
+        const response: AttachFileResponse = {
+          path: filePath,
+          mediaType,
+          bytes: buffer.byteLength,
+        };
+        res.json(response);
+      } catch (error) {
+        next(error);
+      }
+    },
+  );
 
   router.patch("/sessions/:id/workflow", async (req, res, next) => {
     const parsed = bindWorkflowSchema.safeParse(req.body);

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -71,6 +71,16 @@ export const CANVAS_INDEX = `${CANVAS_DIR}/index.html`;
  */
 export const CANVAS_RENDERS_DIR = `${CANVAS_DIR}/renders`;
 
+/** Renderer-only files are materialized here before their paths are included
+ * in a new session's first prompt. Disk-backed attachments never get copied. */
+export const HARNESS_UPLOADS_DIR = ".sapiom/uploads";
+
+/** Hard cap for one pathless clipboard attachment after base64 decoding. */
+export const MAX_INLINE_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+
+/** Renderer-memory cap across all pathless files queued for one new session. */
+export const MAX_INLINE_ATTACHMENTS_TOTAL_BYTES = 50 * 1024 * 1024;
+
 /**
  * Body-parser byte limit for JSON `/api` routes, set well above express's
  * 100 KiB default so larger prompt / analytics payloads parse without a 413.
@@ -948,6 +958,7 @@ export interface SessionRecord {
 // POST   /api/sessions/:id/resume       → HarnessSession (new pty, --resume)
 // DELETE /api/sessions/:id              → { ok: true }   (kill pty)
 // POST   /api/sessions/:id/input        InjectInputRequest → { ok: true }
+// POST   /api/sessions/:id/attachments  AttachFileRequest → AttachFileResponse (materialize only)
 // PATCH  /api/sessions/:id/workflow     BindWorkflowRequest → HarnessSession
 // GET    /api/workflows                 → WorkflowInfo[]
 // POST   /api/workflows/connect         { path } → WorkflowInfo
@@ -992,6 +1003,22 @@ export interface CreateSessionRequest {
    * → server default (see createDefaultBuildLaunchOpts).
    */
   theme?: UiTheme;
+}
+
+/** One pathless clipboard file to materialize inside a new session's cwd. */
+export interface AttachFileRequest {
+  /** `data:<mediaType>;base64,<payload>`. */
+  dataUrl: string;
+  /** Display name only; the server always owns the stored filename. */
+  filename: string;
+}
+
+/** Result of materializing a pathless clipboard file. */
+export interface AttachFileResponse {
+  /** Absolute path beneath the session's `.sapiom/uploads` directory. */
+  path: string;
+  mediaType: string;
+  bytes: number;
 }
 
 /**

--- a/packages/harness/web/e2e/new-session-composer.spec.ts
+++ b/packages/harness/web/e2e/new-session-composer.spec.ts
@@ -61,6 +61,419 @@ test("describing an outcome starts a session and hands the agent that outcome", 
     .toContain("Diff our competitors' pricing pages");
 });
 
+test("a picked file reaches the first request without naming the project", async ({
+  page,
+}) => {
+  await page.getByTestId("rail-create-new").click();
+  await page.evaluate(() => {
+    window.sapiomDesktop = {
+      appVersion: "test",
+      checkForUpdates: async () => ({ kind: "disabled" }),
+      pathForFile: (file: File) => `/Users/test/My Files/${file.name}`,
+    };
+  });
+
+  await page.getByTestId("composer-input").fill("Build an onboarding flow.");
+  await page.getByTestId("composer-file-input").setInputFiles({
+    name: "requirements.pdf",
+    mimeType: "application/pdf",
+    buffer: Buffer.from("requirements"),
+  });
+
+  const files = page.getByTestId("composer-files");
+  await expect(files).toContainText("requirements.pdf");
+  await page.getByTestId("composer-send").click();
+
+  await expect
+    .poll(() => lastInjectText(page))
+    .toContain('"/Users/test/My Files/requirements.pdf"');
+
+  const createRequest = await page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __HARNESS_TEST__?: { lastCreateSession?: { req?: { cwd?: string } } };
+        }
+      ).__HARNESS_TEST__?.lastCreateSession?.req,
+  );
+  expect(createRequest?.cwd).toMatch(/\/build-onboarding-flow$/);
+  expect(createRequest?.cwd).not.toContain("requirements");
+});
+
+test("picker, drop, and pathless clipboard files reach one ordered first request", async ({
+  page,
+}) => {
+  await page.getByTestId("rail-create-new").click();
+  await page.evaluate(() => {
+    window.sapiomDesktop = {
+      appVersion: "test",
+      checkForUpdates: async () => ({ kind: "disabled" }),
+      pathForFile: (file: File) =>
+        file.name === "screenshot.png"
+          ? ""
+          : `/Users/test/Drop Zone/${file.name}`,
+    };
+  });
+
+  await page.getByTestId("composer-input").fill("Build mixed context.");
+  await page.getByTestId("composer-file-input").setInputFiles({
+    name: "requirements.pdf",
+    mimeType: "application/pdf",
+    buffer: Buffer.from("requirements"),
+  });
+
+  const composerBox = page.getByTestId("composer-box");
+  await page.evaluate(() => {
+    const box = document.querySelector<HTMLElement>(
+      "[data-testid='composer-box']",
+    )!;
+    const transfer = new DataTransfer();
+    transfer.items.add(
+      new File(["brief"], "brief.txt", { type: "text/plain" }),
+    );
+    box.dispatchEvent(
+      new DragEvent("dragenter", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: transfer,
+      }),
+    );
+  });
+  await expect(composerBox).toHaveClass(/is-dragging-files/);
+  await expect(page.getByRole("status")).toHaveText("Drop files to attach.");
+  await page.evaluate(() => {
+    const box = document.querySelector<HTMLElement>(
+      "[data-testid='composer-box']",
+    )!;
+    const transfer = new DataTransfer();
+    transfer.items.add(
+      new File(["brief"], "brief.txt", { type: "text/plain" }),
+    );
+    box.dispatchEvent(
+      new DragEvent("drop", {
+        bubbles: true,
+        cancelable: true,
+        dataTransfer: transfer,
+      }),
+    );
+  });
+  await expect(composerBox).not.toHaveClass(/is-dragging-files/);
+
+  await page.evaluate(() => {
+    const input = document.querySelector<HTMLTextAreaElement>(
+      "[data-testid='composer-input']",
+    )!;
+    const transfer = new DataTransfer();
+    transfer.items.add(
+      new File(["pixels"], "screenshot.png", { type: "image/png" }),
+    );
+    input.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: transfer,
+      }),
+    );
+  });
+
+  await expect(page.locator(".composer-file-name")).toHaveText([
+    "requirements.pdf",
+    "brief.txt",
+    "screenshot.png",
+  ]);
+  await page.getByTestId("composer-send").click();
+
+  await expect
+    .poll(() => lastInjectText(page))
+    .toContain("mock-screenshot.png");
+  const proof = await page.evaluate(() => {
+    const testState = (
+      window as unknown as {
+        __HARNESS_TEST__?: {
+          attachFileCalls?: unknown[];
+          lastInjectInput?: { req?: { text?: string } };
+          lastCreateSession?: { req?: { cwd?: string } };
+        };
+      }
+    ).__HARNESS_TEST__;
+    return {
+      calls: testState?.attachFileCalls ?? [],
+      text: testState?.lastInjectInput?.req?.text ?? "",
+      cwd: testState?.lastCreateSession?.req?.cwd ?? "",
+    };
+  });
+  expect(proof.calls).toHaveLength(1);
+  expect(proof.cwd).toMatch(/\/build-mixed-context$/);
+  expect(proof.text.indexOf("requirements.pdf")).toBeLessThan(
+    proof.text.indexOf("brief.txt"),
+  );
+  expect(proof.text.indexOf("brief.txt")).toBeLessThan(
+    proof.text.indexOf("mock-screenshot.png"),
+  );
+});
+
+test("ordinary clipboard text pastes natively without creating an attachment", async ({
+  context,
+  page,
+}) => {
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  await page.getByTestId("rail-create-new").click();
+  await page.evaluate(() => navigator.clipboard.writeText("pasted plain text"));
+
+  const input = page.getByTestId("composer-input");
+  await input.focus();
+  await page.keyboard.press("ControlOrMeta+V");
+
+  await expect(input).toHaveValue("pasted plain text");
+  await expect(page.getByTestId("composer-files")).toHaveCount(0);
+});
+
+test("attachment controls expose names, live status, and keyboard removal", async ({
+  page,
+}) => {
+  await page.getByTestId("rail-create-new").click();
+  await page.evaluate(() => {
+    window.sapiomDesktop = {
+      appVersion: "test",
+      checkForUpdates: async () => ({ kind: "disabled" }),
+      pathForFile: (file: File) => `/Users/test/${file.name}`,
+    };
+  });
+
+  await expect(page.getByTestId("composer-attach-files")).toHaveAccessibleName(
+    "Attach files",
+  );
+  await expect(page.getByTestId("composer-send")).toHaveAccessibleName(
+    "Start session",
+  );
+  await expect(page.getByRole("status")).toHaveText("No files attached.");
+
+  await page.getByTestId("composer-file-input").setInputFiles({
+    name: "keyboard.pdf",
+    mimeType: "application/pdf",
+    buffer: Buffer.from("keyboard"),
+  });
+  await expect(page.getByRole("status")).toHaveText("1 file attached.");
+
+  const remove = page.getByRole("button", { name: "Remove keyboard.pdf" });
+  await page.getByTestId("composer-input").focus();
+  await page.keyboard.press("Tab");
+  await expect(remove).toBeFocused();
+  expect(
+    await remove.evaluate((element) => getComputedStyle(element).outlineStyle),
+  ).not.toBe("none");
+  await page.keyboard.press("Enter");
+  await expect(page.getByRole("status")).toHaveText("No files attached.");
+});
+
+test("attachment rows stay contained with touch-sized removal at a narrow viewport", async ({
+  page,
+}) => {
+  await page.getByTestId("rail-create-new").click();
+  await page.setViewportSize({ width: 360, height: 800 });
+  await page.evaluate(() => {
+    window.sapiomDesktop = {
+      appVersion: "test",
+      checkForUpdates: async () => ({ kind: "disabled" }),
+      pathForFile: (file: File) => `/Users/test/Very Long Folder/${file.name}`,
+    };
+  });
+  await page.getByTestId("composer-file-input").setInputFiles([
+    {
+      name: "a-very-long-requirements-document-name.pdf",
+      mimeType: "application/pdf",
+      buffer: Buffer.from("one"),
+    },
+    {
+      name: "another-very-long-reference-document-name.txt",
+      mimeType: "text/plain",
+      buffer: Buffer.from("two"),
+    },
+  ]);
+  await expect(page.getByRole("status")).toHaveText("2 files attached.");
+
+  const layout = await page.getByTestId("composer-box").evaluate((box) => {
+    const rows = Array.from(
+      box.querySelectorAll<HTMLElement>(".composer-file"),
+    );
+    const boxRect = box.getBoundingClientRect();
+    return {
+      contained:
+        box.scrollWidth <= box.clientWidth + 1 &&
+        rows.every((row) => {
+          const rect = row.getBoundingClientRect();
+          return rect.left >= boxRect.left && rect.right <= boxRect.right + 1;
+        }),
+      removeWidths: Array.from(
+        box.querySelectorAll<HTMLElement>(".composer-file-remove"),
+        (button) => button.getBoundingClientRect().width,
+      ),
+    };
+  });
+  expect(layout.contained).toBe(true);
+  expect(layout.removeWidths.every((width) => width >= 44)).toBe(true);
+});
+
+test("re-adding and removing files keeps only the intended first-request paths", async ({
+  page,
+}) => {
+  await page.getByTestId("rail-create-new").click();
+  await page.evaluate(() => {
+    window.sapiomDesktop = {
+      appVersion: "test",
+      checkForUpdates: async () => ({ kind: "disabled" }),
+      pathForFile: (file: File) => `/Users/test/${file.name}`,
+    };
+  });
+  const input = page.getByTestId("composer-file-input");
+  const repeated = {
+    name: "keep.pdf",
+    mimeType: "application/pdf",
+    buffer: Buffer.from("same"),
+  };
+  await input.setInputFiles(repeated);
+  await input.setInputFiles(repeated);
+  await input.setInputFiles({
+    name: "remove.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("remove"),
+  });
+
+  await expect(page.locator(".composer-file-name")).toHaveText([
+    "keep.pdf",
+    "remove.txt",
+  ]);
+  await page.getByRole("button", { name: "Remove remove.txt" }).click();
+  await expect(page.locator(".composer-file-name")).toHaveText(["keep.pdf"]);
+
+  await page.getByTestId("composer-input").fill("Use selected context.");
+  await page.getByTestId("composer-send").click();
+  await expect
+    .poll(() => lastInjectText(page))
+    .toContain("/Users/test/keep.pdf");
+  expect(await lastInjectText(page)).not.toContain("remove.txt");
+});
+
+test("an attachment-only start uses the fallback project and sends the file", async ({
+  page,
+}) => {
+  await page.getByTestId("rail-create-new").click();
+  await page.evaluate(() => {
+    window.sapiomDesktop = {
+      appVersion: "test",
+      checkForUpdates: async () => ({ kind: "disabled" }),
+      pathForFile: (file: File) => `/Users/test/${file.name}`,
+    };
+  });
+  await page.getByTestId("composer-file-input").setInputFiles({
+    name: "brief.pdf",
+    mimeType: "application/pdf",
+    buffer: Buffer.from("brief"),
+  });
+
+  await page.getByTestId("composer-send").click();
+  await expect
+    .poll(() => lastInjectText(page))
+    .toContain("/Users/test/brief.pdf");
+  const cwd = await page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __HARNESS_TEST__?: { lastCreateSession?: { req?: { cwd?: string } } };
+        }
+      ).__HARNESS_TEST__?.lastCreateSession?.req?.cwd ?? "",
+  );
+  expect(cwd).toMatch(/\/sapiom-agent$/);
+});
+
+test("an upload failure rolls back, retains the queue, sends nothing, and retries once", async ({
+  page,
+}) => {
+  await page.getByTestId("rail-create-new").click();
+  await page.evaluate(() => {
+    window.sapiomDesktop = {
+      appVersion: "test",
+      checkForUpdates: async () => ({ kind: "disabled" }),
+      pathForFile: () => "",
+    };
+  });
+  await page.getByTestId("composer-input").fill("Build from this screenshot.");
+  await page.evaluate(() => {
+    const input = document.querySelector<HTMLTextAreaElement>(
+      "[data-testid='composer-input']",
+    )!;
+    const transfer = new DataTransfer();
+    transfer.items.add(
+      new File(["pixels"], "retry-screenshot.png", { type: "image/png" }),
+    );
+    input.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: transfer,
+      }),
+    );
+  });
+  await expect(page.getByTestId("composer-files")).toContainText(
+    "retry-screenshot.png",
+  );
+  await page.evaluate(() => {
+    (
+      window as unknown as { __MOCK_ATTACH_FILE_FAIL_ONCE__?: boolean }
+    ).__MOCK_ATTACH_FILE_FAIL_ONCE__ = true;
+    const send = document.querySelector<HTMLButtonElement>(
+      "[data-testid='composer-send']",
+    )!;
+    send.click();
+    send.click();
+  });
+
+  await expect(page.getByTestId("composer-send")).toBeDisabled();
+  await expect(page.getByRole("status")).toHaveText(
+    "Starting session with 1 file attached.",
+  );
+  await expect(page.getByTestId("composer-send")).toBeEnabled();
+  await expect(page.getByTestId("new-session-composer")).toBeVisible();
+  await expect(page.getByTestId("composer-files")).toContainText(
+    "retry-screenshot.png",
+  );
+  await expect(page.getByTestId("toast")).toContainText(
+    /retry-screenshot\.png.*materialization failed/i,
+  );
+
+  const failedProof = await page.evaluate(() => {
+    const state = (
+      window as unknown as {
+        __HARNESS_TEST__?: {
+          createSessionCalls?: unknown[];
+          killSessionCalls?: unknown[];
+          lastInjectInput?: unknown;
+        };
+      }
+    ).__HARNESS_TEST__;
+    return {
+      creates: state?.createSessionCalls?.length ?? 0,
+      kills: state?.killSessionCalls?.length ?? 0,
+      injected: state?.lastInjectInput != null,
+    };
+  });
+  expect(failedProof).toEqual({ creates: 1, kills: 1, injected: false });
+
+  await page.getByTestId("composer-send").click();
+  await expect
+    .poll(() => lastInjectText(page))
+    .toContain("mock-retry-screenshot.png");
+  const createCount = await page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __HARNESS_TEST__?: { createSessionCalls?: unknown[] };
+        }
+      ).__HARNESS_TEST__?.createSessionCalls?.length ?? 0,
+  );
+  expect(createCount).toBe(2);
+});
+
 test("holds the prompt until the session is ready (Claude signed in), then sends it", async ({
   page,
 }) => {

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -83,6 +83,11 @@ import type { PaletteAction } from "./lib/palette";
 import { toggleTheme } from "./lib/theme";
 import { loadUiPrefs, saveUiPrefs } from "./lib/ui-prefs";
 import { useNavigationHistory, type NavigationVisit } from "./lib/navigation-history";
+import {
+  buildIdeaWithAttachments,
+  materializeAttachments,
+  type NewSessionAttachment,
+} from "./lib/new-session-attachments";
 import { CANVAS_MIN, RAIL_MIN, isMobileShell, useMobileShell, usePaneWidths } from "./lib/use-pane-widths";
 import { useHarnessState, type ObservedRun, type RunTarget } from "./lib/use-harness-state";
 import {
@@ -107,6 +112,11 @@ const HELD_PROMPT_TIMEOUT_MS = 10 * 60_000;
  * screen) survives the grace and surfaces the hint.
  */
 const HELD_PROMPT_HINT_DELAY_MS = 4_000;
+
+interface CreateSessionAtOptions {
+  /** Keep the create-new queue mounted while inline files are materialized. */
+  keepComposerOpen?: boolean;
+}
 
 /**
  * Live sessions belonging to the focused subject, in tab order (oldest first,
@@ -787,8 +797,12 @@ export const App = (): JSX.Element => {
 
   // The ONE choke point for session creation: sets the focus to the new
   // session's folder (so the main panel shows it) and fires telemetry once.
-  const createSessionAt = async (cwd: string, agentHarness: HarnessKind): Promise<HarnessSession> => {
-    setComposing(false);
+  const createSessionAt = async (
+    cwd: string,
+    agentHarness: HarnessKind,
+    options: CreateSessionAtOptions = {},
+  ): Promise<HarnessSession> => {
+    if (!options.keepComposerOpen) setComposing(false);
     setReviewSummary(null);
     setOverviewOpen(false);
     setFocusedAgentPath(cwd);
@@ -814,6 +828,24 @@ export const App = (): JSX.Element => {
     await createSessionAt(cwd, agentHarness);
   };
 
+  const sendScaffoldPrompt = (
+    session: HarnessSession,
+    cwd: string,
+    idea?: string,
+  ): void => {
+    const base =
+      `Scaffold a new Sapiom agent project in this directory: ${starterScaffoldInstruction(cwd, "default")}, ` +
+      "then run npm install, read AGENTS.md, and use the sapiom-agent-authoring skill to";
+    const trimmedIdea = idea?.trim();
+    sendPromptWhenReady(
+      session.id,
+      trimmedIdea
+        ? `${base} build this:\n\n${trimmedIdea}`
+        : `${base} define the first agent.`,
+      "Couldn't send the scaffold prompt. Ask the coding agent to call sapiom_dev_agents_scaffold.",
+    );
+  };
+
   // The idea-to-agent path. Starts a session at the (new) folder, then
   // hands the agent the scaffold prompt.
   /**
@@ -830,17 +862,7 @@ export const App = (): JSX.Element => {
     idea?: string,
   ): Promise<void> => {
     const session = await createSessionAt(cwd, agentHarness);
-    const base =
-      `Scaffold a new Sapiom agent project in this directory: ${starterScaffoldInstruction(cwd, "default")}, ` +
-      "then run npm install, read AGENTS.md, and use the sapiom-agent-authoring skill to";
-    const trimmedIdea = idea?.trim();
-    sendPromptWhenReady(
-      session.id,
-      trimmedIdea
-        ? `${base} build this:\n\n${trimmedIdea}`
-        : `${base} define the first agent.`,
-      "Couldn't send the scaffold prompt. Ask the coding agent to call sapiom_dev_agents_scaffold.",
-    );
+    sendScaffoldPrompt(session, cwd, idea);
   };
 
   // The tab strip's + and the empty state's Start: begin ANOTHER session on the
@@ -914,15 +936,42 @@ export const App = (): JSX.Element => {
     return projectDirSuggestion(nextAvailableName(base, taken), projectRoot || null);
   };
 
-  const handleComposerSubmitIdea = (idea: string, agentHarness: HarnessKind): void => {
+  const handleComposerSubmitIdea = async (
+    idea: string,
+    agentHarness: HarnessKind,
+    attachments: readonly NewSessionAttachment[],
+  ): Promise<void> => {
     const cwd = uniqueProjectDir(idea.trim() ? slugifyIdea(idea) : FALLBACK_PROJECT_NAME);
     if (!cwd) {
-      harness.showToast("Set a project folder first — use the + to open one.");
-      return;
+      throw new Error("Set a project folder first — use the + to open one.");
     }
     // Terminal-first: the new session's canvas slides in once it paints.
     setRightCollapsed(true);
-    void handleScaffoldSession(cwd, agentHarness, idea.trim() || undefined);
+    const session = await createSessionAt(cwd, agentHarness, {
+      keepComposerOpen: true,
+    });
+    try {
+      const resolved = await materializeAttachments(
+        session.id,
+        attachments,
+        harness.attachFile,
+      );
+      sendScaffoldPrompt(
+        session,
+        cwd,
+        buildIdeaWithAttachments(idea, resolved),
+      );
+      setComposing(false);
+    } catch (error) {
+      // The first prompt is registered only after every upload succeeds. Kill
+      // the provisional session on failure so retrying reuses the same folder
+      // and queue instead of leaving a blank tab behind.
+      await harness.closeSession(session.id).catch((rollbackError: unknown) => {
+        console.error("[harness] attachment rollback failed:", rollbackError);
+      });
+      harness.removePendingWorkspace(cwd);
+      throw error;
+    }
   };
 
   const handleComposerUseTemplate = (template: GalleryTemplate): void => {
@@ -1576,6 +1625,7 @@ export const App = (): JSX.Element => {
                 <NewSessionComposer
                   firstRun={state.firstRun === true}
                   onSubmitIdea={handleComposerSubmitIdea}
+                  onAttachmentError={harness.showToast}
                   onUseTemplate={handleComposerUseTemplate}
                   onBrowseTemplates={() => setTemplatesOpen(true)}
                   listHarnesses={harness.listHarnesses}

--- a/packages/harness/web/src/components/NewSessionComposer.tsx
+++ b/packages/harness/web/src/components/NewSessionComposer.tsx
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { JSX, RefObject } from "react";
-import type { HarnessEntry, HarnessKind, TemplateListResponse } from "@shared/types";
+import {
+  MAX_INLINE_ATTACHMENTS_TOTAL_BYTES,
+  type HarnessEntry,
+  type HarnessKind,
+  type TemplateListResponse,
+} from "@shared/types";
 
 import type { FsListResponse } from "../lib/api";
 import {
@@ -11,6 +16,12 @@ import {
 } from "../lib/harness-registry";
 import { formatComplexity, type GalleryTemplate } from "../lib/templates";
 import { loadUiPrefs, saveUiPrefs } from "../lib/ui-prefs";
+import { getDesktopBridge } from "../lib/desktop";
+import {
+  filesToAttachments,
+  mergeAttachments,
+  type NewSessionAttachment,
+} from "../lib/new-session-attachments";
 import { AnchoredPopover } from "./AnchoredPopover";
 import { StartDialog } from "./StartDialog";
 import { HarnessBrandIcon } from "./HarnessBrandIcon";
@@ -73,7 +84,13 @@ interface NewSessionComposerProps {
   firstRun: boolean;
   /** Start a session and hand the agent this outcome (empty → default starter).
    *  App derives the folder and runs the scaffold+inject path. */
-  onSubmitIdea: (idea: string, harness: HarnessKind) => void;
+  onSubmitIdea: (
+    idea: string,
+    harness: HarnessKind,
+    attachments: readonly NewSessionAttachment[],
+  ) => Promise<void>;
+  /** Surface a file-resolution or submit failure in the app's existing toast. */
+  onAttachmentError: (message: string) => void;
   /** Start a session from a catalog template (clone + first run). */
   onUseTemplate: (template: GalleryTemplate) => void;
   /** Navigate to the full templates catalog. */
@@ -99,6 +116,7 @@ interface NewSessionComposerProps {
 export function NewSessionComposer({
   firstRun,
   onSubmitIdea,
+  onAttachmentError,
   onUseTemplate,
   onBrowseTemplates,
   listHarnesses,
@@ -121,13 +139,23 @@ export function NewSessionComposer({
   const [pickerOpen, setPickerOpen] = useState(false);
   const [templates, setTemplates] = useState<GalleryTemplate[]>([]);
   const [addOpen, setAddOpen] = useState(false);
+  const [attachments, setAttachments] = useState<NewSessionAttachment[]>([]);
+  const [draggingFiles, setDraggingFiles] = useState(false);
+  const [queueing, setQueueing] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
   // While the composer is dropping away to make room for the terminal. The
   // action (which starts the session) fires once the exit has played.
   const [leaving, setLeaving] = useState(false);
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const harnessTriggerRef = useRef<HTMLButtonElement>(null);
   const addTriggerRef = useRef<HTMLButtonElement>(null);
+  const attachmentsRef = useRef<NewSessionAttachment[]>([]);
+  const submittingRef = useRef(false);
+  const queueingRef = useRef(false);
+  const queueTailRef = useRef<Promise<void>>(Promise.resolve());
+  const pendingQueueCountRef = useRef(0);
   const closePicker = useCallback(() => setPickerOpen(false), []);
 
   // Registry-driven agent picker, same correction NewSessionModal applies: an
@@ -183,7 +211,96 @@ export function NewSessionComposer({
     setLeaving(true);
     window.setTimeout(action, 170);
   };
-  const submit = (): void => leaveThen(() => onSubmitIdea(idea.trim(), harness));
+  const submit = (): void => {
+    if (leaving || submittingRef.current || queueingRef.current) return;
+    submittingRef.current = true;
+    setSubmitting(true);
+    setLeaving(true);
+    const queuedAttachments = attachmentsRef.current;
+    window.setTimeout(() => {
+      void onSubmitIdea(idea.trim(), harness, queuedAttachments).catch(
+        (err: unknown) => {
+          submittingRef.current = false;
+          setLeaving(false);
+          setSubmitting(false);
+          textareaRef.current?.focus();
+          onAttachmentError(
+            (err as Error).message ||
+              "Couldn't start a session with those files.",
+          );
+        },
+      );
+    }, 170);
+  };
+
+  const queueFiles = (files: readonly File[]): void => {
+    if (files.length === 0 || submittingRef.current) return;
+    const pathForFile = getDesktopBridge()?.pathForFile;
+    pendingQueueCountRef.current += 1;
+    queueingRef.current = true;
+    setQueueing(true);
+
+    const processFiles = async (): Promise<void> => {
+      const usedInlineBytes = attachmentsRef.current.reduce(
+        (total, attachment) =>
+          total + (attachment.kind === "inline" ? attachment.bytes : 0),
+        0,
+      );
+      const result = await filesToAttachments(
+        files,
+        pathForFile,
+        Math.max(0, MAX_INLINE_ATTACHMENTS_TOTAL_BYTES - usedInlineBytes),
+      );
+      if (result.attachments.length > 0) {
+        const next = mergeAttachments(
+          attachmentsRef.current,
+          result.attachments,
+        );
+        attachmentsRef.current = next;
+        setAttachments(next);
+      }
+      if (result.errors.length > 0) {
+        onAttachmentError(result.errors.join(" "));
+      }
+    };
+
+    const task = queueTailRef.current.then(processFiles);
+    queueTailRef.current = task.catch(() => {});
+    void task
+      .catch((error: unknown) => {
+        onAttachmentError(
+          (error as Error).message || "Couldn't attach those files.",
+        );
+      })
+      .then(() => {
+        pendingQueueCountRef.current -= 1;
+        if (pendingQueueCountRef.current === 0) {
+          queueingRef.current = false;
+          setQueueing(false);
+        }
+      });
+  };
+
+  const removeAttachment = (id: string): void => {
+    if (submittingRef.current) return;
+    const next = attachmentsRef.current.filter((item) => item.id !== id);
+    attachmentsRef.current = next;
+    setAttachments(next);
+  };
+
+  const attachmentCountLabel =
+    attachments.length === 0
+      ? "No files attached."
+      : attachments.length === 1
+        ? "1 file attached."
+        : `${attachments.length} files attached.`;
+  const attachmentStatus = draggingFiles
+    ? "Drop files to attach."
+    : submitting
+      ? `Starting session with ${attachmentCountLabel.toLowerCase()}`
+      : queueing
+        ? "Preparing attached files."
+        : attachmentCountLabel;
 
   return (
     <div
@@ -216,12 +333,69 @@ export function NewSessionComposer({
           ))}
         </div>
 
-        <div className="composer-box">
+        <div
+          className={
+            "composer-box" +
+            (draggingFiles ? " is-dragging-files" : "") +
+            (submitting || queueing ? " is-busy" : "")
+          }
+          data-testid="composer-box"
+          role="group"
+          aria-label="New session request"
+          aria-busy={submitting || queueing}
+          aria-describedby="composer-attachment-status"
+          onPaste={(event) => {
+            const itemFiles = Array.from(event.clipboardData.items)
+              .filter((item) => item.kind === "file")
+              .flatMap((item) => {
+                const file = item.getAsFile();
+                return file ? [file] : [];
+              });
+            const files =
+              itemFiles.length > 0
+                ? itemFiles
+                : Array.from(event.clipboardData.files ?? []);
+            if (files.length === 0) return;
+            event.preventDefault();
+            queueFiles(files);
+          }}
+          onDragEnter={(event) => {
+            if (!Array.from(event.dataTransfer.types).includes("Files")) return;
+            event.preventDefault();
+            if (submittingRef.current) return;
+            setDraggingFiles(true);
+          }}
+          onDragOver={(event) => {
+            if (!Array.from(event.dataTransfer.types).includes("Files")) return;
+            event.preventDefault();
+            if (submittingRef.current) return;
+            event.dataTransfer.dropEffect = "copy";
+            setDraggingFiles(true);
+          }}
+          onDragLeave={(event) => {
+            const next = event.relatedTarget;
+            if (next instanceof Node && event.currentTarget.contains(next))
+              return;
+            setDraggingFiles(false);
+          }}
+          onDrop={(event) => {
+            if (!Array.from(event.dataTransfer.types).includes("Files")) return;
+            event.preventDefault();
+            setDraggingFiles(false);
+            queueFiles(Array.from(event.dataTransfer.files));
+          }}
+        >
+          {draggingFiles && (
+            <div className="composer-drop-hint" aria-hidden="true">
+              <Icon name="CloudUpload" size={18} /> Drop files to attach
+            </div>
+          )}
           <textarea
             ref={textareaRef}
             className="composer-input"
             data-testid="composer-input"
             placeholder="Describe the outcome you want"
+            aria-label="Describe the outcome you want"
             value={idea}
             rows={2}
             autoFocus
@@ -234,6 +408,35 @@ export function NewSessionComposer({
               }
             }}
           />
+          {attachments.length > 0 && (
+            <ul
+              className="composer-files"
+              data-testid="composer-files"
+              aria-label="Attached files"
+            >
+              {attachments.map((attachment) => (
+                <li
+                  key={attachment.id}
+                  className="composer-file"
+                  {...trackingAttrs({ object: "file" })}
+                >
+                  <Icon name="Paperclip" size={13} />
+                  <span className="composer-file-name" title={attachment.name}>
+                    {attachment.name}
+                  </span>
+                  <button
+                    type="button"
+                    className="composer-file-remove"
+                    aria-label={`Remove ${attachment.name}`}
+                    disabled={submitting}
+                    onClick={() => removeAttachment(attachment.id)}
+                  >
+                    <Icon name="X" size={11} />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
           <div className="composer-box-actions">
             <button
               ref={addTriggerRef}
@@ -246,6 +449,30 @@ export function NewSessionComposer({
             >
               <Icon name="Plus" size={16} />
             </button>
+            <button
+              type="button"
+              className="composer-attach"
+              data-testid="composer-attach-files"
+              aria-label="Attach files"
+              data-tooltip="Attach files"
+              disabled={submitting}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Icon name="Paperclip" size={15} />
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              hidden
+              data-testid="composer-file-input"
+              onChange={(event) => {
+                queueFiles(
+                  event.target.files ? Array.from(event.target.files) : [],
+                );
+                event.target.value = "";
+              }}
+            />
 
             <div className="composer-box-right">
               <button
@@ -291,12 +518,23 @@ export function NewSessionComposer({
                 data-testid="composer-send"
                 aria-label="Start session"
                 title="Start session"
+                disabled={submitting || queueing}
                 onClick={submit}
               >
                 <Icon name="ArrowUp" size={16} />
               </button>
             </div>
           </div>
+        </div>
+        <div
+          id="composer-attachment-status"
+          className="visually-hidden"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          data-testid="composer-attachment-status"
+        >
+          {attachmentStatus}
         </div>
       </div>
 

--- a/packages/harness/web/src/lib/analytics/before-send.ts
+++ b/packages/harness/web/src/lib/analytics/before-send.ts
@@ -86,8 +86,8 @@ function isSecretSurface(properties: Record<string, unknown>): boolean {
 /**
  * `object` values whose on-screen label is written by the USER, not by us.
  *
- * An agent, workspace or session is named by whoever made it, so its label is
- * user content and lands in `$el_text` verbatim — production has shipped us
+ * An agent, workspace, session, or file is named by whoever made it, so its
+ * label is user content and lands in `$el_text` verbatim — production has shipped us
  * `fetch-recent-weather`, `newsletter-autopilot`, `twitter-run` and
  * `Ewan's Organization` this way. That is wrong twice: it puts user-authored
  * strings in analytics, and it shreds the numbers, because "clicked an agent in
@@ -97,7 +97,14 @@ function isSecretSurface(properties: Record<string, unknown>): boolean {
  * from OUR registry, low-cardinality and safe, and it's the label that makes
  * the on-ramp funnel readable.
  */
-const USER_NAMED_OBJECTS: ReadonlySet<string> = new Set(["agent", "workspace", "session", "run", "directory"]);
+const USER_NAMED_OBJECTS: ReadonlySet<string> = new Set([
+  "agent",
+  "workspace",
+  "session",
+  "run",
+  "directory",
+  "file",
+]);
 
 /** Whether this click's `object` marks it as a user-named entity. */
 function isUserNamedObject(properties: Record<string, unknown>): boolean {

--- a/packages/harness/web/src/lib/analytics/redaction-gate.test.ts
+++ b/packages/harness/web/src/lib/analytics/redaction-gate.test.ts
@@ -30,8 +30,9 @@ import { beforeSend } from "./before-send";
 /** Fixture values chosen to be unmistakable if they ever survive. */
 const AGENT = "acme-client-secret";
 const FOLDER = "quarterly-revenue";
+const FILE = "confidential-acquisition-plan.pdf";
 const ABS_PATH = "/Users/jrandom/code/quarterly-revenue";
-const NEEDLES = [AGENT, FOLDER, ABS_PATH, "/Users/", "jrandom"];
+const NEEDLES = [AGENT, FOLDER, FILE, ABS_PATH, "/Users/", "jrandom"];
 
 function capture(properties: Record<string, unknown>): CaptureResult {
   return { event: "$autocapture", properties } as CaptureResult;
@@ -167,6 +168,21 @@ describe("redaction gate — realistic clicks must not carry user names or paths
           object: "directory",
           $el_text: FOLDER,
           $elements_chain: `button.dir-picker-item:attr__class="dir-picker-item"attr__data-testid="dir-picker-item-${FOLDER}"text="${FOLDER}"nth-child="1"`,
+        }),
+      ),
+    );
+  });
+
+  it("composer attachment row (object=file)", () => {
+    expectNoLeak(
+      beforeSend(
+        capture({
+          object: "file",
+          surface: "composer",
+          $el_text: FILE,
+          $elements_chain:
+            `button.composer-file-remove:attr__class="composer-file-remove"attr__aria-label="Remove ${FILE}"nth-child="1";` +
+            `li.composer-file:attr__class="composer-file"text="${FILE}"nth-child="1"`,
         }),
       ),
     );

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -9,6 +9,8 @@ import type {
   AccountPlanView,
   AdoptSessionRequest,
   AppState,
+  AttachFileRequest,
+  AttachFileResponse,
   BindWorkflowRequest,
   CreateSessionRequest,
   FsDirEntry,
@@ -261,6 +263,7 @@ export interface HarnessApi {
   authStatus(): Promise<AuthStatusResponse>;
   getState(): Promise<AppState>;
   createSession(req: CreateSessionRequest): Promise<HarnessSession>;
+  attachFile(id: string, req: AttachFileRequest): Promise<AttachFileResponse>;
   listSessions(): Promise<HarnessSession[]>;
   sessionHistory(cwd: string): Promise<SessionSummary[]>;
   /**
@@ -409,6 +412,16 @@ class RealApi implements HarnessApi {
       method: "POST",
       body: JSON.stringify({ theme: getTheme(), ...req }),
     });
+  }
+
+  attachFile(id: string, req: AttachFileRequest): Promise<AttachFileResponse> {
+    return this.request<AttachFileResponse>(
+      `/api/sessions/${encodeURIComponent(id)}/attachments`,
+      {
+        method: "POST",
+        body: JSON.stringify(req),
+      },
+    );
   }
 
   listSessions(): Promise<HarnessSession[]> {
@@ -989,6 +1002,19 @@ class MockApi implements HarnessApi {
 
   async createSession(req: CreateSessionRequest): Promise<HarnessSession> {
     await delay(300);
+    if (typeof window !== "undefined") {
+      const win = window as unknown as {
+        __HARNESS_TEST__?: Record<string, unknown>;
+      };
+      const previous =
+        (win.__HARNESS_TEST__?.createSessionCalls as unknown[] | undefined) ??
+        [];
+      win.__HARNESS_TEST__ = {
+        ...(win.__HARNESS_TEST__ ?? {}),
+        lastCreateSession: { req },
+        createSessionCalls: [...previous, { req }],
+      };
+    }
     const session: HarnessSession = {
       id: `sess-mock-${this.sessions.length + 1}`,
       agentSessionId: null,
@@ -1050,6 +1076,54 @@ class MockApi implements HarnessApi {
       setTimeout(promote, 700);
     }
     return session;
+  }
+
+  async attachFile(
+    id: string,
+    req: AttachFileRequest,
+  ): Promise<AttachFileResponse> {
+    await delay();
+    const session = this.sessions.find((item) => item.id === id);
+    if (!session)
+      throw new ApiError(404, "session not found", "session not found");
+
+    const testWindow =
+      typeof window === "undefined"
+        ? undefined
+        : (window as unknown as {
+            __MOCK_ATTACH_FILE_FAIL_ONCE__?: boolean;
+          });
+    if (testWindow?.__MOCK_ATTACH_FILE_FAIL_ONCE__) {
+      testWindow.__MOCK_ATTACH_FILE_FAIL_ONCE__ = false;
+      throw new ApiError(
+        500,
+        "attachment materialization failed",
+        "attachment materialization failed",
+      );
+    }
+
+    const match = /^data:([^;]+);base64,([\s\S]+)$/i.exec(req.dataUrl);
+    if (!match)
+      throw new ApiError(400, "invalid attachment", "invalid attachment");
+    const filename = req.filename.split(/[\\/]/).pop() || "pasted-file";
+    const response: AttachFileResponse = {
+      path: `${session.cwd}/.sapiom/uploads/mock-${filename}`,
+      mediaType: match[1]!,
+      bytes: atob(match[2]!).length,
+    };
+
+    if (typeof window !== "undefined") {
+      const win = window as unknown as {
+        __HARNESS_TEST__?: Record<string, unknown>;
+      };
+      const previous =
+        (win.__HARNESS_TEST__?.attachFileCalls as unknown[] | undefined) ?? [];
+      win.__HARNESS_TEST__ = {
+        ...(win.__HARNESS_TEST__ ?? {}),
+        attachFileCalls: [...previous, { id, req, response }],
+      };
+    }
+    return response;
   }
 
   async listSessions(): Promise<HarnessSession[]> {
@@ -1127,6 +1201,17 @@ class MockApi implements HarnessApi {
         ? { ...session, status: "exited" as const, exitCode: 0 }
         : session,
     );
+    if (typeof window !== "undefined") {
+      const win = window as unknown as {
+        __HARNESS_TEST__?: Record<string, unknown>;
+      };
+      const previous =
+        (win.__HARNESS_TEST__?.killSessionCalls as string[] | undefined) ?? [];
+      win.__HARNESS_TEST__ = {
+        ...(win.__HARNESS_TEST__ ?? {}),
+        killSessionCalls: [...previous, id],
+      };
+    }
   }
 
   async injectInput(id: string, req: InjectInputRequest): Promise<void> {

--- a/packages/harness/web/src/lib/new-session-attachments.test.ts
+++ b/packages/harness/web/src/lib/new-session-attachments.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from "vitest";
+import { MAX_INLINE_ATTACHMENT_BYTES } from "@shared/types";
+
+import {
+  buildIdeaWithAttachments,
+  filesToAttachments,
+  materializeAttachments,
+  mergeAttachments,
+  type NewSessionAttachment,
+} from "./new-session-attachments";
+
+const pathAttachment = (id: string, path: string): NewSessionAttachment => ({
+  id,
+  kind: "path",
+  name: path.split(/[\\/]/).pop() ?? path,
+  path,
+});
+
+const inlineAttachment = (
+  id: string,
+  fingerprint: string,
+): NewSessionAttachment => ({
+  id,
+  kind: "inline",
+  name: "screenshot.png",
+  mediaType: "image/png",
+  bytes: 6,
+  dataUrl: "data:image/png;base64,cGl4ZWxz",
+  fingerprint,
+});
+
+describe("filesToAttachments", () => {
+  it("uses a desktop path without reading or copying bytes", async () => {
+    const file = new File(["not read"], "brief.pdf", {
+      type: "application/pdf",
+    });
+    const arrayBuffer = vi.spyOn(file, "arrayBuffer");
+
+    const result = await filesToAttachments(
+      [file],
+      () => "/Users/me/My Files/brief.pdf",
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.attachments).toEqual([
+      expect.objectContaining({
+        kind: "path",
+        name: "brief.pdf",
+        path: "/Users/me/My Files/brief.pdf",
+      }),
+    ]);
+    expect(arrayBuffer).not.toHaveBeenCalled();
+  });
+
+  it("falls back to inline bytes for a pathless clipboard image", async () => {
+    const result = await filesToAttachments([
+      new File(["pixels"], "screenshot.png", { type: "image/png" }),
+    ]);
+
+    expect(result.errors).toEqual([]);
+    expect(result.attachments).toEqual([
+      expect.objectContaining({
+        kind: "inline",
+        name: "screenshot.png",
+        mediaType: "image/png",
+        bytes: 6,
+        dataUrl: "data:image/png;base64,cGl4ZWxz",
+        fingerprint: expect.stringMatching(/^[0-9a-f]{64}$/),
+      }),
+    ]);
+  });
+
+  it("rejects a pathless file over 10 MiB with its filename", async () => {
+    const result = await filesToAttachments([
+      new File(
+        [new Uint8Array(MAX_INLINE_ATTACHMENT_BYTES + 1)],
+        "huge-screenshot.png",
+        { type: "image/png" },
+      ),
+    ]);
+
+    expect(result.attachments).toEqual([]);
+    expect(result.errors).toEqual([
+      expect.stringContaining("huge-screenshot.png"),
+    ]);
+  });
+
+  it("rejects a file that would exceed the remaining inline queue budget", async () => {
+    const result = await filesToAttachments(
+      [new File(["four"], "second.txt", { type: "text/plain" })],
+      undefined,
+      3,
+    );
+
+    expect(result.attachments).toEqual([]);
+    expect(result.errors).toEqual([expect.stringContaining("second.txt")]);
+  });
+});
+
+describe("mergeAttachments", () => {
+  it("deduplicates a repeated disk path while preserving selection order", () => {
+    const first = pathAttachment("1", "/tmp/first.png");
+    const duplicate = pathAttachment("2", "/tmp/first.png");
+    const second = pathAttachment("3", "/tmp/second.pdf");
+
+    expect(mergeAttachments([first], [duplicate, second])).toEqual([
+      first,
+      second,
+    ]);
+  });
+
+  it("deduplicates repeated inline content even when queue ids differ", () => {
+    const first = inlineAttachment("inline-1", "same-bytes");
+    const duplicate = inlineAttachment("inline-2", "same-bytes");
+
+    expect(mergeAttachments([first], [duplicate])).toEqual([first]);
+  });
+});
+
+describe("materializeAttachments", () => {
+  it("preserves mixed path and inline attachment order", async () => {
+    const upload = vi.fn(async () => ({
+      path: "/project/.sapiom/uploads/screenshot.png",
+      mediaType: "image/png",
+      bytes: 6,
+    }));
+    const inline = inlineAttachment("inline-1", "pixels");
+
+    await expect(
+      materializeAttachments(
+        "session-1",
+        [pathAttachment("path-1", "/tmp/brief.pdf"), inline],
+        upload,
+      ),
+    ).resolves.toEqual([
+      { name: "brief.pdf", path: "/tmp/brief.pdf" },
+      {
+        name: "screenshot.png",
+        path: "/project/.sapiom/uploads/screenshot.png",
+      },
+    ]);
+    expect(upload).toHaveBeenCalledWith("session-1", {
+      filename: "screenshot.png",
+      dataUrl: "data:image/png;base64,cGl4ZWxz",
+    });
+  });
+
+  it("names the inline file when an upload fails and resolves no partial result", async () => {
+    const upload = vi.fn().mockRejectedValue(new Error("disk full"));
+
+    await expect(
+      materializeAttachments(
+        "session-1",
+        [
+          pathAttachment("path-1", "/tmp/brief.pdf"),
+          inlineAttachment("inline-1", "pixels"),
+        ],
+        upload,
+      ),
+    ).rejects.toThrow("Couldn't attach screenshot.png: disk full");
+  });
+});
+
+describe("buildIdeaWithAttachments", () => {
+  it("preserves the idea and quotes a POSIX path with spaces", () => {
+    expect(
+      buildIdeaWithAttachments("Build this flow.", [
+        { name: "flow.png", path: "/Users/me/My Files/flow.png" },
+      ]),
+    ).toBe(
+      'Build this flow.\n\nAttached files (read each as context):\n"/Users/me/My Files/flow.png"',
+    );
+  });
+
+  it("keeps a quoted Windows path's backslashes intact", () => {
+    expect(
+      buildIdeaWithAttachments("Build it.", [
+        { name: "spec.pdf", path: "C:\\My Files\\spec.pdf" },
+      ]),
+    ).toBe(
+      'Build it.\n\nAttached files (read each as context):\n"C:\\My Files\\spec.pdf"',
+    );
+  });
+
+  it("supports an attachment-only request", () => {
+    expect(
+      buildIdeaWithAttachments("", [
+        { name: "brief.pdf", path: "/tmp/brief.pdf" },
+      ]),
+    ).toBe("Attached files (read each as context):\n/tmp/brief.pdf");
+  });
+
+  it("keeps the existing no-idea path when there are no attachments", () => {
+    expect(buildIdeaWithAttachments("", [])).toBeUndefined();
+  });
+});

--- a/packages/harness/web/src/lib/new-session-attachments.ts
+++ b/packages/harness/web/src/lib/new-session-attachments.ts
@@ -1,0 +1,212 @@
+/**
+ * Ephemeral files queued on the create-new screen. Disk-backed files stay as
+ * paths; clipboard-only files gain their project-local path later through the
+ * attachment endpoint. Keeping the union here stops the component and App
+ * from inventing parallel queue shapes as the remaining slices land.
+ */
+import type { AttachFileRequest, AttachFileResponse } from "@shared/types";
+import {
+  MAX_INLINE_ATTACHMENT_BYTES,
+  MAX_INLINE_ATTACHMENTS_TOTAL_BYTES,
+} from "@shared/types";
+
+import { quotePathForTerminal } from "./terminal-drop";
+
+export type NewSessionAttachment =
+  | {
+      id: string;
+      kind: "path";
+      name: string;
+      path: string;
+    }
+  | {
+      id: string;
+      kind: "inline";
+      name: string;
+      mediaType: string;
+      bytes: number;
+      dataUrl: string;
+      /** SHA-256 of the bytes, used to deduplicate repeated clipboard files. */
+      fingerprint: string;
+    };
+
+export interface ResolvedNewSessionAttachment {
+  name: string;
+  path: string;
+}
+
+export interface QueueFilesResult {
+  attachments: NewSessionAttachment[];
+  errors: string[];
+}
+
+function attachmentName(file: File): string {
+  return file.name || "pasted-file";
+}
+
+function bytesToDataUrl(bytes: Uint8Array, mediaType: string): string {
+  const chunks: string[] = [];
+  const chunkSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += chunkSize) {
+    chunks.push(
+      String.fromCharCode(...bytes.subarray(offset, offset + chunkSize)),
+    );
+  }
+  return `data:${mediaType};base64,${btoa(chunks.join(""))}`;
+}
+
+async function fingerprint(bytes: Uint8Array): Promise<string> {
+  const digestInput = new Uint8Array(bytes.byteLength);
+  digestInput.set(bytes);
+  const digest = await crypto.subtle.digest("SHA-256", digestInput.buffer);
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+/**
+ * Convert browser files without copying disk-backed files. Files that Electron
+ * cannot map to disk (for example pasted screenshots) become bounded inline
+ * entries that the server can materialize after the session exists.
+ */
+export async function filesToAttachments(
+  files: readonly File[],
+  pathForFile?: (file: File) => string,
+  inlineBudgetBytes = MAX_INLINE_ATTACHMENTS_TOTAL_BYTES,
+): Promise<QueueFilesResult> {
+  const attachments: NewSessionAttachment[] = [];
+  const errors: string[] = [];
+  let inlineBytes = 0;
+
+  for (const file of files) {
+    const name = attachmentName(file);
+    let path = "";
+    try {
+      path = pathForFile?.(file) ?? "";
+    } catch {
+      // A bridge lookup failure is equivalent to a pathless browser File.
+    }
+
+    if (path) {
+      attachments.push({
+        id: crypto.randomUUID(),
+        kind: "path",
+        name,
+        path,
+      });
+      continue;
+    }
+
+    if (file.size > MAX_INLINE_ATTACHMENT_BYTES) {
+      errors.push(
+        `${name} is too large to paste (${file.size} bytes; limit ${MAX_INLINE_ATTACHMENT_BYTES} bytes).`,
+      );
+      continue;
+    }
+    if (inlineBytes + file.size > inlineBudgetBytes) {
+      errors.push(
+        `${name} would exceed the ${MAX_INLINE_ATTACHMENTS_TOTAL_BYTES}-byte pasted-file limit for one session.`,
+      );
+      continue;
+    }
+
+    try {
+      const mediaType = file.type || "application/octet-stream";
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      if (bytes.byteLength > MAX_INLINE_ATTACHMENT_BYTES) {
+        errors.push(
+          `${name} is too large to paste (${bytes.byteLength} bytes; limit ${MAX_INLINE_ATTACHMENT_BYTES} bytes).`,
+        );
+        continue;
+      }
+      attachments.push({
+        id: crypto.randomUUID(),
+        kind: "inline",
+        name,
+        mediaType,
+        bytes: bytes.byteLength,
+        dataUrl: bytesToDataUrl(bytes, mediaType),
+        fingerprint: await fingerprint(bytes),
+      });
+      inlineBytes += bytes.byteLength;
+    } catch {
+      errors.push(`Couldn't read ${name}.`);
+    }
+  }
+
+  return { attachments, errors };
+}
+
+function attachmentKey(attachment: NewSessionAttachment): string {
+  return attachment.kind === "path"
+    ? `path:${attachment.path}`
+    : `inline:${attachment.fingerprint}`;
+}
+
+/** Add unique files in user-selected order; re-picking one path is a no-op. */
+export function mergeAttachments(
+  current: readonly NewSessionAttachment[],
+  incoming: readonly NewSessionAttachment[],
+): NewSessionAttachment[] {
+  const seen = new Set(current.map(attachmentKey));
+  const merged = [...current];
+  for (const attachment of incoming) {
+    const key = attachmentKey(attachment);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(attachment);
+  }
+  return merged;
+}
+
+/** Resolve inline entries in order while passing native paths through. */
+export async function materializeAttachments(
+  sessionId: string,
+  attachments: readonly NewSessionAttachment[],
+  upload: (
+    sessionId: string,
+    request: AttachFileRequest,
+  ) => Promise<AttachFileResponse>,
+): Promise<ResolvedNewSessionAttachment[]> {
+  const resolved: ResolvedNewSessionAttachment[] = [];
+  for (const attachment of attachments) {
+    if (attachment.kind === "path") {
+      resolved.push({ name: attachment.name, path: attachment.path });
+      continue;
+    }
+
+    try {
+      const response = await upload(sessionId, {
+        dataUrl: attachment.dataUrl,
+        filename: attachment.name,
+      });
+      resolved.push({ name: attachment.name, path: response.path });
+    } catch (error) {
+      const reason = (error as Error).message;
+      throw new Error(
+        `Couldn't attach ${attachment.name}${reason ? `: ${reason}` : "."}`,
+        { cause: error },
+      );
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Preserve the user's words verbatim and add one terminal-safe path per file.
+ * The caller deliberately derives the project slug before calling this, so a
+ * filename can never rename the project being created.
+ */
+export function buildIdeaWithAttachments(
+  idea: string,
+  attachments: readonly ResolvedNewSessionAttachment[],
+): string | undefined {
+  const trimmedIdea = idea.trim();
+  if (attachments.length === 0) return trimmedIdea || undefined;
+
+  const paths = attachments
+    .map((attachment) => quotePathForTerminal(attachment.path))
+    .join("\n");
+  const context = `Attached files (read each as context):\n${paths}`;
+  return trimmedIdea ? `${trimmedIdea}\n\n${context}` : context;
+}

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppState,
+  AttachFileRequest,
+  AttachFileResponse,
   BackgroundTask,
   BusMessage,
   RunView,
@@ -141,6 +143,10 @@ export interface HarnessStateHook {
    *  resume view, not one directory at a time). */
   loadHistory: (cwds: string[]) => Promise<void>;
   createSession: (req: CreateSessionRequest) => Promise<HarnessSession>;
+  attachFile: (
+    sessionId: string,
+    request: AttachFileRequest,
+  ) => Promise<AttachFileResponse>;
   /** The live template gallery + one template's detail (server relays core;
    *  the API key never reaches the browser). Surfaced here so components stay
    *  prop-driven rather than reaching for a module-level api singleton. */
@@ -1208,6 +1214,14 @@ export function useHarnessState(): HarnessStateHook {
     [selectSession],
   );
 
+  const attachFile = useCallback(
+    (
+      sessionId: string,
+      request: AttachFileRequest,
+    ): Promise<AttachFileResponse> => api.attachFile(sessionId, request),
+    [],
+  );
+
   const listTemplates = useCallback(
     (): Promise<TemplateListResponse> => api.listTemplates(),
     [],
@@ -1772,6 +1786,7 @@ export function useHarnessState(): HarnessStateHook {
     historyLoading,
     loadHistory,
     createSession,
+    attachFile,
     listTemplates,
     getTemplate,
     getWorkflowInputContract,

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -9454,6 +9454,7 @@ button.rail-footer-card:hover {
 
 /* The composer box: a raised, rounded field with a two-part action row. */
 .composer-box {
+  position: relative;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -9471,6 +9472,30 @@ button.rail-footer-card:hover {
   border-color: color-mix(in srgb, var(--brand) 55%, var(--ui-line-strong));
   box-shadow: var(--shadow);
 }
+.composer-box.is-dragging-files {
+  border-color: var(--brand);
+  background: color-mix(in srgb, var(--brand) 7%, var(--surface-raised));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--brand) 18%, transparent);
+}
+.composer-box.is-busy {
+  border-color: color-mix(in srgb, var(--brand) 38%, var(--ui-line-strong));
+  cursor: progress;
+}
+.composer-drop-hint {
+  position: absolute;
+  inset: var(--sp1);
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--sp2);
+  border-radius: calc(var(--r-lg) - var(--sp1));
+  background: color-mix(in srgb, var(--brand) 10%, var(--surface-raised));
+  color: var(--text);
+  font-size: var(--type-ui);
+  font-weight: 590;
+  pointer-events: none;
+}
 .composer-input {
   width: 100%;
   border: 0;
@@ -9487,6 +9512,50 @@ button.rail-footer-card:hover {
 }
 .composer-input:focus-visible {
   outline: none;
+}
+.composer-files {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp2);
+  margin: var(--sp2) 0 0;
+  padding: 0;
+  list-style: none;
+}
+.composer-file {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp2);
+  min-width: 0;
+  max-width: 260px;
+  height: var(--control-h-xs);
+  padding: 0 var(--sp1) 0 var(--sp2);
+  border: 1px solid var(--ui-line-strong);
+  border-radius: var(--radius);
+  background: var(--surface-hover);
+  color: var(--text-dim);
+}
+.composer-file-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--type-label);
+}
+.composer-file-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--control-h-2xs);
+  height: var(--control-h-2xs);
+  padding: 0;
+  border: 0;
+  border-radius: var(--r-sm, 5px);
+  background: transparent;
+  color: var(--text-faint);
+  cursor: pointer;
+}
+.composer-file-remove:hover {
+  background: var(--surface-raised);
+  color: var(--text);
 }
 .composer-box-actions {
   display: flex;
@@ -9543,8 +9612,78 @@ button.rail-footer-card:hover {
   transform: translateY(-1px);
   box-shadow: var(--shadow-soft);
 }
+.composer-send:disabled,
+.composer-attach:disabled,
+.composer-file-remove:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+.composer-send:disabled:hover {
+  transform: none;
+  box-shadow: none;
+}
 .composer-send:active {
   transform: translateY(0);
+}
+.composer-chip:focus-visible,
+.composer-attach:focus-visible,
+.composer-file-remove:focus-visible,
+.composer-send:focus-visible,
+.composer-templates-all:focus-visible,
+.composer-template-card:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+@media (max-width: 640px) {
+  .composer-home {
+    justify-content: flex-start;
+    padding: var(--sp5) var(--sp3);
+  }
+  .composer-files {
+    width: 100%;
+    flex-direction: column;
+  }
+  .composer-file {
+    width: 100%;
+    max-width: 100%;
+    min-height: var(--icon-lg);
+    height: auto;
+  }
+  .composer-file-remove {
+    width: var(--icon-lg);
+    min-width: var(--icon-lg);
+    height: var(--icon-lg);
+    margin-left: auto;
+  }
+  .composer-box-actions {
+    flex-wrap: wrap;
+  }
+  .composer-box-right {
+    width: 100%;
+    margin-left: 0;
+  }
+  .composer-harness {
+    flex: 1;
+    justify-content: flex-start;
+  }
+  .composer-attach,
+  .composer-send {
+    width: var(--icon-lg);
+    height: var(--icon-lg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .composer-home {
+    animation: none;
+  }
+  .composer-box,
+  .composer-chip,
+  .composer-attach,
+  .composer-send {
+    transition: none;
+  }
 }
 
 /* Starter template row. */


### PR DESCRIPTION
<!--
Thank you for contributing to sapiom-js.
Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
-->

## Primary change type

<!-- Select exactly one primary type. -->

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

<!-- What problem does this solve, and why is the change needed? -->

Files can already be supplied to an agent from a live session, but the create-new composer could only send text. That forced users to create a session first and attach context afterward, preventing the first request from containing the files needed to start useful work.

## Summary and scope

<!-- Describe what changed, including what is intentionally out of scope. -->

Add an attachment queue to the create-new composer with file picking, drag and drop, and clipboard file/image paste. Path-backed desktop files remain zero-copy; pathless browser and clipboard files are materialized through an authenticated local endpoint before session creation. The queue preserves order, deduplicates files, supports removal and retry, enforces per-file and aggregate limits, rolls back provisional sessions on upload failure, and redacts attachment metadata from analytics.

The UI includes accessible live status, keyboard-removable rows, narrow-screen controls, reduced-motion behavior, and clear queued/uploading/error states. Existing live-session terminal drag/drop and copy/paste behavior is intentionally unchanged, and ordinary text paste in the create-new composer remains native text input. This PR does not claim packaged Linux or Windows execution; explicit Windows/POSIX path cases are covered locally and their packaged smoke remains for CI.

## Related work

<!--
Link the issue or prior maintainer discussion when required by CONTRIBUTING.md.
Use N/A for a direct PR that does not need one.
-->

Related issue or discussion: [Approved Slack discussion](https://sapiom.slack.com/archives/C09SDAQS3T3/p1786729359912369?thread_ts=1786728554.835109&cid=C09SDAQS3T3)

## Validation

<!-- List the exact commands or manual checks you ran and their results. -->

```text
pnpm --filter @sapiom/harness build — passed on the rebased commit
pnpm --filter @sapiom/harness typecheck — passed on the rebased commit
pnpm --filter @sapiom/harness lint — passed with 0 errors and 1 pre-existing unused-import warning in src/server/rest.test.ts
pnpm --filter @sapiom/harness test — passed: 141 files / 2,095 tests plus 4 performance tests
pnpm --filter @sapiom/harness test:ui — passed: 319 Chromium tests, including all 15 create-new composer cases
pnpm terminology:check — passed: 422 files, no stale allowlist entries
pnpm provider-copy:check — passed: 74 audited files
pnpm --filter @sapiom/harness-desktop typecheck — passed
pnpm --filter @sapiom/harness-desktop test — passed: 18 files / 152 tests
macOS arm64 desktop package and isolated packaged smoke — passed: 13 checks, 1 intentional Windows-only skip
Packaged macOS manual validation — Finder file paste queued the exact native zero-copy path; ordinary text paste remained text; removal worked; DevTools probes verified pathless drag/drop and clipboard-file fallback
git diff --check origin/main...HEAD — passed
```

### Tests and documentation

<!-- Describe tests and documentation added or updated. Use N/A with a reason when appropriate. -->

Added unit coverage for attachment validation, ordering, deduplication, size limits, Windows/POSIX paths, inline materialization, confinement, analytics redaction, rollback, and retry. Added 15 Playwright create-new composer cases covering picker, drop, clipboard files, ordinary text paste, accessibility, responsiveness, attachment-only submission, and failure recovery. Added the approved product, architecture, program-design, slice, mockup, and validation record under `docs/plans/new-session-file-uploads/`, plus a patch Changeset.

## Compatibility and release impact

- Breaking or externally visible changes: The create-new composer now accepts picked, dropped, and pasted files for the first agent request. Existing live-session attachment behavior and text-only submissions are preserved; no migration is required.
- Changeset: Added `.changeset/new-session-file-uploads.md` for a patch release of `@sapiom/harness`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

<!--
If AI was used, name the tool, explain what it generated or changed, and
describe how you verified the result.
-->

Codex was used to implement the feature, tests, design records, release note, and validation automation. The result was reviewed through focused and full unit, performance, Playwright, desktop, packaged-app, manual Finder clipboard, and static quality checks listed above; the branch was also rebased onto current `main` and retested before publication.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
