### PR TITLE
[SAP-2750] Expose typed coding-run repository failures

### DIFF
--- a/.changeset/bright-repositories-explain.md
+++ b/.changeset/bright-repositories-explain.md
@@ -3,6 +3,6 @@
 "@sapiom/agent-core": patch
 ---
 
-Expose structured `CodingRunHttpError` details for failed coding requests and clarify that repository handles represent Sapiom-hosted repositories rather than external Git imports.
+Expose structured `CodingRunHttpError` details for failed coding requests and clarify repository-handle usage.
 
-Teach generated agent projects to terminate immediately on deterministic coding-repository failures instead of consuming the workflow step's remaining attempts.
+Add guidance for handling deterministic coding-repository failures.

--- a/.changeset/bright-repositories-explain.md
+++ b/.changeset/bright-repositories-explain.md
@@ -1,0 +1,8 @@
+---
+"@sapiom/tools": minor
+"@sapiom/agent-core": patch
+---
+
+Expose structured `CodingRunHttpError` details for failed coding requests and clarify that repository handles represent Sapiom-hosted repositories rather than external Git imports.
+
+Teach generated agent projects to terminate immediately on deterministic coding-repository failures instead of consuming the workflow step's remaining attempts.

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -264,6 +264,42 @@ types are the source of truth.** The full surface is the `Sapiom` interface in `
 `ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
 catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
 
+### Coding Repositories and Deterministic Launch Failures
+
+`gitRepository` must be an active, tenant-owned Sapiom repository returned by
+`repositories.create()`, `repositories.get()`, or `repositories.list()`. `repositories.attach()`
+only reconstructs one of those previously returned handles from saved `slug` and `cloneUrl`
+values. It makes no network request, performs no validation or registration, and cannot import
+a GitHub repository or another external Git origin. Coding launch sends only the repository slug;
+the `cloneUrl` passed to `attach()` is not sent.
+
+Coding launch and polling throw `CodingRunHttpError` for non-successful HTTP responses. Catch the
+deterministic `repository_not_found` code and return `fail()` when the agent run should stop without
+using its remaining attempts. Set `canFail: true` on that step, and rethrow errors that may be
+transient:
+
+```typescript
+import { fail, pauseUntilSignal } from "@sapiom/agent";
+import { CodingRunHttpError } from "@sapiom/tools";
+
+// Inside a step with `canFail: true`:
+try {
+  const handle = await ctx.sapiom.models.coding.launch({
+    task,
+    gitRepository: repo,
+  });
+  return pauseUntilSignal(handle, { resumeStep: "finalize" });
+} catch (error) {
+  if (
+    error instanceof CodingRunHttpError &&
+    error.code === "repository_not_found"
+  ) {
+    return fail(error.message);
+  }
+  throw error;
+}
+```
+
 ## Failure Handling & Retries
 
 There is no automatic per-step retry. Express it explicitly — this keeps the graph readable.

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -264,25 +264,19 @@ types are the source of truth.** The full surface is the `Sapiom` interface in `
 `ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
 catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
 
-### Coding Repositories and Deterministic Launch Failures
+### Coding Repository Errors
 
-`gitRepository` must be an active, tenant-owned Sapiom repository returned by
-`repositories.create()`, `repositories.get()`, or `repositories.list()`. `repositories.attach()`
-only reconstructs one of those previously returned handles from saved `slug` and `cloneUrl`
-values. It makes no network request, performs no validation or registration, and cannot import
-a GitHub repository or another external Git origin. Coding launch sends only the repository slug;
-the `cloneUrl` passed to `attach()` is not sent.
+Use a repository returned by `repositories.create()`, `repositories.get()`, or
+`repositories.list()`. `repositories.attach()` rehydrates one of those handles; it does not import
+an external Git repository.
 
-Coding launch and polling throw `CodingRunHttpError` for non-successful HTTP responses. Catch the
-deterministic `repository_not_found` code and return `fail()` when the agent run should stop without
-using its remaining attempts. Set `canFail: true` on that step, and rethrow errors that may be
-transient:
+Coding requests throw `CodingRunHttpError` for HTTP failures. A step with `canFail: true` can handle
+`repository_not_found` with `fail()` and rethrow other errors:
 
 ```typescript
 import { fail, pauseUntilSignal } from "@sapiom/agent";
 import { CodingRunHttpError } from "@sapiom/tools";
 
-// Inside a step with `canFail: true`:
 try {
   const handle = await ctx.sapiom.models.coding.launch({
     task,

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -264,6 +264,42 @@ types are the source of truth.** The full surface is the `Sapiom` interface in `
 `ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
 catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
 
+### Coding Repositories and Deterministic Launch Failures
+
+`gitRepository` must be an active, tenant-owned Sapiom repository returned by
+`repositories.create()`, `repositories.get()`, or `repositories.list()`. `repositories.attach()`
+only reconstructs one of those previously returned handles from saved `slug` and `cloneUrl`
+values. It makes no network request, performs no validation or registration, and cannot import
+a GitHub repository or another external Git origin. Coding launch sends only the repository slug;
+the `cloneUrl` passed to `attach()` is not sent.
+
+Coding launch and polling throw `CodingRunHttpError` for non-successful HTTP responses. Catch the
+deterministic `repository_not_found` code and return `fail()` when the agent run should stop without
+using its remaining attempts. Set `canFail: true` on that step, and rethrow errors that may be
+transient:
+
+```typescript
+import { fail, pauseUntilSignal } from "@sapiom/agent";
+import { CodingRunHttpError } from "@sapiom/tools";
+
+// Inside a step with `canFail: true`:
+try {
+  const handle = await ctx.sapiom.models.coding.launch({
+    task,
+    gitRepository: repo,
+  });
+  return pauseUntilSignal(handle, { resumeStep: "finalize" });
+} catch (error) {
+  if (
+    error instanceof CodingRunHttpError &&
+    error.code === "repository_not_found"
+  ) {
+    return fail(error.message);
+  }
+  throw error;
+}
+```
+
 ## Failure Handling & Retries
 
 There is no automatic per-step retry. Express it explicitly — this keeps the graph readable.

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -264,25 +264,19 @@ types are the source of truth.** The full surface is the `Sapiom` interface in `
 `ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
 catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
 
-### Coding Repositories and Deterministic Launch Failures
+### Coding Repository Errors
 
-`gitRepository` must be an active, tenant-owned Sapiom repository returned by
-`repositories.create()`, `repositories.get()`, or `repositories.list()`. `repositories.attach()`
-only reconstructs one of those previously returned handles from saved `slug` and `cloneUrl`
-values. It makes no network request, performs no validation or registration, and cannot import
-a GitHub repository or another external Git origin. Coding launch sends only the repository slug;
-the `cloneUrl` passed to `attach()` is not sent.
+Use a repository returned by `repositories.create()`, `repositories.get()`, or
+`repositories.list()`. `repositories.attach()` rehydrates one of those handles; it does not import
+an external Git repository.
 
-Coding launch and polling throw `CodingRunHttpError` for non-successful HTTP responses. Catch the
-deterministic `repository_not_found` code and return `fail()` when the agent run should stop without
-using its remaining attempts. Set `canFail: true` on that step, and rethrow errors that may be
-transient:
+Coding requests throw `CodingRunHttpError` for HTTP failures. A step with `canFail: true` can handle
+`repository_not_found` with `fail()` and rethrow other errors:
 
 ```typescript
 import { fail, pauseUntilSignal } from "@sapiom/agent";
 import { CodingRunHttpError } from "@sapiom/tools";
 
-// Inside a step with `canFail: true`:
 try {
   const handle = await ctx.sapiom.models.coding.launch({
     task,

--- a/packages/agent-core/templates/coding-pause/AGENTS.md
+++ b/packages/agent-core/templates/coding-pause/AGENTS.md
@@ -74,8 +74,8 @@ return pauseUntilSignal(run, { resumeStep: "finalize" }); // suspend on the run'
 - **The resumed step's `input` IS the run's result signal payload.** Annotate it with `CodingResultPayload` (from `@sapiom/tools`) — you don't have to hand-roll the shape.
 - That payload crossed a wire boundary, so it carries **no live handles** — to act on the run's sandbox, re-attach one from **`executionEnvironment`** with `ctx.sapiom.sandboxes.attach(result.executionEnvironment.id)` (`executionEnvironment` is `null` when the run provisioned none, e.g. a launch failure). Anything else the resumed step needs, stash in `ctx.shared` before pausing.
 - **To stub the resume payload** (e.g. to exercise the failure branch), override `models.coding.run` _in the launching step_ — that one value is both the `run()` result and the payload the paused step resumes with. `models.coding.launch` is accepted there too.
-- `gitRepository` must be an active Sapiom repository returned by `repositories.create`, `get`, or `list`. `repositories.attach` only rehydrates a previously returned handle; it makes no request and cannot import an external Git origin. Coding launch sends its slug, not the attached `cloneUrl`.
-- Coding launch and polling throw `CodingRunHttpError` on HTTP failures. A step with `canFail: true` can catch `code === "repository_not_found"` and return `fail(error.message)` to stop immediately; rethrow failures that may be transient.
+- `gitRepository` accepts a Sapiom repository returned by `repositories.create`, `get`, or `list`; `repositories.attach` only rehydrates such a handle.
+- Coding requests throw `CodingRunHttpError` on HTTP failures. A step with `canFail: true` can return `fail(error.message)` for `repository_not_found` and rethrow other errors.
 
 ## Determinism
 

--- a/packages/agent-core/templates/coding-pause/AGENTS.md
+++ b/packages/agent-core/templates/coding-pause/AGENTS.md
@@ -74,6 +74,8 @@ return pauseUntilSignal(run, { resumeStep: "finalize" }); // suspend on the run'
 - **The resumed step's `input` IS the run's result signal payload.** Annotate it with `CodingResultPayload` (from `@sapiom/tools`) — you don't have to hand-roll the shape.
 - That payload crossed a wire boundary, so it carries **no live handles** — to act on the run's sandbox, re-attach one from **`executionEnvironment`** with `ctx.sapiom.sandboxes.attach(result.executionEnvironment.id)` (`executionEnvironment` is `null` when the run provisioned none, e.g. a launch failure). Anything else the resumed step needs, stash in `ctx.shared` before pausing.
 - **To stub the resume payload** (e.g. to exercise the failure branch), override `models.coding.run` _in the launching step_ — that one value is both the `run()` result and the payload the paused step resumes with. `models.coding.launch` is accepted there too.
+- `gitRepository` must be an active Sapiom repository returned by `repositories.create`, `get`, or `list`. `repositories.attach` only rehydrates a previously returned handle; it makes no request and cannot import an external Git origin. Coding launch sends its slug, not the attached `cloneUrl`.
+- Coding launch and polling throw `CodingRunHttpError` on HTTP failures. A step with `canFail: true` can catch `code === "repository_not_found"` and return `fail(error.message)` to stop immediately; rethrow failures that may be transient.
 
 ## Determinism
 

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -264,6 +264,42 @@ types are the source of truth.** The full surface is the `Sapiom` interface in `
 `ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
 catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
 
+### Coding Repositories and Deterministic Launch Failures
+
+`gitRepository` must be an active, tenant-owned Sapiom repository returned by
+`repositories.create()`, `repositories.get()`, or `repositories.list()`. `repositories.attach()`
+only reconstructs one of those previously returned handles from saved `slug` and `cloneUrl`
+values. It makes no network request, performs no validation or registration, and cannot import
+a GitHub repository or another external Git origin. Coding launch sends only the repository slug;
+the `cloneUrl` passed to `attach()` is not sent.
+
+Coding launch and polling throw `CodingRunHttpError` for non-successful HTTP responses. Catch the
+deterministic `repository_not_found` code and return `fail()` when the agent run should stop without
+using its remaining attempts. Set `canFail: true` on that step, and rethrow errors that may be
+transient:
+
+```typescript
+import { fail, pauseUntilSignal } from "@sapiom/agent";
+import { CodingRunHttpError } from "@sapiom/tools";
+
+// Inside a step with `canFail: true`:
+try {
+  const handle = await ctx.sapiom.models.coding.launch({
+    task,
+    gitRepository: repo,
+  });
+  return pauseUntilSignal(handle, { resumeStep: "finalize" });
+} catch (error) {
+  if (
+    error instanceof CodingRunHttpError &&
+    error.code === "repository_not_found"
+  ) {
+    return fail(error.message);
+  }
+  throw error;
+}
+```
+
 ## Failure Handling & Retries
 
 There is no automatic per-step retry. Express it explicitly — this keeps the graph readable.

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -264,25 +264,19 @@ types are the source of truth.** The full surface is the `Sapiom` interface in `
 `ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
 catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
 
-### Coding Repositories and Deterministic Launch Failures
+### Coding Repository Errors
 
-`gitRepository` must be an active, tenant-owned Sapiom repository returned by
-`repositories.create()`, `repositories.get()`, or `repositories.list()`. `repositories.attach()`
-only reconstructs one of those previously returned handles from saved `slug` and `cloneUrl`
-values. It makes no network request, performs no validation or registration, and cannot import
-a GitHub repository or another external Git origin. Coding launch sends only the repository slug;
-the `cloneUrl` passed to `attach()` is not sent.
+Use a repository returned by `repositories.create()`, `repositories.get()`, or
+`repositories.list()`. `repositories.attach()` rehydrates one of those handles; it does not import
+an external Git repository.
 
-Coding launch and polling throw `CodingRunHttpError` for non-successful HTTP responses. Catch the
-deterministic `repository_not_found` code and return `fail()` when the agent run should stop without
-using its remaining attempts. Set `canFail: true` on that step, and rethrow errors that may be
-transient:
+Coding requests throw `CodingRunHttpError` for HTTP failures. A step with `canFail: true` can handle
+`repository_not_found` with `fail()` and rethrow other errors:
 
 ```typescript
 import { fail, pauseUntilSignal } from "@sapiom/agent";
 import { CodingRunHttpError } from "@sapiom/tools";
 
-// Inside a step with `canFail: true`:
 try {
   const handle = await ctx.sapiom.models.coding.launch({
     task,

--- a/packages/agent-core/templates/default/AGENTS.md
+++ b/packages/agent-core/templates/default/AGENTS.md
@@ -74,8 +74,8 @@ return pauseUntilSignal(run, { resumeStep: "finalize" }); // suspend on the run'
 - **The resumed step's `input` IS the run's result signal payload.** Annotate it with `CodingResultPayload` (from `@sapiom/tools`) — you don't have to hand-roll the shape.
 - That payload crossed a wire boundary, so it carries **no live handles** — to act on the run's sandbox, re-attach one from **`executionEnvironment`** with `ctx.sapiom.sandboxes.attach(result.executionEnvironment.id)` (`executionEnvironment` is `null` when the run provisioned none, e.g. a launch failure). Anything else the resumed step needs, stash in `ctx.shared` before pausing.
 - **To stub the resume payload** (e.g. to exercise the failure branch), override `models.coding.run` _in the launching step_ — that one value is both the `run()` result and the payload the paused step resumes with. `models.coding.launch` is accepted there too.
-- `gitRepository` must be an active Sapiom repository returned by `repositories.create`, `get`, or `list`. `repositories.attach` only rehydrates a previously returned handle; it makes no request and cannot import an external Git origin. Coding launch sends its slug, not the attached `cloneUrl`.
-- Coding launch and polling throw `CodingRunHttpError` on HTTP failures. A step with `canFail: true` can catch `code === "repository_not_found"` and return `fail(error.message)` to stop immediately; rethrow failures that may be transient.
+- `gitRepository` accepts a Sapiom repository returned by `repositories.create`, `get`, or `list`; `repositories.attach` only rehydrates such a handle.
+- Coding requests throw `CodingRunHttpError` on HTTP failures. A step with `canFail: true` can return `fail(error.message)` for `repository_not_found` and rethrow other errors.
 
 ## Determinism
 

--- a/packages/agent-core/templates/default/AGENTS.md
+++ b/packages/agent-core/templates/default/AGENTS.md
@@ -74,6 +74,8 @@ return pauseUntilSignal(run, { resumeStep: "finalize" }); // suspend on the run'
 - **The resumed step's `input` IS the run's result signal payload.** Annotate it with `CodingResultPayload` (from `@sapiom/tools`) — you don't have to hand-roll the shape.
 - That payload crossed a wire boundary, so it carries **no live handles** — to act on the run's sandbox, re-attach one from **`executionEnvironment`** with `ctx.sapiom.sandboxes.attach(result.executionEnvironment.id)` (`executionEnvironment` is `null` when the run provisioned none, e.g. a launch failure). Anything else the resumed step needs, stash in `ctx.shared` before pausing.
 - **To stub the resume payload** (e.g. to exercise the failure branch), override `models.coding.run` _in the launching step_ — that one value is both the `run()` result and the payload the paused step resumes with. `models.coding.launch` is accepted there too.
+- `gitRepository` must be an active Sapiom repository returned by `repositories.create`, `get`, or `list`. `repositories.attach` only rehydrates a previously returned handle; it makes no request and cannot import an external Git origin. Coding launch sends its slug, not the attached `cloneUrl`.
+- Coding launch and polling throw `CodingRunHttpError` on HTTP failures. A step with `canFail: true` can catch `code === "repository_not_found"` and return `fail(error.message)` to stop immediately; rethrow failures that may be transient.
 
 ## Determinism
 

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -181,11 +181,7 @@ export interface Sapiom {
     get(slug: string): Promise<Repository>;
     list(): Promise<Repository[]>;
     delete(slug: string): Promise<void>;
-    /**
-     * Rehydrate a previously returned Sapiom repository without a network
-     * request or validation. This cannot import an external Git origin, and
-     * coding launch sends only `slug`, not the supplied `cloneUrl`.
-     */
+    /** Rehydrate a Sapiom repository handle returned by `create`, `get`, or `list`. */
     attach(slug: string, cloneUrl: string): Repository;
   };
   readonly models: {

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -181,6 +181,11 @@ export interface Sapiom {
     get(slug: string): Promise<Repository>;
     list(): Promise<Repository[]>;
     delete(slug: string): Promise<void>;
+    /**
+     * Rehydrate a previously returned Sapiom repository without a network
+     * request or validation. This cannot import an external Git origin, and
+     * coding launch sends only `slug`, not the supplied `cloneUrl`.
+     */
     attach(slug: string, cloneUrl: string): Repository;
   };
   readonly models: {

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -37,6 +37,7 @@ export type {
 // Validate / build a `CodingResultPayload`, and the env `type` whose `id` is a
 // sandbox name for `sandboxes.attach(id)`.
 export {
+  CodingRunHttpError,
   codingResultSchema,
   CodingResultSchemaError,
   toResumePayload,

--- a/packages/tools/src/models/README.md
+++ b/packages/tools/src/models/README.md
@@ -17,7 +17,7 @@ if (run.result?.success) await repo.pushFromSandbox(run.sandbox, { message: "fea
 
 - **`run` blocks until the agent finishes; `launch` doesn't.** `run` polls to completion, which for a real task can take several minutes. Use `launch` when you'd rather kick off the run, do other work, and check on it yourself with `handle.status()` or `handle.wait()`.
 
-- **`gitRepository` sets up a managed checkout for you.** Pass an active repository returned by `repositories.create()`, `repositories.get()`, or `repositories.list()`. The gateway resolves its Sapiom slug and clones it into the sandbox at `/workspace/<slug>` with push access already configured — which is exactly what `repo.pushFromSandbox(run.sandbox)` needs afterward. `repositories.attach()` can rehydrate one of those previously returned handles, but it cannot import an external Git repository; coding launch sends the slug and does not send the attached `cloneUrl`. Without `gitRepository`, the agent works in an empty sandbox and there's nothing to push.
+- **`gitRepository` sets up a managed checkout for you.** Pass a repository returned by `repositories.create()`, `repositories.get()`, or `repositories.list()`. `repositories.attach()` can rehydrate one of those handles but cannot import an external Git repository. Without `gitRepository`, the agent works in an empty sandbox and there's nothing to push.
 
 - **The sandbox stays alive after the run by default.** This lets a later step read files, run commands, or push from it. Pass `keepSandbox: false` to tear it down automatically when the run finishes (after which you can't push from it).
 
@@ -29,41 +29,7 @@ if (run.result?.success) await repo.pushFromSandbox(run.sandbox, { message: "fea
 
 - **Each run is billed.** Runs that fail or are aborted still cost. Check `run.result?.success` and `run.error` before relying on a run's output.
 
-- **Coding HTTP failures are structured.** `run`, `launch`, `handle.status()`, and `handle.wait()` throw `CodingRunHttpError` for a non-successful HTTP response. Inspect `status`, `code`, `requestId`, and `body` instead of parsing the message. In a workflow step, catch a deterministic `repository_not_found` and return `fail(error.message)` when retrying cannot succeed; leave transient errors uncaught or handle them with the workflow's retry policy.
-
-```ts
-import { defineStep, fail, pauseUntilSignal } from "@sapiom/agent";
-import { CODING_RESULT_SIGNAL, CodingRunHttpError } from "@sapiom/tools";
-
-const kickoff = defineStep({
-  name: "kickoff",
-  next: [],
-  canFail: true,
-  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "finalize" },
-  async run(
-    input: { slug: string; cloneUrl: string; task: string },
-    ctx,
-  ) {
-    // These values came from create(), get(), or list() in an earlier step.
-    const repo = ctx.sapiom.repositories.attach(input.slug, input.cloneUrl);
-    try {
-      const handle = await ctx.sapiom.models.coding.launch({
-        task: input.task,
-        gitRepository: repo,
-      });
-      return pauseUntilSignal(handle, { resumeStep: "finalize" });
-    } catch (error) {
-      if (
-        error instanceof CodingRunHttpError &&
-        error.code === "repository_not_found"
-      ) {
-        return fail(error.message);
-      }
-      throw error;
-    }
-  },
-});
-```
+- **Coding HTTP failures are structured.** `run`, `launch`, `handle.status()`, and `handle.wait()` throw `CodingRunHttpError`. Inspect `status`, `code`, `requestId`, and `body`; workflow steps can return `fail(error.message)` for `repository_not_found` and rethrow other errors.
 
 ## Reference
 

--- a/packages/tools/src/models/README.md
+++ b/packages/tools/src/models/README.md
@@ -17,7 +17,7 @@ if (run.result?.success) await repo.pushFromSandbox(run.sandbox, { message: "fea
 
 - **`run` blocks until the agent finishes; `launch` doesn't.** `run` polls to completion, which for a real task can take several minutes. Use `launch` when you'd rather kick off the run, do other work, and check on it yourself with `handle.status()` or `handle.wait()`.
 
-- **`gitRepository` sets up the checkout for you.** Passing a repository clones it into the sandbox at `/workspace/<slug>` with push access already configured — which is exactly what `repo.pushFromSandbox(run.sandbox)` needs afterward. Without it, the agent works in an empty sandbox and there's nothing to push.
+- **`gitRepository` sets up a managed checkout for you.** Pass an active repository returned by `repositories.create()`, `repositories.get()`, or `repositories.list()`. The gateway resolves its Sapiom slug and clones it into the sandbox at `/workspace/<slug>` with push access already configured — which is exactly what `repo.pushFromSandbox(run.sandbox)` needs afterward. `repositories.attach()` can rehydrate one of those previously returned handles, but it cannot import an external Git repository; coding launch sends the slug and does not send the attached `cloneUrl`. Without `gitRepository`, the agent works in an empty sandbox and there's nothing to push.
 
 - **The sandbox stays alive after the run by default.** This lets a later step read files, run commands, or push from it. Pass `keepSandbox: false` to tear it down automatically when the run finishes (after which you can't push from it).
 
@@ -29,8 +29,44 @@ if (run.result?.success) await repo.pushFromSandbox(run.sandbox, { message: "fea
 
 - **Each run is billed.** Runs that fail or are aborted still cost. Check `run.result?.success` and `run.error` before relying on a run's output.
 
+- **Coding HTTP failures are structured.** `run`, `launch`, `handle.status()`, and `handle.wait()` throw `CodingRunHttpError` for a non-successful HTTP response. Inspect `status`, `code`, `requestId`, and `body` instead of parsing the message. In a workflow step, catch a deterministic `repository_not_found` and return `fail(error.message)` when retrying cannot succeed; leave transient errors uncaught or handle them with the workflow's retry policy.
+
+```ts
+import { defineStep, fail, pauseUntilSignal } from "@sapiom/agent";
+import { CODING_RESULT_SIGNAL, CodingRunHttpError } from "@sapiom/tools";
+
+const kickoff = defineStep({
+  name: "kickoff",
+  next: [],
+  canFail: true,
+  pause: { signal: CODING_RESULT_SIGNAL, resumeStep: "finalize" },
+  async run(
+    input: { slug: string; cloneUrl: string; task: string },
+    ctx,
+  ) {
+    // These values came from create(), get(), or list() in an earlier step.
+    const repo = ctx.sapiom.repositories.attach(input.slug, input.cloneUrl);
+    try {
+      const handle = await ctx.sapiom.models.coding.launch({
+        task: input.task,
+        gitRepository: repo,
+      });
+      return pauseUntilSignal(handle, { resumeStep: "finalize" });
+    } catch (error) {
+      if (
+        error instanceof CodingRunHttpError &&
+        error.code === "repository_not_found"
+      ) {
+        return fail(error.message);
+      }
+      throw error;
+    }
+  },
+});
+```
+
 ## Reference
 
 `agent.coding.run(spec)` · `agent.coding.launch(spec)`
 
-See the exported types (`CodingRunSpec`, `CodingRunResult`, `RunHandle`) for full signatures.
+See the exported types (`CodingRunSpec`, `CodingRunResult`, `RunHandle`, `CodingRunHttpError`) for full signatures.

--- a/packages/tools/src/models/errors.ts
+++ b/packages/tools/src/models/errors.ts
@@ -1,8 +1,4 @@
-/**
- * Error thrown when a coding-run HTTP request returns a non-2xx response.
- * Exposes the status, parsed response body, stable error code, and gateway
- * request id for programmatic handling.
- */
+/** Error thrown when a coding-run HTTP request is unsuccessful. */
 export class CodingRunHttpError extends Error {
   readonly status: number;
   readonly code: string | null;
@@ -19,7 +15,6 @@ export class CodingRunHttpError extends Error {
   }
 }
 
-/** Parse a failed response once, preserving JSON or raw text for the caller. */
 export async function ensureCodingRunOk(
   response: Response,
   errorPrefix: string,

--- a/packages/tools/src/models/errors.ts
+++ b/packages/tools/src/models/errors.ts
@@ -1,0 +1,51 @@
+/**
+ * Error thrown when a coding-run HTTP request returns a non-2xx response.
+ * Exposes the status, parsed response body, stable error code, and gateway
+ * request id for programmatic handling.
+ */
+export class CodingRunHttpError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+  readonly requestId: string | null;
+  readonly body: unknown;
+
+  constructor(message: string, status: number, body: unknown) {
+    super(message);
+    this.name = "CodingRunHttpError";
+    this.status = status;
+    this.body = body;
+    this.code = stringField(body, "error") ?? stringField(body, "code");
+    this.requestId = stringField(body, "requestId");
+  }
+}
+
+/** Parse a failed response once, preserving JSON or raw text for the caller. */
+export async function ensureCodingRunOk(
+  response: Response,
+  errorPrefix: string,
+): Promise<Response> {
+  if (response.ok) return response;
+
+  const text = await response.text().catch(() => "");
+  let body: unknown;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+
+  throw new CodingRunHttpError(
+    stringField(body, "message") ??
+      `${errorPrefix}: ${response.status}${text ? ` ${text}` : ""}`,
+    response.status,
+    body,
+  );
+}
+
+function stringField(value: unknown, field: string): string | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const candidate = (value as Record<string, unknown>)[field];
+  return typeof candidate === "string" ? candidate : null;
+}

--- a/packages/tools/src/models/index.ts
+++ b/packages/tools/src/models/index.ts
@@ -53,10 +53,7 @@ const TERMINAL = new Set<RunStatus>(["completed", "failed"]);
 export interface CodingRunSpec {
   /** Natural-language instruction for the coding agent. */
   task: string;
-  /**
-   * Active Sapiom repository to clone at `/workspace/<slug>`. The gateway uses
-   * its slug; an attached external clone URL is not imported or sent.
-   */
+  /** Sapiom repository to clone into the coding sandbox. */
   gitRepository?: Repository;
   /** Reuse an existing sandbox instead of provisioning a fresh one. */
   sandbox?: Sandbox;

--- a/packages/tools/src/models/index.ts
+++ b/packages/tools/src/models/index.ts
@@ -24,6 +24,9 @@ import { Transport, defaultTransport } from "../_client/index.js";
 import type { DispatchHandle } from "../dispatch.js";
 import { Sandbox } from "../sandboxes/index.js";
 import type { Repository } from "../repositories/index.js";
+import { ensureCodingRunOk, CodingRunHttpError } from "./errors.js";
+
+export { CodingRunHttpError };
 
 const DEFAULT_BASE_URL =
   process.env.SAPIOM_MODELS_URL ??
@@ -50,7 +53,10 @@ const TERMINAL = new Set<RunStatus>(["completed", "failed"]);
 export interface CodingRunSpec {
   /** Natural-language instruction for the coding agent. */
   task: string;
-  /** Repo to clone into the sandbox at `/workspace/<slug>` and operate on. */
+  /**
+   * Active Sapiom repository to clone at `/workspace/<slug>`. The gateway uses
+   * its slug; an attached external clone URL is not imported or sent.
+   */
   gitRepository?: Repository;
   /** Reuse an existing sandbox instead of provisioning a fresh one. */
   sandbox?: Sandbox;
@@ -317,17 +323,37 @@ function buildBody(spec: CodingRunSpec): Record<string, unknown> {
   };
 }
 
+async function codingRequest<T>(
+  url: string,
+  init: RequestInit,
+  transport: Transport,
+): Promise<T> {
+  const response = await transport.fetch(url, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(init.headers ?? {}),
+    },
+  });
+  await ensureCodingRunOk(response, `${init.method ?? "GET"} ${url} failed`);
+  return (await response.json()) as T;
+}
+
 export async function codingLaunch(
   spec: CodingRunSpec,
   transport: Transport = defaultTransport(),
   baseUrl = DEFAULT_BASE_URL,
 ): Promise<RunHandle> {
   // 202 + a launch document; the execution_environment relationship is always present.
-  const doc = await transport.request<RunDoc>(`${baseUrl}/models/v1/coding/runs`, {
-    method: "POST",
-    body: JSON.stringify(buildBody(spec)),
-    headers: workflowResumeHeaders(transport.resumeToken),
-  });
+  const doc = await codingRequest<RunDoc>(
+    `${baseUrl}/models/v1/coding/runs`,
+    {
+      method: "POST",
+      body: JSON.stringify(buildBody(spec)),
+      headers: workflowResumeHeaders(transport.resumeToken),
+    },
+    transport,
+  );
   const runId = doc.data.id;
   const envId = doc.data.relationships?.execution_environment?.data?.id;
   // Reuse the caller's sandbox handle when they supplied one; otherwise adopt the
@@ -336,8 +362,10 @@ export async function codingLaunch(
   const sandbox = spec.sandbox ?? Sandbox.attach(envId ?? runId, {}, transport);
 
   const fetchDoc = () =>
-    transport.request<RunDoc>(
+    codingRequest<RunDoc>(
       `${baseUrl}/models/v1/coding/runs/${encodeURIComponent(runId)}`,
+      {},
+      transport,
     );
   const toResult = (d: RunDoc): CodingRunResult => ({
     runId,

--- a/packages/tools/src/models/launch.spec.ts
+++ b/packages/tools/src/models/launch.spec.ts
@@ -7,13 +7,23 @@
  * unaffected.
  */
 import { createClient } from "../index.js";
-import { CODING_RESULT_SIGNAL } from "./index.js";
+import { CODING_RESULT_SIGNAL, CodingRunHttpError } from "./index.js";
 
-function fakeLaunchFetch(capture?: {
+interface Capture {
   headers?: Record<string, string>;
-}): typeof globalThis.fetch {
+  body?: Record<string, unknown>;
+  calls?: number;
+}
+
+function fakeLaunchFetch(capture?: Capture): typeof globalThis.fetch {
   return (async (_url: string, init: RequestInit = {}) => {
-    if (capture) capture.headers = init.headers as Record<string, string>;
+    if (capture) {
+      capture.headers = init.headers as Record<string, string>;
+      capture.body = init.body
+        ? (JSON.parse(init.body as string) as Record<string, unknown>)
+        : undefined;
+      capture.calls = (capture.calls ?? 0) + 1;
+    }
     return {
       ok: true,
       status: 202,
@@ -43,6 +53,111 @@ describe("agent.coding.launch — dispatch handle", () => {
   it("CODING_RESULT_SIGNAL is the capability-stable terminal signal", () => {
     expect(CODING_RESULT_SIGNAL).toBe("models.coding.result");
   });
+
+  it("sends only an attached repository's slug and attach performs no request", async () => {
+    const capture: Capture = {};
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeLaunchFetch(capture),
+    });
+    const repo = sapiom.repositories.attach(
+      "external-looking",
+      "https://github.com/acme/example.git",
+    );
+
+    expect(capture.calls).toBeUndefined();
+    await sapiom.models.coding.launch({ task: "inspect", gitRepository: repo });
+
+    expect(capture.calls).toBe(1);
+    expect(capture.body).toMatchObject({
+      task: "inspect",
+      git_repository: "external-looking",
+    });
+    expect(JSON.stringify(capture.body)).not.toContain("github.com");
+    expect(capture.body).not.toHaveProperty("clone_url");
+    expect(capture.body).not.toHaveProperty("cloneUrl");
+  });
+});
+
+describe("agent.coding — typed HTTP failures", () => {
+  const repositoryMessage =
+    "The requested git_repository is not an active Sapiom repository available to this tenant. " +
+    "Use a repository returned by repositories.create(), repositories.get(), or repositories.list(). " +
+    "repositories.attach() only rehydrates a previously returned Sapiom repository; it does not import an external repository.";
+
+  it.each(["launch", "run"] as const)(
+    "exposes status, code, requestId, and parsed JSON for a %s 404",
+    async (operation) => {
+      const body = {
+        statusCode: 404,
+        error: "repository_not_found",
+        message: repositoryMessage,
+        requestId: "req-123",
+      };
+      const fetch = (async () => ({
+        ok: false,
+        status: 404,
+        text: async () => JSON.stringify(body),
+      })) as unknown as typeof globalThis.fetch;
+      const sapiom = createClient({ apiKey: "k", fetch });
+
+      const error = await sapiom.models.coding[operation]({
+        task: "inspect",
+      }).catch((caught: unknown) => caught);
+      expect(error).toBeInstanceOf(CodingRunHttpError);
+      expect(error).toMatchObject({
+        name: "CodingRunHttpError",
+        status: 404,
+        code: "repository_not_found",
+        requestId: "req-123",
+        body,
+        message: repositoryMessage,
+      });
+    },
+  );
+
+  it("preserves non-JSON error text with null code and requestId", async () => {
+    const fetch = (async () => ({
+      ok: false,
+      status: 502,
+      text: async () => "upstream unavailable",
+    })) as unknown as typeof globalThis.fetch;
+    const sapiom = createClient({ apiKey: "k", fetch });
+
+    await expect(
+      sapiom.models.coding.launch({ task: "inspect" }),
+    ).rejects.toMatchObject({
+      name: "CodingRunHttpError",
+      status: 502,
+      code: null,
+      requestId: null,
+      body: "upstream unavailable",
+    });
+  });
+
+  it.each(["status", "wait"] as const)(
+    "uses the same typed error for handle.%s() polling",
+    async (operation) => {
+      const fetch = jest
+        .fn()
+        .mockImplementationOnce(fakeLaunchFetch())
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 404,
+          text: async () =>
+            JSON.stringify({ code: "run_not_found", requestId: "req-poll" }),
+        } as Response) as unknown as typeof globalThis.fetch;
+      const sapiom = createClient({ apiKey: "k", fetch });
+      const handle = await sapiom.models.coding.launch({ task: "inspect" });
+
+      await expect(handle[operation]()).rejects.toMatchObject({
+        name: "CodingRunHttpError",
+        status: 404,
+        code: "run_not_found",
+        requestId: "req-poll",
+      });
+    },
+  );
 });
 
 describe("agent.coding.launch — workflow resume token", () => {

--- a/packages/tools/src/repositories/README.md
+++ b/packages/tools/src/repositories/README.md
@@ -14,6 +14,8 @@ const { pushed, sha } = await repo.pushFromSandbox(run.sandbox, { message: "buil
 
 - **Repositories are hosted by Sapiom, not GitHub.** Clones and pushes are authenticated through the Sapiom git gateway using your tenant credentials — there are no personal access tokens or SSH keys to manage. The `cloneUrl` on a repository is the unauthenticated origin; the credentials to clone it yourself are returned when you create the repo.
 
+- **`attach` only rehydrates a Sapiom repository handle.** Use it with the `slug` and `cloneUrl` previously returned by `create`, `get`, or `list`, such as when passing repository data between workflow steps. It performs no network request, validation, or registration. Coding launch sends only the repository slug, so `attach` cannot import a GitHub repository or another external Git origin and its supplied `cloneUrl` is not sent with the coding request.
+
 - **`pushFromSandbox` requires the repo to already be checked out in the sandbox.** It does not clone — it commits and pushes from the repo's checkout at `/workspace/<slug>`. The straightforward way to get that checkout is to run a coding agent with `gitRepository: repo`, which clones the repo into exactly that path. The two methods are meant to be used together; calling `pushFromSandbox` on a sandbox where the repo was never cloned will fail.
 
 - **`pushFromSandbox` publishes the agent's work.** It commits any pending changes and pushes the current commit, so your work reaches the repo whether the agent left changes uncommitted, already committed them, or both. It returns `{ pushed, sha, branch }`; a failed push (e.g. the repo was never cloned into the sandbox) throws.

--- a/packages/tools/src/repositories/README.md
+++ b/packages/tools/src/repositories/README.md
@@ -14,7 +14,7 @@ const { pushed, sha } = await repo.pushFromSandbox(run.sandbox, { message: "buil
 
 - **Repositories are hosted by Sapiom, not GitHub.** Clones and pushes are authenticated through the Sapiom git gateway using your tenant credentials — there are no personal access tokens or SSH keys to manage. The `cloneUrl` on a repository is the unauthenticated origin; the credentials to clone it yourself are returned when you create the repo.
 
-- **`attach` only rehydrates a Sapiom repository handle.** Use it with the `slug` and `cloneUrl` previously returned by `create`, `get`, or `list`, such as when passing repository data between workflow steps. It performs no network request, validation, or registration. Coding launch sends only the repository slug, so `attach` cannot import a GitHub repository or another external Git origin and its supplied `cloneUrl` is not sent with the coding request.
+- **`attach` rehydrates an existing Sapiom repository handle.** Use values previously returned by `create`, `get`, or `list`; it does not import an external Git repository.
 
 - **`pushFromSandbox` requires the repo to already be checked out in the sandbox.** It does not clone — it commits and pushes from the repo's checkout at `/workspace/<slug>`. The straightforward way to get that checkout is to run a coding agent with `gitRepository: repo`, which clones the repo into exactly that path. The two methods are meant to be used together; calling `pushFromSandbox` on a sandbox where the repo was never cloned will fail.
 

--- a/packages/tools/src/repositories/index.ts
+++ b/packages/tools/src/repositories/index.ts
@@ -118,12 +118,7 @@ export class Repository {
       .catch(() => undefined);
   }
 
-  /**
-   * Rehydrate a Sapiom repository returned by `create`, `get`, or `list` without
-   * a round-trip. This does not validate or register the repository, and its
-   * clone URL is not an external-repository import mechanism. Coding launch
-   * sends only the slug, not the clone URL supplied here.
-   */
+  /** Rehydrate a Sapiom repository handle returned by `create`, `get`, or `list`. */
   static attach(
     slug: string,
     cloneUrl: string,

--- a/packages/tools/src/repositories/index.ts
+++ b/packages/tools/src/repositories/index.ts
@@ -118,7 +118,12 @@ export class Repository {
       .catch(() => undefined);
   }
 
-  /** Adopt a known repo without a round-trip (e.g. one returned from another step). */
+  /**
+   * Rehydrate a Sapiom repository returned by `create`, `get`, or `list` without
+   * a round-trip. This does not validate or register the repository, and its
+   * clone URL is not an external-repository import mechanism. Coding launch
+   * sends only the slug, not the clone URL supplied here.
+   */
   static attach(
     slug: string,
     cloneUrl: string,

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -25,6 +25,7 @@ import {
   SpeechHttpError,
   BrowserAutomationHttpError,
   KeysHttpError,
+  CodingRunHttpError,
 } from "./index.js";
 
 describe("@sapiom/tools public surface", () => {
@@ -103,6 +104,8 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof SpeechHttpError).toBe("function");
     expect(typeof BrowserAutomationHttpError).toBe("function");
     expect(typeof KeysHttpError).toBe("function");
+    expect(typeof CodingRunHttpError).toBe("function");
+    expect(typeof models.CodingRunHttpError).toBe("function");
     expect(typeof Sandbox).toBe("function"); // class constructor
     expect(typeof Repository).toBe("function");
   });

--- a/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
@@ -264,6 +264,42 @@ types are the source of truth.** The full surface is the `Sapiom` interface in `
 `ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
 catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
 
+### Coding Repositories and Deterministic Launch Failures
+
+`gitRepository` must be an active, tenant-owned Sapiom repository returned by
+`repositories.create()`, `repositories.get()`, or `repositories.list()`. `repositories.attach()`
+only reconstructs one of those previously returned handles from saved `slug` and `cloneUrl`
+values. It makes no network request, performs no validation or registration, and cannot import
+a GitHub repository or another external Git origin. Coding launch sends only the repository slug;
+the `cloneUrl` passed to `attach()` is not sent.
+
+Coding launch and polling throw `CodingRunHttpError` for non-successful HTTP responses. Catch the
+deterministic `repository_not_found` code and return `fail()` when the agent run should stop without
+using its remaining attempts. Set `canFail: true` on that step, and rethrow errors that may be
+transient:
+
+```typescript
+import { fail, pauseUntilSignal } from "@sapiom/agent";
+import { CodingRunHttpError } from "@sapiom/tools";
+
+// Inside a step with `canFail: true`:
+try {
+  const handle = await ctx.sapiom.models.coding.launch({
+    task,
+    gitRepository: repo,
+  });
+  return pauseUntilSignal(handle, { resumeStep: "finalize" });
+} catch (error) {
+  if (
+    error instanceof CodingRunHttpError &&
+    error.code === "repository_not_found"
+  ) {
+    return fail(error.message);
+  }
+  throw error;
+}
+```
+
 ## Failure Handling & Retries
 
 There is no automatic per-step retry. Express it explicitly — this keeps the graph readable.

--- a/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
@@ -264,25 +264,19 @@ types are the source of truth.** The full surface is the `Sapiom` interface in `
 `ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
 catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
 
-### Coding Repositories and Deterministic Launch Failures
+### Coding Repository Errors
 
-`gitRepository` must be an active, tenant-owned Sapiom repository returned by
-`repositories.create()`, `repositories.get()`, or `repositories.list()`. `repositories.attach()`
-only reconstructs one of those previously returned handles from saved `slug` and `cloneUrl`
-values. It makes no network request, performs no validation or registration, and cannot import
-a GitHub repository or another external Git origin. Coding launch sends only the repository slug;
-the `cloneUrl` passed to `attach()` is not sent.
+Use a repository returned by `repositories.create()`, `repositories.get()`, or
+`repositories.list()`. `repositories.attach()` rehydrates one of those handles; it does not import
+an external Git repository.
 
-Coding launch and polling throw `CodingRunHttpError` for non-successful HTTP responses. Catch the
-deterministic `repository_not_found` code and return `fail()` when the agent run should stop without
-using its remaining attempts. Set `canFail: true` on that step, and rethrow errors that may be
-transient:
+Coding requests throw `CodingRunHttpError` for HTTP failures. A step with `canFail: true` can handle
+`repository_not_found` with `fail()` and rethrow other errors:
 
 ```typescript
 import { fail, pauseUntilSignal } from "@sapiom/agent";
 import { CodingRunHttpError } from "@sapiom/tools";
 
-// Inside a step with `canFail: true`:
 try {
   const handle = await ctx.sapiom.models.coding.launch({
     task,


### PR DESCRIPTION
## Summary

- export `CodingRunHttpError` with structured status, code, request ID, and response body fields
- apply the typed error consistently to coding launch and polling requests
- clarify supported `repositories.attach()` usage
- add tests, author guidance, and package release notes

## Rollout

The corresponding service contract is live and its production repository canaries passed.

## Verification

- test suites pass on Node.js 20 and 22
- CodeQL, examples, desktop smoke, and Playwright checks pass

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/b813283a-c382-4595-b242-6f62f745da3b)