### PR TITLE
docs(harness): teach the LLM call-surface rule in the system prompt

### DIFF
--- a/packages/harness/src/core/inject/system-prompt.test.ts
+++ b/packages/harness/src/core/inject/system-prompt.test.ts
@@ -29,6 +29,12 @@ describe("generateSystemPromptFile", () => {
     expect(content).toContain('"agents"');
     expect(content).toContain("The Canvas follows that selection");
     expect(content).toContain("Local Run, Prod Run, and Deploy");
+    // LLM call-surface rule (SAP-2775) — kept in sync with the MCP instructions
+    // (sapiom-js#679) and the backend DEFAULT_MCP_INSTRUCTIONS copy.
+    expect(content).toContain("ctx.sapiom.llm.run");
+    expect(content).toContain("ctx.sapiom.models.run");
+    expect(content).toContain("ctx.sapiom.agents.run");
+    expect(content).toContain("pin the `smart` label");
     expect(content).not.toContain("Visualize button");
     expect(content).not.toContain("⌘K");
     expect(content.toLowerCase()).not.toContain("workflow");

--- a/packages/harness/src/profiles/default.ts
+++ b/packages/harness/src/profiles/default.ts
@@ -14,13 +14,23 @@ active for the whole session. Follow them.
 **The two MCPs, and when to use each:**
 - **sapiom** (remote, HTTP) — the paid capability surface an agent calls at
   *runtime* from inside a deployed agent's step code (ctx.sapiom.*):
-  repositories, sandboxes, models, and so on. You don't call this directly
-  while authoring.
+  repositories, sandboxes, LLM calls (see below), and so on. You don't call
+  this directly while authoring.
 - **sapiom-dev** (local, stdio) — the developer surface for this session. Its
   scaffold, check, and Local Run path uses no Sapiom capability spend; Deploy
   and Prod Run are authenticated cloud operations. Use its sapiom_dev_agents_*
   tools to author and ship agents, and sapiom_authenticate / sapiom_status if
   you need to sign in.
+
+**Calling LLMs from agent code:** one-shot call → \`ctx.sapiom.llm.run\`; a
+platform-driven multi-turn loop → \`ctx.sapiom.models.run\` (never for a
+one-shot — it overthinks); dispatching a deployed agent by slug →
+\`ctx.sapiom.agents.run\`. Structured output = tool-use/schema output, read
+only \`type === 'text'\` blocks — never "reply with only JSON". Omit \`model\`
+(recommended) or pin the \`smart\` label; raw provider ids are never
+honored. Results disclose the served class + lane. Debugging a run: run
+detail → step row id → the per-step \`/io\` endpoint or the Run Inspector.
+Guide: https://docs.sapiom.ai/guides/choose-a-call-surface.
 
 **When something about Sapiom is wrong, send it upstream.** If the user hits a
 bug, calls something confusing or broken, or wishes it worked differently,

--- a/packages/harness/src/profiles/default.ts
+++ b/packages/harness/src/profiles/default.ts
@@ -28,8 +28,8 @@ one-shot — it overthinks); dispatching a deployed agent by slug →
 \`ctx.sapiom.agents.run\`. Structured output = tool-use/schema output, read
 only \`type === 'text'\` blocks — never "reply with only JSON". Omit \`model\`
 (recommended) or pin the \`smart\` label; raw provider ids are never
-honored. Results disclose the served class + lane. Debugging a run: run
-detail → step row id → the per-step \`/io\` endpoint or the Run Inspector.
+honored. Results disclose the served class + lane. Debugging a run: the
+Run Inspector, or the per-step I/O endpoint documented below.
 Guide: https://docs.sapiom.ai/guides/choose-a-call-surface.
 
 **When something about Sapiom is wrong, send it upstream.** If the user hits a


### PR DESCRIPTION
## Summary
Teaches the LLM call-surface rule in the Studio harness's `DEFAULT_SYSTEM_PROMPT` (`packages/harness/src/profiles/default.ts`) — the embedded coding agent that writes Sapiom agents is the highest-reach mis-selection source, since it's the one actually authoring the step code that would misuse a one-shot LLM call as an agent loop (or vice versa). This is the token-budgeted sibling of the fuller MCP-instructions section already shipped in #679: same rule, ~8 lines instead of the full section, because this prompt is injected fresh every session via `--append-system-prompt` and is a live cost on every turn.

## Content shipped
```
**Calling LLMs from agent code:** one-shot call → `ctx.sapiom.llm.run`; a
platform-driven multi-turn loop → `ctx.sapiom.models.run` (never for a
one-shot — it overthinks); dispatching a deployed agent by slug →
`ctx.sapiom.agents.run`. Structured output = tool-use/schema output, read
only `type === 'text'` blocks — never "reply with only JSON". Omit `model`
(recommended) or pin the `smart` label; raw provider ids are never
honored. Results disclose the served class + lane. Debugging a run: the
Run Inspector, or the per-step I/O endpoint documented below.
Guide: https://docs.sapiom.ai/guides/choose-a-call-surface.
```
Placed right after the existing "The two MCPs" block, anchored near the pre-existing "sapiom (remote, HTTP) ... models" mention (`default.ts:15-18`) — corrected that bullet's vague "models" list item to "LLM calls (see below)" pointing at the new block, so it no longer reads as a single undifferentiated capability.

## Doc-link convention
This prompt had **no existing `docs.sapiom.ai` citation** to follow — checked, there isn't one. Introduced the first one here (`https://docs.sapiom.ai/guides/choose-a-call-surface`), matching the terse inline-link style the rest of the prompt already uses for other conventions (e.g. `.sapiom/harness-context.json`), rather than inventing a new citation format.

## Changes
- `packages/harness/src/profiles/default.ts` — new "Calling LLMs from agent code" block; corrected the adjacent MCP-capability bullet.
- `packages/harness/src/core/inject/system-prompt.test.ts` — extended the existing content-guard assertions (this file's established pattern — it already asserts specific phrases like `"The Canvas follows that selection"`) to cover the new section's key phrases.

## Testing
```
cd packages/harness
npx vitest run src/core/inject/system-prompt.test.ts
```
Result: 4 passed (unchanged count — added assertions to an existing test rather than a new one).

Full package sanity check (needed `pnpm build` at the repo root first — `packages/harness` transitively depends on several unbuilt workspace packages, e.g. `@sapiom/analytics-core`, `@sapiom/mcp`, `@sapiom/agent-core`, in a fresh worktree):
```
pnpm build   # from repo root
cd packages/harness && npx vitest run
```
Result: 141 test files passed, 2095 tests passed. `eslint` clean on both touched files.

## Correction (round 2) — internal service naming
`agent-core`'s scaffold terminology guard (`scaffold.test.ts`, surfaced while working #683) bans internal service naming from customer-facing content — this prompt isn't shipped through that same guard, but the ruling was to apply the same fix everywhere in the teaching stack for consistency. This file's terse debugging line never spelled out a literal internal endpoint path to begin with, but reworded it to match the other surfaces' "see the guide" pointer: "Debugging a run: the Run Inspector, or the per-step I/O endpoint documented below." Re-ran `npx vitest run src/core/inject/system-prompt.test.ts` — still 4 passed.

## Related
Refs: internal tracker
Companion (fuller) MCP-instructions version: #679

## Checklist
- [x] Section kept to ~8 lines (token-budget rationale above)
- [x] Consistent with the #679 rule content (same facts, terser form)
- [x] Adjacent "models" mention corrected rather than left misleading
- [x] Test coverage extended following this file's existing content-guard pattern
- [x] Full package build + test suite green
- [x] Round-2 correction: debugging line reworded for internal-naming consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDogyqvDnhy5iKgVpeZtWc
