### PR TITLE
docs(skills): teach composition for multi-stage systems + drop the pin-smart no-op

### DIFF
--- a/.changeset/skill-compose-and-drop-pin.md
+++ b/.changeset/skill-compose-and-drop-pin.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/agent-core": patch
+"@sapiom/cli": patch
+---
+
+`sapiom-agent-authoring` skill + scaffold `AGENTS.md`: system-design teaching for multi-stage builds. New "Composing Deployed Agents" section — one agent per PROJECT; a multi-stage system is several small projects composed via `ctx.sapiom.agents.run`, with a worked coordinator example — and the scaffold's "keep exactly one `defineAgent` export" rule now says so inline, so it reads as a per-project rule rather than a design instruction to inline every stage. Also drops the "pass `smart` if you must pin" no-op from the label rule (omitting `model` is the recommendation; `smart` already is the default).

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -423,7 +423,8 @@ const research = await ctx.sapiom.agents.run({
 // and does NOT throw — a non-completed child is data the coordinator must
 // branch on, or a failed stage silently feeds `null` downstream.
 if (research.status !== "completed") {
-  return fail(`research-topic ${research.status}: ${research.error?.message}`);
+  // (fail() requires this step to declare canFail: true)
+  return fail(`research-topic ${research.status}: ${String(research.error)}`);
 }
 const script = await ctx.sapiom.agents.run({
   definition: "write-script",

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -419,6 +419,12 @@ const research = await ctx.sapiom.agents.run({
   definition: "research-topic", // the deployed child's slug
   input: { topic: input.topic },
 });
+// agents.run resolves on ANY terminal status (completed | failed | cancelled)
+// and does NOT throw — a non-completed child is data the coordinator must
+// branch on, or a failed stage silently feeds `null` downstream.
+if (research.status !== "completed") {
+  return fail(`research-topic ${research.status}: ${research.error?.message}`);
+}
 const script = await ctx.sapiom.agents.run({
   definition: "write-script",
   input: { research: research.output },

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -346,8 +346,9 @@ const response = await ctx.sapiom.llm.run({
     messages: [{ role: "user", content: `Classify this support ticket: ${input.text}` }],
     max_tokens: 256,
   },
-  // No `model` — omit it and let the platform choose (recommended). To pin
-  // instead: `model: "smart"` (a label, never a raw provider model id).
+  // No `model` — omit it and let the platform choose (recommended; passing
+  // "smart" would be a no-op — it already is the default — and a raw provider
+  // model id is never honored).
   output: {
     name: "classify_ticket",
     schema: {
@@ -377,8 +378,8 @@ the result back out. For a **plain-text** reply instead, use
 **You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
 `models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
 against its configured label set — never a raw provider model id (never honored, on any
-surface). Omit it entirely to let the platform choose (the recommended default); pass
-`"smart"` if you must pin. The result discloses what actually served, in the platform's own
+surface). Omit it entirely to let the platform choose (the recommended default) — passing
+`"smart"` is a no-op: it already is the default. The result discloses what actually served, in the platform's own
 vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
 lane it executed in) — never a model or provider id.
 
@@ -388,6 +389,46 @@ Find the run in the dashboard's run detail view, find the suspicious step's row 
 open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
 
 Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+
+## Composing Deployed Agents (System Design)
+
+**One agent per project — but a system is several projects.** The "keep exactly one
+`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system. A
+multi-stage system ("research → write script → voiceover → assemble → post") is not one
+big agent with five steps: it is several small agents, each its own project, deployed
+separately, composed by a thin coordinator that dispatches them by slug. A small deployed
+agent is independently testable, versioned, and reusable from more than one caller; a
+monolith couples every stage into a single deploy unit and step graph, so any stage change
+redeploys — and risks — all of them.
+
+**Wrong** — one project inlining every stage as a step:
+
+```typescript
+// DON'T: video-pipeline/index.ts with research, script, voiceover, assemble,
+// post as five steps of ONE defineAgent. No stage is reusable or
+// independently testable, and every stage change redeploys all five.
+```
+
+**Right** — each stage its own deployed project; a coordinator composes them:
+
+```typescript
+// research-topic/, write-script/, generate-voiceover/, assemble-video/,
+// post-video/: five small projects, each deployed on its own slug.
+// video-pipeline/ is then just the coordinator:
+const research = await ctx.sapiom.agents.run({
+  definition: "research-topic", // the deployed child's slug
+  input: { topic: input.topic },
+});
+const script = await ctx.sapiom.agents.run({
+  definition: "write-script",
+  input: { research: research.output },
+});
+// …and so on. Use agents.launch + pauseUntilSignal for a long-running child
+// so the coordinator's step doesn't time out.
+```
+
+Building a system in one session? Scaffold the stages as separate projects and deploy
+bottom-up — children first, the coordinator last (it dispatches them by their slugs).
 
 ## Naming Conventions
 

--- a/packages/agent-core/src/__tests__/skill-sync.test.ts
+++ b/packages/agent-core/src/__tests__/skill-sync.test.ts
@@ -68,9 +68,18 @@ describe("sapiom-agent-authoring content guards", () => {
 // guard the load-bearing composition rule and the encoding directly (a mojibake
 // em dash — bytes \u00e2\u0080\u0094 as characters — shipped here once).
 describe("template AGENTS.md content", () => {
-  for (const template of readdirSync(TEMPLATES_DIR)) {
-    it(`template "${template}" AGENTS.md is clean UTF-8 and carries the composition rule`, () => {
-      const md = readFileSync(path.join(TEMPLATES_DIR, template, "AGENTS.md"), "utf8");
+  const agentsMdPaths = [
+    ...readdirSync(TEMPLATES_DIR).map((template) =>
+      path.join(TEMPLATES_DIR, template, "AGENTS.md"),
+    ),
+    // The CLI ships its own separately published template copy — the exact
+    // drift path that let a mojibake em dash land in two files and not the third.
+    path.resolve(PKG_ROOT, "..", "cli", "templates", "default", "AGENTS.md"),
+  ];
+  for (const mdPath of agentsMdPaths) {
+    it(`${path.relative(path.resolve(PKG_ROOT, "..", ".."), mdPath)} is clean UTF-8 and carries the composition rule`, () => {
+      if (!existsSync(mdPath)) return; // cli package may not exist on every branch
+      const md = readFileSync(mdPath, "utf8");
       expect(md).not.toContain("\u00e2"); // mojibake telltale (â)
       expect(md).toContain("one agent per project");
       expect(md).toContain("ctx.sapiom.agents.run");

--- a/packages/agent-core/src/__tests__/skill-sync.test.ts
+++ b/packages/agent-core/src/__tests__/skill-sync.test.ts
@@ -46,6 +46,38 @@ describe("sapiom-agent-authoring skill sync", () => {
   }
 });
 
+// Content guards on the canonical (propagated to every copy by the identity
+// tests above). Byte-identity alone cannot stop an identical WRONG copy: the
+// pin no-op below already survived one correction round in this file.
+describe("sapiom-agent-authoring content guards", () => {
+  const canonical = readFileSync(CANONICAL, "utf8");
+
+  it("never re-teaches the pin no-op (smart already is the default)", () => {
+    expect(canonical.toLowerCase()).not.toContain("if you must pin");
+  });
+
+  it("teaches composition for multi-stage systems, with failure branching", () => {
+    expect(canonical).toContain("Composing Deployed Agents");
+    // agents.run resolves on any terminal status and does not throw — the
+    // worked example must branch on a non-completed child.
+    expect(canonical).toContain('research.status !== "completed"');
+  });
+});
+
+// The scaffold templates also ship an AGENTS.md; it has no canonical source, so
+// guard the load-bearing composition rule and the encoding directly (a mojibake
+// em dash — bytes \u00e2\u0080\u0094 as characters — shipped here once).
+describe("template AGENTS.md content", () => {
+  for (const template of readdirSync(TEMPLATES_DIR)) {
+    it(`template "${template}" AGENTS.md is clean UTF-8 and carries the composition rule`, () => {
+      const md = readFileSync(path.join(TEMPLATES_DIR, template, "AGENTS.md"), "utf8");
+      expect(md).not.toContain("\u00e2"); // mojibake telltale (â)
+      expect(md).toContain("one agent per project");
+      expect(md).toContain("ctx.sapiom.agents.run");
+    });
+  }
+});
+
 // The Claude Code plugin (repo root, plugins/sapiom — SAP-1366) carries its own
 // copy of the skill. Guarded: the plugin may not exist yet on this branch.
 describe("plugin skill copy (when present)", () => {

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -423,7 +423,8 @@ const research = await ctx.sapiom.agents.run({
 // and does NOT throw — a non-completed child is data the coordinator must
 // branch on, or a failed stage silently feeds `null` downstream.
 if (research.status !== "completed") {
-  return fail(`research-topic ${research.status}: ${research.error?.message}`);
+  // (fail() requires this step to declare canFail: true)
+  return fail(`research-topic ${research.status}: ${String(research.error)}`);
 }
 const script = await ctx.sapiom.agents.run({
   definition: "write-script",

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -419,6 +419,12 @@ const research = await ctx.sapiom.agents.run({
   definition: "research-topic", // the deployed child's slug
   input: { topic: input.topic },
 });
+// agents.run resolves on ANY terminal status (completed | failed | cancelled)
+// and does NOT throw — a non-completed child is data the coordinator must
+// branch on, or a failed stage silently feeds `null` downstream.
+if (research.status !== "completed") {
+  return fail(`research-topic ${research.status}: ${research.error?.message}`);
+}
 const script = await ctx.sapiom.agents.run({
   definition: "write-script",
   input: { research: research.output },

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -346,8 +346,9 @@ const response = await ctx.sapiom.llm.run({
     messages: [{ role: "user", content: `Classify this support ticket: ${input.text}` }],
     max_tokens: 256,
   },
-  // No `model` — omit it and let the platform choose (recommended). To pin
-  // instead: `model: "smart"` (a label, never a raw provider model id).
+  // No `model` — omit it and let the platform choose (recommended; passing
+  // "smart" would be a no-op — it already is the default — and a raw provider
+  // model id is never honored).
   output: {
     name: "classify_ticket",
     schema: {
@@ -377,8 +378,8 @@ the result back out. For a **plain-text** reply instead, use
 **You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
 `models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
 against its configured label set — never a raw provider model id (never honored, on any
-surface). Omit it entirely to let the platform choose (the recommended default); pass
-`"smart"` if you must pin. The result discloses what actually served, in the platform's own
+surface). Omit it entirely to let the platform choose (the recommended default) — passing
+`"smart"` is a no-op: it already is the default. The result discloses what actually served, in the platform's own
 vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
 lane it executed in) — never a model or provider id.
 
@@ -388,6 +389,46 @@ Find the run in the dashboard's run detail view, find the suspicious step's row 
 open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
 
 Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+
+## Composing Deployed Agents (System Design)
+
+**One agent per project — but a system is several projects.** The "keep exactly one
+`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system. A
+multi-stage system ("research → write script → voiceover → assemble → post") is not one
+big agent with five steps: it is several small agents, each its own project, deployed
+separately, composed by a thin coordinator that dispatches them by slug. A small deployed
+agent is independently testable, versioned, and reusable from more than one caller; a
+monolith couples every stage into a single deploy unit and step graph, so any stage change
+redeploys — and risks — all of them.
+
+**Wrong** — one project inlining every stage as a step:
+
+```typescript
+// DON'T: video-pipeline/index.ts with research, script, voiceover, assemble,
+// post as five steps of ONE defineAgent. No stage is reusable or
+// independently testable, and every stage change redeploys all five.
+```
+
+**Right** — each stage its own deployed project; a coordinator composes them:
+
+```typescript
+// research-topic/, write-script/, generate-voiceover/, assemble-video/,
+// post-video/: five small projects, each deployed on its own slug.
+// video-pipeline/ is then just the coordinator:
+const research = await ctx.sapiom.agents.run({
+  definition: "research-topic", // the deployed child's slug
+  input: { topic: input.topic },
+});
+const script = await ctx.sapiom.agents.run({
+  definition: "write-script",
+  input: { research: research.output },
+});
+// …and so on. Use agents.launch + pauseUntilSignal for a long-running child
+// so the coordinator's step doesn't time out.
+```
+
+Building a system in one session? Scaffold the stages as separate projects and deploy
+bottom-up — children first, the coordinator last (it dispatches them by their slugs).
 
 ## Naming Conventions
 

--- a/packages/agent-core/templates/coding-pause/AGENTS.md
+++ b/packages/agent-core/templates/coding-pause/AGENTS.md
@@ -6,7 +6,7 @@ The full authoring guide ships inside this project at `.claude/skills/sapiom-age
 
 ## Authoring
 
-- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export â one agent per PROJECT. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (see the sapiom-agent-authoring skill’s "Composing Deployed Agents").
 - **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
 
 ## The entry input contract

--- a/packages/agent-core/templates/coding-pause/AGENTS.md
+++ b/packages/agent-core/templates/coding-pause/AGENTS.md
@@ -6,7 +6,7 @@ The full authoring guide ships inside this project at `.claude/skills/sapiom-age
 
 ## Authoring
 
-- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export â one agent per PROJECT. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (see the sapiom-agent-authoring skill’s "Composing Deployed Agents").
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export — one agent per project. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (see the sapiom-agent-authoring skill’s "Composing Deployed Agents").
 - **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
 
 ## The entry input contract

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -423,7 +423,8 @@ const research = await ctx.sapiom.agents.run({
 // and does NOT throw — a non-completed child is data the coordinator must
 // branch on, or a failed stage silently feeds `null` downstream.
 if (research.status !== "completed") {
-  return fail(`research-topic ${research.status}: ${research.error?.message}`);
+  // (fail() requires this step to declare canFail: true)
+  return fail(`research-topic ${research.status}: ${String(research.error)}`);
 }
 const script = await ctx.sapiom.agents.run({
   definition: "write-script",

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -419,6 +419,12 @@ const research = await ctx.sapiom.agents.run({
   definition: "research-topic", // the deployed child's slug
   input: { topic: input.topic },
 });
+// agents.run resolves on ANY terminal status (completed | failed | cancelled)
+// and does NOT throw — a non-completed child is data the coordinator must
+// branch on, or a failed stage silently feeds `null` downstream.
+if (research.status !== "completed") {
+  return fail(`research-topic ${research.status}: ${research.error?.message}`);
+}
 const script = await ctx.sapiom.agents.run({
   definition: "write-script",
   input: { research: research.output },

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -346,8 +346,9 @@ const response = await ctx.sapiom.llm.run({
     messages: [{ role: "user", content: `Classify this support ticket: ${input.text}` }],
     max_tokens: 256,
   },
-  // No `model` — omit it and let the platform choose (recommended). To pin
-  // instead: `model: "smart"` (a label, never a raw provider model id).
+  // No `model` — omit it and let the platform choose (recommended; passing
+  // "smart" would be a no-op — it already is the default — and a raw provider
+  // model id is never honored).
   output: {
     name: "classify_ticket",
     schema: {
@@ -377,8 +378,8 @@ the result back out. For a **plain-text** reply instead, use
 **You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
 `models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
 against its configured label set — never a raw provider model id (never honored, on any
-surface). Omit it entirely to let the platform choose (the recommended default); pass
-`"smart"` if you must pin. The result discloses what actually served, in the platform's own
+surface). Omit it entirely to let the platform choose (the recommended default) — passing
+`"smart"` is a no-op: it already is the default. The result discloses what actually served, in the platform's own
 vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
 lane it executed in) — never a model or provider id.
 
@@ -388,6 +389,46 @@ Find the run in the dashboard's run detail view, find the suspicious step's row 
 open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
 
 Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+
+## Composing Deployed Agents (System Design)
+
+**One agent per project — but a system is several projects.** The "keep exactly one
+`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system. A
+multi-stage system ("research → write script → voiceover → assemble → post") is not one
+big agent with five steps: it is several small agents, each its own project, deployed
+separately, composed by a thin coordinator that dispatches them by slug. A small deployed
+agent is independently testable, versioned, and reusable from more than one caller; a
+monolith couples every stage into a single deploy unit and step graph, so any stage change
+redeploys — and risks — all of them.
+
+**Wrong** — one project inlining every stage as a step:
+
+```typescript
+// DON'T: video-pipeline/index.ts with research, script, voiceover, assemble,
+// post as five steps of ONE defineAgent. No stage is reusable or
+// independently testable, and every stage change redeploys all five.
+```
+
+**Right** — each stage its own deployed project; a coordinator composes them:
+
+```typescript
+// research-topic/, write-script/, generate-voiceover/, assemble-video/,
+// post-video/: five small projects, each deployed on its own slug.
+// video-pipeline/ is then just the coordinator:
+const research = await ctx.sapiom.agents.run({
+  definition: "research-topic", // the deployed child's slug
+  input: { topic: input.topic },
+});
+const script = await ctx.sapiom.agents.run({
+  definition: "write-script",
+  input: { research: research.output },
+});
+// …and so on. Use agents.launch + pauseUntilSignal for a long-running child
+// so the coordinator's step doesn't time out.
+```
+
+Building a system in one session? Scaffold the stages as separate projects and deploy
+bottom-up — children first, the coordinator last (it dispatches them by their slugs).
 
 ## Naming Conventions
 

--- a/packages/agent-core/templates/default/AGENTS.md
+++ b/packages/agent-core/templates/default/AGENTS.md
@@ -6,7 +6,7 @@ The full authoring guide ships inside this project at `.claude/skills/sapiom-age
 
 ## Authoring
 
-- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export.
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export â one agent per PROJECT. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (see the sapiom-agent-authoring skill’s "Composing Deployed Agents").
 - **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
 
 ## The entry input contract

--- a/packages/agent-core/templates/default/AGENTS.md
+++ b/packages/agent-core/templates/default/AGENTS.md
@@ -6,7 +6,7 @@ The full authoring guide ships inside this project at `.claude/skills/sapiom-age
 
 ## Authoring
 
-- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export â one agent per PROJECT. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (see the sapiom-agent-authoring skill’s "Composing Deployed Agents").
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export — one agent per project. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (see the sapiom-agent-authoring skill’s "Composing Deployed Agents").
 - **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
 
 ## The entry input contract

--- a/packages/cli/templates/default/AGENTS.md
+++ b/packages/cli/templates/default/AGENTS.md
@@ -12,4 +12,4 @@ This project defines exactly one Sapiom agent in `index.ts`, authored against `@
 
 - Use `npm run check` as the tight feedback loop — prefer it over reasoning about whether the graph is valid.
 - For exact command options, run `sapiom agents --help`, and pass `--json` to any command for machine-readable output. Don't hardcode capability lists or schemas — query them at runtime.
-- Keep exactly one `defineAgent(...)` export in `index.ts`.
+- Keep exactly one `defineAgent(...)` export in `index.ts` — one agent per project. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run`.

--- a/packages/cli/templates/default/AGENTS.md
+++ b/packages/cli/templates/default/AGENTS.md
@@ -12,4 +12,4 @@ This project defines exactly one Sapiom agent in `index.ts`, authored against `@
 
 - Use `npm run check` as the tight feedback loop — prefer it over reasoning about whether the graph is valid.
 - For exact command options, run `sapiom agents --help`, and pass `--json` to any command for machine-readable output. Don't hardcode capability lists or schemas — query them at runtime.
-- Keep exactly one `defineAgent(...)` export in `index.ts` — one agent per project. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run`.
+- Keep exactly one `defineAgent(...)` export in `index.ts` — one agent per project. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (see the sapiom-agent-authoring skill’s "Composing Deployed Agents").

--- a/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
@@ -423,7 +423,8 @@ const research = await ctx.sapiom.agents.run({
 // and does NOT throw — a non-completed child is data the coordinator must
 // branch on, or a failed stage silently feeds `null` downstream.
 if (research.status !== "completed") {
-  return fail(`research-topic ${research.status}: ${research.error?.message}`);
+  // (fail() requires this step to declare canFail: true)
+  return fail(`research-topic ${research.status}: ${String(research.error)}`);
 }
 const script = await ctx.sapiom.agents.run({
   definition: "write-script",

--- a/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
@@ -419,6 +419,12 @@ const research = await ctx.sapiom.agents.run({
   definition: "research-topic", // the deployed child's slug
   input: { topic: input.topic },
 });
+// agents.run resolves on ANY terminal status (completed | failed | cancelled)
+// and does NOT throw — a non-completed child is data the coordinator must
+// branch on, or a failed stage silently feeds `null` downstream.
+if (research.status !== "completed") {
+  return fail(`research-topic ${research.status}: ${research.error?.message}`);
+}
 const script = await ctx.sapiom.agents.run({
   definition: "write-script",
   input: { research: research.output },

--- a/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
@@ -346,8 +346,9 @@ const response = await ctx.sapiom.llm.run({
     messages: [{ role: "user", content: `Classify this support ticket: ${input.text}` }],
     max_tokens: 256,
   },
-  // No `model` — omit it and let the platform choose (recommended). To pin
-  // instead: `model: "smart"` (a label, never a raw provider model id).
+  // No `model` — omit it and let the platform choose (recommended; passing
+  // "smart" would be a no-op — it already is the default — and a raw provider
+  // model id is never honored).
   output: {
     name: "classify_ticket",
     schema: {
@@ -377,8 +378,8 @@ the result back out. For a **plain-text** reply instead, use
 **You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
 `models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
 against its configured label set — never a raw provider model id (never honored, on any
-surface). Omit it entirely to let the platform choose (the recommended default); pass
-`"smart"` if you must pin. The result discloses what actually served, in the platform's own
+surface). Omit it entirely to let the platform choose (the recommended default) — passing
+`"smart"` is a no-op: it already is the default. The result discloses what actually served, in the platform's own
 vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
 lane it executed in) — never a model or provider id.
 
@@ -388,6 +389,46 @@ Find the run in the dashboard's run detail view, find the suspicious step's row 
 open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
 
 Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+
+## Composing Deployed Agents (System Design)
+
+**One agent per project — but a system is several projects.** The "keep exactly one
+`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system. A
+multi-stage system ("research → write script → voiceover → assemble → post") is not one
+big agent with five steps: it is several small agents, each its own project, deployed
+separately, composed by a thin coordinator that dispatches them by slug. A small deployed
+agent is independently testable, versioned, and reusable from more than one caller; a
+monolith couples every stage into a single deploy unit and step graph, so any stage change
+redeploys — and risks — all of them.
+
+**Wrong** — one project inlining every stage as a step:
+
+```typescript
+// DON'T: video-pipeline/index.ts with research, script, voiceover, assemble,
+// post as five steps of ONE defineAgent. No stage is reusable or
+// independently testable, and every stage change redeploys all five.
+```
+
+**Right** — each stage its own deployed project; a coordinator composes them:
+
+```typescript
+// research-topic/, write-script/, generate-voiceover/, assemble-video/,
+// post-video/: five small projects, each deployed on its own slug.
+// video-pipeline/ is then just the coordinator:
+const research = await ctx.sapiom.agents.run({
+  definition: "research-topic", // the deployed child's slug
+  input: { topic: input.topic },
+});
+const script = await ctx.sapiom.agents.run({
+  definition: "write-script",
+  input: { research: research.output },
+});
+// …and so on. Use agents.launch + pauseUntilSignal for a long-running child
+// so the coordinator's step doesn't time out.
+```
+
+Building a system in one session? Scaffold the stages as separate projects and deploy
+bottom-up — children first, the coordinator last (it dispatches them by their slugs).
 
 ## Naming Conventions
 


### PR DESCRIPTION
## Why

Two behavioral-eval findings from the six-scenario authoring gate (run against the released stack; details in the companion internal tracker):

1. **Asked to build a 5-stage pipeline, the authored result was one `defineAgent` with five steps** — `agents.run` composition never appeared, even as an option. Traced in-transcript: the scaffold's "Keep exactly one `defineAgent(...)` export" rule reads as a *design* instruction in context, and the skill's one table row about composition is no counterweight when concretely building.
2. **The skill still taught the pin no-op.** Its label rule said "pass `\"smart\"` if you must pin" (and the worked example's comment offered the same) — advice already removed from the MCP-instructions copies in an earlier correction round, surviving here.

## What changed

- **New skill section: "Composing Deployed Agents (System Design)"** — one agent per PROJECT, but a system is several projects; wrong/right worked example (the five-stage pipeline case) with a thin coordinator dispatching children by slug via `ctx.sapiom.agents.run` (typed against `AgentRunSpec`/`AgentRunResult`), `agents.launch` + `pauseUntilSignal` for long-running children, and bottom-up deploy order. Applied to all **4** skill copies (canonical + 2 templates + plugin) — `skill-sync` enforces identity.
- **Scaffold `AGENTS.md` (all 3 templates)**: the one-export rule now continues "— one agent per PROJECT. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run`", so the rule can no longer be read as "inline every stage".
- **Label rule**: "pass `\"smart\"` if you must pin" → passing `"smart"` is a no-op (it already is the default); same fix in the worked example's comment. Matches the MCP-instructions copies.

## Test evidence

`packages/agent-core`: `npx jest skill-sync` → 7/7 (canonical ↔ both template copies ↔ plugin copy identity). `node scripts/provider-neutral-copy-check.mjs` → passed (74 files). Changeset: patch for `@sapiom/agent-core` + `@sapiom/cli`.

After release, eval scenario s6 (and s2, together with the docs guide fix) gets rerun with the same rig; the gate closes on 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W6yq48r2bGVo3GbDXNV4Np