### PR TITLE
fix(content-generation): resolvedModel is optional on the durable resume payload (SAP-2650)

### DIFF
--- a/.changeset/content-generation-resume-resolved-model-optional.md
+++ b/.changeset/content-generation-resume-resolved-model-optional.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/tools": patch
+---
+
+content-generation: `resolvedModel` is now optional on the durable workflow-resume payload — the backend omits it for uncataloged models (SAP-2650).
+
+`MediaResumeFields.resolvedModel` (shared by `VideoResultPayload` / `ImageResultPayload`) is now `resolvedModel?: string`. A real webhook-driven resume can legitimately arrive without it: for a non-cataloged model the gateway deliberately refuses to thread caller-controlled free text through this field on the resume payload (a stray `\n` would crash `fetch`, and the field would be spoofable), so it omits it best-effort — see SAP-2650.
+
+`resolvedModel` stays **required** everywhere the routed backend always echoes the alias (verbatim even for an uncataloged raw id): `VideoGenerationResult` / `ImageGenerationResult` and the sync / poll / launch handles are unchanged. Only the resume payload contract relaxes; `toVideoResumePayload` / `toImageResumePayload` keep emitting it from the (still-required) result field.

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -384,8 +384,12 @@ export interface ImageLaunchHandle extends DispatchHandle {
  * by then (`pauseUntilSignal` reduces it to its signal + `correlationId`).
  */
 export interface MediaResumeFields {
-  /** The semantic model alias that served this generation (SAP-2576). Always present. */
-  resolvedModel: string;
+  /**
+   * The semantic model alias that served this generation (SAP-2576). Omitted on the durable
+   * workflow-resume path when the model is not cataloged (best-effort) — the backend refuses to
+   * thread caller-controlled free text through this field on the resume payload — see SAP-2650.
+   */
+  resolvedModel?: string;
   /** Per-generation cost (SAP-2576) — `estimateUsd` inline, settled charge via `cost.reference`. */
   cost?: MediaCostEnvelope;
 }


### PR DESCRIPTION
<!--
Thank you for contributing to sapiom-js.
Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
-->

## Primary change type

<!-- Select exactly one primary type. -->

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

PR #638 (SAP-2576) added `MediaResumeFields` with `resolvedModel: string` **required** on the durable workflow-resume payloads (`VideoResultPayload` / `ImageResultPayload`). The companion backend (sapiom/Sapiom#4364, SAP-2650) deliberately **omits** `resolvedModel` from the resume payload for a **non-cataloged** model: it is a safety guard so the gateway never threads caller-controlled free text through this field on the durable payload — a stray `\n` would crash `fetch`, and the field would become spoofable. So a real webhook-driven resume can legitimately arrive with no `resolvedModel`, which contradicts the SDK type declaring it a required `string`. claude-review flagged this as "New (low): SDK soundness" on sapiom/Sapiom#4364.

## Summary and scope

Relax only the durable resume contract: in `MediaResumeFields`, `resolvedModel: string` becomes `resolvedModel?: string`, and its JSDoc now explains it is omitted best-effort on the resume path for uncataloged models (SAP-2650).

Intentionally out of scope: `resolvedModel` stays **required** everywhere the routed backend always echoes the alias (verbatim even for an uncataloged raw id) — `VideoGenerationResult` / `ImageGenerationResult` and the sync / poll / launch handles are untouched. `toVideoResumePayload` / `toImageResumePayload` need no logic change: they still read the (required) `result.resolvedModel` and set a field that is now merely optional on the target type.

## Related work

<!--
Link the issue or prior maintainer discussion when required by CONTRIBUTING.md.
Use N/A for a direct PR that does not need one.
-->

Related issue or discussion: SAP-2576 (E2 cost visibility) and SAP-2650 (backend guard); closes the "New (low) SDK soundness" point from claude-review on sapiom/Sapiom#4364. Follows up #638.

## Validation

<!-- List the exact commands or manual checks you ran and their results. -->

```text
pnpm --filter @sapiom/tools typecheck                     — clean (tsc --noEmit, no errors)
pnpm --filter @sapiom/tools test -- content-generation    — 1 suite, 90 tests passed
npx prettier --check src/content-generation/index.ts .changeset/*.md — all files use Prettier code style
npx eslint src/content-generation/index.ts               — clean (exit 0)
pnpm terminology:check                                    — passed (422 files)
pnpm provider-copy:check                                  — passed (74 files)
```

### Tests and documentation

<!-- Describe tests and documentation added or updated. Use N/A with a reason when appropriate. -->

No test changes: the existing `toVideoResumePayload` / `toImageResumePayload` specs still pass unchanged — the local mappers always set the field from the (required) result, so the relaxed target type does not alter their behavior. The type's JSDoc was updated in place to document the SAP-2650 omission.

## Compatibility and release impact

- Breaking or externally visible changes: Type-only, widening. Consumers that **read** `resolvedModel` off a `VideoResultPayload` / `ImageResultPayload` in a resumed step now receive `string | undefined` and should handle the omitted case (which was already possible at runtime). No runtime behavior changes; sync/poll/launch result types are unchanged.
- Changeset: Added — `.changeset/content-generation-resume-resolved-model-optional.md` (`@sapiom/tools` patch).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

<!--
If AI was used, name the tool, explain what it generated or changed, and
describe how you verified the result.
-->

Claude Code (Opus) made the one-line type change, updated the JSDoc, and wrote the changeset. Verified by running the package typecheck, the content-generation test suite (90 passing), prettier/eslint on the touched file, and the terminology/provider-copy gates — all green — and by confirming no repo consumer reads the resume payload's `resolvedModel` expecting a required `string`.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
