### PR TITLE
feat(tools): served class/lane disclosure, structured output, label ergonomics (SAP-2764)

### DIFF
--- a/.changeset/served-class-lane-disclosure.md
+++ b/.changeset/served-class-lane-disclosure.md
@@ -1,0 +1,12 @@
+---
+"@sapiom/tools": minor
+---
+
+Execution results now expose the server's serving disclosure, in SKU vocabulary — plus structured-output and routing-label ergonomics for `llm.run`. Reissues #673 under the corrected SAP-2764 contract (`servedClass`/`lane`, not the earlier draft's `servedModel`/provider `costUsd`).
+
+- `models.run` (`ModelRunOutcome`) and `models.coding.run` (`CodingRunOutcome`): new optional `servedClass` + `lane` (wire `served_class`, `lane`) — the billing class (size) the run's label resolved to and the lane it executed in. Never a model or provider id. `undefined`/`null` on older servers or when coding cannot observe it — never fabricated.
+- `llm.run` / `llm.redeem` / `llm.callSession`: new `LlmDisclosure` type describing the `served_class` / `lane` fields the server injects top-level into raw `/v2` non-streaming response bodies, plus a `readDisclosure()` helper returning the camel-cased `LlmDisclosureResult`. The response `model` field is unchanged and keeps echoing the requested label.
+- `llm.run` gains an optional `output: { name, schema }` field — the blessed tool-calling pattern for structured output, automated: it appends a forced tool call to the request and forces `tool_choice` onto it. `run`'s return type is unchanged either way (still the verbatim response); read the parsed value with the new `structuredOf()` helper. A new `textOf()` helper reads the plain-text reply, correctly skipping a `thinking` block that may precede it.
+- `model`/`label` fields across `llm.run`, `llm.submit`, `llm.createSession`, `models.run`, and `models.coding.run` are now typed as a soft union (`"smart" | (string & {})`, lint-safely spelled) for autocomplete, with JSDoc settled on "routing label" terminology: omit to let the platform choose, `"smart"` if you must pin, a raw provider model id is never honored.
+
+All additions are optional: existing consumers compile and run unchanged. On results from older servers the mappers and `readDisclosure` return `servedClass`/`lane` as `null` (unknown).

--- a/packages/tools/src/llm/disclosure.spec.ts
+++ b/packages/tools/src/llm/disclosure.spec.ts
@@ -1,0 +1,36 @@
+import { readDisclosure } from "./index.js";
+
+// Serving disclosure on raw /v2 non-streaming bodies: `served_class` + `lane`
+// are injected top-level by the gateway (SKU vocabulary — never a model or
+// provider id, never a provider price); `readDisclosure` camelCases them and
+// treats anything missing/malformed as unknown (null) — old-server safe.
+describe("llm.readDisclosure", () => {
+  it("reads the injected disclosure fields off a /v2 response body", () => {
+    const body = {
+      type: "message",
+      model: "smart", // the echo stays the label
+      served_class: "medium",
+      lane: "run_now",
+    };
+    expect(readDisclosure(body)).toEqual({
+      servedClass: "medium",
+      lane: "run_now",
+    });
+  });
+
+  it("returns nulls for responses from servers that do not disclose (additive-safe)", () => {
+    expect(readDisclosure({ type: "message", model: "smart" })).toEqual({
+      servedClass: null,
+      lane: null,
+    });
+    expect(readDisclosure(null)).toEqual({ servedClass: null, lane: null });
+    expect(readDisclosure(undefined)).toEqual({ servedClass: null, lane: null });
+  });
+
+  it("treats malformed values as unknown, never fabricates", () => {
+    expect(readDisclosure({ served_class: "", lane: 42 })).toEqual({
+      servedClass: null,
+      lane: null,
+    });
+  });
+});

--- a/packages/tools/src/llm/index.ts
+++ b/packages/tools/src/llm/index.ts
@@ -61,6 +61,16 @@ import type { DispatchHandle } from "../dispatch.js";
 const DEFAULT_BASE_URL = resolveServiceUrl("llm", process.env.SAPIOM_LLM_URL);
 
 /**
+ * A routing label — the vocabulary the gateway resolves against its
+ * configured label set (never a raw provider model id). `"smart"` is
+ * suggested for autocomplete; any other string is still accepted, since the
+ * full label set is configured server-side. `Record<never, never>` is the
+ * lint-safe spelling of the `string & {}` idiom (see
+ * `content-generation/index.ts`'s `LiteralUnion`).
+ */
+export type RoutingLabel = "smart" | (string & Record<never, never>);
+
+/**
  * Capability-stable signal a routed job fires when it reaches a terminal state
  * (granted OR failed — it carries the result either way, the resumed step
  * branches). An agent step paused on a submit handle resumes on this; it is the
@@ -92,8 +102,13 @@ export interface LlmRunSpec {
    * is superseded by the routing decision (set the route label via `model` below).
    */
   request: Record<string, unknown>;
-  /** Route label (e.g. `"smart"`, `"small"`, `"medium"`, `"large"`). Omit → the gateway's default label. */
-  model?: string;
+  /**
+   * Routing label (e.g. `"smart"`, `"small"`, `"medium"`, `"large"`). The
+   * gateway resolves it against its configured label set — a raw provider
+   * model id is never honored. Omit to let the gateway choose (the
+   * recommended default); pass `"smart"` if you need to pin explicitly.
+   */
+  model?: RoutingLabel;
   /**
    * Guarantee an answer by spilling to the label's declared fallback when the
    * preferred capacity is saturated (never-429). DEFAULTS TO TRUE here: the
@@ -105,6 +120,24 @@ export interface LlmRunSpec {
   neverFail?: boolean;
   /** Explicit complexity/capacity weight override (gateway clamps to its bounds). */
   complexity?: number;
+  /**
+   * Structured-output convenience — the blessed pattern (a forced tool call),
+   * automated: setting this appends a tool named `name` (schema `schema`) to
+   * `request.tools` and forces `tool_choice` onto it. {@link run}'s return
+   * type is unchanged either way (still the verbatim response); read the
+   * parsed value with {@link structuredOf}. Omit and build `request.tools` /
+   * `tool_choice` yourself for anything this convenience doesn't cover (e.g.
+   * more than one candidate tool).
+   */
+  output?: LlmStructuredOutputSpec;
+}
+
+/** {@link LlmRunSpec.output} — see there for what setting it does. */
+export interface LlmStructuredOutputSpec {
+  /** Tool name the model is forced to call; read back with {@link structuredOf}'s `name`. */
+  name: string;
+  /** JSON Schema (the Anthropic Messages `input_schema` shape) the model's tool call must satisfy. */
+  schema: Record<string, unknown>;
 }
 
 export interface LlmSubmitSpec {
@@ -114,8 +147,13 @@ export interface LlmSubmitSpec {
    * `ctx.shared`) and re-send it to `redeem` when the grant arrives.
    */
   request: Record<string, unknown>;
-  /** Route label (e.g. `"smart"`, `"small"`, `"medium"`, `"large"`). Omit → the gateway's default label. */
-  model?: string;
+  /**
+   * Routing label (e.g. `"smart"`, `"small"`, `"medium"`, `"large"`). The
+   * gateway resolves it against its configured label set — a raw provider
+   * model id is never honored. Omit to let the gateway choose (the
+   * recommended default); pass `"smart"` if you need to pin explicitly.
+   */
+  model?: RoutingLabel;
   /**
    * How long the caller will wait, in minutes. Omitted or <= 0 → run-now (top
    * priority, immediate escalation). The gateway orders jobs earliest-deadline-
@@ -304,6 +342,109 @@ function submitHeaders(spec: LlmSubmitSpec, resumeToken: string | undefined) {
 }
 
 /**
+ * Serving-disclosure fields as they appear on raw `/v2` non-streaming response
+ * bodies — snake_case, injected top-level by the server next to `model`, in
+ * the same casing as the rest of the raw body {@link run} returns. The
+ * response `model` field keeps echoing the requested label; these dedicated
+ * fields report what the request resolved to, in the SKU vocabulary the
+ * platform bills in (billing class/size × lane) — never a model or provider
+ * id, and never a provider price. Absent = the server did not disclose
+ * (older server, resolution failure) — treat as unknown, never assume a
+ * value. (Streaming responses carry the same data as the
+ * `x-sapiom-served-class` / `x-sapiom-lane` response headers instead, which
+ * this module does not read.)
+ */
+export interface LlmDisclosure {
+  /** The billing class (size) the request's label resolved to. */
+  served_class?: string;
+  /** The billing lane the call executed in (e.g. `"run_now"`). */
+  lane?: string;
+}
+
+/** Camel-cased view of {@link LlmDisclosure}; `null` = the server did not disclose. */
+export interface LlmDisclosureResult {
+  servedClass: string | null;
+  lane: string | null;
+}
+
+/**
+ * Read the serving disclosure off a raw `/v2` response body ({@link run} /
+ * {@link redeem} / {@link callSession} results), camelCased. Missing or
+ * malformed fields come back `null` (unknown) — safe on responses from older
+ * servers, which never had this shape.
+ */
+export function readDisclosure(result: unknown): LlmDisclosureResult {
+  const body = (result ?? {}) as LlmDisclosure;
+  return {
+    servedClass: typeof body.served_class === "string" && body.served_class ? body.served_class : null,
+    lane: typeof body.lane === "string" && body.lane ? body.lane : null,
+  };
+}
+
+/**
+ * A single Anthropic Messages content block, narrowed to the fields
+ * {@link textOf} and {@link structuredOf} read. The real union has more
+ * variants (e.g. `thinking`, `redacted_thinking`, `tool_result`); this module
+ * only ever reads `type`, and — depending on that — `text` or `input`/`name`.
+ */
+interface AnthropicContentBlock {
+  type: string;
+  text?: string;
+  name?: string;
+  input?: unknown;
+}
+
+function isContentBlock(value: unknown): value is AnthropicContentBlock {
+  return typeof value === "object" && value !== null && typeof (value as { type?: unknown }).type === "string";
+}
+
+function contentBlocksOf(response: unknown): AnthropicContentBlock[] {
+  const content = (response as { content?: unknown } | null | undefined)?.content;
+  return Array.isArray(content) ? content.filter(isContentBlock) : [];
+}
+
+/**
+ * Extract the response's text block, from a raw {@link run} / {@link redeem} /
+ * {@link callSession} result. Some labels return a `thinking` block ahead of
+ * the text — this skips it (and any other non-`text` block) rather than
+ * assuming the first content entry is the answer. Returns `undefined` when
+ * the response has no text block (e.g. a pure tool-use turn) — never guesses.
+ */
+export function textOf(response: unknown): string | undefined {
+  return contentBlocksOf(response).find((block) => block.type === "text")?.text;
+}
+
+/**
+ * Structured-output convenience for {@link LlmRunSpec.output}: extracts the
+ * matching `tool_use` block's `input`, typed as `TSchema`. Pass `name` to
+ * disambiguate when the request declared more than one tool (e.g. more than
+ * one `output`-shaped call in the same conversation); omitted, the first
+ * `tool_use` block wins. Returns `undefined` when no matching block is
+ * present — never guesses at a shape the response didn't actually return.
+ */
+export function structuredOf<TSchema = unknown>(response: unknown, name?: string): TSchema | undefined {
+  const block = contentBlocksOf(response).find(
+    (b) => b.type === "tool_use" && (name === undefined || b.name === name),
+  );
+  return block?.input as TSchema | undefined;
+}
+
+/**
+ * Build the wire request `run` sends when {@link LlmRunSpec.output} is set:
+ * appends a tool named `output.name` (schema `output.schema`) to any
+ * caller-declared tools, and forces `tool_choice` onto it — the blessed
+ * tool-calling pattern for structured output, automated.
+ */
+function withStructuredOutput(request: Record<string, unknown>, output: LlmStructuredOutputSpec): Record<string, unknown> {
+  const existingTools = Array.isArray(request.tools) ? request.tools : [];
+  return {
+    ...request,
+    tools: [...existingTools, { name: output.name, input_schema: output.schema }],
+    tool_choice: { type: "tool", name: output.name },
+  };
+}
+
+/**
  * Synchronous routed call: `POST /v2/anthropic/v1/messages` on the x402 edge (Surface A —
  * the PATH is the wire shape; this client speaks Anthropic Messages). The gateway
  * selects the deployment (the label via `spec.model`, else the default label), admits it
@@ -311,6 +452,13 @@ function submitHeaders(spec: LlmSubmitSpec, resumeToken: string | undefined) {
  * and returns the completion inline. Billing settles against the caller's
  * Sapiom API key at the edge (identity mode; the default `x-sapiom-api-key`
  * header is exactly what the edge's identity guard reads).
+ *
+ * The response `model` echoes the requested label; the body additionally
+ * carries the serving disclosure ({@link LlmDisclosure}: `served_class` +
+ * `lane`) — read it with {@link readDisclosure}. For a plain text reply, read
+ * it with {@link textOf} rather than indexing `content[0]` (a `thinking`
+ * block can precede the text). For structured output, set `spec.output`
+ * (forces a tool call) and read the result with {@link structuredOf}.
  */
 export async function run<T = Record<string, unknown>>(
   spec: LlmRunSpec,
@@ -324,9 +472,10 @@ export async function run<T = Record<string, unknown>>(
   headers["x-sapiom-never-fail"] = String(spec.neverFail ?? true);
   if (spec.complexity !== undefined)
     headers["x-sapiom-complexity"] = String(spec.complexity);
+  const request = spec.output ? withStructuredOutput(spec.request, spec.output) : spec.request;
   return transport.request<T>(`${baseUrl}/v2/anthropic/v1/messages`, {
     method: "POST",
-    body: JSON.stringify(spec.request),
+    body: JSON.stringify(request),
     headers,
   });
 }
@@ -386,8 +535,10 @@ export async function submit(
  * edge settles it against the caller's account ("payment at redemption",
  * SAP-1496), and the gateway routes it to the exact deployment the grant
  * reserved (single-use, consumed atomically; the response `model` carries the
- * user-facing label). `request.model` may be anything — the reserved deployment
- * wins. Returns the parsed LLM response.
+ * user-facing label, and the body carries the serving disclosure —
+ * {@link LlmDisclosure}, read with {@link readDisclosure}). `request.model`
+ * may be anything — the reserved deployment wins. Returns the parsed LLM
+ * response.
  */
 export async function redeem<T = Record<string, unknown>>(
   link: LlmGrantLink,
@@ -436,10 +587,18 @@ const SESSION_SETTLED = new Set<LlmSessionState>([
 ]);
 
 export interface LlmSessionCreateSpec {
-  /** Route label (e.g. `"smart"`, `"large"`). Mutually exclusive with `model`; omit both → the gateway's default label. */
-  label?: string;
-  /** Pin an exact Sapiom-supported alias. Mutually exclusive with `label`. */
-  model?: string;
+  /**
+   * Routing label (e.g. `"smart"`, `"large"`) — resolved against the
+   * gateway's configured label set; a raw provider model id is never
+   * honored. Mutually exclusive with `model`; omit both to let the gateway
+   * choose (the recommended default).
+   */
+  label?: RoutingLabel;
+  /**
+   * Pin an exact Sapiom-supported alias rather than a resolved label.
+   * Mutually exclusive with `label`.
+   */
+  model?: RoutingLabel;
   /** How long you'll wait for capacity, in minutes. Omitted or <= 0 → run-now. */
   deadlineMinutes?: number;
   /**
@@ -615,7 +774,9 @@ export async function getSession(
  * terminals return 410 (`session_expired` / `session_exhausted`); each call is
  * billed individually against the caller's Sapiom key, exactly like `run`.
  * `request.model` may be anything — the session's reserved deployment wins,
- * and the response `model` carries the user-facing label.
+ * and the response `model` carries the user-facing label (the body also
+ * carries the serving disclosure — {@link LlmDisclosure}, read with
+ * {@link readDisclosure}).
  */
 export async function callSession<T = Record<string, unknown>>(
   session: LlmSessionHandle | LlmSession | string,

--- a/packages/tools/src/llm/structured-output.spec.ts
+++ b/packages/tools/src/llm/structured-output.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * llm.run's structured-output convenience (`spec.output`) and the `textOf` /
+ * `structuredOf` extraction helpers — the automated form of the blessed
+ * tool-calling pattern for a single routed call.
+ */
+import { createClient } from "../index.js";
+import { structuredOf, textOf } from "./index.js";
+
+interface Captured {
+  url?: string;
+  headers?: Record<string, string>;
+  body?: string;
+}
+
+function fakeDirectFetch(cap: Captured, response: Record<string, unknown>): typeof globalThis.fetch {
+  return (async (url: string, init: RequestInit = {}) => {
+    cap.url = url;
+    cap.headers = init.headers as Record<string, string>;
+    cap.body = init.body as string;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => response,
+      text: async () => "",
+    } as unknown as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+describe("textOf", () => {
+  it("extracts the text block", () => {
+    const response = { content: [{ type: "text", text: "hello" }] };
+    expect(textOf(response)).toBe("hello");
+  });
+
+  it("skips a thinking block ahead of the text block", () => {
+    const response = {
+      content: [
+        { type: "thinking", thinking: "reasoning about the answer…" },
+        { type: "text", text: "the answer" },
+      ],
+    };
+    expect(textOf(response)).toBe("the answer");
+  });
+
+  it("returns undefined when there is no text block (e.g. a pure tool-use turn)", () => {
+    const response = { content: [{ type: "tool_use", name: "record", input: {} }] };
+    expect(textOf(response)).toBeUndefined();
+  });
+
+  it("returns undefined for a malformed or missing response, never throws", () => {
+    expect(textOf(null)).toBeUndefined();
+    expect(textOf(undefined)).toBeUndefined();
+    expect(textOf({})).toBeUndefined();
+    expect(textOf({ content: "not an array" })).toBeUndefined();
+  });
+});
+
+describe("structuredOf", () => {
+  it("extracts the tool_use block's input", () => {
+    const response = {
+      content: [{ type: "tool_use", name: "record_person", input: { name: "Priya", age: 34 } }],
+    };
+    expect(structuredOf(response)).toEqual({ name: "Priya", age: 34 });
+  });
+
+  it("disambiguates by tool name when more than one tool_use block is present", () => {
+    const response = {
+      content: [
+        { type: "tool_use", name: "other_tool", input: { wrong: true } },
+        { type: "tool_use", name: "record_person", input: { name: "Priya" } },
+      ],
+    };
+    expect(structuredOf(response, "record_person")).toEqual({ name: "Priya" });
+  });
+
+  it("returns undefined when no tool_use block matches", () => {
+    const response = { content: [{ type: "text", text: "no tool call here" }] };
+    expect(structuredOf(response)).toBeUndefined();
+    expect(structuredOf(response, "record_person")).toBeUndefined();
+  });
+});
+
+describe("llm.run — structured-output convenience (spec.output)", () => {
+  const SCHEMA = {
+    type: "object",
+    properties: { name: { type: "string" }, age: { type: "number" } },
+    required: ["name", "age"],
+  };
+
+  it("injects the tool + forces tool_choice, appended to any caller-declared tools", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeDirectFetch(cap, { ok: true }) });
+    await sapiom.llm.run({
+      request: {
+        messages: [{ role: "user", content: "extract the person" }],
+        max_tokens: 256,
+        tools: [{ name: "unrelated_tool", input_schema: { type: "object" } }],
+      },
+      output: { name: "record_person", schema: SCHEMA },
+    });
+    const body = JSON.parse(cap.body ?? "{}");
+    expect(body.tools).toEqual([
+      { name: "unrelated_tool", input_schema: { type: "object" } },
+      { name: "record_person", input_schema: SCHEMA },
+    ]);
+    expect(body.tool_choice).toEqual({ type: "tool", name: "record_person" });
+  });
+
+  it("does not mutate the caller's original request object", async () => {
+    const cap: Captured = {};
+    const sapiom = createClient({ apiKey: "k", fetch: fakeDirectFetch(cap, { ok: true }) });
+    const request = { messages: [{ role: "user", content: "extract" }], max_tokens: 256 };
+    await sapiom.llm.run({ request, output: { name: "record_person", schema: SCHEMA } });
+    expect(request).not.toHaveProperty("tools");
+    expect(request).not.toHaveProperty("tool_choice");
+  });
+
+  it("leaves the request untouched, and the response type unchanged, when output is omitted", async () => {
+    const cap: Captured = {};
+    const completion = { id: "msg_1", type: "message", content: [{ type: "text", text: "hi" }] };
+    const sapiom = createClient({ apiKey: "k", fetch: fakeDirectFetch(cap, completion) });
+    const request = { messages: [{ role: "user", content: "hi" }], max_tokens: 64 };
+    const res = await sapiom.llm.run({ request });
+    expect(JSON.parse(cap.body ?? "{}")).toEqual(request);
+    expect(res).toEqual(completion);
+  });
+
+  it("round-trips end to end: structuredOf reads the value out of the returned response", async () => {
+    const cap: Captured = {};
+    const completion = {
+      id: "msg_1",
+      type: "message",
+      content: [{ type: "tool_use", name: "record_person", input: { name: "Priya", age: 34 } }],
+    };
+    const sapiom = createClient({ apiKey: "k", fetch: fakeDirectFetch(cap, completion) });
+    const res = await sapiom.llm.run({
+      request: { messages: [{ role: "user", content: "extract" }], max_tokens: 256 },
+      output: { name: "record_person", schema: SCHEMA },
+    });
+    expect(structuredOf<{ name: string; age: number }>(res, "record_person")).toEqual({
+      name: "Priya",
+      age: 34,
+    });
+  });
+});

--- a/packages/tools/src/models/coding-result.spec.ts
+++ b/packages/tools/src/models/coding-result.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * coding.run — terminal wire-result mapping, including the serving-disclosure
+ * fields. Coding servers currently emit `served_class`/`lane` as null (they
+ * cannot observe class/lane yet) and older servers omit them entirely — both
+ * must map to `null` (unknown), never a fabricated value.
+ */
+import { createClient } from "../index.js";
+
+function fakeCodingFetch(wireResult: Record<string, unknown>): typeof globalThis.fetch {
+  return (async (_url: string, init: RequestInit = {}) => {
+    const isPost = (init.method ?? "GET") === "POST";
+    const attributes = isPost
+      ? { status: "pending" }
+      : {
+          status: "completed",
+          summary: "done",
+          result: wireResult,
+          error: null,
+        };
+    return {
+      ok: true,
+      status: isPost ? 202 : 200,
+      json: async () => ({
+        data: {
+          id: "run-xyz",
+          attributes,
+          relationships: { execution_environment: { data: { id: "env-1" } } },
+        },
+      }),
+      text: async () => "",
+    } as unknown as Response;
+  }) as unknown as typeof globalThis.fetch;
+}
+
+const BASE_WIRE = {
+  success: true,
+  turns: 2,
+  model_used: "smart",
+  duration_ms: 900,
+  tool_call_count: 3,
+  usage: { input_tokens: 10, output_tokens: 5 },
+};
+
+describe("coding.run — terminal result mapping", () => {
+  it("maps null disclosure fields (current coding servers) to null", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeCodingFetch({ ...BASE_WIRE, served_class: null, lane: null }),
+    });
+    const result = await sapiom.models.coding.run({ task: "do a thing" });
+    expect(result.status).toBe("completed");
+    expect(result.result?.modelUsed).toBe("smart");
+    expect(result.result?.servedClass).toBeNull();
+    expect(result.result?.lane).toBeNull();
+  });
+
+  it("maps absent disclosure fields (older servers) to null, existing fields untouched", async () => {
+    const sapiom = createClient({ apiKey: "k", fetch: fakeCodingFetch(BASE_WIRE) });
+    const result = await sapiom.models.coding.run({ task: "do a thing" });
+    expect(result.result?.servedClass).toBeNull();
+    expect(result.result?.lane).toBeNull();
+    expect(result.result?.toolCallCount).toBe(3);
+    expect(result.result?.usage.inputTokens).toBe(10);
+  });
+
+  it("passes disclosure values through when a server reports them", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeCodingFetch({ ...BASE_WIRE, served_class: "medium", lane: "run_now" }),
+    });
+    const result = await sapiom.models.coding.run({ task: "do a thing" });
+    expect(result.result?.servedClass).toBe("medium");
+    expect(result.result?.lane).toBe("run_now");
+  });
+});

--- a/packages/tools/src/models/index.ts
+++ b/packages/tools/src/models/index.ts
@@ -61,9 +61,24 @@ export interface CodingRunSpec {
   workingDirectory?: string;
   /** Keep the sandbox alive after the run finishes. SDK default: true (the mesh needs it). */
   keepSandbox?: boolean;
-  /** Override the model the agent runs on. */
-  model?: string;
+  /**
+   * Routing label for the coding agent's LLM calls (e.g. `"smart"`). The
+   * platform resolves it against its configured label set — a raw provider
+   * model id is never honored. Omit to let the platform choose (the
+   * recommended default); pass `"smart"` if you need to pin explicitly.
+   */
+  model?: ModelLabel;
 }
+
+/**
+ * A routing label — the vocabulary the platform resolves against its
+ * configured label set (never a raw provider model id). `"smart"` is
+ * suggested for autocomplete; any other string is still accepted, since the
+ * full label set is configured server-side. `Record<never, never>` is the
+ * lint-safe spelling of the `string & {}` idiom (see
+ * `content-generation/index.ts`'s `LiteralUnion`).
+ */
+export type ModelLabel = "smart" | (string & Record<never, never>);
 
 export interface CodingRunUsage {
   inputTokens: number;
@@ -77,6 +92,19 @@ export interface CodingRunOutcome {
   success: boolean;
   turns: number;
   modelUsed: string | null;
+  /**
+   * The billing class (size) the run's label resolved to, in the SKU
+   * vocabulary the platform bills in (e.g. `"medium"`) — never a model or
+   * provider id. `undefined`/`null` means the server did not disclose it
+   * (coding runs cannot observe this today, and older servers omit the
+   * field) — treat as unknown, never fabricate a value.
+   */
+  servedClass?: string | null;
+  /**
+   * The billing lane the run executed in (e.g. `"run_now"`).
+   * `undefined`/`null` means not disclosed — same caveats as `servedClass`.
+   */
+  lane?: string | null;
   durationMs: number;
   toolCallCount: number;
   usage: CodingRunUsage;
@@ -267,6 +295,8 @@ interface WireResult {
   success: boolean;
   turns: number;
   model_used: string | null;
+  served_class?: string | null;
+  lane?: string | null;
   duration_ms: number;
   tool_call_count: number;
   usage?: {
@@ -297,6 +327,9 @@ function mapResult(r: WireResult | null | undefined): CodingRunOutcome | null {
     success: r.success,
     turns: r.turns,
     modelUsed: r.model_used ?? null,
+    // Disclosure fields: absent on older servers ⇒ null (unknown), never fabricated.
+    servedClass: r.served_class ?? null,
+    lane: r.lane ?? null,
     durationMs: r.duration_ms,
     toolCallCount: r.tool_call_count,
     usage: {
@@ -444,8 +477,13 @@ export interface ModelRunSpec {
   prompt: string;
   /** System prompt steering the agent. */
   system?: string;
-  /** Override the model / routing alias. */
-  model?: string;
+  /**
+   * Routing label for the run's LLM calls (e.g. `"smart"`). The platform
+   * resolves it against its configured label set — a raw provider model id
+   * is never honored. Omit to let the platform choose (the recommended
+   * default); pass `"smart"` if you need to pin explicitly.
+   */
+  model?: ModelLabel;
   /** Max output tokens per turn. */
   maxTokens?: number;
   /** Remote MCP servers the agent may call tools on (network round-trip per call). */
@@ -457,6 +495,19 @@ export interface ModelRunOutcome {
   stopReason: string;
   turns: number;
   modelUsed: string | null;
+  /**
+   * The billing class (size) the run's label resolved to (the final turn's,
+   * on a multi-turn run), in the SKU vocabulary the platform bills in (e.g.
+   * `"medium"`) — never a model or provider id. `undefined`/`null` means the
+   * server did not disclose it (older server, resolution failure) — treat as
+   * unknown, never fabricate a value.
+   */
+  servedClass?: string | null;
+  /**
+   * The billing lane the run executed in (e.g. `"run_now"`).
+   * `undefined`/`null` means not disclosed — same caveats as `servedClass`.
+   */
+  lane?: string | null;
   durationMs: number;
   costUsd: number;
   usage: CodingRunUsage;
@@ -522,6 +573,8 @@ interface ModelWireResult {
   stop_reason: string;
   turns: number;
   model_used: string | null;
+  served_class?: string | null;
+  lane?: string | null;
   duration_ms: number;
   cost_usd: number;
   usage?: {
@@ -552,6 +605,9 @@ function mapModelResult(r: ModelWireResult | null | undefined): ModelRunOutcome 
     stopReason: r.stop_reason,
     turns: r.turns,
     modelUsed: r.model_used ?? null,
+    // Disclosure fields: absent on older servers ⇒ null (unknown), never fabricated.
+    servedClass: r.served_class ?? null,
+    lane: r.lane ?? null,
     durationMs: r.duration_ms,
     costUsd: r.cost_usd,
     usage: {

--- a/packages/tools/src/models/run-launch.spec.ts
+++ b/packages/tools/src/models/run-launch.spec.ts
@@ -9,6 +9,7 @@ import { MODEL_RUN_RESULT_SIGNAL } from "./index.js";
 function fakeFetch(opts: {
   capture?: { headers?: Record<string, string>; url?: string };
   terminal?: boolean;
+  wireResult?: Record<string, unknown>;
 }): typeof globalThis.fetch {
   return (async (url: string, init: RequestInit = {}) => {
     if (opts.capture) {
@@ -21,7 +22,7 @@ function fakeFetch(opts: {
       : {
           status: "completed",
           output: "OK",
-          result: {
+          result: opts.wireResult ?? {
             success: true,
             stop_reason: "end_turn",
             turns: 1,
@@ -73,6 +74,39 @@ describe("agent.run — terminal result mapping", () => {
     expect(result.result?.stopReason).toBe("end_turn");
     expect(result.result?.costUsd).toBe(0.001);
     expect(result.result?.usage.inputTokens).toBe(10);
+  });
+
+  it("maps the serving disclosure (servedClass/lane) when the server reports it", async () => {
+    const sapiom = createClient({
+      apiKey: "k",
+      fetch: fakeFetch({
+        wireResult: {
+          success: true,
+          stop_reason: "end_turn",
+          turns: 1,
+          model_used: "smart",
+          served_class: "medium",
+          lane: "run_now",
+          duration_ms: 1200,
+          cost_usd: 0.001,
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      }),
+    });
+    const result = await sapiom.models.run({ prompt: "say OK" });
+    expect(result.result?.servedClass).toBe("medium");
+    expect(result.result?.lane).toBe("run_now");
+    // The label echo keeps its own meaning, independent of the disclosed class.
+    expect(result.result?.modelUsed).toBe("smart");
+  });
+
+  it("maps a result from an older server (no disclosure fields) to null, never a fabricated value", async () => {
+    // Same wire doc as the base fixture — no served_class/lane keys at all,
+    // the shape a pre-disclosure server emits.
+    const sapiom = createClient({ apiKey: "k", fetch: fakeFetch({}) });
+    const result = await sapiom.models.run({ prompt: "say OK" });
+    expect(result.result?.servedClass).toBeNull();
+    expect(result.result?.lane).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Reissues #673 (closed — the disclosure vocabulary changed under it, twice: first `servedModel`→`servedClass`/`lane` mid-review, then the whole PR was closed to land as part of this broader ergonomics PR) under the corrected disclosure contract, plus the strong-defaults ergonomics items from the same plan. Contract authority: the platform's model-execution contract (internal) — server side landed via a companion server-side change.

**Hard constraint honored: additive only.** No published type or behavior changes for existing consumers — verified with `tsc --noEmit`, full `jest`, and `pnpm build`, all clean.

## What changed (packages/tools)

1. **Disclosure types.** `models.run` (`ModelRunOutcome`) and `models.coding.run` (`CodingRunOutcome`) gain optional `servedClass`/`lane` (wire `served_class`/`lane`) — the billing class the run's label resolved to and the lane it executed in. `llm.run`/`redeem`/`callSession` gain a new `LlmDisclosure` wire-shape type + `readDisclosure()` helper returning the camelCased `LlmDisclosureResult`. All `undefined`/`null` on older servers or where the platform doesn't disclose — never fabricated.
2. **Structured-output convenience for `llm.run`.** New optional `output: { name, schema }` on `LlmRunSpec` — automates the blessed tool-calling pattern (appends a forced tool + `tool_choice`). `run()`'s return type is unchanged either way. New `structuredOf()` reads the parsed value back out; new `textOf()` reads the plain-text reply, correctly skipping a `thinking` block that may precede it.
3. **Label ergonomics.** `model`/`label` fields across `llm.run`, `llm.submit`, `llm.createSession`, `models.run`, `models.coding.run` are now a soft union (`"smart" | (string & Record<never, never>)` — the lint-safe spelling of `string & {}`, matching `content-generation/index.ts`'s existing `LiteralUnion`) for autocomplete, with JSDoc settled on "routing label" terminology: omit to let the platform choose, `"smart"` if you must pin, a raw provider model id is never honored.

**Explicitly out of scope** (per the plan): no `deadlineMinutes` on `models.*`/`agents.*` (server side, hasn't shipped) and no `inspectStep` (separate PR). Also dropped `#673`'s `degradation` reservation on all three result types — its round-2 review left that unresolved (untyped reserved surface for an unshipped feature); out of scope here, can land with a follow-up.

## Design choice — structured output (deliverable #2)

**Chosen:** additive `output?: { name, schema }` on `LlmRunSpec`, which only builds the request (injects the tool + forces `tool_choice`); `run()`'s return type is **never** touched — still `Promise<T>`, the verbatim response, for every caller regardless of whether `output` is set. Reading the parsed value is a second, explicit step via the new `structuredOf(response, name?)` helper (paired with `textOf()` for the plain-text case).

**Rejected: TS overloads that return the parsed object directly when `output` is set.** Better single-call ergonomics, but overload resolution keyed on an optional property inside an object-literal parameter is fragile in TypeScript — it would need a conditional generic (`S extends { output: infer O } ? Parsed<O> : T`) to make `run()`'s return type branch on the shape of `spec`, and that's exactly the kind of change most likely to regress an existing caller's inference in some edge case I can't fully enumerate. Given the hard "zero breaking changes" constraint, I chose the design with no way to touch the existing contract at all over the one with better ergonomics but non-zero regression risk.

## Wire-shape verification (deliverable #1)

Verified against a fresh pull of the current server-side implementation rather than trusting an older checkout:

- `models.run`'s wire response: `served_class`/`lane` always present as keys (null when unresolved), plus `cost_usd` — confirmed real, non-null size×lane estimate in the common case (deprecated as an *authoritative* customer figure, not nulled server-side). **I left `ModelRunOutcome.costUsd` completely untouched** (still `number`, non-nullable) — widening it to `number | null` is exactly the kind of type change the additive-only mandate rules out, even though the server does occasionally send `null` for a narrow legacy-row case (rows persisted during a brief prior live window). That's a pre-existing type/runtime mismatch in the current published type (not introduced by this PR) — flagging it rather than fixing it, since fixing it properly needs the exact widening this constraint forbids.
- `models.coding.run`'s wire response: `served_class`/`lane` always present (null today — coding can't observe them), and confirmed **no `cost_usd` key at all** — coding never had a real cost signal to preserve, unlike `models.run`.
- The gateway backing `llm.run`/`redeem`/`callSession`: injects `served_class`+`lane` top-level into buffered 2xx JSON bodies (confirmed no `cost_usd`, no `usage` injection — `usage` is already native to the Anthropic Messages response, nothing to add there).
- **Caveat, can't verify from here:** server-side rollout of the disclosure fields may lag this SDK change; fields are optional and absent until served, so `served_class`/`lane` may not appear on live responses immediately even though both the server and this SDK now support them.

## Testing

- `packages/tools`: `npm run test` → **32 suites, 583 passed** (564 baseline + 19 new: disclosure mapping for both old- and new-server shapes on `models.run`/`models.coding.run`, `readDisclosure` happy/absent/malformed, `textOf`/`structuredOf` including the thinking-block-skip case, `output`'s request-building — non-mutation of the caller's object, merging with existing tools, unchanged behavior when omitted, end-to-end round trip).
- `npm run typecheck` clean, `npm run lint` clean, `npm run build` clean, `node scripts/provider-neutral-copy-check.mjs` passes (74 audited files) — had to reword one JSDoc line to reuse an already-allowlisted phrase (`"Anthropic Messages"` exact match) rather than a new "Anthropic's ___" construction the checker doesn't recognize.

Refs: internal tracker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDogyqvDnhy5iKgVpeZtWc
