### PR TITLE
fix(examples): Content Pack renders the quote into its graphics and ships a coherent teaser clip (SAP-2781)

### DIFF
--- a/examples/content-repurposing-pipeline/AGENTS.md
+++ b/examples/content-repurposing-pipeline/AGENTS.md
@@ -24,8 +24,9 @@ repurpose ─▶ graphics ⇄ collectGraphic ─▶ clip ⇄ collectClip ─▶ 
   'collectGraphic' }`); `collectGraphic` records it and loops back for the next quote or
   advances once every graphic is in. Sequential, not a concurrent `Promise.all` — see
   "Why sequential" below.
-- **clip ⇄ collectClip** — launches an async image-to-video job from the first
-  graphic and `pauseUntilSignal`s on it. The
+- **clip ⇄ collectClip** — launches an async text-to-video job (a cataloged
+  semantic alias, with a purpose-written short visual prompt — never the LLM's
+  narration-shaped output; see `buildClipPrompt`) and `pauseUntilSignal`s on it. The
   `pause: { signal: VIDEO_RESULT_SIGNAL, resumeStep: 'collectClip' }` declaration is
   the graph edge; the video-generation webhook fires the signal to resume `collectClip`.
 - **package** — renders the whole pack as one markdown doc and uploads it to file

--- a/examples/content-repurposing-pipeline/README.md
+++ b/examples/content-repurposing-pipeline/README.md
@@ -19,11 +19,11 @@ repurpose ──▶ graphics ⇄ collectGraphic ──▶ clip ⇄ collectClip �
 2. **graphics ⇄ collectGraphic** — one quote-graphic image at a time
    (`images.launch`, async): launch the job, pause until the webhook resumes
    `collectGraphic`, record it, then loop back for the next quote or advance.
-3. **clip ⇄ collectClip** — renders a short teaser clip that puts the lead
-   pull-quote on screen: launches an async text-to-video job (`video.launch`,
-   a cataloged semantic alias) with a purpose-written short visual prompt and
-   pauses on it; the video-generation webhook resumes `collectClip` when the
-   clip is ready.
+3. **clip ⇄ collectClip** — renders a short decorative teaser clip: launches an
+   async text-to-video job (`video.launch`, a cataloged semantic alias) with a
+   purpose-written short visual prompt — deliberately no on-screen text, since
+   general video models render text illegibly — and pauses on it; the
+   video-generation webhook resumes `collectClip` when the clip is ready.
 4. **package** — assembles the whole pack as one markdown document and uploads it
    to file storage (`fileStorage.upload`) for a durable `fileId` + download URL.
 5. **deliver** — fans the pack out to every `deliverTo` recipient
@@ -74,9 +74,11 @@ iterating on the copy, and keep `numQuotes` small for real runs.
 Quote graphics render on `ideogram-v3`, a typography-capable cataloged alias —
 the quote text is drawn INTO the image, so a model with strong text rendering is
 non-negotiable (`gpt-image-2` also fits). `clip` defaults to `kling-standard`, a
-cataloged semantic video alias. Pass a different alias via the `model` input to
-trade quality for cost; only cataloged aliases resolve (raw provider ids get no
-neutral-param normalization and are rejected once allowlist enforcement lands).
+cataloged semantic video alias; the teaser is decorative and text-free, because
+general video models render on-screen text illegibly. Pass a different alias via
+the `model` input to trade quality for cost. Prefer cataloged aliases: raw
+provider ids get no neutral-param normalization, and allowlist enforcement
+(SAP-2582) is expected to reject them outright.
 
 ## Files
 

--- a/examples/content-repurposing-pipeline/README.md
+++ b/examples/content-repurposing-pipeline/README.md
@@ -14,14 +14,16 @@ repurpose ──▶ graphics ⇄ collectGraphic ──▶ clip ⇄ collectClip �
 
 1. **repurpose** — an LLM (`ctx.sapiom.models.run`) rewrites the source into every
    channel at once: the tweet thread, the LinkedIn post, the newsletter, the
-   pull-quotes to render, and a short video script. `dryRun` stops here with the
-   copy only (no paid media).
+   pull-quotes to render, and a short visual prompt for the teaser clip.
+   `dryRun` stops here with the copy only (no paid media).
 2. **graphics ⇄ collectGraphic** — one quote-graphic image at a time
    (`images.launch`, async): launch the job, pause until the webhook resumes
    `collectGraphic`, record it, then loop back for the next quote or advance.
-3. **clip ⇄ collectClip** — animates the first quote graphic into a short
-   teaser: launches an async image-to-video job (`video.launch`) and pauses on
-   it; the video-generation webhook resumes `collectClip` when the clip is ready.
+3. **clip ⇄ collectClip** — renders a short teaser clip that puts the lead
+   pull-quote on screen: launches an async text-to-video job (`video.launch`,
+   a cataloged semantic alias) with a purpose-written short visual prompt and
+   pauses on it; the video-generation webhook resumes `collectClip` when the
+   clip is ready.
 4. **package** — assembles the whole pack as one markdown document and uploads it
    to file storage (`fileStorage.upload`) for a durable `fileId` + download URL.
 5. **deliver** — fans the pack out to every `deliverTo` recipient
@@ -31,8 +33,8 @@ repurpose ──▶ graphics ⇄ collectGraphic ──▶ clip ⇄ collectClip �
 Input: `{ "source": "<your blog post or transcript>", "title": "..." }`. With no
 `source` at all, the run repurposes a built-in sample post and says so in its output.
 Optional: `audience`, `numQuotes` (default 2, max 4), `deliverTo` (one or more
-recipient emails), `schedule` (a cron string), `model` (an advanced image-to-video
-model id), and `dryRun` (copy only).
+recipient emails), `schedule` (a cron string), `model` (a video model — a Sapiom
+semantic alias like `"veo3-fast"`), and `dryRun` (copy only).
 
 ## Delivery: fan-out per recipient
 
@@ -69,10 +71,12 @@ iterating on the copy, and keep `numQuotes` small for real runs.
 
 ## Model choice
 
-`clip` defaults to a high-quality image-to-video model. Pass a cheaper model via
-the `model` input to trade quality for cost. Model ids are an advanced, evolving
-surface and are passed through verbatim; most callers omit `model` and take the
-default.
+Quote graphics render on `ideogram-v3`, a typography-capable cataloged alias —
+the quote text is drawn INTO the image, so a model with strong text rendering is
+non-negotiable (`gpt-image-2` also fits). `clip` defaults to `kling-standard`, a
+cataloged semantic video alias. Pass a different alias via the `model` input to
+trade quality for cost; only cataloged aliases resolve (raw provider ids get no
+neutral-param normalization and are rejected once allowlist enforcement lands).
 
 ## Files
 

--- a/examples/content-repurposing-pipeline/index.test.mjs
+++ b/examples/content-repurposing-pipeline/index.test.mjs
@@ -39,8 +39,8 @@ test("buildGraphicPrompt always renders the quote text into the prompt", () => {
   assert.match(prompt, /Solid deep-navy background/);
 });
 
-test("buildGraphicPrompt leads with the text directive even when the LLM's art direction is the 293742 background-only ask", () => {
-  // The execution-293742 failure shape: the LLM asked for a text-free background.
+test("buildGraphicPrompt leads with the text directive even when the LLM's art direction is a background-only ask", () => {
+  // The SAP-2781 failure shape: the LLM asked for a text-free background.
   const prompt = buildGraphicPrompt({
     quote: "Small teams ship faster.",
     imagePrompt:
@@ -67,7 +67,7 @@ const NARRATION_SCRIPT =
   "SOLUTION (20-40s): Keep the team small enough to see the whole system.\n" +
   "CTA (40-45s): Read the full post.";
 
-test("isNarrationScript flags the execution-293742 narration script", () => {
+test("isNarrationScript flags a sectioned narration script (the SAP-2781 shape)", () => {
   assert.equal(isNarrationScript(NARRATION_SCRIPT), true);
 });
 
@@ -81,18 +81,24 @@ test("isNarrationScript accepts a short single-shot visual prompt", () => {
 });
 
 test("buildClipPrompt replaces a narration script with a purpose-written visual prompt", () => {
-  const prompt = buildClipPrompt(
-    { ...basePack, videoScript: NARRATION_SCRIPT },
-    "Why small teams ship faster",
-  );
+  const prompt = buildClipPrompt({
+    ...basePack,
+    videoScript: NARRATION_SCRIPT,
+  });
   assert.ok(!prompt.includes("HOOK"), "narration script must not be used");
-  assert.match(prompt, /"q1"/, "the lead pull-quote goes on screen instead");
+  // Deliberately decorative: a general video model renders on-screen text
+  // illegibly, so the quote stays in the graphics and the teaser asks for none.
+  assert.match(prompt, /no text/i);
+  assert.ok(
+    !prompt.includes('"q1"'),
+    "no quote text handed to the video model",
+  );
   assert.ok(prompt.length <= 300);
 });
 
 test("buildClipPrompt keeps a genuinely short visual videoScript", () => {
-  const script = "Slow push-in on the pull-quote, bright and clean, 16:9.";
-  const prompt = buildClipPrompt({ ...basePack, videoScript: script }, "Title");
+  const script = "Slow push-in over a bright gradient, no text, 16:9.";
+  const prompt = buildClipPrompt({ ...basePack, videoScript: script });
   assert.equal(prompt, script);
 });
 
@@ -152,7 +158,6 @@ test("graphics launches a typography-capable cataloged model with the quote in t
 test("clip launches a cataloged semantic alias with neutral params and a short visual prompt", async () => {
   const { context, launches } = mediaContext({
     pack: { ...basePack, videoScript: NARRATION_SCRIPT },
-    title: "Why small teams ship faster",
     graphics: [{ quote: "q1", downloadUrl: "https://files/q1.png" }],
     aspectRatio: "16:9",
   });
@@ -178,7 +183,6 @@ test("clip launches a cataloged semantic alias with neutral params and a short v
 test("clip honors a caller-supplied semantic alias", async () => {
   const { context, launches } = mediaContext({
     pack: basePack,
-    title: "T",
     graphics: [],
     aspectRatio: "16:9",
     model: "veo3-fast",

--- a/examples/content-repurposing-pipeline/index.test.mjs
+++ b/examples/content-repurposing-pipeline/index.test.mjs
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { agent, isReservedAddress } from "./index.ts";
+import {
+  agent,
+  buildClipPrompt,
+  buildGraphicPrompt,
+  isNarrationScript,
+  isReservedAddress,
+} from "./index.ts";
 
 test("flags RFC 2606 reserved domains as undeliverable", () => {
   assert.equal(isReservedAddress("ada@example.com"), true);
@@ -15,6 +21,175 @@ test("flags RFC 2606 reserved domains as undeliverable", () => {
 test("leaves a real address alone", () => {
   assert.equal(isReservedAddress("ada@sapiom.ai"), false);
   assert.equal(isReservedAddress("ada@example.com.co"), false);
+});
+
+// ── SAP-2781: the quote graphic must contain the quote ──────────────────────
+
+test("buildGraphicPrompt always renders the quote text into the prompt", () => {
+  const prompt = buildGraphicPrompt({
+    quote: "Coordination cost is the hidden tax on delivery.",
+    imagePrompt: "Solid deep-navy background, modern sans-serif.",
+  });
+  assert.match(
+    prompt,
+    /"Coordination cost is the hidden tax on delivery\."/,
+    "the exact quote must appear in the launch prompt",
+  );
+  assert.match(prompt, /Render this exact text/i);
+  assert.match(prompt, /Solid deep-navy background/);
+});
+
+test("buildGraphicPrompt leads with the text directive even when the LLM's art direction is the 293742 background-only ask", () => {
+  // The execution-293742 failure shape: the LLM asked for a text-free background.
+  const prompt = buildGraphicPrompt({
+    quote: "Small teams ship faster.",
+    imagePrompt:
+      "Plenty of clean negative space in the center for text overlay, no text in the image.",
+  });
+  assert.ok(
+    prompt.indexOf('"Small teams ship faster."') <
+      prompt.indexOf("negative space"),
+    "the render-the-quote directive must come before the art direction",
+  );
+});
+
+test("buildGraphicPrompt falls back to default art direction when the LLM gave none", () => {
+  const prompt = buildGraphicPrompt({ quote: "Ship it.", imagePrompt: "  " });
+  assert.match(prompt, /"Ship it\."/);
+  assert.match(prompt, /solid dark background/i);
+});
+
+// ── SAP-2781: the clip prompt must be a short visual, never the narration script ──
+
+const NARRATION_SCRIPT =
+  "HOOK (0-5s): Ever wonder why small teams outship big ones?\n" +
+  "PROBLEM (5-20s): Every extra person adds coordination overhead...\n" +
+  "SOLUTION (20-40s): Keep the team small enough to see the whole system.\n" +
+  "CTA (40-45s): Read the full post.";
+
+test("isNarrationScript flags the execution-293742 narration script", () => {
+  assert.equal(isNarrationScript(NARRATION_SCRIPT), true);
+});
+
+test("isNarrationScript accepts a short single-shot visual prompt", () => {
+  assert.equal(
+    isNarrationScript(
+      "Slow push-in on a bold pull-quote over a deep-navy background, subtle light sweep.",
+    ),
+    false,
+  );
+});
+
+test("buildClipPrompt replaces a narration script with a purpose-written visual prompt", () => {
+  const prompt = buildClipPrompt(
+    { ...basePack, videoScript: NARRATION_SCRIPT },
+    "Why small teams ship faster",
+  );
+  assert.ok(!prompt.includes("HOOK"), "narration script must not be used");
+  assert.match(prompt, /"q1"/, "the lead pull-quote goes on screen instead");
+  assert.ok(prompt.length <= 300);
+});
+
+test("buildClipPrompt keeps a genuinely short visual videoScript", () => {
+  const script = "Slow push-in on the pull-quote, bright and clean, 16:9.";
+  const prompt = buildClipPrompt({ ...basePack, videoScript: script }, "Title");
+  assert.equal(prompt, script);
+});
+
+/** Build a media-step context: fake shared state + capturing launch fakes. */
+function mediaContext(shared) {
+  const store = new Map(Object.entries(shared));
+  const launches = { image: [], video: [] };
+  const handle = {
+    dispatch: { resultSignal: "sig", correlationId: "corr" },
+  };
+  return {
+    context: {
+      shared: {
+        get: (key) => store.get(key),
+        set: (key, value) => store.set(key, value),
+      },
+      sapiom: {
+        contentGeneration: {
+          images: {
+            launch: async (input) => {
+              launches.image.push(input);
+              return handle;
+            },
+          },
+          video: {
+            launch: async (input) => {
+              launches.video.push(input);
+              return handle;
+            },
+          },
+        },
+      },
+      logger: { info() {}, warn() {}, error() {}, debug() {} },
+    },
+    launches,
+  };
+}
+
+test("graphics launches a typography-capable cataloged model with the quote in the prompt and the shared aspect ratio", async () => {
+  const { context, launches } = mediaContext({
+    pack: basePack,
+    graphicIndex: 0,
+    aspectRatio: "16:9",
+  });
+
+  const directive = await agent.steps.graphics.run({}, context);
+
+  assert.equal(launches.image.length, 1);
+  const launch = launches.image[0];
+  assert.equal(launch.model, "ideogram-v3");
+  assert.equal(launch.aspectRatio, "16:9");
+  assert.match(launch.prompt, /"q1"/, "the quote must be in the image prompt");
+  assert.equal(launch.storage.visibility, "public");
+  assert.equal(directive.kind, "pause_until_signal");
+});
+
+test("clip launches a cataloged semantic alias with neutral params and a short visual prompt", async () => {
+  const { context, launches } = mediaContext({
+    pack: { ...basePack, videoScript: NARRATION_SCRIPT },
+    title: "Why small teams ship faster",
+    graphics: [{ quote: "q1", downloadUrl: "https://files/q1.png" }],
+    aspectRatio: "16:9",
+  });
+
+  const directive = await agent.steps.clip.run({}, context);
+
+  assert.equal(launches.video.length, 1);
+  const launch = launches.video[0];
+  // A cataloged alias, never a raw provider id — the allowlist (SAP-2582/E8)
+  // rejects uncataloged ids, and only cataloged models normalize neutral params.
+  assert.equal(launch.model, "kling-standard");
+  assert.ok(!launch.model.includes("fal-ai/"));
+  assert.equal(launch.aspectRatio, "16:9");
+  assert.equal(launch.duration, 5);
+  assert.equal(launch.passthrough, undefined);
+  assert.ok(
+    !launch.prompt.includes("HOOK"),
+    "the narration script must never reach the video model",
+  );
+  assert.equal(directive.kind, "pause_until_signal");
+});
+
+test("clip honors a caller-supplied semantic alias", async () => {
+  const { context, launches } = mediaContext({
+    pack: basePack,
+    title: "T",
+    graphics: [],
+    aspectRatio: "16:9",
+    model: "veo3-fast",
+  });
+
+  await agent.steps.clip.run({}, context);
+
+  assert.equal(launches.video[0].model, "veo3-fast");
+  // Duration vocabularies differ per alias (veo3-fast has no 5s) and an
+  // unsupported value is a 400, so a custom alias keeps its catalog default.
+  assert.equal(launches.video[0].duration, undefined);
 });
 
 /** Build a minimal `deliver`-step context with a fake email + file-storage surface. */
@@ -124,6 +299,40 @@ test("deliver skips a reserved placeholder recipient without sinking the batch",
     "reserved-address",
   );
   assert.match(directive.output.note, /1 of 2 recipient\(s\) were delivered/);
+});
+
+test("deliver sends an HTML body that embeds the quote graphics", async () => {
+  const messages = [];
+  const { context } = deliverContext(
+    {
+      title: "Test",
+      schedule: "0 9 * * 1",
+      pack: basePack,
+      graphics: [{ quote: "q1", downloadUrl: "https://files/q1.png" }],
+      clip: { fileId: "clip_1", downloadUrl: "https://files/clip.mp4" },
+      packDownloadUrl: "https://files/pack.md",
+      deliverTo: ["a@sapiom.ai"],
+    },
+    {
+      send: async (_inboxId, msg) => {
+        messages.push(msg);
+        return { messageId: "msg_1" };
+      },
+    },
+  );
+
+  await agent.steps.deliver.run({ markdown: "# pack" }, context);
+
+  assert.equal(messages.length, 1);
+  const msg = messages[0];
+  assert.equal(msg.text, "# pack", "markdown stays as the text/plain fallback");
+  assert.match(
+    msg.html,
+    /<img src="https:\/\/files\/q1\.png"/,
+    "graphics must render inline in the inbox",
+  );
+  assert.match(msg.html, /href="https:\/\/files\/clip\.mp4"/);
+  assert.match(msg.html, /href="https:\/\/files\/pack\.md"/);
 });
 
 test("a failed send is reported per-recipient rather than failing the run", async () => {

--- a/examples/content-repurposing-pipeline/index.test.mjs
+++ b/examples/content-repurposing-pipeline/index.test.mjs
@@ -74,7 +74,7 @@ test("isNarrationScript flags a sectioned narration script (the SAP-2781 shape)"
 test("isNarrationScript accepts a short single-shot visual prompt", () => {
   assert.equal(
     isNarrationScript(
-      "Slow push-in on a bold pull-quote over a deep-navy background, subtle light sweep.",
+      "Slow push-in over a deep-navy gradient, subtle light sweep, no text.",
     ),
     false,
   );
@@ -96,10 +96,21 @@ test("buildClipPrompt replaces a narration script with a purpose-written visual 
   assert.ok(prompt.length <= 300);
 });
 
-test("buildClipPrompt keeps a genuinely short visual videoScript", () => {
+test("buildClipPrompt keeps a genuinely short visual videoScript verbatim when it already forbids text", () => {
   const script = "Slow push-in over a bright gradient, no text, 16:9.";
   const prompt = buildClipPrompt({ ...basePack, videoScript: script });
   assert.equal(prompt, script);
+});
+
+test("buildClipPrompt appends the no-text directive to an accepted script that asks for text", () => {
+  // The LLM path must carry the same guarantee as the fallback: a script that
+  // slips past isNarrationScript but asks for on-screen text still must not
+  // hand a text-rendering job to a general video model.
+  const script =
+    "Slow push-in on a bold pull-quote over a deep-navy background, subtle light sweep.";
+  const prompt = buildClipPrompt({ ...basePack, videoScript: script });
+  assert.match(prompt, /^Slow push-in on a bold pull-quote/);
+  assert.match(prompt, /No text, no watermark\.$/);
 });
 
 /** Build a media-step context: fake shared state + capturing launch fakes. */

--- a/examples/content-repurposing-pipeline/index.ts
+++ b/examples/content-repurposing-pipeline/index.ts
@@ -42,10 +42,11 @@ import { z } from "zod/v4";
  *      graphic, on a typography-capable model (`ideogram-v3`).
  *   3. collectGraphic — record the finished graphic, then loop back to `graphics`
  *      for the next quote, or advance once every quote graphic is in.
- *   4. clip — render a short teaser clip of the lead pull-quote: launch an async
- *      text-to-video job (`video.launch`, cataloged alias) with a purpose-written
- *      short visual prompt (`buildClipPrompt`) and `pauseUntilSignal` on it; the
- *      video-generation webhook resumes `collectClip` when the clip is ready.
+ *   4. clip — render a short decorative teaser clip: launch an async text-to-video
+ *      job (`video.launch`, cataloged alias) with a purpose-written short visual
+ *      prompt (`buildClipPrompt`, deliberately no on-screen text) and
+ *      `pauseUntilSignal` on it; the video-generation webhook resumes
+ *      `collectClip` when the clip is ready.
  *   5. collectClip — record the finished clip.
  *   6. package — assemble the whole pack as one markdown document and upload it to
  *      file storage (`fileStorage.upload`) for a durable `fileId` + download URL.
@@ -91,8 +92,8 @@ interface Pack {
   /** Pull-quotes to render as graphics. */
   quoteGraphics: QuoteGraphicSpec[];
   /**
-   * Short single-shot VISUAL prompt for the teaser clip — what's on screen for
-   * {@link CLIP_SECONDS} seconds, not a narrated timeline. Guarded by
+   * Short single-shot VISUAL prompt for the teaser clip — decorative motion with
+   * no on-screen text, not a narrated timeline. Guarded by
    * {@link buildClipPrompt}: a narration-script-shaped value is replaced with a
    * purpose-written prompt (feeding a 45s narration script to a 5s video model is
    * how SAP-2781's garbled clip was made).
@@ -167,11 +168,12 @@ type Ctx = AgentExecutionContext<Shared>;
 const IMAGE_MODEL = "ideogram-v3";
 /**
  * Default teaser-clip model — a cataloged semantic alias (silent 5s text-to-video),
- * swappable via the `model` input. Raw provider ids are off the menu: the allowlist
- * (SAP-2582/E8) rejects uncataloged ids with `400 unknown_model`, and only cataloged
- * models get neutral-param normalization (`aspectRatio`/`duration`). No cataloged
- * image-to-video alias exists yet, so the teaser renders the quote itself rather
- * than animating a finished graphic.
+ * swappable via the `model` input. Raw provider ids are off the menu: only cataloged
+ * models get neutral-param normalization (`aspectRatio`/`duration`), and allowlist
+ * enforcement (SAP-2582/E8) will reject uncataloged ids with `400 unknown_model`
+ * once it lands. At the time of writing no cataloged alias advertises
+ * `referenceImage` (image-to-video), so the teaser is a decorative text-free motion
+ * piece rather than an animation of a finished graphic.
  */
 const DEFAULT_VIDEO_MODEL = "kling-standard";
 /** Aspect ratio shared by the graphics + teaser clip so the pack reads as one set. */
@@ -231,7 +233,7 @@ export function isReservedAddress(email: string): boolean {
 /**
  * Compose the final launch prompt for one quote graphic. The quote TEXT is the
  * artifact, so the render-the-text directive is built here in code rather than
- * trusted to the LLM: SAP-2781 (execution 293742) shipped a blank navy background
+ * trusted to the LLM: SAP-2781 shipped a blank navy background
  * as the "quote graphic" because the LLM's imagePrompt asked for "negative space
  * for text overlay … no text in the image" and no overlay step exists. The LLM's
  * `imagePrompt` is demoted to art direction appended after the text directive.
@@ -268,17 +270,19 @@ export function isNarrationScript(script: string): boolean {
 
 /**
  * The teaser clip's visual prompt: the LLM's `videoScript` when it is genuinely a
- * short visual prompt, else a purpose-written one that puts the lead pull-quote on
- * screen — never a narration script (see {@link isNarrationScript}).
+ * short visual prompt, else a purpose-written decorative fallback — never a
+ * narration script (see {@link isNarrationScript}). Deliberately NO on-screen
+ * text either way: a general video model renders text illegibly (the garbled-clip
+ * half of SAP-2781), so the quote lives in the typography-model graphics and the
+ * teaser stays abstract.
  */
-export function buildClipPrompt(pack: Pack, title: string): string {
+export function buildClipPrompt(pack: Pack): string {
   const script = pack.videoScript.trim();
   if (script && !isNarrationScript(script)) return script;
-  const quote = pack.quoteGraphics[0]?.quote?.trim() || title;
   return (
-    `A clean ${CLIP_SECONDS}-second social teaser: the pull-quote "${quote}" ` +
-    `in bold, legible type on a solid dark background, slow push-in, subtle ` +
-    `light sweep, no scene changes, no other text.`
+    `Abstract, elegant ${CLIP_SECONDS}-second social teaser: slow camera ` +
+    `push-in over a deep-navy gradient with a soft light sweep and drifting ` +
+    `bokeh particles, a single continuous shot, no text, no watermark.`
   );
 }
 
@@ -311,7 +315,9 @@ function parsePack(
       imagePrompt:
         "Clean, modern, solid deep-navy background, large legible sans-serif type, generous margins, no watermark.",
     })),
-    videoScript: `A short, upbeat teaser for "${title}"; slow push-in on the key quote; ${CLIP_SECONDS}s; bright, clean, social-ready.`,
+    // Decorative and text-free, like buildClipPrompt's fallback — video models
+    // render on-screen text illegibly.
+    videoScript: `Upbeat ${CLIP_SECONDS}-second social teaser: slow push-in over a bright, clean gradient, a single continuous shot, no text, no watermark.`,
   };
   if (!output) return fallback;
   try {
@@ -566,8 +572,10 @@ const repurpose = defineStep({
       "prompt by the pipeline, so never request empty space or say the image " +
       'should contain no text. "videoScript" is a short single-shot visual ' +
       `prompt (under 300 characters) for a ${CLIP_SECONDS}-second silent teaser ` +
-      "clip — describe what is on screen, never a narrated timeline or script " +
-      "sections. Tweets must each be <= 280 characters. " +
+      "clip — describe decorative motion with NO on-screen text (video models " +
+      "render text illegibly; the quote lives in the graphics), never a " +
+      "narrated timeline or script sections. Tweets must each be <= 280 " +
+      "characters. " +
       "Reply with ONLY minified JSON: " +
       '{"tweetThread":string[],"linkedInPost":string,"newsletter":string,' +
       '"quoteGraphics":[{"quote":string,"imagePrompt":string}],"videoScript":string}.';
@@ -720,13 +728,12 @@ const clip = defineStep({
   pause: { signal: VIDEO_RESULT_SIGNAL, resumeStep: "collectClip" },
   async run(_input: unknown, ctx: Ctx) {
     const pack = must(ctx.shared.get("pack"), "pack");
-    const title = must(ctx.shared.get("title"), "title");
     const model = ctx.shared.get("model") ?? DEFAULT_VIDEO_MODEL;
-    const prompt = buildClipPrompt(pack, title);
+    const prompt = buildClipPrompt(pack);
 
     ctx.logger.info("rendering teaser clip", { model });
-    // A short text-to-video teaser that puts the lead pull-quote on screen. The
-    // prompt is a purpose-written single-shot visual (buildClipPrompt) — never the
+    // A short decorative text-to-video teaser. The prompt is a purpose-written
+    // single-shot visual with no on-screen text (buildClipPrompt) — never the
     // narration script — and the model a CATALOGED semantic alias, so the neutral
     // params below are validated against its capabilities and mapped to its wire
     // keys server-side (E4). The previous raw `fal-ai/kling-video/v2.1/pro/…` pin

--- a/examples/content-repurposing-pipeline/index.ts
+++ b/examples/content-repurposing-pipeline/index.ts
@@ -11,6 +11,7 @@ import {
   IMAGE_RESULT_SIGNAL,
   VIDEO_RESULT_SIGNAL,
   fileStorage,
+  type AspectRatio,
   type ImageResultPayload,
   type VideoResultPayload,
 } from "@sapiom/tools";
@@ -32,14 +33,18 @@ import { z } from "zod/v4";
  *
  *   1. repurpose — an LLM (`ctx.sapiom.models.run`) rewrites the source into every
  *      channel at once: the tweet thread, the LinkedIn post, the newsletter, the
- *      pull-quotes to render as graphics, and a short video script.
+ *      pull-quotes to render as graphics, and a short visual prompt for the teaser
+ *      clip.
  *   2. graphics — launch an async quote-graphic image job (`images.launch`) for the
  *      next pull-quote and `pauseUntilSignal` on it; the image-generation webhook
- *      resumes `collectGraphic` when it's ready.
+ *      resumes `collectGraphic` when it's ready. The launch prompt is composed in
+ *      code (`buildGraphicPrompt`) so the quote text is ALWAYS rendered into the
+ *      graphic, on a typography-capable model (`ideogram-v3`).
  *   3. collectGraphic — record the finished graphic, then loop back to `graphics`
  *      for the next quote, or advance once every quote graphic is in.
- *   4. clip — animate the first quote graphic into a short teaser clip: launch an
- *      async image-to-video job (`video.launch`) and `pauseUntilSignal` on it; the
+ *   4. clip — render a short teaser clip of the lead pull-quote: launch an async
+ *      text-to-video job (`video.launch`, cataloged alias) with a purpose-written
+ *      short visual prompt (`buildClipPrompt`) and `pauseUntilSignal` on it; the
  *      video-generation webhook resumes `collectClip` when the clip is ready.
  *   5. collectClip — record the finished clip.
  *   6. package — assemble the whole pack as one markdown document and upload it to
@@ -62,11 +67,16 @@ import { z } from "zod/v4";
  * A run with no `deliverTo` recipients skips every send and returns the pack instead.
  */
 
-/** One pull-quote plus the prompt used to render it as a graphic. */
+/** One pull-quote plus the art direction used to render it as a graphic. */
 interface QuoteGraphicSpec {
   /** The short, punchy line pulled from the source. */
   quote: string;
-  /** Full image prompt for the graphic that frames {@link quote}. */
+  /**
+   * Art direction ONLY (palette, background, typography style) for the graphic that
+   * frames {@link quote}. The quote text itself is composed into the final launch
+   * prompt by {@link buildGraphicPrompt} — never trusted to the LLM, which is how
+   * SAP-2781's blank "quote graphic" shipped.
+   */
   imagePrompt: string;
 }
 
@@ -80,7 +90,13 @@ interface Pack {
   newsletter: string;
   /** Pull-quotes to render as graphics. */
   quoteGraphics: QuoteGraphicSpec[];
-  /** Motion/narration prompt for a short teaser clip. */
+  /**
+   * Short single-shot VISUAL prompt for the teaser clip — what's on screen for
+   * {@link CLIP_SECONDS} seconds, not a narrated timeline. Guarded by
+   * {@link buildClipPrompt}: a narration-script-shaped value is replaced with a
+   * purpose-written prompt (feeding a 45s narration script to a 5s video model is
+   * how SAP-2781's garbled clip was made).
+   */
   videoScript: string;
 }
 
@@ -115,7 +131,7 @@ interface RepurposeInput {
   deliverTo?: string[];
   /** Cron cadence this pipeline is meant to run on (carried + reported). */
   schedule?: string;
-  /** Optional image-to-video model id (advanced), passed through verbatim to `video.launch`. */
+  /** Optional video model — a Sapiom semantic alias (e.g. `"veo3-fast"`); cataloged aliases only. */
   model?: string;
   /** When true, generate the copy only — skip graphics, clip, upload, and email. */
   dryRun?: boolean;
@@ -126,7 +142,7 @@ interface Shared extends Record<string, unknown> {
   audience: string;
   schedule: string;
   deliverTo: string[];
-  aspectRatio: string;
+  aspectRatio: AspectRatio;
   model?: string;
   /** Whether to render the (pricey) teaser clip. Off for the built-in sample run. */
   renderClip: boolean;
@@ -144,13 +160,23 @@ interface Shared extends Record<string, unknown> {
 type Ctx = AgentExecutionContext<Shared>;
 
 /**
- * Default image-to-video model, chosen for quality; swap for a budget model via the
- * `model` input. Model ids are an advanced, evolving surface passed through verbatim.
+ * Quote-graphic image model: a typography-capable CATALOGED semantic alias, because
+ * the quote text is rendered INTO the graphic (`gpt-image-2` also fits; the default
+ * fast image model has weak typography and shipped SAP-2781's blank background).
  */
-const DEFAULT_VIDEO_MODEL = "fal-ai/kling-video/v2.1/pro/image-to-video";
-/** Aspect ratio for the graphics + teaser clip. */
-const ASPECT_RATIO = "16:9";
-/** Teaser clip length in seconds — image-to-video models animate short clips best. */
+const IMAGE_MODEL = "ideogram-v3";
+/**
+ * Default teaser-clip model — a cataloged semantic alias (silent 5s text-to-video),
+ * swappable via the `model` input. Raw provider ids are off the menu: the allowlist
+ * (SAP-2582/E8) rejects uncataloged ids with `400 unknown_model`, and only cataloged
+ * models get neutral-param normalization (`aspectRatio`/`duration`). No cataloged
+ * image-to-video alias exists yet, so the teaser renders the quote itself rather
+ * than animating a finished graphic.
+ */
+const DEFAULT_VIDEO_MODEL = "kling-standard";
+/** Aspect ratio shared by the graphics + teaser clip so the pack reads as one set. */
+const ASPECT_RATIO: AspectRatio = "16:9";
+/** Teaser clip length in seconds — short video models render short clips best. */
 const CLIP_SECONDS = 5;
 /** Default cadence when the caller doesn't pass one: 09:00 every Monday. */
 const DEFAULT_SCHEDULE = "0 9 * * 1";
@@ -202,14 +228,58 @@ export function isReservedAddress(email: string): boolean {
   );
 }
 
-/** Resolve a single graphic's usable URL, re-minting from `fileId` when needed. */
-function resolveGraphicUrl(
-  graphic: Graphic,
-  getPublicUrl: (fileId: string) => string,
-): string {
-  if (graphic.downloadUrl) return graphic.downloadUrl;
-  if (graphic.fileId) return getPublicUrl(graphic.fileId);
-  throw new Error("quote graphic has no usable download URL");
+/**
+ * Compose the final launch prompt for one quote graphic. The quote TEXT is the
+ * artifact, so the render-the-text directive is built here in code rather than
+ * trusted to the LLM: SAP-2781 (execution 293742) shipped a blank navy background
+ * as the "quote graphic" because the LLM's imagePrompt asked for "negative space
+ * for text overlay … no text in the image" and no overlay step exists. The LLM's
+ * `imagePrompt` is demoted to art direction appended after the text directive.
+ */
+export function buildGraphicPrompt(spec: QuoteGraphicSpec): string {
+  const quote = spec.quote.trim();
+  const style = spec.imagePrompt.trim();
+  return (
+    `Typography-forward quote graphic. Render this exact text, large, legible, ` +
+    `and centered, as the visual centerpiece of the image: "${quote}". ` +
+    (style ||
+      "Clean, modern, solid dark background, generous margins, no watermark.")
+  );
+}
+
+/**
+ * True when a videoScript reads like a narration script rather than a short
+ * single-shot visual prompt: timeline markers ("HOOK (0-5s)"), script section
+ * headers, multi-paragraph structure, or simply far too much direction for a
+ * {@link CLIP_SECONDS}-second silent clip. Feeding one to a short video model is
+ * how SAP-2781's garbled clip was made — the model hallucinates text-panel UI
+ * trying to depict the script.
+ */
+export function isNarrationScript(script: string): boolean {
+  return (
+    script.length > 300 ||
+    /\(\s*\d+\s*[-–]\s*\d+\s*s(?:ec(?:onds)?)?\s*\)/i.test(script) ||
+    /\b(HOOK|PROBLEM|SOLUTION|CTA|CALL TO ACTION|NARRATOR|VOICE ?OVER|SCENE \d)\b/.test(
+      script,
+    ) ||
+    script.split("\n").filter((line) => line.trim()).length > 3
+  );
+}
+
+/**
+ * The teaser clip's visual prompt: the LLM's `videoScript` when it is genuinely a
+ * short visual prompt, else a purpose-written one that puts the lead pull-quote on
+ * screen — never a narration script (see {@link isNarrationScript}).
+ */
+export function buildClipPrompt(pack: Pack, title: string): string {
+  const script = pack.videoScript.trim();
+  if (script && !isNarrationScript(script)) return script;
+  const quote = pack.quoteGraphics[0]?.quote?.trim() || title;
+  return (
+    `A clean ${CLIP_SECONDS}-second social teaser: the pull-quote "${quote}" ` +
+    `in bold, legible type on a solid dark background, slow push-in, subtle ` +
+    `light sweep, no scene changes, no other text.`
+  );
 }
 
 /**
@@ -235,9 +305,11 @@ function parsePack(
     ],
     linkedInPost: `${title}\n\n${lead}`,
     newsletter: `## ${title}\n\n${lead}`,
-    quoteGraphics: Array.from({ length: numQuotes }, (_, i) => ({
+    quoteGraphics: Array.from({ length: numQuotes }, () => ({
       quote: fallbackQuote || title,
-      imagePrompt: `A clean, modern quote graphic on a solid background, 16:9, no watermark. Quote ${i + 1}: "${fallbackQuote || title}". Large legible sans-serif type, generous margins.`,
+      // Art direction only — the quote text itself is composed in by buildGraphicPrompt.
+      imagePrompt:
+        "Clean, modern, solid deep-navy background, large legible sans-serif type, generous margins, no watermark.",
     })),
     videoScript: `A short, upbeat teaser for "${title}"; slow push-in on the key quote; ${CLIP_SECONDS}s; bright, clean, social-ready.`,
   };
@@ -334,6 +406,65 @@ function renderPackMarkdown(
   ].join("\n");
 }
 
+/** Escape the small set of characters that would break out of HTML text. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Render the pack as a minimal HTML email so the graphics actually show in the
+ * inbox — a plain-text `[graphic](url)` markdown link never renders (SAP-2781's
+ * fourth finding). Graphics embed as `<img>` permalinks; the clip stays a link
+ * (inline `<video>` is stripped by most mail clients). Kept deliberately small,
+ * mirroring `newsletter-autopilot`'s `renderHtml`.
+ */
+export function renderPackHtml(
+  title: string,
+  pack: Pack,
+  graphics: Graphic[],
+  clip: Clip | null,
+  packDownloadUrl: string | null,
+): string {
+  const section = (heading: string, body: string) =>
+    `<h2 style="font-size:16px;margin:24px 0 8px;">${escapeHtml(heading)}</h2>` +
+    body;
+  const pre = (text: string) =>
+    `<div style="white-space:pre-wrap;line-height:1.5;">${escapeHtml(text)}</div>`;
+  const graphicCards = graphics
+    .map((g) => {
+      const caption = `<figcaption style="font-size:13px;color:#555;margin-top:4px;">“${escapeHtml(g.quote)}”</figcaption>`;
+      const image = g.downloadUrl
+        ? `<img src="${escapeHtml(g.downloadUrl)}" alt="${escapeHtml(g.quote)}" style="max-width:100%;border-radius:8px;" />`
+        : `<em>(graphic unavailable)</em>`;
+      return `<figure style="margin:0 0 16px;">${image}${caption}</figure>`;
+    })
+    .join("");
+  const clipHtml = clip?.downloadUrl
+    ? `<a href="${escapeHtml(clip.downloadUrl)}">Watch the teaser clip</a>`
+    : `<em>(not generated)</em>`;
+  const packLink = packDownloadUrl
+    ? `<p style="margin-top:24px;"><a href="${escapeHtml(packDownloadUrl)}">Download the full pack (markdown)</a></p>`
+    : "";
+  return (
+    `<div style="font-family:system-ui,sans-serif;max-width:640px;margin:0 auto;">` +
+    `<h1 style="font-size:20px;margin:0 0 16px;">Content pack: ${escapeHtml(title)}</h1>` +
+    section("Quote graphics", graphicCards || "<em>(none)</em>") +
+    section("Teaser clip", `<p style="margin:0;">${clipHtml}</p>`) +
+    section(
+      "Tweet thread",
+      pre(pack.tweetThread.map((t, i) => `${i + 1}. ${t}`).join("\n")),
+    ) +
+    section("LinkedIn post", pre(pack.linkedInPost)) +
+    section("Newsletter", pre(pack.newsletter)) +
+    packLink +
+    `</div>`
+  );
+}
+
 /**
  * The entry contract — this agent's public API, and what the dashboard "Run
  * once" form renders its labelled fields from. `source` stays optional so the
@@ -375,7 +506,7 @@ const entryInput = z.object({
     .string()
     .optional()
     .describe(
-      "Optional image-to-video model id, passed through to video.launch.",
+      'Optional video model — a Sapiom semantic alias (e.g. "veo3-fast"). Neutral params like aspectRatio are validated against the resolved model, so a cataloged alias is required.',
     ),
   dryRun: z
     .boolean()
@@ -429,8 +560,14 @@ const repurpose = defineStep({
       "You are a content strategist repurposing one long-form SOURCE (a blog post " +
       "or transcript) into a multi-channel content pack for " +
       `${audience}. Keep the author's meaning; do not invent facts. ` +
-      `Write ${numQuotes} short, punchy pull-quote(s), each with an image prompt ` +
-      "for a clean quote graphic. Tweets must each be <= 280 characters. " +
+      `Write ${numQuotes} short, punchy pull-quote(s). Each quote's "imagePrompt" ` +
+      "is ART DIRECTION ONLY for its quote graphic (palette, background, " +
+      "typography style) — the quote text itself is composed into the image " +
+      "prompt by the pipeline, so never request empty space or say the image " +
+      'should contain no text. "videoScript" is a short single-shot visual ' +
+      `prompt (under 300 characters) for a ${CLIP_SECONDS}-second silent teaser ` +
+      "clip — describe what is on screen, never a narrated timeline or script " +
+      "sections. Tweets must each be <= 280 characters. " +
       "Reply with ONLY minified JSON: " +
       '{"tweetThread":string[],"linkedInPost":string,"newsletter":string,' +
       '"quoteGraphics":[{"quote":string,"imagePrompt":string}],"videoScript":string}.';
@@ -454,7 +591,7 @@ const repurpose = defineStep({
     ctx.shared.set("deliverTo", deliverTo);
     ctx.shared.set("aspectRatio", ASPECT_RATIO);
     if (input.model) ctx.shared.set("model", input.model);
-    // The teaser clip (image-to-video) is the priciest, slowest leg. A run nobody
+    // The teaser clip (video generation) is the priciest, slowest leg. A run nobody
     // configured — the built-in sample — renders the quote graphics but stops short of
     // the clip, so a zero-setup run still fires a real visual artifact without becoming
     // the most expensive one in the gallery. Supply your own `source` and the full pack
@@ -512,9 +649,17 @@ const graphics = defineStep({
       of: pack.quoteGraphics.length,
     });
     const handle = await ctx.sapiom.contentGeneration.images.launch({
-      prompt: quote.imagePrompt,
+      // Composed in code so the quote text is ALWAYS rendered into the graphic —
+      // the LLM's imagePrompt is art direction only (see buildGraphicPrompt).
+      prompt: buildGraphicPrompt(quote),
+      // Typography-capable cataloged alias — the default fast model can't render
+      // legible quote text.
+      model: IMAGE_MODEL,
+      // Neutral param (E4): validated against the resolved model and mapped to its
+      // wire key server-side; keeps the graphics consistent with the 16:9 clip.
+      aspectRatio: must(ctx.shared.get("aspectRatio"), "aspectRatio"),
       count: 1,
-      // Public: quote graphics are linked from the emailed pack below, so they
+      // Public: quote graphics are embedded in the emailed pack below, so they
       // need a durable permalink rather than a presigned URL that expires in ~15min.
       storage: { visibility: "public" },
     });
@@ -575,28 +720,27 @@ const clip = defineStep({
   pause: { signal: VIDEO_RESULT_SIGNAL, resumeStep: "collectClip" },
   async run(_input: unknown, ctx: Ctx) {
     const pack = must(ctx.shared.get("pack"), "pack");
-    const graphicsList = must(ctx.shared.get("graphics"), "graphics");
-    const frame = graphicsList[0];
-    const imageUrl = resolveGraphicUrl(frame, (fileId) =>
-      fileStorage.getPublicUrl(fileId),
-    );
+    const title = must(ctx.shared.get("title"), "title");
     const model = ctx.shared.get("model") ?? DEFAULT_VIDEO_MODEL;
+    const prompt = buildClipPrompt(pack, title);
 
-    ctx.logger.info("animating teaser clip", { from: frame.quote });
-    // Animate the first quote graphic into a short teaser. The shared aspect
-    // ratio keeps it consistent with the graphics.
+    ctx.logger.info("rendering teaser clip", { model });
+    // A short text-to-video teaser that puts the lead pull-quote on screen. The
+    // prompt is a purpose-written single-shot visual (buildClipPrompt) — never the
+    // narration script — and the model a CATALOGED semantic alias, so the neutral
+    // params below are validated against its capabilities and mapped to its wire
+    // keys server-side (E4). The previous raw `fal-ai/kling-video/v2.1/pro/…` pin
+    // got no normalization and will be rejected outright once the allowlist
+    // (SAP-2582/E8) closes.
     const handle = await ctx.sapiom.contentGeneration.video.launch({
       model,
-      prompt: pack.videoScript,
-      // Kling 2.1 Pro image-to-video isn't in the semantic catalog, so pass the raw provider
-      // keys via `passthrough` (the escape hatch) rather than the deprecated `params`.
-      passthrough: {
-        image_url: imageUrl,
-        // Kling 2.1 Pro takes duration only as the string enum "5"/"10" and accepts no seed —
-        // matching scene-to-video's handling of the same model.
-        duration: String(CLIP_SECONDS),
-        aspect_ratio: must(ctx.shared.get("aspectRatio"), "aspectRatio"),
-      },
+      prompt,
+      aspectRatio: must(ctx.shared.get("aspectRatio"), "aspectRatio"),
+      // Pin the teaser length only on the default alias (5s is in its catalog
+      // vocabulary). Duration vocabularies differ per model and an unsupported
+      // value is rejected `400 unsupported_param` (never silently dropped), so a
+      // caller-supplied alias keeps its own catalog default instead.
+      ...(model === DEFAULT_VIDEO_MODEL && { duration: CLIP_SECONDS }),
       // Public: the teaser clip is linked from the emailed pack below, so it
       // needs a durable permalink rather than a presigned URL that expires in ~15min.
       storage: { visibility: "public" },
@@ -792,6 +936,15 @@ const deliver = defineStep({
     // independently, then reduce into one delivered/skipped summary. A bad or
     // reserved address degrades that one recipient rather than sinking the batch.
     const inboxId = await resolveSenderInbox(ctx);
+    // HTML body so the graphics render in the inbox (a plain-text markdown link
+    // never does); the markdown stays as the text/plain fallback.
+    const html = renderPackHtml(
+      title,
+      pack,
+      graphicsList,
+      value,
+      packDownloadUrl,
+    );
     const results: { to: string; messageId?: string; skipped?: string }[] = [];
     for (const to of recipients) {
       if (isReservedAddress(to)) {
@@ -803,6 +956,7 @@ const deliver = defineStep({
           to,
           subject,
           text: markdown,
+          html,
         });
         results.push({ to, messageId: sent.messageId });
       } catch (err) {

--- a/examples/content-repurposing-pipeline/index.ts
+++ b/examples/content-repurposing-pipeline/index.ts
@@ -274,11 +274,17 @@ export function isNarrationScript(script: string): boolean {
  * narration script (see {@link isNarrationScript}). Deliberately NO on-screen
  * text either way: a general video model renders text illegibly (the garbled-clip
  * half of SAP-2781), so the quote lives in the typography-model graphics and the
- * teaser stays abstract.
+ * teaser stays abstract. The system prompt asks the LLM for a text-free visual,
+ * but the guarantee lives here — an accepted script that doesn't already forbid
+ * text gets the directive appended.
  */
 export function buildClipPrompt(pack: Pack): string {
   const script = pack.videoScript.trim();
-  if (script && !isNarrationScript(script)) return script;
+  if (script && !isNarrationScript(script)) {
+    return /\bno (?:on-screen )?text\b/i.test(script)
+      ? script
+      : `${script.replace(/[.\s]+$/, "")}. No text, no watermark.`;
+  }
   return (
     `Abstract, elegant ${CLIP_SECONDS}-second social teaser: slow camera ` +
     `push-in over a deep-navy gradient with a soft light sweep and drifting ` +

--- a/examples/content-repurposing-pipeline/template.json
+++ b/examples/content-repurposing-pipeline/template.json
@@ -48,7 +48,7 @@
           "quoteGraphics": [
             {
               "quote": "Coordination cost, not effort, is the hidden tax on delivery.",
-              "imagePrompt": "A clean, modern quote graphic on a solid deep-blue background, 16:9, no watermark, large legible sans-serif type."
+              "imagePrompt": "Solid deep-blue background, large legible sans-serif type, generous margins, no watermark."
             }
           ],
           "videoScript": "Upbeat teaser: slow push-in on the pull-quote; 5s; bright and clean; social-ready."

--- a/examples/content-repurposing-pipeline/template.json
+++ b/examples/content-repurposing-pipeline/template.json
@@ -51,7 +51,7 @@
               "imagePrompt": "Solid deep-blue background, large legible sans-serif type, generous margins, no watermark."
             }
           ],
-          "videoScript": "Upbeat teaser: slow push-in on the pull-quote; 5s; bright and clean; social-ready."
+          "videoScript": "Upbeat 5-second teaser: slow push-in over a bright, clean gradient, a single continuous shot, no text, no watermark."
         }
       }
     },

--- a/examples/newsletter-autopilot/index.ts
+++ b/examples/newsletter-autopilot/index.ts
@@ -674,6 +674,10 @@ const illustrate = defineStep({
       const result = await ctx.sapiom.contentGeneration.images.create({
         prompt: imagePrompt,
         count: 1,
+        // Neutral param (E4): a header banner should be landscape by intent, not
+        // by the model's default (the SAP-2781 lesson — an unpinned ratio ships
+        // whatever the provider felt like).
+        aspectRatio: "16:9",
         storage: { visibility: "public" },
       });
       const img = result.images?.[0];

--- a/examples/personalized-media-at-scale/index.ts
+++ b/examples/personalized-media-at-scale/index.ts
@@ -141,6 +141,37 @@ function must<T>(v: T | undefined, name: string): T {
   return v;
 }
 
+/** Escape the small set of characters that would break out of HTML text. */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * Minimal HTML email body so the personalized asset actually shows in the inbox
+ * (the SAP-2781 lesson: a bare URL in a plain-text body renders as a link at
+ * best). An image embeds inline; a clip stays a link — inline `<video>` is
+ * stripped by most mail clients. The plain-text body remains as the fallback.
+ */
+function renderAssetHtml(asset: Asset): string {
+  const media = !asset.downloadUrl
+    ? `<em>(asset link unavailable)</em>`
+    : asset.medium === "image"
+      ? `<img src="${escapeHtml(asset.downloadUrl)}" alt="A personalized image for ${escapeHtml(asset.name)}" style="max-width:100%;border-radius:8px;" />`
+      : `<a href="${escapeHtml(asset.downloadUrl)}">Watch your personalized clip</a>`;
+  return (
+    `<div style="font-family:system-ui,sans-serif;max-width:640px;margin:0 auto;">` +
+    `<p>Hi ${escapeHtml(asset.name)},</p>` +
+    `<p>We put together a personalized ${escapeHtml(asset.medium)} just for you:</p>` +
+    media +
+    `<p>— The team</p>` +
+    `</div>`
+  );
+}
+
 /**
  * Build the personalized generation prompt for a row. Deterministic on purpose —
  * this template generates media, not copy, so no LLM is in the loop. Swap in
@@ -629,6 +660,9 @@ const deliver = defineStep({
           to: asset.email,
           subject,
           text,
+          // HTML body so an image renders inline in the inbox; `text` stays as
+          // the plain-text fallback.
+          html: renderAssetHtml(asset),
         });
         results.push({
           recipientId: asset.recipientId,

--- a/examples/scene-to-video/index.ts
+++ b/examples/scene-to-video/index.ts
@@ -133,6 +133,12 @@ const SAMPLE_SCENE =
 /**
  * Default image-to-video model. Kling 2.1 Pro is chosen for quality (the v1
  * default); swap for a budget model (Wan i2v, Seedance i2v) via the `model` input.
+ *
+ * ⚠️ Raw provider id, uncataloged (SAP-2781 audit): the semantic video catalog has
+ * no image-to-video alias yet, and this template's keyframe→animate design needs
+ * one — so this pin gets no neutral-param normalization and WILL be rejected with
+ * `400 unknown_model` once allowlist enforcement (SAP-2582/E8) closes. Repoint to
+ * the image-to-video semantic alias the moment the catalog grows one.
  */
 const DEFAULT_VIDEO_MODEL = "fal-ai/kling-video/v2.1/pro/image-to-video";
 /** Video merge model used by `stitch` — concats the clips into one video. */


### PR DESCRIPTION
Fixes [SAP-2781](https://linear.app/sapiom/issue/SAP-2781/templates-content-pack-ships-a-blank-quote-graphic-no-text-ever-added) — a follow-up in the media-reliability epic (SAP-2787).

## What was wrong (evidence on the ticket)

The platform worked end to end; the template was the bug:

1. **The quote text never got added.** The LLM's `imagePrompt` asked for a background with *"no text in the image"*, no compositing step exists, and the blank navy background shipped as the finished "quote graphic".
2. **The clip prompt was the wrong artifact.** The full 45-second narration script (`videoScript`) went to a 5-second image-to-video model with the blank background as keyframe → hallucinated gibberish text panels.
3. **Aspect ratio ignored** — no `aspectRatio` on the image launch, and the raw uncataloged Kling id meant no param normalization ever ran.
4. **Plain-text email** — even a good graphic never rendered in an inbox.

## The fix (`examples/content-repurposing-pipeline`)

- **The quote is now composed into the image launch prompt in code** (`buildGraphicPrompt`), never trusted to the LLM, and graphics render on the typography-capable cataloged alias **`ideogram-v3`** instead of the default fast model. The LLM's `imagePrompt` is demoted to art direction only (system prompt updated to match).
- **The clip is a cataloged semantic alias** (**`kling-standard`**, silent 5s text-to-video) driven by a **purpose-written short visual prompt** (`buildClipPrompt`); `isNarrationScript` guards against narration-shaped LLM output. The teaser is deliberately **decorative and text-free** — general video models render on-screen text illegibly, so the quote lives in the typography-model graphics and the clip stays abstract. This also removes the raw `fal-ai/kling-video/v2.1/pro/image-to-video` pin that allowlist enforcement (**SAP-2582/E8**) will reject with `400 unknown_model` — a prerequisite for closing the allowlist.
- **`aspectRatio: "16:9"`** set on the image launch and shared with the clip (neutral E4 params, validated server-side). `duration` is pinned only on the default alias, since duration vocabularies differ per model and an unsupported value is a 400.
- **HTML email body** (`renderPackHtml`) so the graphics embed inline in the inbox; markdown stays as the text/plain fallback.

Note: the clip is now **text-to-video** rather than image-to-video — at the time of writing the semantic catalog has no alias advertising `referenceImage` (verified against the platform's video model catalog on its latest default branch), so "animate the finished graphic" is not currently expressible without a raw provider id.

## Tests (intent asserted, per the ticket)

17 tests pass (`tsx --test`): the quote must appear in the image launch prompt; a narration-shaped script must never reach the video model; the clip prompt must request no on-screen text; the model must be a cataloged alias (no `fal-ai/` ids, no `passthrough`); neutral params must be set; the email must embed the graphics as `<img>`.

## Sibling media template audit (second commit)

- **personalized-media-at-scale** — added an HTML body so the personalized image renders inline (was a bare URL in plain text). Video path already used a cataloged alias + neutral `aspectRatio`; its no-text prompts are deliberate (decorative marketing media).
- **newsletter-autopilot** — pinned the header banner to `aspectRatio: "16:9"`. Already sends HTML; the no-text header illustration is intentional.
- **scene-to-video** — its keyframe→animate design *requires* image-to-video, which the catalog does not offer yet, so the raw Kling pin stays but is now explicitly flagged at the pin as an SAP-2582/E8 hard break to repoint the moment the catalog grows an i2v alias.

## Verification

- `tsc --noEmit` clean on all three touched examples
- `tsx --test index.test.mjs`: 17/17 pass
- `pnpm examples:check` + `pnpm terminology:check` pass
- Prettier clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W2bwKiedonBzeqRH3Um2o8