### PR TITLE
fix(harness): formatValue's truncation marker could push output past VALUE_CAP

### DIFF
--- a/.changeset/fix-formatvalue-budget-overrun.md
+++ b/.changeset/fix-formatvalue-budget-overrun.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Fix a debug-context helper that could return output slightly longer than its configured character budget.

--- a/packages/harness/web/src/lib/extract-step-context.test.ts
+++ b/packages/harness/web/src/lib/extract-step-context.test.ts
@@ -154,14 +154,18 @@ describe("extractStepContext — input/output", () => {
     expect(ctx).toContain("[object Object]");
   });
 
-  it("truncates a very large value and marks the truncation", () => {
+  it("truncates a very large value and marks the truncation, bounding the total output", () => {
     const step: StepView = { id: "s1", name: "big", status: "passed" };
     const huge = "z".repeat(5000);
     const ctx = extractStepContext(step, { output: huge });
     expect(ctx).toContain("… (truncated, 5000 chars total)");
     // The head is kept; the value is not pasted whole.
     expect(ctx).not.toContain(huge);
-    expect(ctx).toContain("z".repeat(2000));
+    // The marker's own length has to come out of VALUE_CAP too, so slightly
+    // less than 2000 chars of content survive -- the total (content +
+    // marker) is what's bounded, not the content alone.
+    expect(ctx).toContain("z".repeat(1968));
+    expect(ctx).not.toContain("z".repeat(1969));
   });
 });
 

--- a/packages/harness/web/src/lib/extract-step-context.ts
+++ b/packages/harness/web/src/lib/extract-step-context.ts
@@ -103,7 +103,9 @@ export function formatLatency(ms: number): string {
  * strings pass through verbatim; anything JSON can't represent (a cycle, a
  * bigint) falls back to `String(value)` so the builder never throws. When the
  * result exceeds the cap it is head-kept (the shape and leading content matter
- * most for a value) with an explicit truncation marker.
+ * most for a value) with an explicit truncation marker, and the TOTAL output
+ * (content + marker) is what respects the cap — not the content alone, or the
+ * marker itself would push the result past VALUE_CAP.
  */
 function formatValue(value: unknown): string {
   let text: string;
@@ -117,10 +119,14 @@ function formatValue(value: unknown): string {
       text = String(value);
     }
   }
-  if (text.length > VALUE_CAP) {
-    return `${text.slice(0, VALUE_CAP)}\n… (truncated, ${text.length} chars total)`;
-  }
-  return text;
+  if (text.length <= VALUE_CAP) return text;
+  // Unlike a "chars dropped" marker, this one reports the original total
+  // length, which doesn't change with where we slice -- so the marker's
+  // length is fixed and a single subtraction (no converging loop needed)
+  // correctly reserves room for it within VALUE_CAP.
+  const marker = `\n… (truncated, ${text.length} chars total)`;
+  const sliceLen = Math.max(0, VALUE_CAP - marker.length);
+  return `${text.slice(0, sliceLen)}${marker}`.slice(0, VALUE_CAP);
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for contributing to sapiom-js.
Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
-->

## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

`formatValue` (`packages/harness/web/src/lib/extract-step-context.ts`) is documented as producing output "capped at VALUE_CAP characters," but it sliced content to exactly `VALUE_CAP` and then appended a truncation marker AFTER the slice — so the total could exceed `VALUE_CAP` by the marker's length. This is the fourth instance of the same bug class found in a repo-wide sweep; the other three (`truncateForPayload`/`clip`/`clamp` in `packages/harness/src/core/`) are fixed in #656 — this one lives in a different subsystem (the web frontend's run-inspector Debug/Explain macro context builder), so it's a separate PR.

## Summary and scope

Unlike the three fixed in #656, this marker (`\n… (truncated, N chars total)`) reports the value's original total length, which doesn't change with where the slice lands — so the fix here is a single subtraction, not a converging loop: the marker's length is fixed once `text.length` is known, so there's nothing to iterate on. Reserve the marker's length within `VALUE_CAP` before slicing.

Out of scope: the three `packages/harness/src/core/` instances (separate PR, #656); no dependency changes.

## Related work

Related issue or discussion: #674

## Validation

```text
# packages/harness: vitest run web/src/lib/extract-step-context.test.ts
51/51 passing
tsc --noEmit (server tsconfig): clean
tsc --noEmit -p web/tsconfig.json: clean
# web/ is excluded from this package's eslint config (.eslintrc.cjs ignorePatterns),
# pre-existing and unrelated to this change
```

### Tests and documentation

Updated the one existing test whose exact-match assertion had encoded the old (over-budget) output as the expected value, with the new expected value computed independently. No user-facing documentation changes needed.

## Compatibility and release impact

- Breaking or externally visible changes: None. `formatValue` is not exported; `extractStepContext`'s signature and return type are unchanged. Truncated output near the cap gets slightly shorter (by the marker's length) to actually respect the documented bound.
- Changeset: Added (`.changeset/fix-formatvalue-budget-overrun.md`), patch bump for `@sapiom/harness`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

I used Claude (Anthropic) as a coding assistant throughout: it helped find the bug (via a repo-wide grep sweep for the same marker pattern), draft the fix and the updated test, and run the verification commands quoted above. I reviewed and ran every command myself, read and understood the resulting diff line by line, and can explain and maintain every change in this PR.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
