### PR TITLE
fix(core): preserve HTTP error details

### DIFF
--- a/.changeset/preserve-http-error-details.md
+++ b/.changeset/preserve-http-error-details.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/core": patch
+---
+
+Preserve structured HTTP error details on core client request failures.

--- a/packages/core/src/client/HttpClient.ts
+++ b/packages/core/src/client/HttpClient.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 
+import type { HttpError, HttpResponse } from "../types/http.js";
+
 /**
  * Request configuration for the HTTP client
  */
@@ -33,6 +35,31 @@ export interface HttpClientConfig {
   headers: Record<string, string>;
   retry?: RetryConfig;
   versionPrefix?: string | null;
+}
+
+class HttpRequestError extends Error implements HttpError {
+  public readonly status: number;
+  public readonly statusText: string;
+  public readonly headers: Record<string, string>;
+  public readonly data: any;
+  public readonly response: HttpResponse;
+
+  constructor(response: Response, data: any, headers: Record<string, string>) {
+    super(
+      `Request failed with status ${response.status}: ${JSON.stringify(data)}`,
+    );
+    this.name = "HttpRequestError";
+    this.status = response.status;
+    this.statusText = response.statusText || "";
+    this.headers = headers;
+    this.data = data;
+    this.response = {
+      status: response.status,
+      statusText: this.statusText,
+      headers,
+      data,
+    };
+  }
 }
 
 /**
@@ -172,8 +199,10 @@ export class HttpClient {
 
       if (!response.ok) {
         const errorData = await this.parseResponse(response);
-        throw new Error(
-          `Request failed with status ${response.status}: ${JSON.stringify(errorData)}`,
+        throw new HttpRequestError(
+          response,
+          errorData,
+          this.responseHeaders(response),
         );
       }
 
@@ -262,6 +291,16 @@ export class HttpClient {
 
     // Return as text
     return text;
+  }
+
+  private responseHeaders(response: Response): Record<string, string> {
+    const headers: Record<string, string> = {};
+    if (typeof response.headers.forEach === "function") {
+      response.headers.forEach((value, key) => {
+        headers[key] = value;
+      });
+    }
+    return headers;
   }
 
   /**

--- a/packages/core/src/client/SapiomClient.test.ts
+++ b/packages/core/src/client/SapiomClient.test.ts
@@ -279,6 +279,40 @@ describe("SapiomClient", () => {
       );
     });
 
+    it("should preserve structured HTTP error details", async () => {
+      const errorData = { error: "Payment Required", transactionId: "tx-123" };
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 402,
+        statusText: "Payment Required",
+        headers: new Headers({
+          "content-type": "application/json",
+          "x-sapiom-transaction-id": "tx-123",
+        }),
+        json: jest.fn().mockResolvedValue(errorData),
+        text: jest.fn().mockResolvedValue(JSON.stringify(errorData)),
+      });
+
+      await expect(client.request({ url: "/paid" })).rejects.toMatchObject({
+        name: "HttpRequestError",
+        message: expect.stringMatching(/Request failed with status 402/),
+        status: 402,
+        statusText: "Payment Required",
+        data: errorData,
+        headers: expect.objectContaining({
+          "x-sapiom-transaction-id": "tx-123",
+        }),
+        response: expect.objectContaining({
+          status: 402,
+          statusText: "Payment Required",
+          data: errorData,
+          headers: expect.objectContaining({
+            "x-sapiom-transaction-id": "tx-123",
+          }),
+        }),
+      });
+    });
+
     it("should handle error responses with text content", async () => {
       const errorText = "Internal Server Error";
       mockFetch.mockResolvedValueOnce({


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Core `HttpClient` failures currently throw a plain `Error`, so callers lose the parsed response body, status text, and headers. That makes typed recovery from HTTP failures harder than it needs to be.

## Summary and scope

Keep the existing error message, but attach structured HTTP details to the thrown error. The change is limited to the core client failure path and its existing test coverage.

## Related work

Related issue or discussion: N/A — direct PR for a small core client bug. I checked recent related PRs; #598 and #625/#626/#627 cover different 402/header issues.

## Validation

```text
pnpm --filter @sapiom/core build — passed
pnpm --filter @sapiom/core typecheck — passed
pnpm --filter @sapiom/core lint — passed with existing warnings outside this change
pnpm --filter @sapiom/core test — passed
```

### Tests and documentation

Kept the structured error test for a 402 response. Documentation is N/A because this does not add a package-root export or new public API.

## Compatibility and release impact

- Breaking or externally visible changes: Non-breaking; existing error messages are preserved.
- Changeset: Added `.changeset/preserve-http-error-details.md` for `@sapiom/core`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Used Codex to inspect the client path, make the small code/test update, rebase the branch, and run validation.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/641" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - HTTP request failures now preserve structured error details, including status, status text, response headers, parsed response data, and the nested response object.
  - Non-successful responses provide more useful information for troubleshooting and error handling.

- **Tests**
  - Added coverage confirming that structured metadata is retained for HTTP payment-required errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->