### PR TITLE
docs(tools): make the 0.27.0 changelog entry consumer-neutral

### DIFF
--- a/packages/tools/CHANGELOG.md
+++ b/packages/tools/CHANGELOG.md
@@ -6,14 +6,14 @@
 
 - 2b133e2: content-generation: surface the SAP-2576 per-generation cost envelope + `resolvedModel` across every media-result path
 
-  Consumers (e.g. Polsia ads re-billing its customers' wallets) can now price a generation without a second API call, consistently across synchronous image calls, polled results, launch handles, AND durable workflow resumes:
+  Consumers (e.g. a platform re-billing generations to its own customers) can now price a generation without a second API call, consistently across synchronous image calls, polled results, launch handles, AND durable workflow resumes:
 
   - New `MediaCostEnvelope` (`estimateUsd` inline + the settled charge out-of-band via `cost.reference`) and `resolvedModel` on `ImageGenerationResult` / `VideoGenerationResult` and the `images.launch` / `video.launch` handles.
   - `resolvedModel` is **required** (the routed backend always echoes it — a cataloged raw id reverse-maps to its alias, an uncataloged one is echoed verbatim), matching the backend SAP-2576 contract. `cost` stays optional (quote/reference are best-effort).
   - The durable resume payload (`VideoResultPayload` / `ImageResultPayload`, via `toVideoResumePayload` / `toImageResumePayload`) now carries `resolvedModel` + `cost` (new shared `MediaResumeFields`), so a workflow step that bills in the **resumed** step — after generation — can still read `cost.reference`.
   - For video the envelope resolves at submit and is threaded from the dispatch handle onto the polled result (the gateway's queue passthrough carries neither).
 
-  > Companion (backend, chengdu): the Fal workflow-resume producer must emit `resolvedModel` + `cost` in the resume payload JSON for real webhook-driven resumes to carry them; the SDK mapper covers local stubs/tests only.
+  > Companion (backend): the Fal workflow-resume producer must emit `resolvedModel` + `cost` in the resume payload JSON for real webhook-driven resumes to carry them; the SDK mapper covers local stubs/tests only.
 
 - beb3139: content-generation: route `video.create` / `video.launch` through the `/v1/capabilities/content.generation.video` router (SAP-2575)
 


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [x] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The `@sapiom/tools` 0.27.0 changelog entry illustrates the cost envelope with a specific downstream consumer and references an internal codename in the backend-companion note. Changelog copy is published on GitHub and inside every npm tarball, and best practice for a public package is that it addresses an anonymous consumer: examples should describe roles ("a platform re-billing its own customers"), not name particular companies or internal projects.

## Summary and scope

Two lines in `packages/tools/CHANGELOG.md` (the 0.27.0 entry):

- The cost-envelope consumer example now reads "a platform re-billing generations to its own customers".
- The backend-companion note drops a codename ("backend, chengdu" → "backend").

Nothing about the described SDK behavior changes. Intentionally out of scope: SAP-\* ticket references (established convention throughout this changelog) and all other files.

## Related work

Related issue or discussion: companion to the trusted-author review workflow PR, which adds the check that keeps this class of copy out of future changesets.

## Validation

```text
node scripts/agent-studio-terminology-check.mjs   — passed (422 files)
node scripts/provider-neutral-copy-check.mjs      — passed (74 audited files)
git diff --stat                                   — 1 file changed, 2 insertions(+), 2 deletions(-)
```

### Tests and documentation

N/A — prose-only edit to an existing changelog entry; no runtime code, types, or tests are affected.

## Compatibility and release impact

- Breaking or externally visible changes: none at runtime. The corrected text ships with the next `@sapiom/tools` publish; the already-published 0.27.0 tarball is immutable, so this fixes the repo copy and everything going forward.
- Changeset: not added — no change to package behavior or API. `changeset version` prepends new entries and does not regenerate old ones, so this edit persists.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code (Fable) located the lines, made the two-line rewording, and ran the terminology and provider-copy checks listed above. Verified by reading the resulting diff.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zfz3PpSY4aDtMahCCvBhA
