### PR TITLE
feat(agent-core): inspectStep for per-attempt full-fidelity step I/O (SAP-2778)

### DIFF
--- a/.changeset/inspect-step-io.md
+++ b/.changeset/inspect-step-io.md
@@ -1,0 +1,8 @@
+---
+"@sapiom/agent-core": minor
+---
+
+Adds `inspectStep(opts, client)` — fetches one step attempt's full-fidelity `input`/`output`/`error`/`logs` (`GET /executions/:id/steps/:stepId/io`), at a higher size cap than `inspect()`'s own `steps[]` bounds its aggregate read to. Reach for it when a step's fields on the execution projection look truncated.
+
+- New exported `inspectStep`, `InspectStepOptions`, `StepIoDetail`, and `decodeStepIoDetail` (the tolerant decoder, mirroring `decodeExecutionProjection`'s degradation posture).
+- `StepProjection` gains an optional `id` field (the step-attempt row id) — previously decoded from the wire but silently dropped; needed to call `inspectStep` from an `inspect()` read. `null` on a read from a server that doesn't report it — existing consumers are unaffected.

--- a/packages/agent-core/src/__tests__/step-io-detail.wire.fixture.json
+++ b/packages/agent-core/src/__tests__/step-io-detail.wire.fixture.json
@@ -1,0 +1,43 @@
+{
+  "executionId": "exec_0001",
+  "id": "step_0002",
+  "stepName": "render",
+  "stepOrder": 1,
+  "attempt": 2,
+  "status": "failed",
+  "input": {
+    "items": 12
+  },
+  "output": null,
+  "error": {
+    "message": "template not found",
+    "trace": {
+      "frames": [
+        {
+          "function": "render",
+          "file": "src/steps/render.ts",
+          "line": 12,
+          "column": 11
+        },
+        {
+          "function": "run",
+          "file": "src/engine/runner.ts",
+          "line": 88,
+          "column": 5
+        }
+      ],
+      "sourceMapped": true,
+      "raw": "Error: template not found\n    at render (dist/steps/render.mjs:8:9)"
+    },
+    "traceUnavailableReason": null
+  },
+  "logs": [
+    {
+      "ts": "2026-01-01T00:00:46.000Z",
+      "level": "error",
+      "msg": "template not found"
+    }
+  ],
+  "startedAt": "2026-01-01T00:00:45.000Z",
+  "finishedAt": "2026-01-01T00:02:30.000Z"
+}

--- a/packages/agent-core/src/decode.ts
+++ b/packages/agent-core/src/decode.ts
@@ -28,6 +28,7 @@ import type {
   StepErrorFrame,
   StepErrorTrace,
   StepEvent,
+  StepIoDetail,
   StepProjection,
 } from "./types.js";
 
@@ -172,6 +173,7 @@ export function decodeExecutionRef(raw: unknown): ExecutionRef {
 function decodeStep(raw: unknown): StepProjection {
   const r = rec(raw);
   return {
+    id: strOrNull(r.id),
     stepName: str("", r.stepName),
     stepOrder: numOr(0, r.stepOrder),
     attempt: numOr(0, r.attempt),
@@ -200,6 +202,29 @@ function decodeStep(raw: unknown): StepProjection {
  * fabricated `$0`). This is the reusable entry point tickets 2/4 use to re-decode
  * a projection body after an SSE-triggered refetch.
  */
+/**
+ * Normalize a raw `GET /executions/:id/steps/:stepId/io` body into a complete
+ * {@link StepIoDetail}. Same degradation posture as {@link decodeExecutionProjection}:
+ * missing structural fields fall back to empty-ish defaults rather than throwing.
+ */
+export function decodeStepIoDetail(raw: unknown): StepIoDetail {
+  const r = rec(raw);
+  return {
+    executionId: str("", r.executionId),
+    id: str("", r.id),
+    stepName: str("", r.stepName),
+    stepOrder: numOr(0, r.stepOrder),
+    attempt: numOr(0, r.attempt),
+    status: str("", r.status),
+    input: r.input ?? null,
+    output: r.output ?? null,
+    error: decodeStepError(r.error),
+    logs: r.logs ?? null,
+    startedAt: strOrNull(r.startedAt),
+    finishedAt: strOrNull(r.finishedAt),
+  };
+}
+
 export function decodeExecutionProjection(raw: unknown): ExecutionProjection {
   const r = rec(raw);
   const id = str("", r.id, r.executionId);

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -86,6 +86,7 @@ export type { RunOptions, RunResult } from "./run.js";
 export type {
   ExecutionProjection,
   StepProjection,
+  StepIoDetail,
   CostNode,
   SettleState,
   ExecutionRef,
@@ -102,11 +103,12 @@ export { SSE_EVENT_TYPES } from "./types.js";
 // projection decode (tolerant normalization of the REST body) — the reusable
 // entry point consumers use to re-decode a body after an SSE refetch. The
 // finer-grained helpers stay module-internal to keep the published surface small.
-export { decodeExecutionProjection } from "./decode.js";
+export { decodeExecutionProjection, decodeStepIoDetail } from "./decode.js";
 
 // inspect / logs (networked)
 export {
   inspect,
+  inspectStep,
   listExecutions,
   inspectBuild,
   waitForExecution,
@@ -114,6 +116,7 @@ export {
 } from "./inspect.js";
 export type {
   InspectOptions,
+  InspectStepOptions,
   InspectBuildOptions,
   InspectBuildResult,
   BuildDetail,

--- a/packages/agent-core/src/inspect.parity.spec.ts
+++ b/packages/agent-core/src/inspect.parity.spec.ts
@@ -15,11 +15,12 @@
  * is what these tests do.
  */
 import type { GatewayClient } from "./client.js";
-import { decodeExecutionProjection } from "./decode.js";
-import { inspect, listExecutions } from "./inspect.js";
+import { decodeExecutionProjection, decodeStepIoDetail } from "./decode.js";
+import { inspect, inspectStep, listExecutions } from "./inspect.js";
 import wireFixture from "./__tests__/execution-detail.wire.fixture.json";
 import withCostFixture from "./__tests__/execution-projection.with-cost.fixture.json";
 import preseamFixture from "./__tests__/execution-projection.preseam.fixture.json";
+import stepIoWireFixture from "./__tests__/step-io-detail.wire.fixture.json";
 
 /** A GatewayClient that returns `body` for any GET, recording the path. */
 function clientReturning(body: unknown): { client: GatewayClient; paths: string[] } {
@@ -55,6 +56,14 @@ describe("inspect() decodes the real execution-detail wire", () => {
     expect(result.traceParent).toBeNull();
     expect(result.parentExecutionId).toBeNull();
     expect(result.steps[1]?.spanId).toBe("span_0002");
+  });
+
+  it("carries each step attempt's row id (SAP-2778: the stepExecutionId inspectStep takes)", async () => {
+    const { client } = clientReturning(wireFixture);
+    const result = await inspect({ executionId: "exec_0001" }, client);
+
+    expect(result.steps[0]?.id).toBe("step_0001");
+    expect(result.steps[1]?.id).toBe("step_0002");
   });
 
   it("reports cost as null when the detail read is cost-agnostic (no fabricated $0)", async () => {
@@ -184,5 +193,75 @@ describe("listExecutions() is tree-aware (with documented server-side degrade)",
   it("returns [] for a non-array body rather than throwing", async () => {
     const { client } = clientReturning(null);
     expect(await listExecutions(client)).toEqual([]);
+  });
+});
+
+describe("inspectStep() decodes the real step-io wire (SAP-2778)", () => {
+  it("hits the per-attempt endpoint and carries identity + status through", async () => {
+    const { client, paths } = clientReturning(stepIoWireFixture);
+    const result = await inspectStep(
+      { executionId: "exec_0001", stepExecutionId: "step_0002" },
+      client,
+    );
+
+    expect(paths).toEqual(["/executions/exec_0001/steps/step_0002/io"]);
+    expect(result.executionId).toBe("exec_0001");
+    expect(result.id).toBe("step_0002");
+    expect(result.stepName).toBe("render");
+    expect(result.stepOrder).toBe(1);
+    expect(result.attempt).toBe(2);
+    expect(result.status).toBe("failed");
+  });
+
+  it("carries input/output/logs at the higher per-attempt fidelity", async () => {
+    const { client } = clientReturning(stepIoWireFixture);
+    const result = await inspectStep(
+      { executionId: "exec_0001", stepExecutionId: "step_0002" },
+      client,
+    );
+
+    expect(result.input).toEqual({ items: 12 });
+    expect(result.output).toBeNull();
+    expect(result.logs).toEqual([
+      { ts: "2026-01-01T00:00:46.000Z", level: "error", msg: "template not found" },
+    ]);
+    expect(result.startedAt).toBe("2026-01-01T00:00:45.000Z");
+    expect(result.finishedAt).toBe("2026-01-01T00:02:30.000Z");
+  });
+
+  it("decodes the structured error the same way as the execution-detail read", async () => {
+    const { client } = clientReturning(stepIoWireFixture);
+    const result = await inspectStep(
+      { executionId: "exec_0001", stepExecutionId: "step_0002" },
+      client,
+    );
+
+    expect(result.error?.message).toBe("template not found");
+    expect(result.error?.traceUnavailableReason).toBeNull();
+    expect(result.error?.trace?.sourceMapped).toBe(true);
+    expect(result.error?.trace?.frames).toEqual([
+      { function: "render", file: "src/steps/render.ts", line: 12, column: 11 },
+      { function: "run", file: "src/engine/runner.ts", line: 88, column: 5 },
+    ]);
+  });
+
+  it("does not throw on an empty/garbage body — missing fields degrade honestly", () => {
+    expect(() => decodeStepIoDetail(undefined)).not.toThrow();
+    expect(() => decodeStepIoDetail({})).not.toThrow();
+    const degraded = decodeStepIoDetail({});
+    expect(degraded).toEqual({
+      executionId: "",
+      id: "",
+      stepName: "",
+      stepOrder: 0,
+      attempt: 0,
+      status: "",
+      input: null,
+      output: null,
+      error: null,
+      logs: null,
+      startedAt: null,
+      finishedAt: null,
+    });
   });
 });

--- a/packages/agent-core/src/inspect.ts
+++ b/packages/agent-core/src/inspect.ts
@@ -6,8 +6,17 @@
  * programmatic consumers; the CLI alias these as "logs" on its command surface.
  */
 import { GatewayClient } from "./client.js";
-import { decodeExecutionProjection, decodeExecutionRef } from "./decode.js";
-import type { ExecutionProjection, ExecutionRef, SseEvent } from "./types.js";
+import {
+  decodeExecutionProjection,
+  decodeExecutionRef,
+  decodeStepIoDetail,
+} from "./decode.js";
+import type {
+  ExecutionProjection,
+  ExecutionRef,
+  SseEvent,
+  StepIoDetail,
+} from "./types.js";
 import { watchExecution } from "./watch.js";
 
 export interface BuildDetail {
@@ -38,6 +47,36 @@ export async function inspect(
 ): Promise<ExecutionProjection> {
   const raw = await client.get<unknown>(`/executions/${opts.executionId}`);
   return decodeExecutionProjection(raw);
+}
+
+// ── Inspect one step attempt's full-fidelity I/O ───────────────────────────────
+
+export interface InspectStepOptions {
+  executionId: string;
+  /** A step attempt's row id — `ExecutionProjection.steps[].id` from {@link inspect}. */
+  stepExecutionId: string;
+}
+
+/**
+ * Fetch one step attempt's `input` / `output` / `error` / `logs` at a higher
+ * size cap than {@link inspect}'s own `steps[]` bounds its aggregate read to —
+ * reach for this when a step's fields on the execution projection look
+ * truncated (SAP-2778). The SDK is a thin passthrough of the REST shape,
+ * normalized (see {@link decodeStepIoDetail}) so a degraded body decodes
+ * rather than throwing.
+ *
+ * Throws `AgentOperationError` (code `HTTP_*` | `NETWORK`) on gateway errors —
+ * including a 404 for an unknown execution/step or one outside the caller's
+ * tenant (no existence leak).
+ */
+export async function inspectStep(
+  opts: InspectStepOptions,
+  client: GatewayClient,
+): Promise<StepIoDetail> {
+  const raw = await client.get<unknown>(
+    `/executions/${opts.executionId}/steps/${opts.stepExecutionId}/io`,
+  );
+  return decodeStepIoDetail(raw);
 }
 
 // ── Wait for an execution to settle ────────────────────────────────────────────

--- a/packages/agent-core/src/inspect.ts
+++ b/packages/agent-core/src/inspect.ts
@@ -53,7 +53,14 @@ export async function inspect(
 
 export interface InspectStepOptions {
   executionId: string;
-  /** A step attempt's row id — `ExecutionProjection.steps[].id` from {@link inspect}. */
+  /**
+   * A step attempt's row id — `ExecutionProjection.steps[].id` from
+   * {@link inspect}. That field is optional and may be absent or `null` (a
+   * server that doesn't yet report it, or a step attempt from before this id
+   * existed) — there is no fallback for that case here; fall back to Run
+   * Inspector or the projection's own `input`/`output`/`logs` instead of
+   * calling `inspectStep`.
+   */
   stepExecutionId: string;
 }
 

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -184,6 +184,13 @@ export interface DispatchRef {
  * inside {@link ExecutionProjection.steps}.
  */
 export interface StepProjection {
+  /**
+   * The step-attempt row id — pass it as `stepExecutionId` to {@link inspectStep}
+   * for this attempt's full-fidelity I/O (a higher size cap than this
+   * projection's own `input`/`output`/`logs`). `null` on a read from a server
+   * that doesn't yet report it.
+   */
+  id: string | null;
   stepName: string;
   stepOrder: number;
   attempt: number;
@@ -288,4 +295,31 @@ export interface ExecutionProjection {
 
   // ── steps ────────────────────────────────────────────────────────────────────
   steps: StepProjection[];
+}
+
+/**
+ * One step attempt's full-fidelity I/O — {@link inspectStep}'s result, fetched
+ * by execution id + `StepProjection.id`. Same audit columns as
+ * {@link StepProjection}, at a higher size cap than the execution-detail read
+ * bounds its aggregate `steps[]` to: reach for this when a step's `input` /
+ * `output` / `logs` on the execution projection looks truncated.
+ */
+export interface StepIoDetail {
+  executionId: string;
+  /** The step-attempt row id — the same value as the source `StepProjection.id`. */
+  id: string;
+  stepName: string;
+  stepOrder: number;
+  attempt: number;
+  status: string;
+  /** Input this attempt was handed, at the higher per-attempt size cap. */
+  input: unknown;
+  /** Output this attempt produced (null on throw), at the higher size cap. */
+  output: unknown;
+  /** Structured error if the attempt threw; null on success — same shape as {@link StepProjection.error}. */
+  error: StepError | null;
+  /** Executor-side log buffer (dispatched attempts only); null for in-process steps. */
+  logs: unknown;
+  startedAt: string | null;
+  finishedAt: string | null;
 }

--- a/packages/agent-core/src/types.ts
+++ b/packages/agent-core/src/types.ts
@@ -187,10 +187,13 @@ export interface StepProjection {
   /**
    * The step-attempt row id — pass it as `stepExecutionId` to {@link inspectStep}
    * for this attempt's full-fidelity I/O (a higher size cap than this
-   * projection's own `input`/`output`/`logs`). `null` on a read from a server
-   * that doesn't yet report it.
+   * projection's own `input`/`output`/`logs`). Optional: absent (or `null`) on
+   * a read from a server that doesn't yet report it, or on a hand-constructed
+   * projection that predates this field — treat both the same way, by falling
+   * back to Run Inspector / the projection's own `input`/`output`/`logs`
+   * instead of calling {@link inspectStep}.
    */
-  id: string | null;
+  id?: string | null;
   stepName: string;
   stepOrder: number;
   attempt: number;


### PR DESCRIPTION
## Summary

Exposes per-step-attempt full-fidelity I/O to programmatic consumers — the data path a platform step-inspection feature needs, and the SDK counterpart to a corresponding backend MCP tool (companion change, server-side).

Refs: internal tracker

## What changed

- New `inspectStep(opts, client)` hitting `GET /executions/:id/steps/:stepId/io`, mirroring `inspect()`/`inspectBuild()`'s existing `(opts, client) -> Promise<T>` calling convention rather than introducing a new one.
- New exported `StepIoDetail` (mirrors the engine's server-side DTO shape) and `decodeStepIoDetail`, following `decodeExecutionProjection`'s tolerant degradation posture — never throws on a malformed/partial body, missing fields become `null`/empty defaults, never fabricated. `error` decodes through the existing `decodeStepError` so a caller gets the same structured `StepError` shape `inspect()` already returns for the identical underlying wire form.
- `StepProjection` gains an optional `id` (the step-attempt row id). The wire already sent this on every execution-detail read, but `decodeStep()` silently dropped it — so there was no way to get from an `inspect()` read to the `stepExecutionId` `inspectStep` needs. Fixed as part of this change, since the feature is unusable end-to-end without it. Additive: `null` on an older server; existing consumers unaffected.
- Fixture-based parity tests in `inspect.parity.spec.ts`, anchored to a new code-authoritative fixture matching the shape of the real wire response, matching the file's existing "assert against the real wire, not a shape drawn to please the decoder" convention.

## Why this design

Mirrors `inspectBuild`'s pattern (a second, more specific "inspect" verb alongside the general `inspect()`) rather than adding a mode flag to `inspect()` itself — the step-IO read is a genuinely different endpoint with a different cap tier, not a variant of the execution read.

## Testing

- `packages/agent-core`: `npx jest` → **18 suites, 176 passed** (all pre-existing tests untouched + 5 new: endpoint path construction, per-attempt field fidelity, structured-error decode parity, and honest degradation on an empty/garbage body).
- `npm run typecheck` clean, `npm run lint` clean, `pnpm --filter "@sapiom/agent-core..." build` clean (also confirms the new `StepProjection.id` compiles through every dependent).

Companion change: a server-side companion PR (internal), not linked here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CDogyqvDnhy5iKgVpeZtWc
