### PR TITLE
docs(mcp): teach the LLM call-surface rule in the authoring instructions

### DIFF
--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -60,9 +60,11 @@ describe("server instructions", () => {
     expect(AUTHORING_INSTRUCTIONS).toContain("models.coding.run");
     expect(AUTHORING_INSTRUCTIONS).toContain("ctx.sapiom.agents.run");
     expect(AUTHORING_INSTRUCTIONS).toContain("You never pick a model");
-    expect(AUTHORING_INSTRUCTIONS).toContain(
-      "GET /v1/workflows/executions/:id/steps/:stepId/io",
-    );
+    // The internal `workflows`-service naming must never reach this customer-facing
+    // primer — the per-step debugging endpoint lives in the docs guide, not spelled
+    // out here verbatim (matches this package's own scaffold terminology guard).
+    expect(AUTHORING_INSTRUCTIONS).toContain("Run Inspector");
+    expect(AUTHORING_INSTRUCTIONS).not.toContain("/v1/workflows/");
   });
 
   it("documents the complete ctx.shared quota contract", () => {

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -54,6 +54,17 @@ describe("server instructions", () => {
     );
   });
 
+  it("teaches the LLM call-surface rule (SAP-2775) — kept byte-identical to the backend copy", () => {
+    expect(AUTHORING_INSTRUCTIONS).toContain("ctx.sapiom.llm.run");
+    expect(AUTHORING_INSTRUCTIONS).toContain("ctx.sapiom.models.run");
+    expect(AUTHORING_INSTRUCTIONS).toContain("models.coding.run");
+    expect(AUTHORING_INSTRUCTIONS).toContain("ctx.sapiom.agents.run");
+    expect(AUTHORING_INSTRUCTIONS).toContain("You never pick a model");
+    expect(AUTHORING_INSTRUCTIONS).toContain(
+      "GET /v1/workflows/executions/:id/steps/:stepId/io",
+    );
+  });
+
   it("documents the complete ctx.shared quota contract", () => {
     expect(AUTHORING_INSTRUCTIONS).toContain(
       "inclusive 256 KiB (262,144-byte) quota",

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -75,6 +75,24 @@ and returns a live URL; a \`failed\` status carries the build/start logs — fix
   don't memorize the catalog; use autocomplete/typecheck. Schedules (cron triggers) are
   a top-level \`@sapiom/tools\` import, not under \`ctx.sapiom\`.
 
+## Calling LLMs and running agent loops (from agent code)
+- **One LLM call → \`ctx.sapiom.llm.run\`** — summarize, extract, classify, one-shot generate.
+  For structured/JSON output, request tool-use/schema output and read only
+  \`type === 'text'\` content blocks (a \`thinking\` block may be present); never
+  "reply with only JSON" + string parsing.
+- **Platform-driven agent loop → \`ctx.sapiom.models.run\`** — a multi-turn reasoning +
+  tool-calling task (minutes, not seconds). \`models.coding.run\` for sandboxed coding tasks.
+  Never use this for a one-shot completion — it will loop and overthink.
+- **Dispatch a deployed agent by slug → \`ctx.sapiom.agents.run\`** — compose systems from
+  small deployed agents rather than one monolithic workflow.
+- **You never pick a model.** Say how long you can wait (\`deadlineMinutes\` where supported)
+  — the platform picks the model and reports the served class and lane on the result. You may
+  pin a class label (\`small\` / \`medium\` / \`large\` / \`smart\`); raw provider model ids
+  (e.g. Anthropic ids) are not honored.
+- **Debugging a run:** run detail → find the suspicious step row id →
+  \`GET /v1/workflows/executions/:id/steps/:stepId/io\` returns that attempt's full-fidelity
+  input/output/error/logs.
+
 Full reference: https://docs.sapiom.ai/agents/quick-start (authoring · capabilities ·
 reference · examples), plus the \`AGENTS.md\` and \`sapiom-agent-authoring\` skill inside
 your scaffolded project.`;

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -86,9 +86,9 @@ and returns a live URL; a \`failed\` status carries the build/start logs — fix
 - **Dispatch a deployed agent by slug → \`ctx.sapiom.agents.run\`** — compose systems from
   small deployed agents rather than one monolithic workflow.
 - **You never pick a model.** Say how long you can wait (\`deadlineMinutes\` where supported)
-  — the platform picks the model and reports the served class and lane on the result. You may
-  pin a class label (\`small\` / \`medium\` / \`large\` / \`smart\`); raw provider model ids
-  (e.g. Anthropic ids) are not honored.
+  — the platform picks the model and reports the served class and lane on the result.
+  **Omit \`model\` entirely (recommended)** — the platform routes it. If you must pin, use
+  the \`smart\` label. Raw provider model ids are never honored.
 - **Debugging a run:** run detail → find the suspicious step row id →
   \`GET /v1/workflows/executions/:id/steps/:stepId/io\` returns that attempt's full-fidelity
   input/output/error/logs.

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -84,14 +84,13 @@ and returns a live URL; a \`failed\` status carries the build/start logs — fix
   tool-calling task (minutes, not seconds). \`models.coding.run\` for sandboxed coding tasks.
   Never use this for a one-shot completion — it will loop and overthink.
 - **Dispatch a deployed agent by slug → \`ctx.sapiom.agents.run\`** — compose systems from
-  small deployed agents rather than one monolithic workflow.
+  small deployed agents rather than one large monolith.
 - **You never pick a model.** Say how long you can wait (\`deadlineMinutes\` where supported)
   — the platform picks the model and reports the served class and lane on the result.
   **Omit \`model\` entirely (recommended)** — the platform routes it. If you must pin, use
   the \`smart\` label. Raw provider model ids are never honored.
-- **Debugging a run:** run detail → find the suspicious step row id →
-  \`GET /v1/workflows/executions/:id/steps/:stepId/io\` returns that attempt's full-fidelity
-  input/output/error/logs.
+- **Debugging a run:** open the Run Inspector, or fetch a step's full input/output via
+  the per-step endpoint documented in the guide.
 
 Full reference: https://docs.sapiom.ai/agents/quick-start (authoring · capabilities ·
 reference · examples), plus the \`AGENTS.md\` and \`sapiom-agent-authoring\` skill inside


### PR DESCRIPTION
## Summary
Companion to a server-side change (internal tracker). Adds the same "LLM calls & agent loops" section to the bundled offline fallback `AUTHORING_INSTRUCTIONS` (`packages/mcp/src/instructions.ts`) — served when the live startup fetch to `GET {apiURL}/v1/mcp/instructions` fails. Teaches an authoring agent:
- One-shot LLM call → `ctx.sapiom.llm.run` (read only `type === 'text'` blocks, never string-parse JSON out of a response that may carry a `thinking` block).
- Platform-driven multi-turn agent loop → `ctx.sapiom.models.run` / `models.coding.run` (never for a one-shot completion).
- Dispatch a deployed agent by slug → `ctx.sapiom.agents.run`.
- The "you never pick a model" `deadlineMinutes`/label contract.
- A debugging pointer for a run.

Highest-reach usability fix in the project: the live-fetched copy (server-side change) reaches every existing Studio session on its next connect; this bundled fallback keeps the offline case in sync.

## Changes
- `packages/mcp/src/instructions.ts` — added the new section to `AUTHORING_INSTRUCTIONS`, placed right after the `ctx.sapiom.*` capability bullet in "Canonical rules" (matching the server-served copy's placement).
- `packages/mcp/src/instructions.test.ts` — added a test asserting the new section's key phrases so it can't be silently dropped later.

## Byte-identity
The new section is byte-for-byte identical between this file and the server's live-fetched copy — verified with a checksum of just the new `## Calling LLMs and running agent loops` section in both.

**Note (pre-existing, out of scope here):** this file as a *whole* was already not byte-identical to the server-served copy before this change, for unrelated reasons — this file's title, its older "Two ways to use Sapiom" aliasing section, and its `ctx.shared` 256 KiB quota paragraph (#677) are absent from or worded differently than the server-served copy. This PR and its companion only guarantee identity for the *new* section added here; the pre-existing drift is flagged separately, not fixed in this PR.

## Correction (post-review)
The section originally said *"You may pin a class label (`small` / `medium` / `large` / `smart`); raw provider model ids (e.g. Anthropic ids) are not honored."* — wrong against what's actually shipped: today's server-side label allowlist (internal) does not include `small`/`medium`/`large` — those are the SKU spec's **future** vocabulary and would warn-and-default today, not pin. Replaced with present-truth guidance: omit `model` entirely (recommended), or pin the one label that's contract-attested to work (`smart`) — raw provider model ids are never honored. Kept byte-identical to the companion server-side fix; re-verified the shared section's checksum matches the server-served copy and its persisted snapshot.

## Testing
```
cd packages/mcp
npx vitest run src/instructions.test.ts
```
Result: 5 passed (was 4; +1 for the new LLM-usage-rule content test). Re-ran after the correction — still 5 passed.

## Correction (round 2) — internal service naming
This package's own scaffold terminology guard (`agent-core`'s `scaffold.test.ts`, surfaced while working #683) bans internal service naming from anything shipped to a customer. Two phrases in this section leaked that internal naming: a literal debugging endpoint path, and "compose systems from small deployed agents rather than one large automation." Ruling: the literal path's one deliberate home is the canonical public guide; every other teaching surface points there instead of repeating it. Replaced both — debugging line now reads "open the Run Inspector, or fetch a step's full input/output via the per-step endpoint documented in the guide"; the other phrase is now "one large monolith." Re-verified the shared section's checksum still matches the server-served copy. Updated the drift-guard test's assertion accordingly — re-ran: still 5 passed.

## Related
Refs: internal tracker

## Checklist
- [x] New section byte-identical to the server-served copy (checksum-verified)
- [x] Test added guarding the new section's key phrases
- [x] Post-review correction: model-pinning claim fixed to match shipped label allowlist
- [x] Round-2 correction: internal service naming removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDogyqvDnhy5iKgVpeZtWc
