### PR TITLE
fix(tools): resolve models.launch overrides against models namespace

### DIFF
--- a/.changeset/fix-models-launch-stub-key.md
+++ b/.changeset/fix-models-launch-stub-key.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": patch
+---
+
+Fix stub override resolution in `models.launch` to query `models.launch` and `models.run` instead of stale `agent` namespace keys.

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -790,7 +790,7 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
         const correlationId = `stub-run-${++launchSeq}`;
         // `launch()` honors `models.launch` first, then the shared `models.run`.
         const result = {
-          ...resolveModelResult(spec, dispatchedKeys("agent")),
+          ...resolveModelResult(spec, dispatchedKeys("models")),
           runId: correlationId,
         };
         // The resume payload IS the result (no live handles to strip).

--- a/packages/tools/src/stub/stub-calls-sink.test.ts
+++ b/packages/tools/src/stub/stub-calls-sink.test.ts
@@ -155,3 +155,38 @@ describe("stub calls sink — per-step isolation", () => {
     expect(callsB[0].capability).toBe("search.scrape");
   });
 });
+
+describe("stub models.launch — override key resolution", () => {
+  it("honors models.launch and models.run overrides for models.launch()", async () => {
+    const customResult = {
+      runId: "custom-run",
+      status: "completed" as const,
+      output: "custom agent output",
+      result: {
+        success: true,
+        stopReason: "end_turn",
+        turns: 1,
+        modelUsed: "stub-model",
+        durationMs: 0,
+        costUsd: 0,
+        usage: {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheCreateTokens: 0,
+          thinkingTokens: 0,
+        },
+      },
+      error: null,
+    };
+    const client = createStubClient({
+      overrides: { "models.launch": customResult },
+    });
+
+    const handle = await client.models.launch({ prompt: "test" });
+    const res = await handle.wait();
+
+    expect(res.output).toBe("custom agent output");
+  });
+});
+


### PR DESCRIPTION
## Primary change type
- [x] Bug fix

## Problem and motivation
`packages/tools/src/stub/index.ts` queried `dispatchedKeys("agent")` inside `client.models.launch`, leaving overrides keyed under `"models.launch"` and `"models.run"` silently ignored during local execution.

## Summary and scope
Updated `client.models.launch` to query `dispatchedKeys("models")`, matching the comment contract and the pattern used in `models.coding.launch`.

## Related work
Fixes #646

## Validation
```text
pnpm --filter @sapiom/tools test — pass
pnpm --filter @sapiom/tools typecheck — pass
```

### Tests and documentation
Added unit test in `packages/tools/src/stub/stub-calls-sink.test.ts` asserting `models.launch` correctly resolves `models.launch` overrides.

## Compatibility and release impact
- Breaking or externally visible changes: None.
- Changeset: Added patch changeset for `@sapiom/tools`.

## Security
- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability.

## AI assistance
- [x] I used AI assistance and have described it below.
AI assisted in identifying the stale `"agent"` namespace string in `stub/index.ts` and crafting the unit test.

## Checklist
- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests.
- [x] I ran the relevant build, typecheck, lint, and test commands.
- [x] I added a Changeset for a published-package change.
- [x] I can explain and maintain every submitted change.