### PR TITLE
fix(content-generation): launch stubs honor the create override key + shared media factories (SAP-2576)

### DIFF
--- a/.changeset/stub-launch-create-key.md
+++ b/.changeset/stub-launch-create-key.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": patch
+---
+
+content-generation (stub): `images.launch` / `video.launch` now also honor the sync verb's override key (`contentGeneration.images.create` / `contentGeneration.video.create`), so a step that moves from `create()` to `launch()` — the documented fix for long-running fan-outs — keeps its stub instead of silently falling back to the built-in default. Precedence: `<ns>.launch` (the call you wrote) wins, then `<ns>.create`, then the legacy `<ns>.run` spelling, which stays honored for back-compat (contentGeneration has no `run` method, but the key resolved before this release). Internally the four inlined media stub payloads collapsed into shared `stubImageResult` / `stubVideoResult` factories, so the `create` and `launch` defaults can no longer drift apart.

--- a/packages/tools/src/stub/content-generation.spec.ts
+++ b/packages/tools/src/stub/content-generation.spec.ts
@@ -129,3 +129,63 @@ describe("createStubClient().contentGeneration — resolvedModel on the launch p
     expect(override).toEqual({ video: { url: "https://cdn/override.mp4" } });
   });
 });
+
+// contentGeneration has no `run` method — its blocking sibling is `create`. The launch stubs
+// therefore consult `<ns>.launch`, then `<ns>.create` (so a step that moves from create() to
+// launch() keeps its stub), then the legacy `<ns>.run` spelling for back-compat.
+describe("createStubClient().contentGeneration — launch override keys", () => {
+  it("honors a create-key override on launch (a step moving create → launch keeps its stub)", async () => {
+    const override = Object.freeze({
+      images: [{ url: "https://cdn/from-create-key.png" }],
+      resolvedModel: "my-model",
+    });
+    const stub = createStubClient({
+      overrides: { "contentGeneration.images.create": override },
+    });
+
+    const handle = await stub.contentGeneration.images.launch({ prompt: "x" });
+
+    expect(handle.resolvedModel).toBe("my-model");
+    expect((await handle.wait()).images?.[0]?.url).toBe(
+      "https://cdn/from-create-key.png",
+    );
+  });
+
+  it("the launch key wins over create when both are supplied", async () => {
+    const stub = createStubClient({
+      overrides: {
+        "contentGeneration.video.launch": {
+          video: { url: "https://cdn/launch.mp4" },
+          resolvedModel: "from-launch",
+        },
+        "contentGeneration.video.create": {
+          video: { url: "https://cdn/create.mp4" },
+          resolvedModel: "from-create",
+        },
+      },
+    });
+
+    const handle = await stub.contentGeneration.video.launch({ prompt: "x" });
+
+    expect(handle.resolvedModel).toBe("from-launch");
+    expect((await handle.wait()).video?.url).toBe("https://cdn/launch.mp4");
+  });
+
+  it("the legacy run key keeps working on launch (back-compat with pre-0.28.1 stubs)", async () => {
+    const stub = createStubClient({
+      overrides: {
+        "contentGeneration.images.run": {
+          images: [{ url: "https://cdn/from-run-key.png" }],
+          resolvedModel: "from-run",
+        },
+      },
+    });
+
+    const handle = await stub.contentGeneration.images.launch({ prompt: "x" });
+
+    expect(handle.resolvedModel).toBe("from-run");
+    expect((await handle.wait()).images?.[0]?.url).toBe(
+      "https://cdn/from-run-key.png",
+    );
+  });
+});

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -63,8 +63,10 @@ import {
   toImageResumePayload,
 } from "../content-generation/index.js";
 import type {
+  ImageCreateInput,
   ImageGenerationResult,
   ImageLaunchHandle,
+  VideoCreateInput,
   VideoGenerationResult,
   VideoLaunchHandle,
 } from "../content-generation/index.js";
@@ -278,6 +280,18 @@ function resolve(
  */
 function dispatchedKeys(namespace: string): string[] {
   return [`${namespace}.launch`, `${namespace}.run`];
+}
+
+/**
+ * The override keys a contentGeneration `launch` accepts, in precedence order: the method
+ * actually called (`<ns>.launch`), then the real blocking sibling (`<ns>.create` — the key
+ * authors already write for the sync verb, so a step that moves from `create()` to `launch()`
+ * keeps its stub), then the legacy `<ns>.run` spelling {@link dispatchedKeys} consulted here
+ * before 0.28.1 — contentGeneration has no `run` method, but the key resolved, so it stays
+ * honored for back-compat.
+ */
+function mediaDispatchedKeys(namespace: string): string[] {
+  return [`${namespace}.launch`, `${namespace}.create`, `${namespace}.run`];
 }
 
 /**
@@ -538,6 +552,52 @@ function stubRunHandle(
     {},
     callsSink,
   ) as RunHandle;
+}
+
+// Default media results for the contentGeneration stub — ONE factory per media type, shared by
+// `create` and `launch` so the two verbs can never drift (the create/launch resolvedModel drift
+// fixed in #664 came from inlined twin literals). SAP-2576: the routed backend always echoes a
+// resolvedModel (a required field), so the factory does too — set here, inside the fallback,
+// never post-mutated onto a resolved override.
+function stubImageResult(input: ImageCreateInput): ImageGenerationResult {
+  return {
+    images: [
+      {
+        url: "https://content.local/stub-image.png",
+        contentType: "image/png",
+        width: 512,
+        height: 512,
+        // mirror the real behavior: a fileId only when storage was requested.
+        ...(input.storage
+          ? {
+              fileId: "stub-file",
+              downloadUrl: "https://content.local/stub-download",
+              downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
+            }
+          : {}),
+      },
+    ],
+    resolvedModel: input.model ?? "stub-model",
+  };
+}
+
+/** As {@link stubImageResult}, for video. */
+function stubVideoResult(input: VideoCreateInput): VideoGenerationResult {
+  return {
+    video: {
+      url: "https://content.local/stub-video.mp4",
+      contentType: "video/mp4",
+      // mirror the real behavior: a fileId only when storage was requested.
+      ...(input.storage
+        ? {
+            fileId: "stub-file",
+            downloadUrl: "https://content.local/stub-download",
+            downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
+          }
+        : {}),
+    },
+    resolvedModel: input.model ?? "stub-model",
+  };
 }
 
 function stubAgentResult(): ModelRunResult {
@@ -1042,56 +1102,18 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
       images: {
         create: (input) =>
           Promise.resolve(
-            // SAP-2576: the routed backend always echoes a resolvedModel (a required field), so the
-            // stub does too. Set it INSIDE the fallback factory — not by post-mutating the resolved
-            // result — so a caller-supplied override wins and a frozen override is never mutated.
-            r("contentGeneration.images.create", [input], () => ({
-              images: [
-                {
-                  url: "https://content.local/stub-image.png",
-                  contentType: "image/png",
-                  width: 512,
-                  height: 512,
-                  // mirror the real behavior: a fileId only when storage was requested.
-                  ...(input.storage
-                    ? {
-                        fileId: "stub-file",
-                        downloadUrl: "https://content.local/stub-download",
-                        downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
-                      }
-                    : {}),
-                },
-              ],
-              resolvedModel: input.model ?? "stub-model",
-            })) as ImageGenerationResult,
+            // Fallback shared with `launch` via stubImageResult (a caller-supplied override
+            // wins verbatim; a frozen override is never mutated).
+            r("contentGeneration.images.create", [input], () =>
+              stubImageResult(input),
+            ) as ImageGenerationResult,
           ),
         launch: (input) => {
           const requestId = `stub-image-${++launchSeq}`;
           const resolved = r(
-            dispatchedKeys("contentGeneration.images"),
+            mediaDispatchedKeys("contentGeneration.images"),
             [input],
-            // SAP-2576: the routed backend always echoes a resolvedModel; mirror that in the stub.
-            // Set it INSIDE the fallback factory — not by post-mutating the resolved result — so a
-            // caller-supplied override wins and a frozen override is never mutated (same contract
-            // as the sync `create` path above).
-            () => ({
-              images: [
-                {
-                  url: "https://content.local/stub-image.png",
-                  contentType: "image/png",
-                  width: 512,
-                  height: 512,
-                  ...(input.storage
-                    ? {
-                        fileId: "stub-file",
-                        downloadUrl: "https://content.local/stub-download",
-                        downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
-                      }
-                    : {}),
-                },
-              ],
-              resolvedModel: input.model ?? "stub-model",
-            }),
+            () => stubImageResult(input),
           ) as ImageGenerationResult;
           // Mirror the real client's `withDispatchCost`: stamp the resolvedModel onto a COPY, so
           // the handle, `wait()`, and the resume payload all carry the same value — an invariant
@@ -1122,48 +1144,18 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
       video: {
         create: (input) =>
           Promise.resolve(
-            // SAP-2576: set resolvedModel INSIDE the fallback factory (not by post-mutating the
-            // resolved result) so a caller-supplied override wins and a frozen override is never
-            // mutated. The real routed backend always echoes it; the required type expects it.
-            r("contentGeneration.video.create", [input], () => ({
-              video: {
-                url: "https://content.local/stub-video.mp4",
-                contentType: "video/mp4",
-                // mirror the real behavior: a fileId only when storage was requested.
-                ...(input.storage
-                  ? {
-                      fileId: "stub-file",
-                      downloadUrl: "https://content.local/stub-download",
-                      downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
-                    }
-                  : {}),
-              },
-              resolvedModel: input.model ?? "stub-model",
-            })) as VideoGenerationResult,
+            // Fallback shared with `launch` via stubVideoResult (a caller-supplied override
+            // wins verbatim; a frozen override is never mutated).
+            r("contentGeneration.video.create", [input], () =>
+              stubVideoResult(input),
+            ) as VideoGenerationResult,
           ),
         launch: (input) => {
           const requestId = `stub-video-${++launchSeq}`;
           const resolved = r(
-            dispatchedKeys("contentGeneration.video"),
+            mediaDispatchedKeys("contentGeneration.video"),
             [input],
-            // SAP-2576: the routed backend always echoes a resolvedModel; mirror that in the stub.
-            // Set it INSIDE the fallback factory — not by post-mutating the resolved result — so a
-            // caller-supplied override wins and a frozen override is never mutated (same contract
-            // as the sync `create` path above).
-            () => ({
-              video: {
-                url: "https://content.local/stub-video.mp4",
-                contentType: "video/mp4",
-                ...(input.storage
-                  ? {
-                      fileId: "stub-file",
-                      downloadUrl: "https://content.local/stub-download",
-                      downloadUrlExpiresAt: "2026-01-01T00:00:00Z",
-                    }
-                  : {}),
-              },
-              resolvedModel: input.model ?? "stub-model",
-            }),
+            () => stubVideoResult(input),
           ) as VideoGenerationResult;
           // Mirror the real client's `withDispatchCost`: stamp the resolvedModel onto a COPY, so
           // the handle, `wait()`, and the resume payload all carry the same value — an invariant


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Two findings deferred out of #664's adversarial review, both in the content-generation stub's override machinery (`packages/tools/src/stub/index.ts`):

1. **A `contentGeneration.images.create` / `video.create` override is silently ignored by `launch()`.** The launch stubs resolve `dispatchedKeys(ns)` = `[<ns>.launch, <ns>.run]` — a key set designed for `models.coding`, where `.run` is a real blocking method. contentGeneration has no `run()`; its blocking sibling is `create`. So an author who stubbed the create key (the exact key shipped in `examples/news-roundup/.sapiom-dev/stubs.json`) and moves a step from `create()` to `launch()` — the documented fix for long-running fan-outs — gets the built-in default payload with no error, and their test passes against fabricated data.
2. **The four media fallback factories are pairwise byte-identical clones.** The `create`/`launch` twins each inline the same payload literal, which is the mechanical cause of the drift class behind both #650 (create fixed, launch forgotten) and #664 (launch caught up): any stub-payload change is a multi-site edit with no compiler help.

## Summary and scope

- New `mediaDispatchedKeys(ns)` = `[<ns>.launch, <ns>.create, <ns>.run]`, used by both launch stubs. Precedence: the call the author wrote wins, then the real blocking sibling, then the legacy `.run` spelling — kept because it resolved on this path since 0.25.0, even though it never matched a real method.
- The four inlined payload literals collapse into shared `stubImageResult(input)` / `stubVideoResult(input)` module factories, following the file's existing `stubCodingResult` / `stubAgentResult` pattern, so the `create` and `launch` defaults can no longer drift.
- Three new tests: create-key honored by launch (frozen override, verbatim); launch-key precedence over create; legacy `.run` back-compat.
- Changeset (patch) documenting the new key precedence.

Intentionally out of scope: the pre-existing `models.launch` key bug (it resolves `dispatchedKeys("agent")` while its docstring and sibling `models.run` promise `models.*` keys) — different namespace, tracked separately; and the stub module-doc rewrite describing override semantics in general.

## Related work

Related issue or discussion: SAP-2576 — follow-up to the #664 review (deferred findings: phantom `.run` key / `.create` ignored on launch, and stub factory duplication).

## Validation

```text
pnpm --filter @sapiom/tools build — Done (cjs + esm + esm-pkg)
pnpm --filter @sapiom/tools test — 28 suites, 551 tests, all passed (3 new:
  create-key honored by launch, launch-key precedence, legacy .run back-compat)
node scripts/pr-label-classifier.mjs (validatePullRequestTemplate) — complete: true
```

### Tests and documentation

Three tests added in `packages/tools/src/stub/content-generation.spec.ts` (new "launch override keys" describe block). The existing 8 stub content-generation tests all still pass unchanged, locking the factory extraction as behavior-preserving. Key precedence documented in the `mediaDispatchedKeys` JSDoc and the changeset.

## Compatibility and release impact

- Breaking or externally visible changes: None breaking. Additive: launch stubs now consult the `.create` override key as a fallback (previously ignored); `.launch` and `.run` keys behave exactly as before, and default (no-override) payloads are byte-identical.
- Changeset: Added `.changeset/stub-launch-create-key.md` (patch for `@sapiom/tools`).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code (Fable 5) implemented the deferred findings from its adversarial review of #664 (design, code, tests, changeset). Verified by the package build and the full `@sapiom/tools` jest suite (551 tests), with the pre-existing 8 stub content-generation tests passing unchanged as the behavior-preservation check for the factory extraction.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
