### PR TITLE
feat(content-generation): surface E4 neutral param vocabulary on the SDK (SAP-2579)

### DIFF
--- a/.changeset/e4-sdk-neutral-params.md
+++ b/.changeset/e4-sdk-neutral-params.md
@@ -1,0 +1,14 @@
+---
+"@sapiom/tools": minor
+---
+
+content-generation: surface the E4 neutral param vocabulary on the SDK (SAP-2579)
+
+`contentGeneration.images.create` / `.launch` and `contentGeneration.video.create` / `.launch` now
+accept the neutral params as first-class typed fields — images: `aspectRatio`, `count`, `seed`,
+`negativePrompt`, `referenceImage`, `outputFormat`; video: `aspectRatio`, `resolution`, `duration`,
+`audio`, `seed`, `negativePrompt`, `referenceImage` — plus a `passthrough` escape hatch. The router
+validates each against the chosen model **before payment** and maps it to that model's provider
+format, so a caller can write `video.create({ prompt, aspectRatio: "9:16", audio: true, duration: 10 })`
+without any provider-specific param names. `numImages` and `params` keep working as `@deprecated`
+aliases of `count` and `passthrough`. New exported types: `AspectRatio`, `Resolution`, `OutputFormat`.

--- a/.changeset/e4-sdk-neutral-params.md
+++ b/.changeset/e4-sdk-neutral-params.md
@@ -10,5 +10,6 @@ accept the neutral params as first-class typed fields — images: `aspectRatio`,
 `audio`, `seed`, `negativePrompt`, `referenceImage` — plus a `passthrough` escape hatch. The router
 validates each against the chosen model **before payment** and maps it to that model's provider
 format, so a caller can write `video.create({ prompt, aspectRatio: "9:16", audio: true, duration: 10 })`
-without any provider-specific param names. `numImages` and `params` keep working as `@deprecated`
-aliases of `count` and `passthrough`. New exported types: `AspectRatio`, `Resolution`, `OutputFormat`.
+without any provider-specific param names. `numImages` and `params` keep working, now `@deprecated`
+in favour of `count` and `passthrough` (not drop-in aliases — the merge order is `params` < neutral
+fields < `passthrough`). New exported types: `AspectRatio`, `Resolution`, `OutputFormat`.

--- a/packages/tools/src/content-generation/README.md
+++ b/packages/tools/src/content-generation/README.md
@@ -169,8 +169,10 @@ Shared:
   defaults to a fast model. Most callers omit it.
 - `storage` (optional) — persist outputs; `{ visibility: "private" | "public" }`.
 - `passthrough` (optional) — escape hatch for a raw provider knob the neutral
-  vocabulary doesn't cover yet.
-- `numImages` / `params` — **deprecated** aliases of `count` / `passthrough`, still honored.
+  vocabulary doesn't cover; merged last, so it overrides the neutral fields.
+- `numImages` / `params` — **deprecated**, still honored; superseded by `count` /
+  `passthrough`. (`params` and `passthrough` are not drop-in aliases: the merge
+  order is `params` < neutral fields < `passthrough`.)
 
 Each returned image is `{ url, contentType?, width?, height?, fileId?,
 downloadUrl?, downloadUrlExpiresAt?, storageError? }`; any additional

--- a/packages/tools/src/content-generation/README.md
+++ b/packages/tools/src/content-generation/README.md
@@ -61,10 +61,12 @@ out.video?.downloadUrl; // ready-to-use, short-lived signed URL for the stored f
 out.video?.url; // provider-hosted URL (may be short-lived / unauthenticated)
 ```
 
-Video input takes `prompt`, plus optional `storage`, `model`, and `params` (as with
-images), and two async controls: `pollIntervalMs` (poll cadence, default 5s) and
-`timeoutMs` (give up and throw if it isn't ready in time, default 5 min). The
-returned `video` is `{ url, contentType?, fileId?, downloadUrl?, downloadUrlExpiresAt?, storageError? }`.
+Video input takes `prompt`, plus the optional neutral params (`aspectRatio`,
+`resolution`, `duration`, `audio`, `seed`, `negativePrompt`, `referenceImage` —
+see [Input params](#input-params)), `storage`, `model`, and two async controls:
+`pollIntervalMs` (poll cadence, default 5s) and `timeoutMs` (give up and throw if
+it isn't ready in time, default 5 min). The returned `video` is
+`{ url, contentType?, fileId?, downloadUrl?, downloadUrlExpiresAt?, storageError? }`.
 
 ## Dispatchable video: `video.launch`
 
@@ -135,18 +137,44 @@ Import `VideoResultPayload` from `@sapiom/tools` to annotate the resumed step's
 `input` type; import `toVideoResumePayload` to map a live `VideoGenerationResult`
 to this shape when wiring local tests.
 
-## Image input
+## Input params
 
-- `prompt` (required) — the text prompt.
-- `numImages` (optional) — how many images to generate.
+Describe **what you want** with neutral params instead of provider-specific knobs.
+They're validated against the chosen model *before* you're charged and mapped to
+that model's wire format, so switching models doesn't mean rewriting the call.
+Passing an unsupported param throws `ContentGenerationHttpError` (`unsupported_param`)
+**before any charge** — the response also carries `resolvedModel` and `cost`.
+
+```typescript
+const out = await sapiom.contentGeneration.video.create({
+  prompt: "a calm ocean wave at sunset",
+  aspectRatio: "9:16",
+  audio: true,
+  duration: 10,
+});
+out.resolvedModel; // the alias that served it
+out.cost?.estimateUsd; // what it cost
+```
+
+**Images** (`images.create` / `images.launch`): `prompt` (required), plus optional
+`aspectRatio`, `count`, `seed`, `negativePrompt`, `referenceImage`, `outputFormat`.
+
+**Video** (`video.create` / `video.launch`): `prompt` (required), plus optional
+`aspectRatio`, `resolution`, `duration` (whole seconds), `audio`, `seed`,
+`negativePrompt`, `referenceImage`.
+
+Shared:
+
+- `model` (optional) — a semantic alias (e.g. `"flux-fast"`, `"veo3-fast"`);
+  defaults to a fast model. Most callers omit it.
 - `storage` (optional) — persist outputs; `{ visibility: "private" | "public" }`.
-- `model` (optional) — defaults to a fast image model; most callers omit it.
-- `params` (optional) — advanced, model-specific parameters (e.g. `image_size`,
-  `seed`, `guidance_scale`).
+- `passthrough` (optional) — escape hatch for a raw provider knob the neutral
+  vocabulary doesn't cover yet.
+- `numImages` / `params` — **deprecated** aliases of `count` / `passthrough`, still honored.
 
 Each returned image is `{ url, contentType?, width?, height?, fileId?,
 downloadUrl?, downloadUrlExpiresAt?, storageError? }`; any additional
-model-specific fields (e.g. `seed`) are returned on the result as-is.
+model-specific fields are returned on the result as-is.
 
 ## Gotchas
 

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -1323,6 +1323,145 @@ describe("cost envelope (SAP-2576)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// E4 (SAP-2579) — neutral param vocabulary forwarded top-level (camelCase)
+// ---------------------------------------------------------------------------
+
+describe("neutral params (E4/SAP-2579)", () => {
+  it("createImage forwards the image neutral params + passthrough top-level", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ images: [], resolvedModel: "flux-fast" }),
+    ]);
+
+    await createImage(
+      {
+        prompt: "x",
+        aspectRatio: "9:16",
+        count: 2,
+        seed: 7,
+        negativePrompt: "blurry",
+        referenceImage: "https://img/ref.png",
+        outputFormat: "webp",
+        passthrough: { guidance_scale: 3 },
+      },
+      transport,
+      BASE,
+    );
+
+    // Every neutral field rides top-level camelCase (matching the router's ImageCreateRequest);
+    // passthrough stays a nested object forwarded verbatim.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      aspectRatio: "9:16",
+      count: 2,
+      seed: 7,
+      negativePrompt: "blurry",
+      referenceImage: "https://img/ref.png",
+      outputFormat: "webp",
+      passthrough: { guidance_scale: 3 },
+    });
+  });
+
+  it("createVideo forwards the video neutral params (the M1 headline call) top-level", async () => {
+    const { transport, calls } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({ requestId: "r", responseUrl: `${BASE}/queue/r` })
+          : null,
+      (c) =>
+        c.init.method === "GET"
+          ? jsonResponse({ video: { url: "https://media/v.mp4" } })
+          : null,
+    ]);
+
+    // The literal M1 promise: no provider model id, no per-model param folklore.
+    await createVideo(
+      {
+        prompt: "a wave",
+        aspectRatio: "9:16",
+        audio: true,
+        duration: 10,
+        pollIntervalMs: 1,
+      },
+      transport,
+      BASE,
+    );
+
+    // pollIntervalMs is a client-side control — it stays off the wire.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "a wave",
+      aspectRatio: "9:16",
+      audio: true,
+      duration: 10,
+    });
+  });
+
+  it("launchImage + launchVideo forward neutral params alongside their dispatch shape", async () => {
+    const img = makeLaunchTransport(
+      { requestId: "i", responseUrl: `${BASE}/queue/i` },
+      { images: [{ url: "u" }] },
+    );
+    await launchImage(
+      { prompt: "x", aspectRatio: "1:1", count: 3 },
+      img.transport,
+      BASE,
+    );
+    expect(JSON.parse(img.calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      dispatch: "async",
+      aspectRatio: "1:1",
+      count: 3,
+    });
+
+    const vid = makeLaunchTransport(
+      { requestId: "v", responseUrl: `${BASE}/queue/v` },
+      { video: { url: "u" } },
+    );
+    await launchVideo(
+      { prompt: "x", resolution: "1080p", negativePrompt: "text" },
+      vid.transport,
+      BASE,
+    );
+    expect(JSON.parse(vid.calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      resolution: "1080p",
+      negativePrompt: "text",
+    });
+  });
+
+  it("keeps the deprecated numImages/params working (forwarded verbatim)", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({ images: [] })]);
+
+    await createImage(
+      { prompt: "x", numImages: 4, params: { image_size: "square" } },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      numImages: 4,
+      params: { image_size: "square" },
+    });
+  });
+
+  it("drops an explicit null neutral field (JS caller) instead of sending it", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({ images: [] })]);
+
+    await createImage(
+      {
+        prompt: "x",
+        aspectRatio: null as unknown as undefined,
+        count: null as unknown as undefined,
+      },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ prompt: "x" });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // toVideoResumePayload()
 // ---------------------------------------------------------------------------
 

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -102,18 +102,17 @@ export interface MediaCostEnvelope {
 }
 
 /**
- * Neutral param vocabulary (E4/SAP-2579) — the SDK mirror of the backend catalog's `AspectRatio` /
- * `Resolution` / `OutputFormat` (`media-catalog.types.ts`). A caller sets these as first-class fields
- * on {@link ImageCreateInput} / {@link VideoCreateInput}; the router validates each against the
- * resolved model's capabilities BEFORE payment and maps it to that model's provider wire key. Passing
- * a value the model doesn't support is rejected `400 unsupported_param` (never silently dropped). Each
- * model supports a subset — the union is the full vocabulary.
+ * Neutral aspect-ratio vocabulary — and the entry point to the E4 (SAP-2579) neutral param contract
+ * shared with {@link Resolution} and {@link OutputFormat}. A caller sets these as first-class fields on
+ * {@link ImageCreateInput} / {@link VideoCreateInput}; the router validates each against the resolved
+ * model's capabilities BEFORE payment and maps it to that model's provider wire key. A value the model
+ * doesn't support is rejected `400 unsupported_param` (never silently dropped). Each model supports a
+ * subset — the union is the full vocabulary. Mirrors the backend catalog (`media-catalog.types.ts`).
  */
-/** Neutral aspect-ratio vocabulary. */
 export type AspectRatio = "1:1" | "16:9" | "9:16" | "4:3" | "3:4";
-/** Neutral resolution vocabulary (video). */
+/** Neutral resolution vocabulary (video). See {@link AspectRatio} for how neutral params validate. */
 export type Resolution = "480p" | "720p" | "1080p";
-/** Neutral output-format vocabulary (`"mp4"` is video-only). */
+/** Neutral output-format vocabulary (`"mp4"` is video-only). See {@link AspectRatio}. */
 export type OutputFormat = "png" | "jpeg" | "webp" | "mp4";
 
 export interface ImageCreateInput {
@@ -139,8 +138,8 @@ export interface ImageCreateInput {
   negativePrompt?: string;
   /** Reference image (a hosted URL or a Sapiom `fileId`) for img2img, where the model supports it. */
   referenceImage?: string;
-  /** Output image format. */
-  outputFormat?: OutputFormat;
+  /** Output image format (`"mp4"` is video-only, so it is excluded here). */
+  outputFormat?: Exclude<OutputFormat, "mp4">;
   /**
    * Escape hatch: raw provider wire params, merged last so they win over the neutral fields.
    * Supersedes the deprecated {@link ImageCreateInput.params}; use only for a knob the neutral

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -112,7 +112,7 @@ export interface MediaCostEnvelope {
 export type AspectRatio = "1:1" | "16:9" | "9:16" | "4:3" | "3:4";
 /** Neutral resolution vocabulary (video). See {@link AspectRatio} for how neutral params validate. */
 export type Resolution = "480p" | "720p" | "1080p";
-/** Neutral output-format vocabulary (`"mp4"` is video-only). See {@link AspectRatio}. */
+/** Neutral output-format vocabulary (`"mp4"` for video; image formats otherwise). See {@link AspectRatio}. */
 export type OutputFormat = "png" | "jpeg" | "webp" | "mp4";
 
 export interface ImageCreateInput {
@@ -138,8 +138,8 @@ export interface ImageCreateInput {
   negativePrompt?: string;
   /** Reference image (a hosted URL or a Sapiom `fileId`) for img2img, where the model supports it. */
   referenceImage?: string;
-  /** Output image format (`"mp4"` is video-only, so it is excluded here). */
-  outputFormat?: Exclude<OutputFormat, "mp4">;
+  /** Output image format. */
+  outputFormat?: OutputFormat;
   /**
    * Escape hatch: raw provider wire params, merged last so they win over the neutral fields.
    * Supersedes the deprecated {@link ImageCreateInput.params}; use only for a knob the neutral

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -101,27 +101,65 @@ export interface MediaCostEnvelope {
   reference?: string;
 }
 
+/**
+ * Neutral param vocabulary (E4/SAP-2579) — the SDK mirror of the backend catalog's `AspectRatio` /
+ * `Resolution` / `OutputFormat` (`media-catalog.types.ts`). A caller sets these as first-class fields
+ * on {@link ImageCreateInput} / {@link VideoCreateInput}; the router validates each against the
+ * resolved model's capabilities BEFORE payment and maps it to that model's provider wire key. Passing
+ * a value the model doesn't support is rejected `400 unsupported_param` (never silently dropped). Each
+ * model supports a subset — the union is the full vocabulary.
+ */
+/** Neutral aspect-ratio vocabulary. */
+export type AspectRatio = "1:1" | "16:9" | "9:16" | "4:3" | "3:4";
+/** Neutral resolution vocabulary (video). */
+export type Resolution = "480p" | "720p" | "1080p";
+/** Neutral output-format vocabulary (`"mp4"` is video-only). */
+export type OutputFormat = "png" | "jpeg" | "webp" | "mp4";
+
 export interface ImageCreateInput {
   /** Text prompt describing the image to generate. */
   prompt: string;
-  /** Number of images to generate. */
-  numImages?: number;
   /**
-   * Optional model selector. Defaults to a fast image model; most callers omit it.
-   *
-   * When set, pass a raw *provider* model id — as with video, the SDK forwards `model`
-   * verbatim to the gateway, so a backend semantic alias is not resolved here.
+   * Optional model selector — a Sapiom semantic alias (e.g. `"flux-fast"`, `"flux-pro/kontext"`)
+   * resolved to a provider model server-side. A legacy raw provider id still works. Most callers
+   * omit it (defaults to a fast image model).
    */
   model?: string;
+
+  // ── Neutral params (E4/SAP-2579). Validated against the resolved model's capabilities BEFORE
+  // payment and mapped to its provider wire keys; an unsupported one → 400 `unsupported_param`
+  // (never silently dropped). Omit ⇒ the provider default. See {@link AspectRatio} et al.
+  /** Aspect ratio of the generated image. */
+  aspectRatio?: AspectRatio;
+  /** Number of images to generate. Supersedes the deprecated {@link ImageCreateInput.numImages}. */
+  count?: number;
+  /** Deterministic seed, where the model exposes one. */
+  seed?: number;
+  /** Negative prompt, where the model supports one. */
+  negativePrompt?: string;
+  /** Reference image (a hosted URL or a Sapiom `fileId`) for img2img, where the model supports it. */
+  referenceImage?: string;
+  /** Output image format. */
+  outputFormat?: OutputFormat;
+  /**
+   * Escape hatch: raw provider wire params, merged last so they win over the neutral fields.
+   * Supersedes the deprecated {@link ImageCreateInput.params}; use only for a knob the neutral
+   * vocabulary lacks.
+   */
+  passthrough?: Record<string, unknown>;
+
   /**
    * Optional: persist each generated output to Sapiom file storage. When set, every
    * item in `images` comes back annotated with `fileId` (or `storageError` if
    * persisting that one failed).
    */
   storage?: StorageOptions;
+  /** @deprecated use {@link ImageCreateInput.count}. Number of images to generate. Still honored. */
+  numImages?: number;
   /**
-   * Advanced: extra model-specific parameters, forwarded verbatim
-   * (e.g. `image_size`, `seed`, `guidance_scale`).
+   * @deprecated use the neutral fields above, or {@link ImageCreateInput.passthrough} for an
+   * uncovered knob. Extra model-specific parameters, forwarded verbatim (e.g. `image_size`,
+   * `guidance_scale`). Still honored.
    */
   params?: Record<string, unknown>;
 }
@@ -269,6 +307,52 @@ function workflowResumeHeaders(
 }
 
 /**
+ * The E4 (SAP-2579) neutral param fields + the deprecated aliases, forwarded verbatim as top-level
+ * camelCase body fields — matching the router's `ImageCreateRequest`. The SDK only forwards; the
+ * router validates against the resolved model's caps, maps to provider wire keys, and applies the
+ * merge precedence (`params` < neutral fields < `passthrough`). `count`/`outputFormat` are image-only.
+ */
+const IMAGE_PARAM_KEYS = [
+  "aspectRatio",
+  "count",
+  "seed",
+  "negativePrompt",
+  "referenceImage",
+  "outputFormat",
+  "passthrough",
+  "numImages",
+  "params",
+] as const;
+
+/** As {@link IMAGE_PARAM_KEYS}, for video: no `count`/`outputFormat`; adds `resolution`/`duration`/`audio`. */
+const VIDEO_PARAM_KEYS = [
+  "aspectRatio",
+  "resolution",
+  "duration",
+  "audio",
+  "seed",
+  "negativePrompt",
+  "referenceImage",
+  "passthrough",
+  "params",
+] as const;
+
+/**
+ * Copy each present param field from `input` onto the request `body` (top-level, camelCase). `!= null`
+ * drops an explicit JS `null` (treated as unset — mirroring the router's `pickNeutralParams` and the
+ * sibling `model` / `storage` handling), so `aspectRatio: null` from a JS caller never hits the wire.
+ */
+function applyMediaParams(
+  body: Record<string, unknown>,
+  input: Record<string, unknown>,
+  keys: readonly string[],
+): void {
+  for (const key of keys) {
+    if (input[key] != null) body[key] = input[key];
+  }
+}
+
+/**
  * Generate one or more images from a prompt. Pass `storage` to persist each output
  * (the returned images then carry `fileId`). Failed requests throw
  * {@link ContentGenerationHttpError}.
@@ -286,15 +370,14 @@ export async function createImage(
 ): Promise<ImageGenerationResult> {
   assertPrompt(input.prompt);
 
-  // Map to the router's camelCase `ImageCreateRequest`. `params` rides as a nested
-  // field (not spread) so the adapter forwards it verbatim. `!= null` keeps a JS
-  // caller's explicit null off the wire; `storage` uses a truthy check so
-  // `storage: null` is "no storage" rather than a null field.
+  // Map to the router's camelCase `ImageCreateRequest`. `model`/`storage` keep their own guards
+  // (`storage` truthy, so `storage: null` means "no storage"); the E4 neutral params + the
+  // deprecated `numImages`/`params` ride top-level via `applyMediaParams` for the router to
+  // validate + map (`params`/`passthrough` stay nested objects, forwarded verbatim).
   const body: Record<string, unknown> = { prompt: input.prompt };
   if (input.model != null) body.model = input.model;
-  if (input.numImages !== undefined) body.numImages = input.numImages;
   if (input.storage) body.storage = input.storage;
-  if (input.params != null) body.params = input.params;
+  applyMediaParams(body, input as unknown as Record<string, unknown>, IMAGE_PARAM_KEYS);
 
   const raw = await capabilityCall<RawImageResult>(
     "content.generation.images",
@@ -464,17 +547,14 @@ export async function launchImage(
 ): Promise<ImageLaunchHandle> {
   assertPrompt(input.prompt);
 
-  // Mirror createImage's body byte-for-byte, plus `dispatch: 'async'` to select the
-  // queue path. `params` rides nested; `storage` uses a truthy check (so `storage: null`
-  // is "no storage"); `!= null` keeps an explicit JS null off the wire.
+  // Mirror createImage's body, plus `dispatch: 'async'` to select the queue path.
   const body: Record<string, unknown> = {
     prompt: input.prompt,
     dispatch: "async",
   };
   if (input.model != null) body.model = input.model;
-  if (input.numImages !== undefined) body.numImages = input.numImages;
   if (input.storage) body.storage = input.storage;
-  if (input.params != null) body.params = input.params;
+  applyMediaParams(body, input as unknown as Record<string, unknown>, IMAGE_PARAM_KEYS);
 
   const handle = await capabilityCall<ImageDispatchResponse>(
     "content.generation.images",
@@ -600,13 +680,44 @@ export interface VideoCreateInput {
    * @example "veo3-fast"
    */
   model?: LiteralUnion<KnownVideoModel>;
+
+  // ── Neutral params (E4/SAP-2579) — same contract as {@link ImageCreateInput}: validated against
+  // the resolved model's capabilities BEFORE payment, mapped to its provider wire keys; an
+  // unsupported one → 400 `unsupported_param`. Omit ⇒ the provider default.
+  /** Aspect ratio of the generated video. */
+  aspectRatio?: AspectRatio;
+  /** Output resolution, where the model exposes one. */
+  resolution?: Resolution;
+  /**
+   * Duration in whole seconds. Omit to get the model's catalog default — the priced duration then
+   * equals the generated one (no under-authorization on a longer-than-priced render).
+   */
+  duration?: number;
+  /** Native audio, where the model supports it. */
+  audio?: boolean;
+  /** Deterministic seed, where the model exposes one. */
+  seed?: number;
+  /** Negative prompt, where the model supports one. */
+  negativePrompt?: string;
+  /** Reference image (a hosted URL or a Sapiom `fileId`) for image-to-video, where supported. */
+  referenceImage?: string;
+  /**
+   * Escape hatch: raw provider wire params, merged last so they win over the neutral fields.
+   * Supersedes the deprecated {@link VideoCreateInput.params}; use only for a knob the neutral
+   * vocabulary lacks.
+   */
+  passthrough?: Record<string, unknown>;
+
   /**
    * Optional: persist the generated output to Sapiom file storage. When set, the
    * returned `video` comes back annotated with `fileId` (or `storageError` if
    * persisting failed).
    */
   storage?: StorageOptions;
-  /** Advanced: extra model-specific parameters, forwarded verbatim. */
+  /**
+   * @deprecated use the neutral fields above, or {@link VideoCreateInput.passthrough} for an
+   * uncovered knob. Extra model-specific parameters, forwarded verbatim. Still honored.
+   */
   params?: Record<string, unknown>;
   /** How often to poll while the video generates (default 5s). */
   pollIntervalMs?: number;
@@ -762,14 +873,13 @@ export async function createVideo(
 ): Promise<VideoGenerationResult> {
   assertPrompt(input.prompt);
 
-  // Map to the router's camelCase video request. `params` rides as a nested field
-  // (not spread) so the adapter forwards it verbatim; `model` is a body field the
-  // adapter resolves — mirrors createImage's body byte-for-byte.
+  // Map to the router's camelCase `VideoCreateRequest` — mirrors createImage. `model` is a body
+  // field the adapter resolves; `storage` truthy so `storage: null` is "no storage"; the E4 neutral
+  // params + deprecated `params` ride top-level via `applyMediaParams`.
   const body: Record<string, unknown> = { prompt: input.prompt };
   if (input.model != null) body.model = input.model;
-  // Truthy check (not `!== undefined`) so `storage: null` is treated as "no storage".
   if (input.storage) body.storage = input.storage;
-  if (input.params != null) body.params = input.params;
+  applyMediaParams(body, input as unknown as Record<string, unknown>, VIDEO_PARAM_KEYS);
 
   // Submit through the capability router — the video capability's adapter always
   // returns a queue handle (camelCase requestId/statusUrl/responseUrl), never the
@@ -940,13 +1050,12 @@ export async function launchVideo(
 ): Promise<VideoLaunchHandle> {
   assertPrompt(input.prompt);
 
-  // Mirror createVideo's body byte-for-byte — video is async-only, so there's no
-  // `dispatch` field to add (unlike launchImage, which sets `dispatch: 'async'` to
-  // pick the queue path over images' sync default).
+  // Mirror createVideo's body — video is async-only, so there's no `dispatch` field to add
+  // (unlike launchImage, which sets `dispatch: 'async'`).
   const body: Record<string, unknown> = { prompt: input.prompt };
   if (input.model != null) body.model = input.model;
   if (input.storage) body.storage = input.storage;
-  if (input.params != null) body.params = input.params;
+  applyMediaParams(body, input as unknown as Record<string, unknown>, VIDEO_PARAM_KEYS);
 
   const handle = await capabilityCall<VideoDispatchResponse>(
     "content.generation.video",

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -97,10 +97,16 @@ export { FileStorageHttpError } from "./file-storage/index.js";
 
 export * as contentGeneration from "./content-generation/index.js";
 export { ContentGenerationHttpError } from "./content-generation/index.js";
-// The concrete video model ids the gateway serves, so callers can discover valid
-// values (and avoid passing a backend semantic alias, which the SDK does not resolve).
+// Concrete video model ids the gateway serves, for callers that want to pin one. Prefer a semantic
+// alias (e.g. "veo3-fast") — the routed video capability resolves it server-side (SAP-2575).
 export { VIDEO_MODELS } from "./content-generation/index.js";
 export type { KnownVideoModel } from "./content-generation/index.js";
+// Neutral param vocabulary (E4/SAP-2579) — name these when building typed media inputs.
+export type {
+  AspectRatio,
+  Resolution,
+  OutputFormat,
+} from "./content-generation/index.js";
 // Surfaced top-level for the static `pause: { signal }` decl on a workflow step.
 export { VIDEO_RESULT_SIGNAL } from "./content-generation/index.js";
 export { IMAGE_RESULT_SIGNAL } from "./content-generation/index.js";


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Milestone M1 of the Media Generation Capability Contract ("callable by intent, with cost")
is marked Done, but its E4 deliverable — the **neutral param vocabulary** — only landed on the
backend (`ImageCreateRequest` / `VideoCreateRequest` in `backend/src/capabilities/content-generation`),
never on this SDK. Those backend DTOs are explicitly documented as mirroring the SDK's
`ImageCreateInput` / `VideoCreateInput` "field-for-field", and they diverged: no `sapiom-js` PR was
ever attached to SAP-2579.

The consequence is that M1's headline promise does not typecheck against the SDK today:

```ts
contentGeneration.video.create({ prompt, aspectRatio: "9:16", audio: true, duration: 10 })
// aspectRatio / audio / duration are not fields on VideoCreateInput
```

The input interfaces are closed and the request body is built from a fixed allowlist with no
`...input` spread, so a caller cannot reach the neutral contract at all — even an untyped top-level
field is dropped before the wire, and stuffing values into `params` sends them verbatim to the
provider (bypassing the neutral normalizer). Callers are forced back onto raw provider param names,
the exact "per-model folklore" the contract set out to remove.

## Summary and scope

Mirror the backend E4 contract onto the SDK — the SDK only **types and forwards**; the router still
validates against the resolved model's capabilities before payment and maps to provider wire keys.

- New exported types `AspectRatio`, `Resolution`, `OutputFormat` (mirror of `media-catalog.types.ts`;
  strict literal unions, matching the SDK's house convention for enum-like fields).
- `ImageCreateInput` gains `aspectRatio`, `count`, `seed`, `negativePrompt`, `referenceImage`,
  `outputFormat`, `passthrough`.
- `VideoCreateInput` gains `aspectRatio`, `resolution`, `duration`, `audio`, `seed`, `negativePrompt`,
  `referenceImage`, `passthrough`.
- `numImages` and `params` are kept working as `@deprecated` aliases of `count` / `passthrough`.
- All four builders (`createImage`, `launchImage`, `createVideo`, `launchVideo`) forward the fields
  top-level camelCase via a shared `applyMediaParams` helper (`!= null` drops explicit JS null, as the
  router's `pickNeutralParams` does); `params` / `passthrough` stay nested objects forwarded verbatim.
- Docs: README input section rewritten around the neutral vocabulary with the M1 headline example;
  the image `model` JSDoc corrected (aliases resolve server-side), and a stale barrel-export comment
  that told callers to avoid aliases (contradicting the SAP-2575 repoint) fixed.

**Out of scope (intentional):** migrating `examples/` off `params` folklore — the strict unions require
narrowing each example's own zod schema (`aspectRatio: string` → `AspectRatio`), a separate change;
examples keep compiling via the still-supported `params`. Also out: the E2 stub gap where the offline
`.create` stubs omit `resolvedModel` (separate epic). Both are noted as follow-ups.

## Related work

Related issue or discussion: SAP-2579 (E4 — Normalized param contract), M1 of
https://linear.app/sapiom/project/media-generation-capability-contract-befb6c525932 — this is the
SDK companion to the backend E4 work (sapiom/Sapiom PRs #4349–#4365).

## Validation

```text
pnpm --filter @sapiom/tools typecheck                                 — pass (after building the @sapiom/analytics-core workspace dep)
pnpm --filter @sapiom/tools build                                     — pass (cjs + esm)
pnpm --filter @sapiom/tools test                                      — 538 passed, 27 suites (incl. 5 new neutral-param tests)
pnpm --filter @sapiom/tools exec eslint src/content-generation src/index.ts — clean (exit 0)
pnpm terminology:check                                                — pass (422 files)
pnpm provider-copy:check                                              — pass (74 files)
```

### Tests and documentation

Added a `neutral params (E4/SAP-2579)` describe block in `content-generation/index.spec.ts` (5 tests):
image and video neutral params forwarded top-level camelCase (incl. the M1 headline call), launch
variants alongside their dispatch shape, deprecated `numImages`/`params` still forwarded verbatim, and
an explicit-null neutral field dropped. README updated (neutral vocabulary + headline example); JSDoc
updated on the input types and the barrel export.

## Compatibility and release impact

- Breaking or externally visible changes: None — purely additive. New optional input fields and three
  new exported types; `numImages` / `params` remain honored (now `@deprecated`). No wire/URL changes.
- Changeset: Added — `.changeset/e4-sdk-neutral-params.md` (`@sapiom/tools` minor).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code (Opus 4.8, 1M context) surveyed the merged backend E4 contract at `origin/dev`
(`content-generation.types.ts`, `media-catalog.types.ts`, `param-normalizer.ts`), mirrored it onto the
SDK input types, and wrote the forwarding helper, tests, docs, and changeset. Verified by running the
package typecheck, build, full test suite (538 passing), eslint, and the terminology / provider-copy
gates — all listed under Validation.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
