### PR TITLE
docs(skills): retarget the intake-rule reference to the in-repo sibling

### DIFF
--- a/plugins/sapiom/skills/establishing-authoring-clarity/SKILL.md
+++ b/plugins/sapiom/skills/establishing-authoring-clarity/SKILL.md
@@ -8,8 +8,9 @@ description: Use at the START of authoring a Sapiom template or agent in sapiom-
 ## Overview
 
 Before you author a Sapiom template or agent, establish **what you're building from**. Same rule
-as the frontend intake it mirrors: **search first; then — only if you can't find it — ask before
-you build.** Never ask before searching; never invent the product in a vacuum.
+as its sibling intake, `establishing-studio-design-clarity`: **search first; then — only if you
+can't find it — ask before you build.** Never ask before searching; never invent the product in a
+vacuum.
 
 The authoring-specific trap: a published template is judged by *the person deciding whether to use
 it* (`examples/AUTHORING.md`) — so the **outcome, the target user, and the copy are the substance,


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [x] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The `establishing-authoring-clarity` skill's overview cites "the frontend intake it mirrors" — an intake that does not exist in this repository, the same class of unresolvable pointer #662 removed from the "Sibling skill" section. A reader of this repo can't follow it anywhere.

## Summary and scope

One sentence in `plugins/sapiom/skills/establishing-authoring-clarity/SKILL.md`: the intake-rule reference now points at the in-repo sibling, `establishing-studio-design-clarity` (#661). No rule content changes; nothing else is touched.

## Related work

Related issue or discussion: completes the cleanup from #662; surfaced by the automated review on that PR.

## Validation

```text
npx prettier --check plugins/sapiom/skills/establishing-authoring-clarity/SKILL.md — file was not previously prettier-formatted; this PR deliberately keeps the diff to the one sentence rather than reformatting
git diff origin/main..HEAD --stat — 1 file changed, 3 insertions(+), 2 deletions(-)
grep — no remaining references in the file to intakes outside this repo
```

### Tests and documentation

N/A — prose-only edit to a plugin skill document; no runtime code, types, or tests are affected.

## Compatibility and release impact

- Breaking or externally visible changes: none. Plugin skill docs are not part of any published npm package.
- Changeset: not applicable — no published package is touched.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code (Fable) made the one-sentence edit and verified via the grep and diff listed above that no other out-of-repo intake references remain in the file.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012zfz3PpSY4aDtMahCCvBhA
