### PR TITLE
fix(fetch): preserve Request __sapiom metadata

### DIFF
--- a/packages/fetch/src/fetch.ts
+++ b/packages/fetch/src/fetch.ts
@@ -1,4 +1,3 @@
-import { SapiomClient } from "@sapiom/core";
 import {
   BaseSapiomIntegrationConfig,
   initializeSapiomClient,
@@ -120,7 +119,13 @@ export function createFetch(config?: SapiomFetchConfig): typeof fetch {
     input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
+    const inputMetadata =
+      input instanceof Request ? (input as any).__sapiom : undefined;
     let request = new Request(input, init);
+
+    if (inputMetadata !== undefined) {
+      (request as any).__sapiom = inputMetadata;
+    }
 
     const requestMetadata = (request as any).__sapiom || {};
     const userMetadata = { ...defaultMetadata, ...requestMetadata };
@@ -138,10 +143,12 @@ export function createFetch(config?: SapiomFetchConfig): typeof fetch {
         const headers = new Headers(request.headers);
         headers.set("Sapiom-Identity", identityHeaders["Sapiom-Identity"]);
         request = new Request(request, { headers });
+        (request as any).__sapiom = requestMetadata;
       }
     }
 
     request = await handleAuthorization(request, authConfig, defaultMetadata);
+    (request as any).__sapiom = requestMetadata;
 
     const startTime = Date.now();
     let response: Response | null = null;

--- a/packages/fetch/src/http-client.integration.test.ts
+++ b/packages/fetch/src/http-client.integration.test.ts
@@ -549,6 +549,24 @@ describe("HTTP Client Integration Tests", () => {
       expect(mocks.create).not.toHaveBeenCalled();
       expect(mocks.complete).not.toHaveBeenCalled();
     });
+
+    it("should skip Sapiom when Request metadata sets enabled false", async () => {
+      fetchMock.get("https://api.example.com/public", {
+        status: 200,
+        body: { public: true },
+      });
+
+      const fetch = createFetch({ sapiomClient: mockSapiomClient });
+      const request = new Request("https://api.example.com/public");
+      (request as any).__sapiom = { enabled: false };
+
+      const response = await fetch(request);
+      await flushPromises();
+
+      expect(response.status).toBe(200);
+      expect(mocks.create).not.toHaveBeenCalled();
+      expect(mocks.complete).not.toHaveBeenCalled();
+    });
   });
 
   // ============================================================================


### PR DESCRIPTION
## Summary

Fixes #690

`@sapiom/fetch` documents per-request overrides by attaching `__sapiom` metadata directly to a `Request`, including `{ enabled: false }` to bypass Sapiom for one request.

However, `createFetch()` cloned the input with `new Request(input, init)` before reading metadata. Native `Request` cloning does not preserve custom properties, so `Request.__sapiom` was lost.

This PR preserves the metadata before cloning and reattaches it to cloned requests so per-request overrides keep working.

---

## Changes

- Read `__sapiom` metadata from the original `Request` before cloning.
- Reattach metadata to the cloned request.
- Preserve metadata across later internal request clones.
- Add a regression test for `Request.__sapiom = { enabled: false }`.

---

## How to Test

```bash
corepack pnpm --filter @sapiom/fetch test
corepack pnpm --filter @sapiom/fetch lint
corepack pnpm --filter @sapiom/fetch typecheck
corepack pnpm --filter @sapiom/fetch build
git diff --check
```

---

## Checklist

- [x] Tests pass — new regression test covers `Request.__sapiom = { enabled: false }`
- [x] Lint, typecheck, and build clean
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only

---

## Risk & Impact

**Low.** The fix only affects how `__sapiom` metadata survives internal `Request` cloning — it reads and reattaches the metadata rather than changing any clone or fetch behavior. Requests without `__sapiom` metadata are unaffected.

**Type:** 🐛 Bug fix
**Fixes:** #690