### PR TITLE
docs(skills): teach the LLM call-surface rule + naming conventions

### DIFF
--- a/.changeset/teach-llm-call-surface-rule.md
+++ b/.changeset/teach-llm-call-surface-rule.md
@@ -1,0 +1,15 @@
+---
+"@sapiom/agent-core": patch
+"@sapiom/tools": patch
+---
+
+`sapiom-agent-authoring` skill: teaches the LLM call-surface rule from step
+code (`llm.run` one-shot vs `models.run` platform-driven loop vs `agents.run`
+deployed-agent dispatch, with a worked example against the "reply with only
+JSON" + string-parsing mistake) and settles the platform's naming
+conventions (the overloaded "agent"/"run"/"task"/"session"/"dispatch" terms,
+and "label" as the author-facing term for a `model:` value). Synced across
+the canonical source, both scaffold templates, and the Claude Code plugin
+copy. `@sapiom/tools`: corrected stale `agent.run`/`agent.coding` naming in
+`models/index.ts`'s doc comments — the actual exported namespace is
+`models`.

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -305,6 +305,114 @@ try {
 }
 ```
 
+## Calling LLMs from Steps
+
+Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the
+job is the most common mistake in authored agents:
+
+| Capability              | Use for                                                                                            | Never for                                                          |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `ctx.sapiom.llm.run`    | ONE LLM call — summarize, extract, classify, one-shot generate                                       | A multi-turn task, or anything needing its own tool-calling loop      |
+| `ctx.sapiom.models.run` | A platform-driven multi-turn reasoning + tool-calling loop (minutes, not seconds). `models.coding.run` for sandboxed coding tasks. | A one-shot completion — it will loop and overthink                    |
+| `ctx.sapiom.agents.run` | Dispatching a DEPLOYED agent by slug — composing systems from small deployed agents                  | Anything that isn't itself a deployed agent                           |
+
+**⚠️ The mistake to never repeat:** sending single-shot, fixed-shape intent through a
+multi-turn surface (`models.run`, or the deferred `llm.submit`/`redeem` lane) instead of
+one `llm.run` call. The symptom: the run takes far longer than the task needs, "overthinks"
+a trivial extraction, and — if the caller just grabs the first content block hoping it's the
+answer — returns a `thinking` block instead.
+
+### Worked example: a trivial fixed-shape-JSON task
+
+**Wrong** — one-shot intent sent through the multi-turn loop, then the answer string-parsed
+out of free text:
+
+```typescript
+// DON'T: models.run for a one-shot extraction — it loops and overthinks, and
+// "reply with only JSON" is brittle (prose, invalid JSON, or a leading
+// `thinking` block all break a naive `JSON.parse(content[0])`).
+const run = await ctx.sapiom.models.run({
+  prompt: `Reply with ONLY JSON: {"priority": "...", "category": "..."} for: ${input.text}`,
+});
+const parsed = JSON.parse(run.output ?? "{}"); // brittle, and pays for a reasoning loop
+```
+
+**Right** — `llm.run`, a forced tool call for the fixed shape, and an explicit
+`type`-filtered read (never assume `content[0]` is the answer — a `thinking` block can
+precede it):
+
+```typescript
+const response = await ctx.sapiom.llm.run({
+  request: {
+    messages: [{ role: "user", content: `Classify this support ticket: ${input.text}` }],
+    max_tokens: 256,
+    tools: [
+      {
+        name: "classify_ticket",
+        input_schema: {
+          type: "object",
+          properties: {
+            priority: { type: "string", enum: ["low", "medium", "high"] },
+            category: { type: "string" },
+          },
+          required: ["priority", "category"],
+        },
+      },
+    ],
+    tool_choice: { type: "tool", name: "classify_ticket" },
+  },
+  model: "smart", // a label — omit to let the platform choose (recommended)
+});
+
+const content = response.content as Array<{ type: string; input?: unknown; text?: string }>;
+const toolUse = content.find((block) => block.type === "tool_use");
+const { priority, category } = toolUse!.input as { priority: string; category: string };
+```
+
+The same `type`-filter discipline applies to a **plain-text** reply too — read
+`content.find((b) => b.type === "text")?.text`, never `content[0]`.
+
+> `@sapiom/tools` is landing a structured-output convenience for exactly this pattern
+> (`llm.run({ ..., output: { name, schema } })` plus `structuredOf()`/`textOf()` helpers that
+> automate the tool/`tool_choice` wiring and the `type`-filtered read above). Check
+> `ctx.sapiom.llm`'s current types/autocomplete before hand-rolling it — it may already be
+> there by the time you're reading this.
+
+### The label rule
+
+**You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
+`models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
+against its configured label set — never a raw provider model id (never honored, on any
+surface). Omit it entirely to let the platform choose (the recommended default); pass
+`"smart"` if you must pin. The result discloses what actually served, in the platform's own
+vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
+lane it executed in) — never a model or provider id.
+
+### Debugging a run
+
+Find the run in the dashboard's run detail view, find the suspicious step's row id, then
+open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
+
+Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+
+## Naming Conventions
+
+Several words are overloaded across this platform. Know which meaning a given context
+uses — conflating two costs you a wrong capability choice, not just a wrong word:
+
+| Term         | Meaning(s) on this platform                                                                                                                                                                                                                                                                                                    |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **agent**    | (1) `@sapiom/agent` — this authoring framework (`defineAgent`, this skill). (2) A **deployed agent** — one project's compiled definition, dispatched by `ctx.sapiom.agents.run`/`launch` (addressed by its slug via `AgentRunSpec.definition`) — the customer-facing name is always "agent," even where the SDK's own internal source comments still use older, non-public vocabulary for the same concept. (3) `ctx.sapiom.models.run`'s managed multi-turn loop — a platform-internal "agent-runs" service you CALL, never author. (4) A **Claude Code subagent** (`.claude/agents/*/PROMPT.md`) — an unrelated feature of the coding tool itself, not part of the Sapiom SDK (see the separate `writing-agents` skill, which is about that, not this). |
+| **run**      | (1) `ctx.sapiom.llm.run` — one synchronous LLM call. (2) `ctx.sapiom.models.run` / `agents.run` — `launch()` + `wait()`, blocking until terminal (vs. `launch()` alone, which returns a pausable handle). (3) An execution instance/row of any of the above — the thing you inspect/debug. (4) The dashboard's Run button / Local Run / Prod Run (Studio UI actions, not an API call).                                                                                                                                                                                                                                       |
+| **task**     | `CodingRunSpec.task` — the coding agent's prompt-equivalent field. Deliberately not called `prompt`: it's handed to a sandboxed coding agent, not a bare LLM call.                                                                                                                                                            |
+| **session**  | (1) `ctx.sapiom.llm.createSession`/`callSession` — reserved LLM capacity accepting repeated drop-in calls until its TTL/budget ends it (Surface B, replacing `submit`/`redeem`). (2) A Studio harness terminal session — unrelated, no LLM-capacity semantics.                                                                |
+| **dispatch** | The structural contract (`DispatchHandle`) a long-running capability's `launch()` handle satisfies so a step can `pauseUntilSignal(handle, …)` and resume on completion. Every dispatched capability (coding, `models.run`, `agents.run`, more later) shares this ONE contract — "dispatch" always means this pattern, never anything else.  |
+| **label**    | The author-facing term for a `model:`/`label:` value (e.g. `"smart"`) — never "class" (a separate, future billing-size dimension) and never a raw provider model id (never honored, on any surface).                                                                                                                          |
+
+**The rule new capabilities must follow:** don't re-overload "agent" or "run" further. If a
+new capability needs its own verb, name it something else (`dispatch`, `launch`, `submit`,
+`create*`) rather than adding a sixth meaning to a word that already has five.
+
 ## Failure Handling & Retries
 
 There is no automatic per-step retry. Express it explicitly — this keeps the graph readable.
@@ -522,4 +630,5 @@ Write each step the way it should run in production — never weaken logic to sh
 | [Authoring guide](https://docs.sapiom.ai/agents/authoring) | Full step model, failure patterns, pause/resume, determinism |
 | [Quickstart](https://docs.sapiom.ai/agents/quick-start)    | Scaffold → write → test → deploy walkthrough                 |
 | [Capabilities](https://docs.sapiom.ai/capabilities)        | The full `ctx.sapiom.*` catalog with pricing                 |
+| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why |
 | `AGENTS.md` in your scaffold                               | The quick in-project reference                               |

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -305,6 +305,114 @@ try {
 }
 ```
 
+## Calling LLMs from Steps
+
+Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the
+job is the most common mistake in authored agents:
+
+| Capability              | Use for                                                                                            | Never for                                                          |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `ctx.sapiom.llm.run`    | ONE LLM call — summarize, extract, classify, one-shot generate                                       | A multi-turn task, or anything needing its own tool-calling loop      |
+| `ctx.sapiom.models.run` | A platform-driven multi-turn reasoning + tool-calling loop (minutes, not seconds). `models.coding.run` for sandboxed coding tasks. | A one-shot completion — it will loop and overthink                    |
+| `ctx.sapiom.agents.run` | Dispatching a DEPLOYED agent by slug — composing systems from small deployed agents                  | Anything that isn't itself a deployed agent                           |
+
+**⚠️ The mistake to never repeat:** sending single-shot, fixed-shape intent through a
+multi-turn surface (`models.run`, or the deferred `llm.submit`/`redeem` lane) instead of
+one `llm.run` call. The symptom: the run takes far longer than the task needs, "overthinks"
+a trivial extraction, and — if the caller just grabs the first content block hoping it's the
+answer — returns a `thinking` block instead.
+
+### Worked example: a trivial fixed-shape-JSON task
+
+**Wrong** — one-shot intent sent through the multi-turn loop, then the answer string-parsed
+out of free text:
+
+```typescript
+// DON'T: models.run for a one-shot extraction — it loops and overthinks, and
+// "reply with only JSON" is brittle (prose, invalid JSON, or a leading
+// `thinking` block all break a naive `JSON.parse(content[0])`).
+const run = await ctx.sapiom.models.run({
+  prompt: `Reply with ONLY JSON: {"priority": "...", "category": "..."} for: ${input.text}`,
+});
+const parsed = JSON.parse(run.output ?? "{}"); // brittle, and pays for a reasoning loop
+```
+
+**Right** — `llm.run`, a forced tool call for the fixed shape, and an explicit
+`type`-filtered read (never assume `content[0]` is the answer — a `thinking` block can
+precede it):
+
+```typescript
+const response = await ctx.sapiom.llm.run({
+  request: {
+    messages: [{ role: "user", content: `Classify this support ticket: ${input.text}` }],
+    max_tokens: 256,
+    tools: [
+      {
+        name: "classify_ticket",
+        input_schema: {
+          type: "object",
+          properties: {
+            priority: { type: "string", enum: ["low", "medium", "high"] },
+            category: { type: "string" },
+          },
+          required: ["priority", "category"],
+        },
+      },
+    ],
+    tool_choice: { type: "tool", name: "classify_ticket" },
+  },
+  model: "smart", // a label — omit to let the platform choose (recommended)
+});
+
+const content = response.content as Array<{ type: string; input?: unknown; text?: string }>;
+const toolUse = content.find((block) => block.type === "tool_use");
+const { priority, category } = toolUse!.input as { priority: string; category: string };
+```
+
+The same `type`-filter discipline applies to a **plain-text** reply too — read
+`content.find((b) => b.type === "text")?.text`, never `content[0]`.
+
+> `@sapiom/tools` is landing a structured-output convenience for exactly this pattern
+> (`llm.run({ ..., output: { name, schema } })` plus `structuredOf()`/`textOf()` helpers that
+> automate the tool/`tool_choice` wiring and the `type`-filtered read above). Check
+> `ctx.sapiom.llm`'s current types/autocomplete before hand-rolling it — it may already be
+> there by the time you're reading this.
+
+### The label rule
+
+**You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
+`models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
+against its configured label set — never a raw provider model id (never honored, on any
+surface). Omit it entirely to let the platform choose (the recommended default); pass
+`"smart"` if you must pin. The result discloses what actually served, in the platform's own
+vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
+lane it executed in) — never a model or provider id.
+
+### Debugging a run
+
+Find the run in the dashboard's run detail view, find the suspicious step's row id, then
+open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
+
+Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+
+## Naming Conventions
+
+Several words are overloaded across this platform. Know which meaning a given context
+uses — conflating two costs you a wrong capability choice, not just a wrong word:
+
+| Term         | Meaning(s) on this platform                                                                                                                                                                                                                                                                                                    |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **agent**    | (1) `@sapiom/agent` — this authoring framework (`defineAgent`, this skill). (2) A **deployed agent** — one project's compiled definition, dispatched by `ctx.sapiom.agents.run`/`launch` (addressed by its slug via `AgentRunSpec.definition`) — the customer-facing name is always "agent," even where the SDK's own internal source comments still use older, non-public vocabulary for the same concept. (3) `ctx.sapiom.models.run`'s managed multi-turn loop — a platform-internal "agent-runs" service you CALL, never author. (4) A **Claude Code subagent** (`.claude/agents/*/PROMPT.md`) — an unrelated feature of the coding tool itself, not part of the Sapiom SDK (see the separate `writing-agents` skill, which is about that, not this). |
+| **run**      | (1) `ctx.sapiom.llm.run` — one synchronous LLM call. (2) `ctx.sapiom.models.run` / `agents.run` — `launch()` + `wait()`, blocking until terminal (vs. `launch()` alone, which returns a pausable handle). (3) An execution instance/row of any of the above — the thing you inspect/debug. (4) The dashboard's Run button / Local Run / Prod Run (Studio UI actions, not an API call).                                                                                                                                                                                                                                       |
+| **task**     | `CodingRunSpec.task` — the coding agent's prompt-equivalent field. Deliberately not called `prompt`: it's handed to a sandboxed coding agent, not a bare LLM call.                                                                                                                                                            |
+| **session**  | (1) `ctx.sapiom.llm.createSession`/`callSession` — reserved LLM capacity accepting repeated drop-in calls until its TTL/budget ends it (Surface B, replacing `submit`/`redeem`). (2) A Studio harness terminal session — unrelated, no LLM-capacity semantics.                                                                |
+| **dispatch** | The structural contract (`DispatchHandle`) a long-running capability's `launch()` handle satisfies so a step can `pauseUntilSignal(handle, …)` and resume on completion. Every dispatched capability (coding, `models.run`, `agents.run`, more later) shares this ONE contract — "dispatch" always means this pattern, never anything else.  |
+| **label**    | The author-facing term for a `model:`/`label:` value (e.g. `"smart"`) — never "class" (a separate, future billing-size dimension) and never a raw provider model id (never honored, on any surface).                                                                                                                          |
+
+**The rule new capabilities must follow:** don't re-overload "agent" or "run" further. If a
+new capability needs its own verb, name it something else (`dispatch`, `launch`, `submit`,
+`create*`) rather than adding a sixth meaning to a word that already has five.
+
 ## Failure Handling & Retries
 
 There is no automatic per-step retry. Express it explicitly — this keeps the graph readable.
@@ -522,4 +630,5 @@ Write each step the way it should run in production — never weaken logic to sh
 | [Authoring guide](https://docs.sapiom.ai/agents/authoring) | Full step model, failure patterns, pause/resume, determinism |
 | [Quickstart](https://docs.sapiom.ai/agents/quick-start)    | Scaffold → write → test → deploy walkthrough                 |
 | [Capabilities](https://docs.sapiom.ai/capabilities)        | The full `ctx.sapiom.*` catalog with pricing                 |
+| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why |
 | `AGENTS.md` in your scaffold                               | The quick in-project reference                               |

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -305,6 +305,114 @@ try {
 }
 ```
 
+## Calling LLMs from Steps
+
+Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the
+job is the most common mistake in authored agents:
+
+| Capability              | Use for                                                                                            | Never for                                                          |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `ctx.sapiom.llm.run`    | ONE LLM call — summarize, extract, classify, one-shot generate                                       | A multi-turn task, or anything needing its own tool-calling loop      |
+| `ctx.sapiom.models.run` | A platform-driven multi-turn reasoning + tool-calling loop (minutes, not seconds). `models.coding.run` for sandboxed coding tasks. | A one-shot completion — it will loop and overthink                    |
+| `ctx.sapiom.agents.run` | Dispatching a DEPLOYED agent by slug — composing systems from small deployed agents                  | Anything that isn't itself a deployed agent                           |
+
+**⚠️ The mistake to never repeat:** sending single-shot, fixed-shape intent through a
+multi-turn surface (`models.run`, or the deferred `llm.submit`/`redeem` lane) instead of
+one `llm.run` call. The symptom: the run takes far longer than the task needs, "overthinks"
+a trivial extraction, and — if the caller just grabs the first content block hoping it's the
+answer — returns a `thinking` block instead.
+
+### Worked example: a trivial fixed-shape-JSON task
+
+**Wrong** — one-shot intent sent through the multi-turn loop, then the answer string-parsed
+out of free text:
+
+```typescript
+// DON'T: models.run for a one-shot extraction — it loops and overthinks, and
+// "reply with only JSON" is brittle (prose, invalid JSON, or a leading
+// `thinking` block all break a naive `JSON.parse(content[0])`).
+const run = await ctx.sapiom.models.run({
+  prompt: `Reply with ONLY JSON: {"priority": "...", "category": "..."} for: ${input.text}`,
+});
+const parsed = JSON.parse(run.output ?? "{}"); // brittle, and pays for a reasoning loop
+```
+
+**Right** — `llm.run`, a forced tool call for the fixed shape, and an explicit
+`type`-filtered read (never assume `content[0]` is the answer — a `thinking` block can
+precede it):
+
+```typescript
+const response = await ctx.sapiom.llm.run({
+  request: {
+    messages: [{ role: "user", content: `Classify this support ticket: ${input.text}` }],
+    max_tokens: 256,
+    tools: [
+      {
+        name: "classify_ticket",
+        input_schema: {
+          type: "object",
+          properties: {
+            priority: { type: "string", enum: ["low", "medium", "high"] },
+            category: { type: "string" },
+          },
+          required: ["priority", "category"],
+        },
+      },
+    ],
+    tool_choice: { type: "tool", name: "classify_ticket" },
+  },
+  model: "smart", // a label — omit to let the platform choose (recommended)
+});
+
+const content = response.content as Array<{ type: string; input?: unknown; text?: string }>;
+const toolUse = content.find((block) => block.type === "tool_use");
+const { priority, category } = toolUse!.input as { priority: string; category: string };
+```
+
+The same `type`-filter discipline applies to a **plain-text** reply too — read
+`content.find((b) => b.type === "text")?.text`, never `content[0]`.
+
+> `@sapiom/tools` is landing a structured-output convenience for exactly this pattern
+> (`llm.run({ ..., output: { name, schema } })` plus `structuredOf()`/`textOf()` helpers that
+> automate the tool/`tool_choice` wiring and the `type`-filtered read above). Check
+> `ctx.sapiom.llm`'s current types/autocomplete before hand-rolling it — it may already be
+> there by the time you're reading this.
+
+### The label rule
+
+**You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
+`models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
+against its configured label set — never a raw provider model id (never honored, on any
+surface). Omit it entirely to let the platform choose (the recommended default); pass
+`"smart"` if you must pin. The result discloses what actually served, in the platform's own
+vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
+lane it executed in) — never a model or provider id.
+
+### Debugging a run
+
+Find the run in the dashboard's run detail view, find the suspicious step's row id, then
+open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
+
+Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+
+## Naming Conventions
+
+Several words are overloaded across this platform. Know which meaning a given context
+uses — conflating two costs you a wrong capability choice, not just a wrong word:
+
+| Term         | Meaning(s) on this platform                                                                                                                                                                                                                                                                                                    |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **agent**    | (1) `@sapiom/agent` — this authoring framework (`defineAgent`, this skill). (2) A **deployed agent** — one project's compiled definition, dispatched by `ctx.sapiom.agents.run`/`launch` (addressed by its slug via `AgentRunSpec.definition`) — the customer-facing name is always "agent," even where the SDK's own internal source comments still use older, non-public vocabulary for the same concept. (3) `ctx.sapiom.models.run`'s managed multi-turn loop — a platform-internal "agent-runs" service you CALL, never author. (4) A **Claude Code subagent** (`.claude/agents/*/PROMPT.md`) — an unrelated feature of the coding tool itself, not part of the Sapiom SDK (see the separate `writing-agents` skill, which is about that, not this). |
+| **run**      | (1) `ctx.sapiom.llm.run` — one synchronous LLM call. (2) `ctx.sapiom.models.run` / `agents.run` — `launch()` + `wait()`, blocking until terminal (vs. `launch()` alone, which returns a pausable handle). (3) An execution instance/row of any of the above — the thing you inspect/debug. (4) The dashboard's Run button / Local Run / Prod Run (Studio UI actions, not an API call).                                                                                                                                                                                                                                       |
+| **task**     | `CodingRunSpec.task` — the coding agent's prompt-equivalent field. Deliberately not called `prompt`: it's handed to a sandboxed coding agent, not a bare LLM call.                                                                                                                                                            |
+| **session**  | (1) `ctx.sapiom.llm.createSession`/`callSession` — reserved LLM capacity accepting repeated drop-in calls until its TTL/budget ends it (Surface B, replacing `submit`/`redeem`). (2) A Studio harness terminal session — unrelated, no LLM-capacity semantics.                                                                |
+| **dispatch** | The structural contract (`DispatchHandle`) a long-running capability's `launch()` handle satisfies so a step can `pauseUntilSignal(handle, …)` and resume on completion. Every dispatched capability (coding, `models.run`, `agents.run`, more later) shares this ONE contract — "dispatch" always means this pattern, never anything else.  |
+| **label**    | The author-facing term for a `model:`/`label:` value (e.g. `"smart"`) — never "class" (a separate, future billing-size dimension) and never a raw provider model id (never honored, on any surface).                                                                                                                          |
+
+**The rule new capabilities must follow:** don't re-overload "agent" or "run" further. If a
+new capability needs its own verb, name it something else (`dispatch`, `launch`, `submit`,
+`create*`) rather than adding a sixth meaning to a word that already has five.
+
 ## Failure Handling & Retries
 
 There is no automatic per-step retry. Express it explicitly — this keeps the graph readable.
@@ -522,4 +630,5 @@ Write each step the way it should run in production — never weaken logic to sh
 | [Authoring guide](https://docs.sapiom.ai/agents/authoring) | Full step model, failure patterns, pause/resume, determinism |
 | [Quickstart](https://docs.sapiom.ai/agents/quick-start)    | Scaffold → write → test → deploy walkthrough                 |
 | [Capabilities](https://docs.sapiom.ai/capabilities)        | The full `ctx.sapiom.*` catalog with pricing                 |
+| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why |
 | `AGENTS.md` in your scaffold                               | The quick in-project reference                               |

--- a/packages/tools/src/models/index.ts
+++ b/packages/tools/src/models/index.ts
@@ -1,11 +1,12 @@
 /**
- * `agent` capability — LLM execution (coding agents). The fuzzy counterpart to a
- * deterministic step: hand it a task in natural language, it edits a checkout in a
- * sandbox.
+ * `models` capability — LLM execution (coding agents + the instant loop). The fuzzy
+ * counterpart to a deterministic step: hand it a task in natural language, it edits
+ * a checkout in a sandbox (`models.coding`) or runs an in-server reasoning loop
+ * (`models.run`, below).
  *
- *   import { agent, repositories } from "@sapiom/tools";
+ *   import { models, repositories } from "@sapiom/tools";
  *   const repo = await repositories.create("landing");
- *   const run = await agent.coding.run({
+ *   const run = await models.coding.run({
  *     task: "Build a one-page landing site in index.html.",
  *     gitRepository: repo,        // auto-cloned into the sandbox at /workspace/<slug>
  *   });
@@ -408,23 +409,23 @@ export async function codingRun(
   return handle.wait();
 }
 
-/** Ambient-bound `agent.coding` namespace. */
+/** Ambient-bound `models.coding` namespace. */
 export const coding = { run: codingRun, launch: codingLaunch };
 
 // ============================================================================
-// Default agent (instant, in-server loop) — `agent.run` / `agent.launch`
+// Default model run (instant, in-server loop) — `models.run` / `models.launch`
 //
-// The fast, no-sandbox sibling of `agent.coding`: hand it a prompt (and optional
+// The fast, no-sandbox sibling of `models.coding`: hand it a prompt (and optional
 // remote MCP tools), the loop runs in Sapiom's server and returns text. No
 // filesystem, no sandbox handle. Multi-model under the hood; you just call
-// `agent.run`. Same dispatch contract as coding, so `launch()` works with
+// `models.run`. Same dispatch contract as coding, so `launch()` works with
 // `pauseUntilSignal(handle, { resumeStep })`.
 // ============================================================================
 
 /**
- * Capability-stable signal an instant agent run fires when it reaches a terminal
+ * Capability-stable signal an instant model run fires when it reaches a terminal
  * state (completed OR failed — it carries the result either way). A workflow step
- * paused on an agent-run handle resumes on this; it's the handle's
+ * paused on a model-run handle resumes on this; it's the handle's
  * `dispatch.resultSignal`.
  */
 export const MODEL_RUN_RESULT_SIGNAL = "models.run.result";

--- a/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
@@ -305,6 +305,114 @@ try {
 }
 ```
 
+## Calling LLMs from Steps
+
+Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the
+job is the most common mistake in authored agents:
+
+| Capability              | Use for                                                                                            | Never for                                                          |
+| ------------------------ | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `ctx.sapiom.llm.run`    | ONE LLM call — summarize, extract, classify, one-shot generate                                       | A multi-turn task, or anything needing its own tool-calling loop      |
+| `ctx.sapiom.models.run` | A platform-driven multi-turn reasoning + tool-calling loop (minutes, not seconds). `models.coding.run` for sandboxed coding tasks. | A one-shot completion — it will loop and overthink                    |
+| `ctx.sapiom.agents.run` | Dispatching a DEPLOYED agent by slug — composing systems from small deployed agents                  | Anything that isn't itself a deployed agent                           |
+
+**⚠️ The mistake to never repeat:** sending single-shot, fixed-shape intent through a
+multi-turn surface (`models.run`, or the deferred `llm.submit`/`redeem` lane) instead of
+one `llm.run` call. The symptom: the run takes far longer than the task needs, "overthinks"
+a trivial extraction, and — if the caller just grabs the first content block hoping it's the
+answer — returns a `thinking` block instead.
+
+### Worked example: a trivial fixed-shape-JSON task
+
+**Wrong** — one-shot intent sent through the multi-turn loop, then the answer string-parsed
+out of free text:
+
+```typescript
+// DON'T: models.run for a one-shot extraction — it loops and overthinks, and
+// "reply with only JSON" is brittle (prose, invalid JSON, or a leading
+// `thinking` block all break a naive `JSON.parse(content[0])`).
+const run = await ctx.sapiom.models.run({
+  prompt: `Reply with ONLY JSON: {"priority": "...", "category": "..."} for: ${input.text}`,
+});
+const parsed = JSON.parse(run.output ?? "{}"); // brittle, and pays for a reasoning loop
+```
+
+**Right** — `llm.run`, a forced tool call for the fixed shape, and an explicit
+`type`-filtered read (never assume `content[0]` is the answer — a `thinking` block can
+precede it):
+
+```typescript
+const response = await ctx.sapiom.llm.run({
+  request: {
+    messages: [{ role: "user", content: `Classify this support ticket: ${input.text}` }],
+    max_tokens: 256,
+    tools: [
+      {
+        name: "classify_ticket",
+        input_schema: {
+          type: "object",
+          properties: {
+            priority: { type: "string", enum: ["low", "medium", "high"] },
+            category: { type: "string" },
+          },
+          required: ["priority", "category"],
+        },
+      },
+    ],
+    tool_choice: { type: "tool", name: "classify_ticket" },
+  },
+  model: "smart", // a label — omit to let the platform choose (recommended)
+});
+
+const content = response.content as Array<{ type: string; input?: unknown; text?: string }>;
+const toolUse = content.find((block) => block.type === "tool_use");
+const { priority, category } = toolUse!.input as { priority: string; category: string };
+```
+
+The same `type`-filter discipline applies to a **plain-text** reply too — read
+`content.find((b) => b.type === "text")?.text`, never `content[0]`.
+
+> `@sapiom/tools` is landing a structured-output convenience for exactly this pattern
+> (`llm.run({ ..., output: { name, schema } })` plus `structuredOf()`/`textOf()` helpers that
+> automate the tool/`tool_choice` wiring and the `type`-filtered read above). Check
+> `ctx.sapiom.llm`'s current types/autocomplete before hand-rolling it — it may already be
+> there by the time you're reading this.
+
+### The label rule
+
+**You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
+`models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
+against its configured label set — never a raw provider model id (never honored, on any
+surface). Omit it entirely to let the platform choose (the recommended default); pass
+`"smart"` if you must pin. The result discloses what actually served, in the platform's own
+vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
+lane it executed in) — never a model or provider id.
+
+### Debugging a run
+
+Find the run in the dashboard's run detail view, find the suspicious step's row id, then
+open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
+
+Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+
+## Naming Conventions
+
+Several words are overloaded across this platform. Know which meaning a given context
+uses — conflating two costs you a wrong capability choice, not just a wrong word:
+
+| Term         | Meaning(s) on this platform                                                                                                                                                                                                                                                                                                    |
+| ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **agent**    | (1) `@sapiom/agent` — this authoring framework (`defineAgent`, this skill). (2) A **deployed agent** — one project's compiled definition, dispatched by `ctx.sapiom.agents.run`/`launch` (addressed by its slug via `AgentRunSpec.definition`) — the customer-facing name is always "agent," even where the SDK's own internal source comments still use older, non-public vocabulary for the same concept. (3) `ctx.sapiom.models.run`'s managed multi-turn loop — a platform-internal "agent-runs" service you CALL, never author. (4) A **Claude Code subagent** (`.claude/agents/*/PROMPT.md`) — an unrelated feature of the coding tool itself, not part of the Sapiom SDK (see the separate `writing-agents` skill, which is about that, not this). |
+| **run**      | (1) `ctx.sapiom.llm.run` — one synchronous LLM call. (2) `ctx.sapiom.models.run` / `agents.run` — `launch()` + `wait()`, blocking until terminal (vs. `launch()` alone, which returns a pausable handle). (3) An execution instance/row of any of the above — the thing you inspect/debug. (4) The dashboard's Run button / Local Run / Prod Run (Studio UI actions, not an API call).                                                                                                                                                                                                                                       |
+| **task**     | `CodingRunSpec.task` — the coding agent's prompt-equivalent field. Deliberately not called `prompt`: it's handed to a sandboxed coding agent, not a bare LLM call.                                                                                                                                                            |
+| **session**  | (1) `ctx.sapiom.llm.createSession`/`callSession` — reserved LLM capacity accepting repeated drop-in calls until its TTL/budget ends it (Surface B, replacing `submit`/`redeem`). (2) A Studio harness terminal session — unrelated, no LLM-capacity semantics.                                                                |
+| **dispatch** | The structural contract (`DispatchHandle`) a long-running capability's `launch()` handle satisfies so a step can `pauseUntilSignal(handle, …)` and resume on completion. Every dispatched capability (coding, `models.run`, `agents.run`, more later) shares this ONE contract — "dispatch" always means this pattern, never anything else.  |
+| **label**    | The author-facing term for a `model:`/`label:` value (e.g. `"smart"`) — never "class" (a separate, future billing-size dimension) and never a raw provider model id (never honored, on any surface).                                                                                                                          |
+
+**The rule new capabilities must follow:** don't re-overload "agent" or "run" further. If a
+new capability needs its own verb, name it something else (`dispatch`, `launch`, `submit`,
+`create*`) rather than adding a sixth meaning to a word that already has five.
+
 ## Failure Handling & Retries
 
 There is no automatic per-step retry. Express it explicitly — this keeps the graph readable.
@@ -522,4 +630,5 @@ Write each step the way it should run in production — never weaken logic to sh
 | [Authoring guide](https://docs.sapiom.ai/agents/authoring) | Full step model, failure patterns, pause/resume, determinism |
 | [Quickstart](https://docs.sapiom.ai/agents/quick-start)    | Scaffold → write → test → deploy walkthrough                 |
 | [Capabilities](https://docs.sapiom.ai/capabilities)        | The full `ctx.sapiom.*` catalog with pricing                 |
+| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why |
 | `AGENTS.md` in your scaffold                               | The quick in-project reference                               |


### PR DESCRIPTION
## Summary
Companion to a server-side companion change — this is the FULL version of the LLM call-surface rule + naming conventions, landing in the canonical `sapiom-agent-authoring` skill (`packages/agent-core/skills/sapiom-agent-authoring/SKILL.md`) rather than the Sapiom-repo monorepo pointer. This is the **highest-reach teaching surface of the whole effort**: it ships into every scaffolded agent project via `.claude/skills/`, and into the Claude Code plugin.

## What landed

**New "## Calling LLMs from Steps" section:**
- Table: `ctx.sapiom.llm.run` (one-shot) vs `ctx.sapiom.models.run` (platform-driven multi-turn loop, `models.coding.run` for sandboxed coding — never for a one-shot, it overthinks) vs `ctx.sapiom.agents.run` (dispatch a deployed agent by slug).
- **Explicit warning** against sending single-shot intent through a multi-turn surface, with a worked "wrong vs right" example: WRONG = `models.run` + "reply with ONLY JSON" + `JSON.parse`; RIGHT = `llm.run` with a forced tool call for the fixed shape, and an explicit `type`-filtered content read (never assume `content[0]` — a `thinking` block can precede it). Notes the incoming `output`/`structuredOf`/`textOf` convenience (#682, still open) that will automate this once it ships, without depending on it now.
- The label rule: never pick a model; omit `model` (recommended) or pin `"smart"`; raw provider ids never honored; results disclose `servedClass`/`lane`.
- A debugging pointer (dashboard run detail → step row id → **Run Inspector**) and the public guide link.

**New "## Naming Conventions" section** — a table settling agent / run / task / session / dispatch, plus "label" as the author-facing term for a `model:` value, and the rule that new capabilities must not add a sixth meaning to an already-overloaded word.

**Synced across all four copies** `skill-sync.test.ts` guards: the canonical source, both scaffold templates (`default`, `coding-pause`), and the Claude Code plugin copy (`plugins/sapiom/skills/`). Verified with checksums (all four MD5-identical) and the test itself.

**`packages/tools/src/models/index.ts` stale-comment fix:** the "Default agent … `agent.run` / `agent.launch`" header named a namespace that's actually exported as `models` — fixed, along with two more instances of the same problem I found in the same file while I was in there: the top-of-file module docstring's OWN self-description (`` `agent` capability`` + a code example calling `agent.coding.run`, when the real export is `models.coding.run` — arguably the more prominent occurrence, since it's the file's own introduction) and the `Ambient-bound `agent.coding` namespace` comment right above the block that flagged the issue. **#682 (open) also touches this file** but a different, non-overlapping region (the `ModelRunSpec`/`CodingRunSpec` type + JSDoc changes) — no hunk collision either way merges first.

## Important finding — an existing terminology guard caught real mistakes in my first draft

`scaffold.test.ts`'s `"copies the %s template with exact Agent terminology"` test bans certain internal service naming (case-insensitive) from anything shipped into a scaffold. My first draft tripped it twice:
1. The Naming Conventions "agent" row explained the internal-vs-external naming split by directly quoting the internal module's own docstring, which uses different internal vocabulary for the same concept. Reworded to convey the same fact (internal source comments use different, non-public vocabulary) without repeating the banned terms.
2. The debugging pointer cited a literal internal REST endpoint path — real (it's what `packages/agent-core/src/client.ts`/`run.ts` actually call), but that internal service naming must never reach scaffolded, customer-facing content. Dropped the literal path; the pointer now just says to use the **Run Inspector**.

**This same constraint may affect four other, already-open PRs in this teaching stack** that used the identical debugging-pointer text verbatim, none of which have this specific guard test, so nothing failed there, but the underlying "don't leak internal service naming to customers" policy this test enforces may still apply:
- #679 (MCP instructions fallback)
- #680 (harness system prompt)
- two companion server-side PRs (backend MCP instructions + migration; server-side skills pointer)

Not touched here — flagging for your call rather than unilaterally reopening four already-reviewed PRs.

## Testing
```
cd packages/agent-core
npx jest skill-sync                    # 7 passed
npx jest src/__tests__/scaffold.test.ts # 19 passed (including the terminology guard)
npx jest                                # full package: 18 suites, 171 passed
```
```
cd packages/tools
npx jest src/models                     # 25 passed
npx jest                                # full package: 29 suites, 564 passed
npx eslint src/models/index.ts && npx tsc --noEmit   # both clean
```
Needed a repo-root `pnpm build` first in this fresh worktree (agent-core/tools/mcp/harness all transitively depend on several unbuilt sibling packages).

Added a changeset (`@sapiom/agent-core` + `@sapiom/tools`, both `patch`) matching this repo's existing convention for skill-content-only changes (e.g. #163, #503).

## Related
Refs: internal tracker
#679, #680 (the rest of the teaching stack in this repo)
#682 (open, touches the same file in a non-overlapping region)
Companion server-side PRs (internal, not linked here)

## Checklist
- [x] Full rule + warning box + worked example + naming conventions (the complete version)
- [x] Synced across all 4 copies `skill-sync.test.ts` guards (checksum + test verified)
- [x] `models/index.ts` stale-comment fix folded in, no overlap with #682
- [x] Terminology-guard test respected — flagged the same risk for 4 earlier PRs rather than silently reopening them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDogyqvDnhy5iKgVpeZtWc
