### PR TITLE
fix(harness): give the workflow registry's temp file a per-process name

### DIFF
--- a/.changeset/proud-ants-study.md
+++ b/.changeset/proud-ants-study.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Give the workflow registry's atomic write a per-process temp file name, so two harness instances sharing the machine-wide workflows.json cannot publish a torn file.

--- a/packages/harness/src/core/workflow-registry.test.ts
+++ b/packages/harness/src/core/workflow-registry.test.ts
@@ -351,9 +351,39 @@ describe("WorkflowRegistry", () => {
       expect(Array.isArray(parsed)).toBe(true);
       expect(parsed).toHaveLength(1);
 
-      // The .tmp file must NOT be left behind (rename completed).
-      const tmpPath = `${registryPath}.tmp`;
-      await expect(fs.access(tmpPath)).rejects.toThrow();
+      // No temp artefact must be left behind (rename completed). The temp name
+      // carries a pid + uuid suffix, so match on the prefix rather than one
+      // fixed path — asserting a fixed name would pass even if a differently
+      // named temp file were orphaned.
+      const base = path.basename(registryPath);
+      const leftovers = (await fs.readdir(path.dirname(registryPath))).filter((name) =>
+        name.startsWith(`${base}.tmp`),
+      );
+      expect(leftovers).toEqual([]);
+    });
+
+    it("two registries sharing one path do not collide on the temp file (the path is machine-wide)", async () => {
+      // writeQueue only serializes writers inside one instance, but the default
+      // registry path is machine-wide (~/.sapiom/harness/workflows.json), so a
+      // CLI and a desktop app run two registries over the same file. With a
+      // fixed .tmp name each would write into the other's temp and rename a
+      // half-written file over the target, which load() then swallows as an
+      // empty list — silent loss of connected workflows.
+      const other = new WorkflowRegistry(registryPath);
+      await writeMarker(path.join(tmpRoot, "proj-a"), 1);
+      await writeMarker(path.join(tmpRoot, "proj-b"), 1);
+
+      await Promise.all([registry.scan(tmpRoot), other.scan(tmpRoot)]);
+
+      const parsed = JSON.parse(await fs.readFile(registryPath, "utf8")) as unknown[];
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed).toHaveLength(2);
+
+      const base = path.basename(registryPath);
+      const leftovers = (await fs.readdir(path.dirname(registryPath))).filter((name) =>
+        name.startsWith(`${base}.tmp`),
+      );
+      expect(leftovers).toEqual([]);
     });
 
     it("a failed persist does not poison the queue — subsequent writes succeed", async () => {

--- a/packages/harness/src/core/workflow-registry.ts
+++ b/packages/harness/src/core/workflow-registry.ts
@@ -9,6 +9,7 @@
  * shared app.
  */
 
+import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -186,10 +187,18 @@ export class WorkflowRegistry {
     // Atomic write: write to a temp file in the same directory (so rename is
     // same-filesystem and thus atomic on POSIX), then rename over the target.
     // A crash mid-write leaves the .tmp file, not a torn workflows.json.
-    // Mirrors the pattern used by SessionManager.persist().
-    const tmpPath = `${this.registryPath}.tmp`;
-    await fs.writeFile(tmpPath, JSON.stringify(this.workflows, null, 2));
-    await fs.rename(tmpPath, this.registryPath);
+    // The temp name is per-process and unique: writeQueue only serializes
+    // writers inside one process, and this path is machine-wide, so a second
+    // harness would otherwise write into the same .tmp concurrently and the
+    // rename would publish a torn file. Mirrors SessionManager.persist().
+    const tmpPath = `${this.registryPath}.tmp-${process.pid}-${randomUUID()}`;
+    try {
+      await fs.writeFile(tmpPath, JSON.stringify(this.workflows, null, 2));
+      await fs.rename(tmpPath, this.registryPath);
+    } catch (err) {
+      await fs.rm(tmpPath, { force: true }).catch(() => {});
+      throw err;
+    }
   }
 
   /** Chains `run` onto the write queue so concurrent mutations never


### PR DESCRIPTION
## Primary change type

- [x] Bug fix

## Problem and motivation

`WorkflowRegistry.persist()` wrote to a fixed temp path:

```ts
// Mirrors the pattern used by SessionManager.persist().
const tmpPath = `${this.registryPath}.tmp`;
```

The comment is not accurate. Every other atomic writer in the package uses a per-process name:

| File | Temp name |
|---|---|
| `core/session-manager.ts:1217` | `.tmp-${pid}-${seq}` |
| `core/workspace-context.ts:145` | `.tmp-${pid}-${uuid}` |
| `core/collector/store-retention.ts:127` | `-tmp-${pid}-${Date.now()}` |
| `core/record-archive.ts:420` | `-tmp-${pid}-${now}-${counter}` |

This was the only one left on a shared name.

`writeQueue` serializes writers within one instance, but the default registry path is machine-wide: `expandHome(HARNESS_PATHS.workflows)`, i.e. `~/.sapiom/harness/workflows.json`. A CLI and a desktop app, or two Studio servers for two projects, run two registries over that one file.

When two `/api/workflows/connect` or `/scan` calls overlap, both write into the same temp. Either one renames it away and the other fails, or the rename publishes a half-written file. `ensureLoaded()` swallows broken JSON with `catch { this.workflows = [] }`, so the visible symptom is connected workflows silently disappearing. The rename is atomic, but sharing the temp voids the guarantee the comment claims.

## Summary and scope

Add a `pid` + `uuid` suffix to the temp name, and remove the temp file if the write or rename throws.

Out of scope: the other atomic writers are already correct and are not touched. The broader question of whether two harness instances should share one registry file at all is left alone; this only makes the existing atomic-write claim hold.

## Related work

Related issue or discussion: N/A — direct PR, focused bug fix with a reproduction, under the direct-PR policy.

## Validation

```text
pnpm --filter @sapiom/harness exec vitest run src/core   — pass (1075/1075)
pnpm --filter @sapiom/harness typecheck                  — pass
pnpm --filter @sapiom/harness lint                       — pass (0 errors)
pnpm build                                               — pass
```

The new test fails on the unpatched code:

```text
Error: ENOENT: no such file or directory, rename '.../workflows.json.tmp' -> '.../workflows.json'
  at WorkflowRegistry.persist src/core/workflow-registry.ts
```

I verified this by reverting only the temp-name line and re-running the file.

### Tests and documentation

Tests: added a case where two registries over one path scan concurrently, asserting the persisted file is intact and no temp artefact is orphaned.

The existing C4 atomicity test asserted `fs.access(`${registryPath}.tmp`)` rejects. That would pass for free once the name changed, and would not catch a temp orphaned under a different name, so it now matches on the `.tmp` prefix across the directory instead.

Documentation: N/A, internal behavior only. The inaccurate code comment is corrected in place.

## Compatibility and release impact

- Breaking or externally visible changes: None. The temp file is an implementation detail and is renamed away in the same operation.
- Changeset: Added (patch, `@sapiom/harness`).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. This is a data-integrity race between the user's own processes, not a trust-boundary issue.

## AI assistance

- [x] I used AI assistance and have described it below.

I used Claude (Claude Code and the Claude app). Claude surveyed the package for atomic writers and reported the inconsistency; I checked each of the four call sites myself and confirmed the registry path is machine-wide before accepting the finding. I directed the fix and the regression test, and Claude wrote them. I validated the test by reverting only the temp-name line and confirming the test fails with the ENOENT above, so it is a real regression test rather than one that passes either way.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
