### PR TITLE
docs(skills): remove internal references leaked into authoring-clarity skill

### DIFF
--- a/plugins/sapiom/skills/establishing-authoring-clarity/SKILL.md
+++ b/plugins/sapiom/skills/establishing-authoring-clarity/SKILL.md
@@ -70,6 +70,6 @@ Ask **after** searching, name the sibling/guide, and put the real fork to them:
 
 ## Sibling skill
 
-This is the sapiom-js half of a pair. The Sapiom-frontend half is **`establishing-design-clarity`**
-(same spine; source of truth is Storybook / the design system instead of `AUTHORING.md`, and it
-dispatches to `enforcing-design-language`).
+**`establishing-studio-design-clarity`** (this repo) — the same intake for **Agent Studio / harness
+UI** work (source: the `@sapiom/design-system` seam). Use it for UI, this one for template/agent
+authoring.


### PR DESCRIPTION
## Summary

Follow-up to #660 (already merged). This is a **public repo**, and the merged `establishing-authoring-clarity` skill's "Sibling skill" section pointed at non-public siblings. Replaces that note with a pointer to the public sibling in this same repo, `establishing-studio-design-clarity`. No other content changes.

## Related
- Follows #660; pairs with #661.
