### PR TITLE
docs(tools): models.run model doc matches warn-and-honor behavior + surface result warnings (SAP-2765)

### DIFF
--- a/.changeset/honest-model-label-warnings.md
+++ b/.changeset/honest-model-label-warnings.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": minor
+---
+
+`models.run`: `ModelRunOutcome` gains an optional `warnings` array surfacing routing/honesty warnings when the platform reports them on the run result — e.g. a supplied `model` value the platform didn't recognize, which (with the SAP-2765 platform-side change) routes via the platform default instead of being silently dropped. Treat absent as no warnings.

--- a/packages/tools/src/models/index.ts
+++ b/packages/tools/src/models/index.ts
@@ -622,9 +622,15 @@ function mapModelResult(r: ModelWireResult | null | undefined): ModelRunOutcome 
     lane: r.lane ?? null,
     durationMs: r.duration_ms,
     costUsd: r.cost_usd,
-    // Passthrough with a runtime guard (the wire is untyped at runtime); the
-    // key stays absent when there are no warnings — `undefined` means none.
-    ...(Array.isArray(r.warnings) ? { warnings: r.warnings.filter((w): w is string => typeof w === "string") } : {}),
+    // Passthrough with a runtime guard (the wire is untyped at runtime). ONE
+    // encoding of "no warnings" reaches consumers: the key is absent unless at
+    // least one string warning survives the guard — a wire `[]` (or a
+    // non-array, or an all-junk array) maps to absent, matching the documented
+    // "treat undefined as none".
+    ...(() => {
+      const warnings = Array.isArray(r.warnings) ? r.warnings.filter((w): w is string => typeof w === "string") : [];
+      return warnings.length ? { warnings } : {};
+    })(),
     usage: {
       inputTokens: r.usage?.input_tokens ?? 0,
       outputTokens: r.usage?.output_tokens ?? 0,

--- a/packages/tools/src/models/index.ts
+++ b/packages/tools/src/models/index.ts
@@ -481,8 +481,10 @@ export interface ModelRunSpec {
   /**
    * Routing label for the run's LLM calls (e.g. `"smart"`). The platform
    * resolves it against its configured label set — a raw provider model id
-   * is never honored. Omit to let the platform choose (the recommended
-   * default); pass `"smart"` if you need to pin explicitly.
+   * is never honored. An unrecognized value is never silently dropped: the
+   * run routes via the platform default and the platform reports it in the
+   * result's `warnings` (SAP-2765). Omit to let the platform choose (the
+   * recommended default); pass `"smart"` if you need to pin explicitly.
    */
   model?: ModelLabel;
   /** Max output tokens per turn. */
@@ -509,6 +511,13 @@ export interface ModelRunOutcome {
    * `undefined`/`null` means not disclosed — same caveats as `servedClass`.
    */
   lane?: string | null;
+  /**
+   * Routing/honesty warnings reported by the platform (SAP-2765) — e.g. a
+   * supplied `model` the platform didn't recognize (the run then routed via
+   * the platform default). Treat `undefined` as none on any path: the wire
+   * omits the key on a clean run and the stub never sets it.
+   */
+  warnings?: string[];
   durationMs: number;
   costUsd: number;
   usage: CodingRunUsage;
@@ -576,6 +585,8 @@ interface ModelWireResult {
   model_used: string | null;
   served_class?: string | null;
   lane?: string | null;
+  /** Present only when the run has warnings (e.g. an unhonored `model` pin); guarded at map time. */
+  warnings?: string[];
   duration_ms: number;
   cost_usd: number;
   usage?: {
@@ -611,6 +622,9 @@ function mapModelResult(r: ModelWireResult | null | undefined): ModelRunOutcome 
     lane: r.lane ?? null,
     durationMs: r.duration_ms,
     costUsd: r.cost_usd,
+    // Passthrough with a runtime guard (the wire is untyped at runtime); the
+    // key stays absent when there are no warnings — `undefined` means none.
+    ...(Array.isArray(r.warnings) ? { warnings: r.warnings.filter((w): w is string => typeof w === "string") } : {}),
     usage: {
       inputTokens: r.usage?.input_tokens ?? 0,
       outputTokens: r.usage?.output_tokens ?? 0,

--- a/packages/tools/src/models/index.ts
+++ b/packages/tools/src/models/index.ts
@@ -558,6 +558,18 @@ export type ModelRunResultPayload = ModelRunResult;
 /** Thrown by {@link modelRunResultSchema}.parse on a malformed resume payload. */
 export class ModelRunResultSchemaError extends Error {}
 
+/**
+ * Guarded `warnings` normalization — enforces the ONE encoding of "no
+ * warnings" (`undefined`) on every path that hands a {@link ModelRunOutcome}
+ * to a consumer: only string elements survive; an empty/absent/malformed value
+ * becomes `undefined`, never a present-but-empty array a consumer's
+ * `if (outcome.warnings)` would misread.
+ */
+function normalizeWarnings(value: unknown): string[] | undefined {
+  const warnings = Array.isArray(value) ? value.filter((w): w is string => typeof w === "string") : [];
+  return warnings.length ? warnings : undefined;
+}
+
 /** Runtime validator for {@link ModelRunResultPayload}. */
 export const modelRunResultSchema = {
   parse(value: unknown): ModelRunResultPayload {
@@ -572,6 +584,15 @@ export const modelRunResultSchema = {
     if (v.output !== null && typeof v.output !== "string") fail("output must be a string or null");
     if (v.result !== null && (typeof v.result !== "object" || !v.result)) fail("result must be an object or null");
     if (v.error !== null && (typeof v.error !== "object" || !v.error)) fail("error must be an object or null");
+    if (v.result) {
+      // Same warnings encoding as the polled path (mapModelResult): the resume
+      // payload is server-serialized, so a wire `[]` would otherwise reach the
+      // resumed step present-but-empty.
+      const r = v.result as Record<string, unknown>;
+      const warnings = normalizeWarnings(r.warnings);
+      if (warnings) r.warnings = warnings;
+      else delete r.warnings;
+    }
     return value as ModelRunResultPayload;
   },
 };
@@ -622,14 +643,13 @@ function mapModelResult(r: ModelWireResult | null | undefined): ModelRunOutcome 
     lane: r.lane ?? null,
     durationMs: r.duration_ms,
     costUsd: r.cost_usd,
-    // Passthrough with a runtime guard (the wire is untyped at runtime). ONE
-    // encoding of "no warnings" reaches consumers: the key is absent unless at
-    // least one string warning survives the guard — a wire `[]` (or a
-    // non-array, or an all-junk array) maps to absent, matching the documented
+    // Passthrough via the shared guard (`normalizeWarnings`): the key is
+    // absent unless at least one string warning survives — a wire `[]`, a
+    // non-array, or an all-junk array maps to absent, matching the documented
     // "treat undefined as none".
     ...(() => {
-      const warnings = Array.isArray(r.warnings) ? r.warnings.filter((w): w is string => typeof w === "string") : [];
-      return warnings.length ? { warnings } : {};
+      const warnings = normalizeWarnings(r.warnings);
+      return warnings ? { warnings } : {};
     })(),
     usage: {
       inputTokens: r.usage?.input_tokens ?? 0,

--- a/packages/tools/src/models/run-launch.spec.ts
+++ b/packages/tools/src/models/run-launch.spec.ts
@@ -4,7 +4,7 @@
  * fake fetch (no real network).
  */
 import { createClient } from "../index.js";
-import { MODEL_RUN_RESULT_SIGNAL } from "./index.js";
+import { MODEL_RUN_RESULT_SIGNAL, modelRunResultSchema } from "./index.js";
 
 function fakeFetch(opts: {
   capture?: { headers?: Record<string, string>; url?: string };
@@ -154,6 +154,34 @@ describe("agent.run — terminal result mapping", () => {
     expect(await runWith("oops")).toBeUndefined();
     // Mixed array → only the string elements survive the guard.
     expect(await runWith([1, "warn-a", null])).toEqual(["warn-a"]);
+  });
+
+  it("the resume payload gets the SAME warnings encoding (modelRunResultSchema normalizes)", async () => {
+    // A step resumed via pauseUntilSignal receives the server-serialized
+    // payload through modelRunResultSchema.parse, not mapModelResult — the
+    // one-encoding guarantee must hold there too.
+    const payload = (warnings?: unknown) => ({
+      runId: "run-abc",
+      status: "completed",
+      output: "OK",
+      result: {
+        success: true,
+        stopReason: "end_turn",
+        turns: 1,
+        modelUsed: null,
+        durationMs: 1200,
+        costUsd: 0.001,
+        ...(warnings !== undefined ? { warnings } : {}),
+        usage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheCreateTokens: 0, thinkingTokens: 0 },
+      },
+      error: null,
+    });
+
+    expect(modelRunResultSchema.parse(payload()).result?.warnings).toBeUndefined();
+    expect(modelRunResultSchema.parse(payload([])).result?.warnings).toBeUndefined();
+    expect(modelRunResultSchema.parse(payload("oops")).result?.warnings).toBeUndefined();
+    expect(modelRunResultSchema.parse(payload([1, "warn-a", null])).result?.warnings).toEqual(["warn-a"]);
+    expect(modelRunResultSchema.parse(payload(["warn-1"])).result?.warnings).toEqual(["warn-1"]);
   });
 });
 

--- a/packages/tools/src/models/run-launch.spec.ts
+++ b/packages/tools/src/models/run-launch.spec.ts
@@ -129,29 +129,31 @@ describe("agent.run — terminal result mapping", () => {
     expect(result.result?.warnings).toEqual(["warn-1", "warn-2"]);
   });
 
-  it("omits warnings on a clean run and guards malformed wire values — absent means none", async () => {
-    // Base fixture has no `warnings` key → stays absent.
-    const clean = createClient({ apiKey: "k", fetch: fakeFetch({}) });
-    expect((await clean.models.run({ prompt: "say OK" })).result?.warnings).toBeUndefined();
-
-    // Not an array → dropped entirely, never a string leaking into a
-    // `string[]`-typed field.
-    const malformed = createClient({
-      apiKey: "k",
-      fetch: fakeFetch({
-        wireResult: {
-          success: true,
-          stop_reason: "end_turn",
-          turns: 1,
-          model_used: null,
-          duration_ms: 1200,
-          cost_usd: 0.001,
-          warnings: "oops",
-          usage: { input_tokens: 10, output_tokens: 5 },
-        },
-      }),
+  it("ONE encoding of 'no warnings' — absent for a missing key, a wire [], or malformed values", async () => {
+    const wireResult = (warnings?: unknown) => ({
+      success: true,
+      stop_reason: "end_turn",
+      turns: 1,
+      model_used: null,
+      duration_ms: 1200,
+      cost_usd: 0.001,
+      ...(warnings !== undefined ? { warnings } : {}),
+      usage: { input_tokens: 10, output_tokens: 5 },
     });
-    expect((await malformed.models.run({ prompt: "say OK" })).result?.warnings).toBeUndefined();
+    const runWith = async (warnings?: unknown) => {
+      const sapiom = createClient({ apiKey: "k", fetch: fakeFetch({ wireResult: wireResult(warnings) }) });
+      return (await sapiom.models.run({ prompt: "say OK" })).result?.warnings;
+    };
+
+    // Missing key → absent.
+    expect(await runWith()).toBeUndefined();
+    // Wire `[]` → ALSO absent — a consumer's `if (outcome.warnings)` must not
+    // render an empty banner depending on which empty encoding the server sent.
+    expect(await runWith([])).toBeUndefined();
+    // Not an array → absent, never a string leaking into a `string[]` field.
+    expect(await runWith("oops")).toBeUndefined();
+    // Mixed array → only the string elements survive the guard.
+    expect(await runWith([1, "warn-a", null])).toEqual(["warn-a"]);
   });
 });
 

--- a/packages/tools/src/models/run-launch.spec.ts
+++ b/packages/tools/src/models/run-launch.spec.ts
@@ -108,6 +108,51 @@ describe("agent.run — terminal result mapping", () => {
     expect(result.result?.servedClass).toBeNull();
     expect(result.result?.lane).toBeNull();
   });
+
+  it("surfaces routing warnings (SAP-2765: e.g. an unhonored `model` pin)", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeFetch({
+        wireResult: {
+          success: true,
+          stop_reason: "end_turn",
+          turns: 1,
+          model_used: null,
+          duration_ms: 1200,
+          cost_usd: 0.001,
+          warnings: ["warn-1", "warn-2"],
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      }),
+    });
+    const result = await sapiom.models.run({ prompt: "say OK", model: "not-a-known-label" });
+    expect(result.result?.warnings).toEqual(["warn-1", "warn-2"]);
+  });
+
+  it("omits warnings on a clean run and guards malformed wire values — absent means none", async () => {
+    // Base fixture has no `warnings` key → stays absent.
+    const clean = createClient({ apiKey: "k", fetch: fakeFetch({}) });
+    expect((await clean.models.run({ prompt: "say OK" })).result?.warnings).toBeUndefined();
+
+    // Not an array → dropped entirely, never a string leaking into a
+    // `string[]`-typed field.
+    const malformed = createClient({
+      apiKey: "k",
+      fetch: fakeFetch({
+        wireResult: {
+          success: true,
+          stop_reason: "end_turn",
+          turns: 1,
+          model_used: null,
+          duration_ms: 1200,
+          cost_usd: 0.001,
+          warnings: "oops",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      }),
+    });
+    expect((await malformed.models.run({ prompt: "say OK" })).result?.warnings).toBeUndefined();
+  });
 });
 
 describe("agent.launch — workflow resume token", () => {


### PR DESCRIPTION
## Summary

Companion to a server-side fix (internal tracker): the server now honors a supplied `model` as a routing label (known label → routed; unknown → platform default + a warning on the result — never a silent drop).

`ModelRunSpec.model` promised "Override the model / routing alias" while the platform silently ignored it — a doc-vs-behavior mismatch. This PR fixes the doc and surfaces the platform's warning on the result.

## What changed

- **Doc fix:** `ModelRunSpec.model` doc-comment now states the actual contract — honored as a routing label when known, warned-and-defaulted when not, omit to let the platform choose.
- **Surface the warning:** additive `ModelRunOutcome.warnings?: string[]`, mapped from the wire with a runtime guard. ONE encoding of "no warnings" reaches consumers: the key is **absent** unless at least one string warning survives the guard (missing key, wire `[]`, non-array, and all-junk arrays all map to absent) — treat `undefined` as none, per the JSDoc and changeset. Without the field the whitelist mapper would drop the platform's warning, defeating "warning surfaced on the result" for the SDK audience.
- Changeset: `@sapiom/tools` minor.

## Testing

- `packages/tools`: models suites 32 passed (new: warning passthrough; single no-warnings encoding across missing key / wire `[]` / non-array / mixed arrays); `tsc --noEmit` and `eslint` clean; `pnpm build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6TdePdocPc7sfYxKegs3Y

