### PR TITLE
fix(harness): deliver initial prompts to Codex

### DIFF
--- a/.changeset/codex-first-prompt-readiness.md
+++ b/.changeset/codex-first-prompt-readiness.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/harness": patch
+---
+
+Release held Agent Studio prompts into Codex once its terminal has rendered a
+settled, non-blocking frame. Initial prompts remain held through trust and
+setup screens, and Claude Code's SessionStart readiness behavior is unchanged.

--- a/.changeset/codex-first-prompt-readiness.md
+++ b/.changeset/codex-first-prompt-readiness.md
@@ -3,8 +3,10 @@
 ---
 
 Release held Agent Studio prompts into Codex once its terminal has rendered a
-settled frame with no recognized blocking screen. Initial prompts remain held
-through Codex trust, sign-in, and setup flows, and Claude Code's SessionStart
-readiness behavior is unchanged. Codex may now report `ready: true` before its
-first rollout/transcript exists: readiness describes an input-safe TUI, not
-durable conversation metadata.
+stable, non-blocking screen. Partial terminal repaints retain recognized
+blockers until the empty composer is positively identified, while a bounded
+fallback prevents animation or an incomplete repaint from waiting forever.
+Initial prompts remain held through Codex trust, sign-in, and setup flows, and
+Claude Code's SessionStart readiness behavior is unchanged. Codex may now
+report `ready: true` before its first rollout/transcript exists: readiness
+describes an input-safe TUI, not durable conversation metadata.

--- a/.changeset/codex-first-prompt-readiness.md
+++ b/.changeset/codex-first-prompt-readiness.md
@@ -3,5 +3,8 @@
 ---
 
 Release held Agent Studio prompts into Codex once its terminal has rendered a
-settled, non-blocking frame. Initial prompts remain held through trust and
-setup screens, and Claude Code's SessionStart readiness behavior is unchanged.
+settled frame with no recognized blocking screen. Initial prompts remain held
+through Codex trust, sign-in, and setup flows, and Claude Code's SessionStart
+readiness behavior is unchanged. Codex may now report `ready: true` before its
+first rollout/transcript exists: readiness describes an input-safe TUI, not
+durable conversation metadata.

--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -153,9 +153,92 @@ describe("CodexAdapter", () => {
       "\x1b[6;1H\x1b[38;5;6;49m› 1. Yes, continue\x1b[7;3H\x1b[39;49m2." +
       "\x1b[7;6HNo,\x1b[7;10Hquit\x1b[9;3H\x1b[2mPress enter to continue";
 
+    // Codex commonly positions words independently. Build that same output
+    // shape around stable copy from codex-cli 0.147.0's checked-in TUI
+    // sources so every signature is also exercised without literal spaces.
+    const cursorPositioned = (...lines: string[]) =>
+      lines
+        .map((line, row) =>
+          line
+            .split(" ")
+            .map((word, column) => `\x1b[${row + 1};${column * 8 + 1}H${word}`)
+            .join(""),
+        )
+        .join("");
+
     it("detects the trust prompt in a real, unmodified pty capture", () => {
       const adapter = new CodexAdapter();
       expect(adapter.detectBlockingPrompt(REAL_TRUST_PROMPT_CAPTURE)).toBe(true);
+    });
+
+    it.each([
+      [
+        "the sign-in chooser",
+        cursorPositioned(
+          "Sign in with ChatGPT to use Codex as part of your paid plan",
+          "or connect an API key for usage-based billing",
+          "Sign in with Device Code",
+          "Provide your own API key",
+        ),
+      ],
+      [
+        "browser authentication",
+        cursorPositioned(
+          "Finish signing in via your browser",
+          "If the link doesn't open automatically, open the following link to authenticate:",
+        ),
+      ],
+      [
+        "device-code authentication",
+        cursorPositioned(
+          "Preparing device code login",
+          "1. Open this link in your browser and sign in",
+          "2. Enter this one-time code after you are signed in",
+        ),
+      ],
+      [
+        "API-key entry",
+        cursorPositioned(
+          "Use your own OpenAI API key for usage-based billing",
+          "Paste or type your API key below. It will be stored locally in auth.json.",
+        ),
+      ],
+      [
+        "the post-login onboarding notice",
+        cursorPositioned(
+          "Before you start:",
+          "Decide how much autonomy you want to grant Codex",
+          "Codex can make mistakes",
+        ),
+      ],
+      [
+        "model migration",
+        cursorPositioned(
+          "Codex just got an upgrade. Introducing GPT-5.5.",
+          "Choose how you'd like Codex to proceed.",
+          "1. Try new model",
+          "2. Use existing model",
+        ),
+      ],
+      [
+        "personality selection",
+        cursorPositioned(
+          "Select Personality",
+          "Choose a communication style for Codex.",
+          "Press enter to confirm or esc to go back",
+        ),
+      ],
+      [
+        "syntax-theme selection",
+        cursorPositioned(
+          "Select Syntax Theme",
+          "Type to filter themes...",
+          "Move up/down to live preview themes",
+        ),
+      ],
+    ])("detects %s as blocking", (_name, capture) => {
+      const adapter = new CodexAdapter();
+      expect(adapter.detectBlockingPrompt(capture)).toBe(true);
     });
 
     it("does not false-positive on ordinary composer/output text", () => {
@@ -164,6 +247,13 @@ describe("CodexAdapter", () => {
         "\x1b]0;my-project\x07\x1b[1;1H\x1b[38;2;231;231;231;49m› Find and fix a bug in @filename" +
         "\x1b[3;1Hgpt-5.5 xhigh · /private/tmp/proj";
       expect(adapter.detectBlockingPrompt(composer)).toBe(false);
+    });
+
+    it("does not treat one isolated onboarding label in ordinary output as a whole blocking screen", () => {
+      const adapter = new CodexAdapter();
+      expect(adapter.detectBlockingPrompt("The docs mention Sign in with ChatGPT to use Codex as part of your paid plan.")).toBe(false);
+      expect(adapter.detectBlockingPrompt("You can choose Provide your own API key during setup.")).toBe(false);
+      expect(adapter.detectBlockingPrompt("The next heading says Select Personality.")).toBe(false);
     });
 
     it("does not false-positive on an OSC sequence terminated by ST (ESC \\\\) rather than BEL", () => {

--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -251,9 +251,26 @@ describe("CodexAdapter", () => {
 
     it("does not treat one isolated onboarding label in ordinary output as a whole blocking screen", () => {
       const adapter = new CodexAdapter();
-      expect(adapter.detectBlockingPrompt("The docs mention Sign in with ChatGPT to use Codex as part of your paid plan.")).toBe(false);
-      expect(adapter.detectBlockingPrompt("You can choose Provide your own API key during setup.")).toBe(false);
-      expect(adapter.detectBlockingPrompt("The next heading says Select Personality.")).toBe(false);
+      expect(
+        adapter.detectBlockingPrompt(
+          "The docs say to trust the contents of this directory.",
+        ),
+      ).toBe(false);
+      expect(
+        adapter.detectBlockingPrompt(
+          "The docs mention Sign in with ChatGPT to use Codex as part of your paid plan.",
+        ),
+      ).toBe(false);
+      expect(
+        adapter.detectBlockingPrompt(
+          "You can choose Provide your own API key during setup.",
+        ),
+      ).toBe(false);
+      expect(
+        adapter.detectBlockingPrompt(
+          "The next heading says Select Personality.",
+        ),
+      ).toBe(false);
     });
 
     it("does not false-positive on an OSC sequence terminated by ST (ESC \\\\) rather than BEL", () => {
@@ -267,7 +284,8 @@ describe("CodexAdapter", () => {
       const capture =
         "\x1b]10;?\x1b\\\x1b]11;?\x1b\\\x1b]0;proj\x07" +
         "\x1b[3;3HDo\x1b[3;6Hyou\x1b[3;10Htrust\x1b[3;16Hthe\x1b[3;20Hcontents" +
-        "\x1b[3;29Hof\x1b[3;32Hthis\x1b[3;37Hdirectory?";
+        "\x1b[3;29Hof\x1b[3;32Hthis\x1b[3;37Hdirectory?" +
+        "\x1b[6;3HYes,\x1b[6;8Hcontinue\x1b[7;3HNo,\x1b[7;7Hquit";
       const adapter = new CodexAdapter();
       expect(adapter.detectBlockingPrompt(capture)).toBe(true);
     });
@@ -275,6 +293,27 @@ describe("CodexAdapter", () => {
     it("returns false for plain text with no escape sequences at all", () => {
       const adapter = new CodexAdapter();
       expect(adapter.detectBlockingPrompt("just some ordinary agent output, nothing special")).toBe(false);
+    });
+  });
+
+  describe("detectReadyPrompt", () => {
+    it("recognizes the empty Codex composer through cursor-positioned rendering", () => {
+      const adapter = new CodexAdapter();
+      expect(
+        adapter.detectReadyPrompt(
+          "\x1b[?2026h\x1b[12;3HAsk\x1b[12;7HCodex\x1b[12;13Hto\x1b[12;16Hdo" +
+            "\x1b[12;19Hanything\x1b[?2026l",
+        ),
+      ).toBe(true);
+    });
+
+    it("does not mistake an onboarding screen for the empty composer", () => {
+      const adapter = new CodexAdapter();
+      expect(
+        adapter.detectReadyPrompt(
+          "Finish signing in via your browser\r\nopen the following link to authenticate",
+        ),
+      ).toBe(false);
     });
   });
 

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -71,7 +71,11 @@ function tuiPhrase(phrase: string): RegExp {
  * its stable rendered copy must be added here.
  */
 const BLOCKING_PROMPT_SIGNATURES: readonly (readonly RegExp[])[] = [
-  [tuiPhrase("trust the contents of this directory")],
+  [
+    tuiPhrase("trust the contents of this directory"),
+    tuiPhrase("Yes, continue"),
+    tuiPhrase("No, quit"),
+  ],
   [
     tuiPhrase("Sign in with ChatGPT to use Codex as part of your paid plan"),
     tuiPhrase("connect an API key for usage-based billing"),
@@ -102,6 +106,11 @@ const BLOCKING_PROMPT_SIGNATURES: readonly (readonly RegExp[])[] = [
   ],
   [tuiPhrase("Select Syntax Theme"), tuiPhrase("Type to filter themes")],
 ];
+
+/** Stable empty-composer copy from codex-cli 0.147.0. This is not required
+ * for the ordinary already-trusted path; SessionManager uses it to prove that
+ * a previously detected onboarding screen has actually been replaced. */
+const READY_PROMPT_PATTERNS = [tuiPhrase("Ask Codex to do anything")];
 
 export interface CodexAdapterOptions {
   /** Overridable for tests. */
@@ -285,7 +294,8 @@ export class CodexAdapter implements HarnessAdapter {
    * is submitted. Confirmed empirically against codex-cli 0.134.0: an idle,
    * fully-interactive session produces no rollout for as long as nothing is
    * submitted. SessionManager therefore publishes fallback readiness after a
-   * quiet, non-blocking frame, while retaining the same check at request time.
+   * non-blocking frame settles (or reaches its bounded liveness ceiling),
+   * while retaining the same check at request time.
    */
   readonly readyFallback = "immediate" as const;
 
@@ -294,6 +304,11 @@ export class CodexAdapter implements HarnessAdapter {
     return BLOCKING_PROMPT_SIGNATURES.some((signature) =>
       signature.every((pattern) => pattern.test(rendered)),
     );
+  }
+
+  detectReadyPrompt(terminalOutput: string): boolean {
+    const rendered = stripAnsi(terminalOutput);
+    return READY_PROMPT_PATTERNS.some((pattern) => pattern.test(rendered));
   }
 
   /**

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -45,18 +45,63 @@ const ROLLOUT_HEAD_BYTES = 65_536;
 const MAX_SCAN_DEPTH = 4; // ~/.codex/sessions/YYYY/MM/DD/*.jsonl
 
 /**
- * Matches Codex's directory-trust confirmation prompt ("Do you trust the
- * contents of this directory? ... 1. Yes, continue  2. No, quit"), after
- * `stripAnsi` — confirmed against a real capture: Codex's TUI positions
- * each *word* with its own cursor-addressing escape sequence instead of
- * emitting literal spaces between them (`trust\x1b[3;16Hthe\x1b[3;20H...`),
- * so even a stripped buffer runs the words together with no separator at
- * all; `\s*` between them tolerates that (and ordinary whitespace, in case
- * a future TUI revision renders differently). See `detectBlockingPrompt`
- * for why this exists at all (Codex's own structured readiness signal can't
- * be relied on standalone, unlike Claude Code's).
+ * Turn a rendered phrase into a pattern that also matches Codex's cursor-
+ * positioned output. Confirmed against real captures: the TUI can position
+ * each *word* separately instead of emitting literal spaces
+ * (`trust\x1b[3;16Hthe\x1b[3;20H...`), so `stripAnsi()` leaves adjacent words.
+ * `\s*` accepts both that representation and ordinary terminal text.
  */
-const TRUST_PROMPT_PATTERN = /trust\s*the\s*contents\s*of\s*this\s*directory/i;
+function tuiPhrase(phrase: string): RegExp {
+  const escapedWords = phrase
+    .trim()
+    .split(/\s+/)
+    .map((word) => word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  return new RegExp(escapedWords.join("\\s*"), "i");
+}
+
+/**
+ * Recognizable signatures for Codex screens that need a human choice before
+ * the composer is safe for injected input. A signature may require multiple
+ * phrases so ordinary agent output mentioning one short label does not hold
+ * later programmatic input indefinitely.
+ *
+ * These strings are verified against codex-cli 0.147.0's onboarding, auth,
+ * model-migration, personality, and theme-picker sources. Detection remains
+ * deliberately best-effort: when Codex adds a new interactive startup screen,
+ * its stable rendered copy must be added here.
+ */
+const BLOCKING_PROMPT_SIGNATURES: readonly (readonly RegExp[])[] = [
+  [tuiPhrase("trust the contents of this directory")],
+  [
+    tuiPhrase("Sign in with ChatGPT to use Codex as part of your paid plan"),
+    tuiPhrase("connect an API key for usage-based billing"),
+  ],
+  [
+    tuiPhrase("Finish signing in via your browser"),
+    tuiPhrase("open the following link to authenticate"),
+  ],
+  [
+    tuiPhrase("Preparing device code login"),
+    tuiPhrase("Open this link in your browser and sign in"),
+  ],
+  [
+    tuiPhrase("Use your own OpenAI API key for usage-based billing"),
+    tuiPhrase("Paste or type your API key"),
+  ],
+  [
+    tuiPhrase("Before you start"),
+    tuiPhrase("Decide how much autonomy you want to grant Codex"),
+  ],
+  [
+    tuiPhrase("Codex just got an upgrade"),
+    tuiPhrase("Choose how you'd like Codex to proceed"),
+  ],
+  [
+    tuiPhrase("Select Personality"),
+    tuiPhrase("Choose a communication style for Codex"),
+  ],
+  [tuiPhrase("Select Syntax Theme"), tuiPhrase("Type to filter themes")],
+];
 
 export interface CodexAdapterOptions {
   /** Overridable for tests. */
@@ -234,28 +279,21 @@ export class CodexAdapter implements HarnessAdapter {
   }
 
   /**
-   * See `HarnessAdapter.detectBlockingPrompt`. Codex needs this (Claude Code
-   * doesn't) because its rollout file — and therefore the SessionStart-
-   * equivalent event `SessionManager` otherwise waits on — isn't written
-   * until the *first* turn is actually submitted, confirmed empirically
-   * against a real `codex-cli 0.134.0`: an idle, fully-interactive session
-   * (trust prompt already accepted, composer visibly ready) produces zero
-   * files under `~/.codex/sessions` for as long as nothing is submitted.
-   * That real signal therefore can't arrive before the very first
-   * injection that needs it — a scrollback check is the only thing that
-   * can stand in for it up to that point.
-   */
-  /**
-   * See `HarnessAdapter.readyFallback`: SessionManager proactively publishes
-   * readiness once Codex has rendered non-blocking output, and
-   * `isReadyEnough` retains the same settled-scrollback rule as a request-time
-   * safeguard. Codex's real readiness signal cannot arrive before the first
-   * injection needs it (see detectBlockingPrompt).
+   * See `HarnessAdapter.readyFallback` and `detectBlockingPrompt`. Codex's
+   * rollout file — and therefore the SessionStart-equivalent event
+   * `SessionManager` otherwise waits on — isn't written until the first turn
+   * is submitted. Confirmed empirically against codex-cli 0.134.0: an idle,
+   * fully-interactive session produces no rollout for as long as nothing is
+   * submitted. SessionManager therefore publishes fallback readiness after a
+   * quiet, non-blocking frame, while retaining the same check at request time.
    */
   readonly readyFallback = "immediate" as const;
 
   detectBlockingPrompt(scrollback: string): boolean {
-    return TRUST_PROMPT_PATTERN.test(stripAnsi(scrollback));
+    const rendered = stripAnsi(scrollback);
+    return BLOCKING_PROMPT_SIGNATURES.some((signature) =>
+      signature.every((pattern) => pattern.test(rendered)),
+    );
   }
 
   /**

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -246,9 +246,11 @@ export class CodexAdapter implements HarnessAdapter {
    * can stand in for it up to that point.
    */
   /**
-   * See `HarnessAdapter.readyFallback`: `isReadyEnough` may trust a settled,
-   * prompt-free scrollback immediately — Codex's real readiness signal cannot
-   * arrive before the first injection needs it (see detectBlockingPrompt).
+   * See `HarnessAdapter.readyFallback`: SessionManager proactively publishes
+   * readiness once Codex has rendered non-blocking output, and
+   * `isReadyEnough` retains the same settled-scrollback rule as a request-time
+   * safeguard. Codex's real readiness signal cannot arrive before the first
+   * injection needs it (see detectBlockingPrompt).
    */
   readonly readyFallback = "immediate" as const;
 

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -512,6 +512,7 @@ describe("SessionManager", () => {
         const detectBlockingPrompt = vi.fn(() => false);
         const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt, readyFallback: "immediate" }) });
         const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        spawns[0]?.emitData("› Ask Codex to do anything\r\n");
 
         const submitPromise = manager.submitInput(session.id, "hello", true);
         expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
@@ -529,6 +530,7 @@ describe("SessionManager", () => {
         const detectBlockingPrompt = vi.fn(() => false);
         const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt, readyFallback: "immediate" }) });
         const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        spawns[0]?.emitData("› Ask Codex to do anything\r\n");
 
         await vi.advanceTimersByTimeAsync(700);
         const submitPromise = manager.submitInput(session.id, "hello", true);
@@ -546,6 +548,7 @@ describe("SessionManager", () => {
         const detectBlockingPrompt = vi.fn(() => showingPrompt);
         const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt, readyFallback: "immediate" }) });
         const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        spawns[0]?.emitData("Do you trust the contents of this directory?\r\n");
 
         const submitPromise = manager.submitInput(session.id, "hello", true);
         await vi.advanceTimersByTimeAsync(700);
@@ -553,8 +556,8 @@ describe("SessionManager", () => {
 
         // Simulated: a human answers the prompt directly in the terminal.
         showingPrompt = false;
-        await vi.advanceTimersByTimeAsync(150); // one READY_POLL_MS tick
-        await vi.advanceTimersByTimeAsync(300);
+        spawns[0]?.emitData("› Ask Codex to do anything\r\n");
+        await vi.advanceTimersByTimeAsync(1_200);
         expect(await submitPromise).toBe(true);
       });
 
@@ -562,6 +565,7 @@ describe("SessionManager", () => {
         const detectBlockingPrompt = vi.fn(() => true);
         const { manager, spawns } = makeManager({ adapter: createFakeAdapter({ detectBlockingPrompt, readyFallback: "immediate" }) });
         const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+        spawns[0]?.emitData("Do you trust the contents of this directory?\r\n");
 
         const submitPromise = manager.submitInput(session.id, "hello", true);
         const assertion = expect(submitPromise).rejects.toThrow(/not ready yet/i);
@@ -612,7 +616,74 @@ describe("SessionManager", () => {
       expect(manager.get(session.id)?.ready).toBe(false);
 
       spawns[0]?.emitData("› Ask Codex to do anything\r\n");
-      await vi.advanceTimersByTimeAsync(150);
+      await vi.advanceTimersByTimeAsync(799);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(manager.get(session.id)?.ready).toBe(true);
+    });
+
+    it("ignores Codex's animation-only synchronized repaints when settling", async () => {
+      const { manager, spawns } = makeManager({ adapter: immediateAdapter() });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      spawns[0]?.emitData("› Ask Codex to do anything\r\n");
+
+      // Real codex-cli 0.147.0 emits a control-only frame like this about
+      // every 80ms while idle. It must not postpone readiness forever.
+      const animationFrame = "\x1b[?2026h\x1b[1;55H\x1b[0m\x1b[49m\x1b[K\x1b[?25l\x1b[?2026l";
+      for (let elapsed = 100; elapsed <= 700; elapsed += 100) {
+        await vi.advanceTimersByTimeAsync(100);
+        spawns[0]?.emitData(animationFrame);
+      }
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(manager.get(session.id)?.ready).toBe(true);
+    });
+
+    it("keeps a blocking screen visible to readiness checks through ANSI-only redraw churn", async () => {
+      const detectBlockingPrompt = vi.fn((scrollback: string) => scrollback.includes("Sign in with ChatGPT"));
+      const { manager, spawns } = makeManager({
+        adapter: immediateAdapter(detectBlockingPrompt),
+      });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      // A real Ratatui repaint — including its boundary markers — can span
+      // several node-pty chunks.
+      spawns[0]?.emitData("\x1b[?20");
+      spawns[0]?.emitData("26h\x1b[2J");
+      spawns[0]?.emitData("\x1b[1;1HSign in with ChatGPT\r\nProvide your own API key");
+      spawns[0]?.emitData("\x1b[?20");
+      spawns[0]?.emitData("26l");
+      // More than the 4KB detector window of raw ANSI noise must not evict the
+      // sign-in copy that remains visibly painted on the terminal.
+      const animationFrame =
+        "\x1b[?2026h" + "\x1b[1;55H\x1b[0m\x1b[49m\x1b[K".repeat(200) + "\x1b[?2026l";
+      spawns[0]?.emitData(animationFrame);
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(manager.get(session.id)?.ready).toBe(false);
+      expect(detectBlockingPrompt).toHaveBeenCalledWith(expect.stringContaining("Sign in with ChatGPT"));
+
+      // The next content-bearing synchronized repaint replaces the old screen.
+      spawns[0]?.emitData("\x1b[?2026h\x1b[1;1H› Ask Codex to do anything\r\n\x1b[?2026l");
+      await vi.advanceTimersByTimeAsync(700);
+      expect(manager.get(session.id)?.ready).toBe(true);
+    });
+
+    it("restarts the settle window when later startup output arrives", async () => {
+      const { manager, spawns } = makeManager({ adapter: immediateAdapter() });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      spawns[0]?.emitData("early Codex banner\r\n");
+
+      await vi.advanceTimersByTimeAsync(600);
+      spawns[0]?.emitData("later startup frame\r\n");
+
+      // Spawn age has passed the old 700ms threshold, but the latest frame
+      // has not been quiet for 700ms yet.
+      await vi.advanceTimersByTimeAsync(749);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
       expect(manager.get(session.id)?.ready).toBe(true);
     });
 
@@ -631,9 +702,39 @@ describe("SessionManager", () => {
       // A human answers through raw terminal input; Codex redraws its composer.
       showingPrompt = false;
       spawns[0]?.emitData("\x1b[1;1H› Ask Codex to do anything\r\n");
-      await vi.advanceTimersByTimeAsync(150);
+      await vi.advanceTimersByTimeAsync(699);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
       expect(manager.get(session.id)?.ready).toBe(true);
       expect(detectBlockingPrompt).toHaveBeenCalled();
+    });
+
+    it("rechecks for a late blocking screen before writing after readiness has latched", async () => {
+      let showingPrompt = false;
+      const { manager, spawns } = makeManager({
+        adapter: immediateAdapter(() => showingPrompt),
+      });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      spawns[0]?.emitData("› Ask Codex to do anything\r\n");
+      await vi.advanceTimersByTimeAsync(750);
+      expect(manager.get(session.id)?.ready).toBe(true);
+
+      showingPrompt = true;
+      spawns[0]?.emitData("Sign in with ChatGPT\r\n");
+      const submitPromise = manager.submitInput(session.id, "held prompt", true);
+      expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
+
+      // `ready` remains the single latched status transition, but injection
+      // waits for the adapter's current frame to become safe again.
+      expect(manager.get(session.id)?.ready).toBe(true);
+      showingPrompt = false;
+      spawns[0]?.emitData("› Ask Codex to do anything\r\n");
+      await vi.advanceTimersByTimeAsync(1_200);
+
+      expect(await submitPromise).toBe(true);
+      expect(spawns[0]?.pty.write).toHaveBeenNthCalledWith(1, "held prompt");
+      expect(spawns[0]?.pty.write).toHaveBeenNthCalledWith(2, "\r");
     });
 
     it("stops after a real readiness signal and does not broadcast ready twice", async () => {
@@ -671,7 +772,7 @@ describe("SessionManager", () => {
       expect(manager.get(session.id)?.ready).toBe(false);
 
       spawns[1]?.emitData("› resumed Codex composer\r\n");
-      await vi.advanceTimersByTimeAsync(150);
+      await vi.advanceTimersByTimeAsync(800);
       expect(manager.get(session.id)?.ready).toBe(true);
     });
 

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -711,7 +711,7 @@ describe("SessionManager", () => {
       spawns[0]?.emitData(
         "\x1b[?2026h\x1b[1;1H› Ask Codex to do anything\r\n\x1b[?2026l",
       );
-      await vi.advanceTimersByTimeAsync(750);
+      await vi.advanceTimersByTimeAsync(850);
       expect(manager.get(session.id)?.ready).toBe(true);
     });
 
@@ -797,13 +797,15 @@ describe("SessionManager", () => {
       const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
       spawns[0]?.emitData("Do you trust the contents of this directory?\r\n");
 
-      await vi.advanceTimersByTimeAsync(2_000);
+      // Leave the prompt open beyond the hard ceiling. Clearing it must start
+      // a fresh candidate window rather than inheriting an already-expired one.
+      await vi.advanceTimersByTimeAsync(6_000);
       expect(manager.get(session.id)?.ready).toBe(false);
 
       // A human answers through raw terminal input; Codex redraws its composer.
       showingPrompt = false;
       spawns[0]?.emitData("\x1b[1;1H› Ask Codex to do anything\r\n");
-      await vi.advanceTimersByTimeAsync(699);
+      await vi.advanceTimersByTimeAsync(749);
       expect(manager.get(session.id)?.ready).toBe(false);
 
       await vi.advanceTimersByTimeAsync(1);

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -573,6 +573,127 @@ describe("SessionManager", () => {
     });
   });
 
+  describe("immediate ready fallback (Codex's first-prompt bridge)", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const immediateAdapter = (detect: (scrollback: string) => boolean = () => false) =>
+      createFakeAdapter({
+        readyFallback: "immediate",
+        detectBlockingPrompt: vi.fn(detect),
+      });
+
+    it("publishes ready after output settles without waiting for submitInput()", async () => {
+      const { manager, spawns } = makeManager({ adapter: immediateAdapter() });
+      const readyStatuses: boolean[] = [];
+      manager.onStatusChange((session) => readyStatuses.push(session.ready));
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      spawns[0]?.emitData("\x1b[1;1H› Ask Codex to do anything\r\n");
+
+      await vi.advanceTimersByTimeAsync(749);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(manager.get(session.id)?.ready).toBe(true);
+      expect(readyStatuses.filter(Boolean)).toHaveLength(1);
+      expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
+    });
+
+    it("requires pty output before publishing ready", async () => {
+      const { manager, spawns } = makeManager({ adapter: immediateAdapter() });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      spawns[0]?.emitData("› Ask Codex to do anything\r\n");
+      await vi.advanceTimersByTimeAsync(150);
+      expect(manager.get(session.id)?.ready).toBe(true);
+    });
+
+    it("waits through a blocking prompt and publishes ready after the user clears it", async () => {
+      let showingPrompt = true;
+      const detectBlockingPrompt = vi.fn(() => showingPrompt);
+      const { manager, spawns } = makeManager({
+        adapter: immediateAdapter(detectBlockingPrompt),
+      });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      spawns[0]?.emitData("Do you trust the contents of this directory?\r\n");
+
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      // A human answers through raw terminal input; Codex redraws its composer.
+      showingPrompt = false;
+      spawns[0]?.emitData("\x1b[1;1H› Ask Codex to do anything\r\n");
+      await vi.advanceTimersByTimeAsync(150);
+      expect(manager.get(session.id)?.ready).toBe(true);
+      expect(detectBlockingPrompt).toHaveBeenCalled();
+    });
+
+    it("stops after a real readiness signal and does not broadcast ready twice", async () => {
+      const detectBlockingPrompt = vi.fn(() => false);
+      const { manager, spawns } = makeManager({
+        adapter: immediateAdapter(detectBlockingPrompt),
+      });
+      const readyStatuses: boolean[] = [];
+      manager.onStatusChange((session) => readyStatuses.push(session.ready));
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      spawns[0]?.emitData("› Ask Codex to do anything\r\n");
+
+      await vi.advanceTimersByTimeAsync(300);
+      manager.setReady(session.id);
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(manager.get(session.id)?.ready).toBe(true);
+      expect(readyStatuses.filter(Boolean)).toHaveLength(1);
+      expect(detectBlockingPrompt).not.toHaveBeenCalled();
+    });
+
+    it("stops the old monitor when its pty exits and is replaced on resume", async () => {
+      const { manager, spawns } = makeManager({ adapter: immediateAdapter() });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      manager.setAgentSessionId(session.id, "agent-1");
+      spawns[0]?.emitData("› old Codex composer\r\n");
+
+      await vi.advanceTimersByTimeAsync(300);
+      spawns[0]?.emitExit(0);
+      await manager.resume(session.id);
+      expect(spawns).toHaveLength(2);
+
+      // The old clean frame must not promote the fresh, still-empty pty.
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      spawns[1]?.emitData("› resumed Codex composer\r\n");
+      await vi.advanceTimersByTimeAsync(150);
+      expect(manager.get(session.id)?.ready).toBe(true);
+    });
+
+    it("does not proactively promote a legacy detect-only adapter", async () => {
+      const detectBlockingPrompt = vi.fn(() => false);
+      const { manager, spawns } = makeManager({
+        adapter: createFakeAdapter({ detectBlockingPrompt }),
+      });
+      const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
+      spawns[0]?.emitData("legacy composer\r\n");
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      // Its pre-existing request-time compatibility path remains intact.
+      const submitPromise = manager.submitInput(session.id, "hello", true);
+      await vi.advanceTimersByTimeAsync(500);
+      expect(await submitPromise).toBe(true);
+      expect(manager.get(session.id)?.ready).toBe(false);
+    });
+  });
+
   describe("hook-timeout ready fallback (Claude Code's broken-hook rescue)", () => {
     beforeEach(() => {
       vi.useFakeTimers();
@@ -650,7 +771,7 @@ describe("SessionManager", () => {
       expect(console.warn).not.toHaveBeenCalledWith(expect.stringContaining("marking ready by fallback"));
     });
 
-    it("is not armed for adapters without hook-timeout (Codex keeps its immediate path, default gets nothing)", async () => {
+    it("is not armed for adapters without a declared fallback", async () => {
       const { manager, spawns } = makeManager({ adapter: createFakeAdapter() });
       const session = await manager.create({ cwd: "/tmp/proj", harness: "claude-code" });
       spawns[0]?.emitData("output\r\n");

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -586,10 +586,15 @@ describe("SessionManager", () => {
       vi.useRealTimers();
     });
 
-    const immediateAdapter = (detect: (scrollback: string) => boolean = () => false) =>
+    const immediateAdapter = (
+      detect: (scrollback: string) => boolean = () => false,
+      detectReady: (scrollback: string) => boolean = (scrollback) =>
+        scrollback.includes("Ask Codex to do anything"),
+    ) =>
       createFakeAdapter({
         readyFallback: "immediate",
         detectBlockingPrompt: vi.fn(detect),
+        detectReadyPrompt: vi.fn(detectReady),
       });
 
     it("publishes ready after output settles without waiting for submitInput()", async () => {
@@ -664,10 +669,106 @@ describe("SessionManager", () => {
       expect(manager.get(session.id)?.ready).toBe(false);
       expect(detectBlockingPrompt).toHaveBeenCalledWith(expect.stringContaining("Sign in with ChatGPT"));
 
-      // The next content-bearing synchronized repaint replaces the old screen.
-      spawns[0]?.emitData("\x1b[?2026h\x1b[1;1H› Ask Codex to do anything\r\n\x1b[?2026l");
+      // A positive composer frame clears the old-screen latch.
+      spawns[0]?.emitData(
+        "\x1b[?2026h\x1b[1;1H› Ask Codex to do anything\r\n\x1b[?2026l",
+      );
       await vi.advanceTimersByTimeAsync(700);
       expect(manager.get(session.id)?.ready).toBe(true);
+    });
+
+    it("retains a blocking screen across partial synchronized diff repaints until the composer is proven", async () => {
+      const detectBlockingPrompt = vi.fn(
+        (output: string) =>
+          output.includes("Sign in with ChatGPT to use Codex") &&
+          output.includes("connect an API key for usage-based billing"),
+      );
+      const { manager, spawns } = makeManager({
+        adapter: immediateAdapter(detectBlockingPrompt),
+      });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
+
+      spawns[0]?.emitData(
+        "\x1b[?2026h\x1b[1;1HSign in with ChatGPT to use Codex\r\n" +
+          "or connect an API key for usage-based billing\x1b[?2026l",
+      );
+      // Real Ratatui arrow-key navigation repaints only the changed choice
+      // row. Losing the earlier full frame here was the review regression.
+      spawns[0]?.emitData(
+        "\x1b[?2026h\x1b[8;1H  1. Sign in with ChatGPT\r\n> 2. Sign in with Device Code\x1b[?2026l",
+      );
+
+      // Even the liveness ceiling must never override a recognized blocker.
+      await vi.advanceTimersByTimeAsync(5_500);
+      expect(manager.get(session.id)?.ready).toBe(false);
+      expect(detectBlockingPrompt).toHaveBeenCalledWith(
+        expect.stringContaining("connect an API key for usage-based billing"),
+      );
+
+      spawns[0]?.emitData(
+        "\x1b[?2026h\x1b[1;1H› Ask Codex to do anything\r\n\x1b[?2026l",
+      );
+      await vi.advanceTimersByTimeAsync(750);
+      expect(manager.get(session.id)?.ready).toBe(true);
+    });
+
+    it("uses a hard ceiling when visible startup animation never leaves a 700ms quiet window", async () => {
+      const { manager, spawns } = makeManager({ adapter: immediateAdapter() });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
+
+      for (let frame = 1; frame <= 12; frame += 1) {
+        spawns[0]?.emitData(
+          `\x1b[?2026h\x1b[1;1HStarting Codex ${frame}\x1b[?2026l`,
+        );
+        await vi.advanceTimersByTimeAsync(400);
+      }
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      // Only 300ms since the latest visible frame, but more than five seconds
+      // since the first: the liveness ceiling now wins.
+      await vi.advanceTimersByTimeAsync(300);
+      expect(manager.get(session.id)?.ready).toBe(true);
+    });
+
+    it("uses the hard ceiling when a clean synchronized repaint never emits its end marker", async () => {
+      const { manager, spawns } = makeManager({ adapter: immediateAdapter() });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
+      spawns[0]?.emitData("\x1b[?2026h\x1b[1;1H› Ask Codex to do anything\r\n");
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(151);
+      expect(manager.get(session.id)?.ready).toBe(true);
+    });
+
+    it("does not let the hard ceiling override a blocking repaint missing its end marker", async () => {
+      const detectBlockingPrompt = (output: string) =>
+        output.includes("Finish signing in via your browser") &&
+        output.includes("open the following link to authenticate");
+      const { manager, spawns } = makeManager({
+        adapter: immediateAdapter(detectBlockingPrompt),
+      });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
+      spawns[0]?.emitData(
+        "\x1b[?2026h\x1b[1;1HFinish signing in via your browser\r\n" +
+          "open the following link to authenticate\r\n",
+      );
+
+      await vi.advanceTimersByTimeAsync(8_000);
+      expect(manager.get(session.id)?.ready).toBe(false);
     });
 
     it("restarts the settle window when later startup output arrives", async () => {
@@ -748,12 +849,15 @@ describe("SessionManager", () => {
       spawns[0]?.emitData("› Ask Codex to do anything\r\n");
 
       await vi.advanceTimersByTimeAsync(300);
+      const detectorCallsBeforeSignal = detectBlockingPrompt.mock.calls.length;
       manager.setReady(session.id);
       await vi.advanceTimersByTimeAsync(1_000);
 
       expect(manager.get(session.id)?.ready).toBe(true);
       expect(readyStatuses.filter(Boolean)).toHaveLength(1);
-      expect(detectBlockingPrompt).not.toHaveBeenCalled();
+      expect(detectBlockingPrompt).toHaveBeenCalledTimes(
+        detectorCallsBeforeSignal,
+      );
     });
 
     it("stops the old monitor when its pty exits and is replaced on resume", async () => {

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -143,12 +143,19 @@ const KILL_ESCALATION_MS = 2_000;
  *  to report the exit itself before synthesizing it from an OS-level check. */
 const KILL_ESCALATION_CONFIRM_MS = 500;
 /**
- * See `isReadyEnough()` / `armReadyFallback()`: for an immediate-fallback
- * harness, how long to give the pty to render its first real frame before
- * trusting a clean scrollback (no known blocking prompt) as a genuine "no
- * prompt showing" rather than just "hasn't drawn anything yet".
+ * See `isReadyEnough()` / `armReadyFallback()`: how long an immediate-
+ * fallback pty must be quiet after its latest content-bearing repaint before
+ * the readiness frame can be treated as stable. Anchoring this to the latest
+ * visible change (not process spawn) prevents an early banner from winning
+ * the race against a trust/login screen that renders a moment later.
  */
 const READY_SETTLE_MS = 700;
+/** Codex/Ratatui brackets each atomic terminal repaint in synchronized-output
+ *  mode. Treat one such repaint as the readiness frame even when node-pty
+ *  splits it across chunks. Pure cursor/style repaints are intentionally
+ *  ignored — Codex emits them roughly every 80ms while sitting idle. */
+const SYNC_OUTPUT_START = "\x1b[?2026h";
+const SYNC_OUTPUT_END = "\x1b[?2026l";
 /** See `isReadyEnough()` / `armReadyFallback()`: how much of the tail of
  *  retained scrollback to scan for a blocking prompt — recent output only,
  *  not the full history a full-screen TUI never truly clears. Generous
@@ -321,9 +328,18 @@ export interface SessionManagerOptions {
 interface PtyHandle {
   pty: IPty;
   buffer: string;
+  /** Latest content-bearing terminal repaint used only for readiness checks.
+   * Unlike `buffer`, animation-only ANSI churn cannot evict the visible text. */
+  readinessBuffer: string;
+  /** Possible beginning of a synchronized-output marker split across chunks. */
+  pendingReadinessPrefix: string;
+  /** Synchronized repaint being assembled across node-pty chunks. */
+  pendingReadinessFrame: string | null;
   emitter: EventEmitter;
-  /** Epoch ms this pty was spawned — see `isReadyEnough`'s settle window. */
+  /** Epoch ms this pty was spawned — anchors the Claude hook-timeout fallback. */
   spawnedAt: number;
+  /** Epoch ms of the latest content-bearing repaint, or null until one draws. */
+  lastOutputAt: number | null;
   /**
    * Whether the app running in this pty has bracketed paste (DEC mode 2004)
    * on, folded from its own output — see `submitInput` and
@@ -892,6 +908,69 @@ export class SessionManager {
     this.activityEmitter.emit("activity", id);
   }
 
+  /**
+   * Maintain a readiness-only view of terminal output. Codex's Ratatui loop
+   * emits a ~500-byte cursor/erase repaint every 80ms even when the visible
+   * screen is unchanged. Counting those chunks as startup progress both
+   * prevents the 700ms settle window from ever completing and pushes a real
+   * sign-in/trust prompt out of the raw 4KB tail. Synchronized-output markers
+   * give us an atomic repaint boundary: retain the latest repaint containing
+   * visible text, and ignore control-only frames. Non-Ratatui adapters fall
+   * back to an ordinary rolling buffer.
+   */
+  private recordReadinessOutput(handle: PtyHandle, chunk: string): void {
+    let rest = handle.pendingReadinessPrefix + chunk;
+    handle.pendingReadinessPrefix = "";
+    while (rest.length > 0) {
+      if (handle.pendingReadinessFrame !== null) {
+        // Search the combined stream so an end marker split across two
+        // node-pty chunks still closes the repaint.
+        const combined = handle.pendingReadinessFrame + rest;
+        const end = combined.indexOf(SYNC_OUTPUT_END);
+        if (end === -1) {
+          handle.pendingReadinessFrame = combined.slice(-SCROLLBACK_BYTES);
+          return;
+        }
+        const throughEnd = end + SYNC_OUTPUT_END.length;
+        const frame = combined.slice(0, throughEnd);
+        handle.pendingReadinessFrame = null;
+        this.commitReadinessOutput(handle, frame, true);
+        rest = combined.slice(throughEnd);
+        continue;
+      }
+
+      const start = rest.indexOf(SYNC_OUTPUT_START);
+      if (start === -1) {
+        // Retain only a suffix that could become a start marker when the next
+        // chunk arrives. Everything before it is ordinary unsynchronized
+        // output and can be committed now.
+        let prefixLength = Math.min(SYNC_OUTPUT_START.length - 1, rest.length);
+        while (prefixLength > 0 && !SYNC_OUTPUT_START.startsWith(rest.slice(-prefixLength))) {
+          prefixLength -= 1;
+        }
+        const outputEnd = rest.length - prefixLength;
+        this.commitReadinessOutput(handle, rest.slice(0, outputEnd), false);
+        handle.pendingReadinessPrefix = rest.slice(outputEnd);
+        return;
+      }
+      this.commitReadinessOutput(handle, rest.slice(0, start), false);
+      handle.pendingReadinessFrame = SYNC_OUTPUT_START;
+      rest = rest.slice(start + SYNC_OUTPUT_START.length);
+    }
+  }
+
+  private commitReadinessOutput(handle: PtyHandle, output: string, replace: boolean): void {
+    // stripAnsi intentionally targets common display escapes and leaves a few
+    // private CSI controls (for example ESC[>4;0m). Remove those first so a
+    // protocol negotiation cannot count as visible TUI content.
+    // eslint-disable-next-line no-control-regex
+    const rendered = stripAnsi(output.replace(/\x1b\[[?>][0-9;]*[ -/]*[@-~]/g, ""));
+    // eslint-disable-next-line no-control-regex
+    if (!/[^\s\x00-\x1f\x7f]/u.test(rendered)) return;
+    handle.lastOutputAt = Date.now();
+    handle.readinessBuffer = (replace ? output : handle.readinessBuffer + output).slice(-SCROLLBACK_BYTES);
+  }
+
   setAgentSessionId(id: string, agentSessionId: string): void {
     const session = this.sessions.get(id);
     if (!session || session.agentSessionId === agentSessionId) return;
@@ -917,20 +996,25 @@ export class SessionManager {
 
   /**
    * Whether `id` should be treated as ready to receive programmatic input
-   * right now — `session.ready` (the real signal), OR, for a harness that
-   * declares `detectBlockingPrompt` (currently: Codex, whose rollout file —
-   * and therefore its SessionStart-equivalent — isn't written until the
-   * *first* turn is submitted, so the real signal can never arrive before
-   * the very first injection that needs it): the pty has had a moment to
-   * render its first real frame (`READY_SETTLE_MS`) and that frame doesn't
-   * show a known blocking prompt. A harness without `detectBlockingPrompt`
-   * (Claude Code) gets no such fallback — its SessionStart hook is reliable
-   * standalone, and a scrollback guess would just reopen the exact race
-   * this mechanism exists to close.
+   * right now. A real/fallback `session.ready` signal normally suffices; an
+   * immediate-fallback adapter gets one last recognized-blocker scan because
+   * readiness is latched while its TUI can still paint a late onboarding
+   * frame. Before readiness, immediate and legacy detect-only adapters require
+   * at least `READY_SETTLE_MS` of quiet output and a clean latest frame. Claude
+   * Code has no immediate shortcut — its SessionStart hook (or preserved
+   * 20-second hook-timeout path) controls readiness.
    */
   private isReadyEnough(session: HarnessSession, handle: PtyHandle): boolean {
-    if (session.ready) return true;
     const adapter = this.adapters[session.harness];
+    // `ready` is intentionally latched for persistence and status broadcasts,
+    // but an immediate-fallback harness can still paint a late onboarding
+    // screen after readiness was inferred. Recheck its latest frame before
+    // every programmatic write; raw terminal input remains ungated so the user
+    // can answer the screen. Real-signal/hook-timeout adapters keep their
+    // existing ready semantics unchanged.
+    if (session.ready) {
+      return adapter?.readyFallback !== "immediate" || !this.hasBlockingPrompt(adapter, handle);
+    }
     // Gated on the DECLARED fallback mode, not on detectBlockingPrompt's mere
     // presence: claude-code now implements detectBlockingPrompt too (for the
     // hook-timeout fallback armed in spawn()), and giving it this immediate
@@ -943,16 +1027,18 @@ export class SessionManager {
     // contract it used to imply.
     if (!adapter?.detectBlockingPrompt) return false;
     if (adapter.readyFallback !== undefined && adapter.readyFallback !== "immediate") return false;
-    if (Date.now() - handle.spawnedAt < READY_SETTLE_MS) return false;
-    // Only the tail: `handle.buffer` is the full retained scrollback
-    // (up to SCROLLBACK_BYTES) and full-screen TUIs never truly "clear" it
-    // — a dismissed prompt's text sits in there forever. A full-screen
-    // redraw re-touches its whole visible frame on every update though
-    // (confirmed against a real capture), so recent output alone reflects
-    // what's actually on screen right now; checking the whole history would
-    // make a session that dismissed its trust prompt minutes ago look
-    // permanently stuck.
-    return !adapter.detectBlockingPrompt(handle.buffer.slice(-BLOCKING_PROMPT_SCAN_BYTES));
+    if (handle.lastOutputAt === null || Date.now() - handle.lastOutputAt < READY_SETTLE_MS) return false;
+    // Only the tail of the latest content-bearing repaint: full-screen TUIs
+    // never truly clear raw scrollback, while animation-only ANSI churn can
+    // evict still-visible text from it. `recordReadinessOutput` maintains the
+    // bounded frame view that avoids both failure modes.
+    return !this.hasBlockingPrompt(adapter, handle);
+  }
+
+  /** Scan only the latest rendered frame; dismissed full-screen prompts remain
+   * in older scrollback forever and must not permanently block the session. */
+  private hasBlockingPrompt(adapter: HarnessAdapter, handle: PtyHandle): boolean {
+    return adapter.detectBlockingPrompt?.(handle.readinessBuffer.slice(-BLOCKING_PROMPT_SCAN_BYTES)) ?? false;
   }
 
   /**
@@ -1056,8 +1142,12 @@ export class SessionManager {
     const handle: PtyHandle = {
       pty,
       buffer: "",
+      readinessBuffer: "",
+      pendingReadinessPrefix: "",
+      pendingReadinessFrame: null,
       emitter,
       spawnedAt: Date.now(),
+      lastOutputAt: null,
       bracketedPaste: initialBracketedPasteState,
       exited,
       resolveExited,
@@ -1077,6 +1167,7 @@ export class SessionManager {
     pty.onData((chunk) => {
       handle.bracketedPaste = trackBracketedPaste(handle.bracketedPaste, chunk);
       handle.buffer = (handle.buffer + chunk).slice(-SCROLLBACK_BYTES);
+      this.recordReadinessOutput(handle, chunk);
       handle.emitter.emit("data", chunk);
       this.recordActivity(session.id);
     });
@@ -1095,19 +1186,17 @@ export class SessionManager {
    * Both modes are conservative on purpose:
    *  - requires SOME output — a pty that hasn't drawn anything yet isn't an
    *    interactive TUI, it's still starting;
-   *  - keeps waiting while a known blocking prompt (trust dialog, theme
-   *    picker, login) is on screen, so the submit `\r` that follows readiness
-   *    can never answer a dialog the user hasn't seen — once the user
-   *    dismisses it, the next poll flips ready;
+   *  - keeps waiting while an adapter-recognized blocking prompt is on screen,
+   *    so known trust/login/setup screens are not answered by injected input;
    *  - dies with the handle (exit clears the interval; a replaced handle is
    *    detected via the ptys map, same idempotency rule as markExited()).
    *
-   * `"immediate"` (Codex) reuses the same settle window and scrollback rule
-   * as `isReadyEnough()`, but proactively calls `setReady()` after output is
-   * visible. That status event closes the first-prompt deadlock: Codex writes
-   * no rollout/session_meta before turn one, while the SPA waits for `ready`
-   * before submitting turn one. Only an EXPLICIT declaration arms this
-   * persistent state transition; detect-only legacy adapters retain their
+   * `"immediate"` (Codex) reuses the same quiet-window and frame rule as
+   * `isReadyEnough()`, but proactively calls `setReady()` after visible output
+   * has stopped changing. That status event closes the first-prompt deadlock:
+   * Codex writes no rollout/session_meta before turn one, while the SPA waits
+   * for `ready` before submitting turn one. Only an EXPLICIT declaration arms
+   * this persistent state transition; detect-only legacy adapters retain their
    * request-time `isReadyEnough()` compatibility path without being promoted.
    *
    * `"hook-timeout"` (Claude Code) retains its generous 20s delay: a healthy
@@ -1125,7 +1214,6 @@ export class SessionManager {
     // existing optional-detector behaviour for third-party adapters.
     if (mode === "immediate" && !adapter.detectBlockingPrompt) return;
 
-    const delayMs = mode === "immediate" ? READY_SETTLE_MS : HOOK_READY_FALLBACK_MS;
     const pollMs = mode === "immediate" ? READY_POLL_MS : HOOK_READY_POLL_MS;
 
     const poll = setInterval(() => {
@@ -1138,9 +1226,16 @@ export class SessionManager {
         clearInterval(poll);
         return;
       }
-      if (Date.now() - handle.spawnedAt < delayMs) return;
-      if (!handle.buffer) return;
-      if (adapter.detectBlockingPrompt?.(handle.buffer.slice(-BLOCKING_PROMPT_SCAN_BYTES))) return;
+      if (mode === "immediate") {
+        if (handle.lastOutputAt === null || Date.now() - handle.lastOutputAt < READY_SETTLE_MS) return;
+      } else {
+        // Preserve Claude's original fallback contract exactly: 20 seconds
+        // from spawn and at least one output byte, without a quiet-window
+        // requirement layered on top.
+        if (Date.now() - handle.spawnedAt < HOOK_READY_FALLBACK_MS) return;
+        if (!handle.buffer) return;
+      }
+      if (this.hasBlockingPrompt(adapter, handle)) return;
       clearInterval(poll);
       if (mode === "hook-timeout") {
         console.warn(

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -150,18 +150,26 @@ const KILL_ESCALATION_CONFIRM_MS = 500;
  * the race against a trust/login screen that renders a moment later.
  */
 const READY_SETTLE_MS = 700;
+/**
+ * A content-animating TUI may never be quiet for READY_SETTLE_MS, and a
+ * malformed/incomplete synchronized-output frame may never close. Do not let
+ * either condition deadlock the first prompt forever: once this much time has
+ * elapsed since the first visible output, an immediate fallback may bypass
+ * the quiet/complete-frame requirement. Recognized blocking prompts still
+ * win, so this is a liveness ceiling, not a safety bypass.
+ */
+const READY_SETTLE_CEILING_MS = 5_000;
 /** Codex/Ratatui brackets each atomic terminal repaint in synchronized-output
  *  mode. Treat one such repaint as the readiness frame even when node-pty
  *  splits it across chunks. Pure cursor/style repaints are intentionally
  *  ignored — Codex emits them roughly every 80ms while sitting idle. */
 const SYNC_OUTPUT_START = "\x1b[?2026h";
 const SYNC_OUTPUT_END = "\x1b[?2026l";
-/** See `isReadyEnough()` / `armReadyFallback()`: how much of the tail of
- *  retained scrollback to scan for a blocking prompt — recent output only,
- *  not the full history a full-screen TUI never truly clears. Generous
- *  relative to one redraw frame (confirmed against a real capture: a single
- *  Codex trust-prompt frame is well under 2KB) without re-scanning unbounded
- *  history. */
+/** See `isReadyEnough()` / `armReadyFallback()`: how much of the bounded
+ *  recent-frame union to scan for a blocking prompt — not the full history a
+ *  full-screen TUI never truly clears. Generous relative to one redraw frame
+ *  (confirmed against a real capture: a single Codex trust-prompt frame is
+ *  well under 2KB) without re-scanning unbounded history. */
 const BLOCKING_PROMPT_SCAN_BYTES = 4_096;
 /**
  * See `armReadyFallback()`: how long after spawn a `readyFallback:
@@ -328,16 +336,27 @@ export interface SessionManagerOptions {
 interface PtyHandle {
   pty: IPty;
   buffer: string;
-  /** Latest content-bearing terminal repaint used only for readiness checks.
+  /** Latest content-bearing terminal repaint used for current-screen checks.
    * Unlike `buffer`, animation-only ANSI churn cannot evict the visible text. */
   readinessBuffer: string;
+  /** Bounded union of recent content-bearing repaints. Ratatui redraws only
+   * changed rows, so one atomic frame does not necessarily describe the whole
+   * screen; this history lets multi-phrase prompt signatures span those diffs. */
+  readinessHistory: string;
+  /** A detected blocking screen remains latched across partial repaints until
+   * the adapter positively identifies its empty interactive composer. */
+  blockingPromptSeen: boolean;
   /** Possible beginning of a synchronized-output marker split across chunks. */
   pendingReadinessPrefix: string;
   /** Synchronized repaint being assembled across node-pty chunks. */
   pendingReadinessFrame: string | null;
+  /** Whether the pending synchronized repaint has produced visible text. */
+  pendingReadinessFrameHasContent: boolean;
   emitter: EventEmitter;
   /** Epoch ms this pty was spawned — anchors the Claude hook-timeout fallback. */
   spawnedAt: number;
+  /** Epoch ms of the first content-bearing output, or null until one draws. */
+  firstContentAt: number | null;
   /** Epoch ms of the latest content-bearing repaint, or null until one draws. */
   lastOutputAt: number | null;
   /**
@@ -915,10 +934,15 @@ export class SessionManager {
    * prevents the 700ms settle window from ever completing and pushes a real
    * sign-in/trust prompt out of the raw 4KB tail. Synchronized-output markers
    * give us an atomic repaint boundary: retain the latest repaint containing
-   * visible text, and ignore control-only frames. Non-Ratatui adapters fall
-   * back to an ordinary rolling buffer.
+   * visible text, keep a bounded union for diff-rendered blocking prompts,
+   * and ignore control-only frames. Non-Ratatui adapters fall back to an
+   * ordinary rolling buffer.
    */
-  private recordReadinessOutput(handle: PtyHandle, chunk: string): void {
+  private recordReadinessOutput(
+    handle: PtyHandle,
+    chunk: string,
+    adapter: HarnessAdapter,
+  ): void {
     let rest = handle.pendingReadinessPrefix + chunk;
     handle.pendingReadinessPrefix = "";
     while (rest.length > 0) {
@@ -929,12 +953,20 @@ export class SessionManager {
         const end = combined.indexOf(SYNC_OUTPUT_END);
         if (end === -1) {
           handle.pendingReadinessFrame = combined.slice(-SCROLLBACK_BYTES);
+          if (
+            !handle.pendingReadinessFrameHasContent &&
+            this.hasVisibleReadinessContent(handle.pendingReadinessFrame)
+          ) {
+            handle.pendingReadinessFrameHasContent = true;
+            this.noteReadinessContent(handle);
+          }
           return;
         }
         const throughEnd = end + SYNC_OUTPUT_END.length;
         const frame = combined.slice(0, throughEnd);
         handle.pendingReadinessFrame = null;
-        this.commitReadinessOutput(handle, frame, true);
+        handle.pendingReadinessFrameHasContent = false;
+        this.commitReadinessOutput(handle, frame, true, adapter);
         rest = combined.slice(throughEnd);
         continue;
       }
@@ -949,26 +981,63 @@ export class SessionManager {
           prefixLength -= 1;
         }
         const outputEnd = rest.length - prefixLength;
-        this.commitReadinessOutput(handle, rest.slice(0, outputEnd), false);
+        this.commitReadinessOutput(
+          handle,
+          rest.slice(0, outputEnd),
+          false,
+          adapter,
+        );
         handle.pendingReadinessPrefix = rest.slice(outputEnd);
         return;
       }
-      this.commitReadinessOutput(handle, rest.slice(0, start), false);
+      this.commitReadinessOutput(handle, rest.slice(0, start), false, adapter);
       handle.pendingReadinessFrame = SYNC_OUTPUT_START;
+      handle.pendingReadinessFrameHasContent = false;
       rest = rest.slice(start + SYNC_OUTPUT_START.length);
     }
   }
 
-  private commitReadinessOutput(handle: PtyHandle, output: string, replace: boolean): void {
+  private hasVisibleReadinessContent(output: string): boolean {
     // stripAnsi intentionally targets common display escapes and leaves a few
     // private CSI controls (for example ESC[>4;0m). Remove those first so a
     // protocol negotiation cannot count as visible TUI content.
-    // eslint-disable-next-line no-control-regex
-    const rendered = stripAnsi(output.replace(/\x1b\[[?>][0-9;]*[ -/]*[@-~]/g, ""));
-    // eslint-disable-next-line no-control-regex
-    if (!/[^\s\x00-\x1f\x7f]/u.test(rendered)) return;
-    handle.lastOutputAt = Date.now();
-    handle.readinessBuffer = (replace ? output : handle.readinessBuffer + output).slice(-SCROLLBACK_BYTES);
+    /* eslint-disable no-control-regex -- readiness parsing must match literal
+     * ESC/BEL control bytes emitted by the pty. */
+    const rendered = stripAnsi(
+      output.replace(/\x1b\[[?>][0-9;]*[ -/]*[@-~]/g, ""),
+    )
+      // An atomic repaint can be split in the middle of a CSI/OSC sequence.
+      // Do not treat the printable parameter bytes in that unfinished suffix
+      // as visible content before the next pty chunk completes it.
+      .replace(/\x1b\[[0-?]*[ -/]*$/u, "")
+      .replace(/\x1b\][^\x07]*$/u, "")
+      .replace(/\x1b[()>=]?$/u, "");
+    const hasVisibleContent = /[^\s\x00-\x1f\x7f]/u.test(rendered);
+    /* eslint-enable no-control-regex */
+    return hasVisibleContent;
+  }
+
+  private noteReadinessContent(handle: PtyHandle): void {
+    const now = Date.now();
+    handle.firstContentAt ??= now;
+    handle.lastOutputAt = now;
+  }
+
+  private commitReadinessOutput(
+    handle: PtyHandle,
+    output: string,
+    replace: boolean,
+    adapter: HarnessAdapter,
+  ): void {
+    if (!this.hasVisibleReadinessContent(output)) return;
+    this.noteReadinessContent(handle);
+    handle.readinessBuffer = (
+      replace ? output : handle.readinessBuffer + output
+    ).slice(-SCROLLBACK_BYTES);
+    handle.readinessHistory = `${handle.readinessHistory}\n${output}`.slice(
+      -BLOCKING_PROMPT_SCAN_BYTES,
+    );
+    this.refreshImmediatePromptState(adapter, handle);
   }
 
   setAgentSessionId(id: string, agentSessionId: string): void {
@@ -1000,9 +1069,10 @@ export class SessionManager {
    * immediate-fallback adapter gets one last recognized-blocker scan because
    * readiness is latched while its TUI can still paint a late onboarding
    * frame. Before readiness, immediate and legacy detect-only adapters require
-   * at least `READY_SETTLE_MS` of quiet output and a clean latest frame. Claude
-   * Code has no immediate shortcut — its SessionStart hook (or preserved
-   * 20-second hook-timeout path) controls readiness.
+   * at least `READY_SETTLE_MS` of quiet output (or the bounded liveness
+   * ceiling) and a clean recent-screen view. Claude Code has no immediate
+   * shortcut — its SessionStart hook (or preserved 20-second hook-timeout
+   * path) controls readiness.
    */
   private isReadyEnough(session: HarnessSession, handle: PtyHandle): boolean {
     const adapter = this.adapters[session.harness];
@@ -1013,7 +1083,10 @@ export class SessionManager {
     // can answer the screen. Real-signal/hook-timeout adapters keep their
     // existing ready semantics unchanged.
     if (session.ready) {
-      return adapter?.readyFallback !== "immediate" || !this.hasBlockingPrompt(adapter, handle);
+      return (
+        adapter?.readyFallback !== "immediate" ||
+        !this.hasCurrentBlockingPrompt(adapter, handle)
+      );
     }
     // Gated on the DECLARED fallback mode, not on detectBlockingPrompt's mere
     // presence: claude-code now implements detectBlockingPrompt too (for the
@@ -1026,19 +1099,120 @@ export class SessionManager {
     // detectBlockingPrompt-without-readyFallback as the legacy "immediate"
     // contract it used to imply.
     if (!adapter?.detectBlockingPrompt) return false;
-    if (adapter.readyFallback !== undefined && adapter.readyFallback !== "immediate") return false;
-    if (handle.lastOutputAt === null || Date.now() - handle.lastOutputAt < READY_SETTLE_MS) return false;
-    // Only the tail of the latest content-bearing repaint: full-screen TUIs
-    // never truly clear raw scrollback, while animation-only ANSI churn can
-    // evict still-visible text from it. `recordReadinessOutput` maintains the
-    // bounded frame view that avoids both failure modes.
-    return !this.hasBlockingPrompt(adapter, handle);
+    if (
+      adapter.readyFallback !== undefined &&
+      adapter.readyFallback !== "immediate"
+    )
+      return false;
+    if (adapter.readyFallback === "immediate") {
+      if (!this.isImmediateFallbackSettled(handle)) return false;
+      return !this.hasImmediateBlockingPrompt(adapter, handle);
+    }
+    if (
+      handle.lastOutputAt === null ||
+      Date.now() - handle.lastOutputAt < READY_SETTLE_MS
+    )
+      return false;
+    return !this.hasRetainedBlockingPrompt(adapter, handle);
   }
 
-  /** Scan only the latest rendered frame; dismissed full-screen prompts remain
-   * in older scrollback forever and must not permanently block the session. */
-  private hasBlockingPrompt(adapter: HarnessAdapter, handle: PtyHandle): boolean {
-    return adapter.detectBlockingPrompt?.(handle.readinessBuffer.slice(-BLOCKING_PROMPT_SCAN_BYTES)) ?? false;
+  private isImmediateFallbackSettled(handle: PtyHandle): boolean {
+    if (handle.firstContentAt === null || handle.lastOutputAt === null)
+      return false;
+    const now = Date.now();
+    const hitCeiling = now - handle.firstContentAt >= READY_SETTLE_CEILING_MS;
+    const completedFrameSettled =
+      handle.pendingReadinessFrame === null &&
+      now - handle.lastOutputAt >= READY_SETTLE_MS;
+    return hitCeiling || completedFrameSettled;
+  }
+
+  /** The best available current frame, excluding older diff repaint history.
+   * Used after readiness has latched so ordinary agent output that quotes old
+   * onboarding copy cannot permanently gate later writes. */
+  private currentReadinessOutput(handle: PtyHandle): string {
+    const output =
+      handle.pendingReadinessFrame ??
+      handle.readinessBuffer + handle.pendingReadinessPrefix;
+    return output.slice(-BLOCKING_PROMPT_SCAN_BYTES);
+  }
+
+  /** A bounded union of recent diff repaints, including an unfinished current
+   * repaint. This is intentionally only used before immediate readiness. */
+  private recentReadinessOutput(handle: PtyHandle): string {
+    const pending =
+      handle.pendingReadinessFrame ?? handle.pendingReadinessPrefix;
+    return `${handle.readinessHistory}\n${pending}`.slice(
+      -BLOCKING_PROMPT_SCAN_BYTES,
+    );
+  }
+
+  /** Preserve a recognized blocker across Ratatui's partial row repaints. The
+   * latch is cleared only by a positive empty-composer match in a clean current
+   * frame; merely failing to re-render every phrase is not evidence that the
+   * screen was dismissed. */
+  private refreshImmediatePromptState(
+    adapter: HarnessAdapter,
+    handle: PtyHandle,
+  ): void {
+    if (
+      adapter.readyFallback !== "immediate" ||
+      !adapter.detectBlockingPrompt ||
+      !adapter.detectReadyPrompt
+    ) {
+      return;
+    }
+
+    const current = this.currentReadinessOutput(handle);
+    const recent = this.recentReadinessOutput(handle);
+    if (adapter.detectBlockingPrompt(recent)) handle.blockingPromptSeen = true;
+    if (!handle.blockingPromptSeen) return;
+
+    if (
+      adapter.detectReadyPrompt(current) &&
+      !adapter.detectBlockingPrompt(current)
+    ) {
+      handle.blockingPromptSeen = false;
+      // Once the real composer is visible, older onboarding frames are no
+      // longer part of the current screen and must not be re-latched later.
+      handle.readinessHistory = current;
+    }
+  }
+
+  private hasImmediateBlockingPrompt(
+    adapter: HarnessAdapter,
+    handle: PtyHandle,
+  ): boolean {
+    if (!adapter.detectReadyPrompt)
+      return this.hasRetainedBlockingPrompt(adapter, handle);
+    this.refreshImmediatePromptState(adapter, handle);
+    return handle.blockingPromptSeen;
+  }
+
+  /** The original readiness-buffer check retained for Claude's hook-timeout
+   * and legacy detect-only adapters. Their fallback semantics must not change
+   * merely because Codex needs partial-frame reconstruction. */
+  private hasRetainedBlockingPrompt(
+    adapter: HarnessAdapter,
+    handle: PtyHandle,
+  ): boolean {
+    return (
+      adapter.detectBlockingPrompt?.(
+        handle.readinessBuffer.slice(-BLOCKING_PROMPT_SCAN_BYTES),
+      ) ?? false
+    );
+  }
+
+  /** Scan only the best available current frame; dismissed full-screen prompts
+   * remain in older scrollback forever and must not block already-ready input. */
+  private hasCurrentBlockingPrompt(
+    adapter: HarnessAdapter,
+    handle: PtyHandle,
+  ): boolean {
+    return (
+      adapter.detectBlockingPrompt?.(this.currentReadinessOutput(handle)) ??
+      false
+    );
   }
 
   /**
@@ -1088,6 +1262,7 @@ export class SessionManager {
   }
 
   private async spawn(session: HarnessSession, spec: SpawnSpec): Promise<void> {
+    const adapter = this.getAdapter(session.harness);
     const spawnFn = this.spawnPty ?? (await loadDefaultSpawn());
     const env: Record<string, string> = {};
     for (const [key, value] of Object.entries(process.env)) {
@@ -1143,10 +1318,14 @@ export class SessionManager {
       pty,
       buffer: "",
       readinessBuffer: "",
+      readinessHistory: "",
+      blockingPromptSeen: false,
       pendingReadinessPrefix: "",
       pendingReadinessFrame: null,
+      pendingReadinessFrameHasContent: false,
       emitter,
       spawnedAt: Date.now(),
+      firstContentAt: null,
       lastOutputAt: null,
       bracketedPaste: initialBracketedPasteState,
       exited,
@@ -1167,7 +1346,7 @@ export class SessionManager {
     pty.onData((chunk) => {
       handle.bracketedPaste = trackBracketedPaste(handle.bracketedPaste, chunk);
       handle.buffer = (handle.buffer + chunk).slice(-SCROLLBACK_BYTES);
-      this.recordReadinessOutput(handle, chunk);
+      this.recordReadinessOutput(handle, chunk, adapter);
       handle.emitter.emit("data", chunk);
       this.recordActivity(session.id);
     });
@@ -1191,9 +1370,10 @@ export class SessionManager {
    *  - dies with the handle (exit clears the interval; a replaced handle is
    *    detected via the ptys map, same idempotency rule as markExited()).
    *
-   * `"immediate"` (Codex) reuses the same quiet-window and frame rule as
-   * `isReadyEnough()`, but proactively calls `setReady()` after visible output
-   * has stopped changing. That status event closes the first-prompt deadlock:
+   * `"immediate"` (Codex) reuses the same quiet-window/ceiling and frame rule
+   * as `isReadyEnough()`, but proactively calls `setReady()` once output is
+   * stable or reaches the bounded liveness ceiling. That status event closes
+   * the first-prompt deadlock:
    * Codex writes no rollout/session_meta before turn one, while the SPA waits
    * for `ready` before submitting turn one. Only an EXPLICIT declaration arms
    * this persistent state transition; detect-only legacy adapters retain their
@@ -1227,7 +1407,7 @@ export class SessionManager {
         return;
       }
       if (mode === "immediate") {
-        if (handle.lastOutputAt === null || Date.now() - handle.lastOutputAt < READY_SETTLE_MS) return;
+        if (!this.isImmediateFallbackSettled(handle)) return;
       } else {
         // Preserve Claude's original fallback contract exactly: 20 seconds
         // from spawn and at least one output byte, without a quiet-window
@@ -1235,7 +1415,11 @@ export class SessionManager {
         if (Date.now() - handle.spawnedAt < HOOK_READY_FALLBACK_MS) return;
         if (!handle.buffer) return;
       }
-      if (this.hasBlockingPrompt(adapter, handle)) return;
+      const hasBlockingPrompt =
+        mode === "immediate"
+          ? this.hasImmediateBlockingPrompt(adapter, handle)
+          : this.hasRetainedBlockingPrompt(adapter, handle);
+      if (hasBlockingPrompt) return;
       clearInterval(poll);
       if (mode === "hook-timeout") {
         console.warn(

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -355,8 +355,9 @@ interface PtyHandle {
   emitter: EventEmitter;
   /** Epoch ms this pty was spawned — anchors the Claude hook-timeout fallback. */
   spawnedAt: number;
-  /** Epoch ms of the first content-bearing output, or null until one draws. */
-  firstContentAt: number | null;
+  /** Epoch ms the current non-blocking readiness candidate began. A recognized
+   * blocker resets it so an expired ceiling cannot promote the next screen. */
+  readinessCandidateAt: number | null;
   /** Epoch ms of the latest content-bearing repaint, or null until one draws. */
   lastOutputAt: number | null;
   /**
@@ -1019,7 +1020,7 @@ export class SessionManager {
 
   private noteReadinessContent(handle: PtyHandle): void {
     const now = Date.now();
-    handle.firstContentAt ??= now;
+    handle.readinessCandidateAt ??= now;
     handle.lastOutputAt = now;
   }
 
@@ -1117,10 +1118,11 @@ export class SessionManager {
   }
 
   private isImmediateFallbackSettled(handle: PtyHandle): boolean {
-    if (handle.firstContentAt === null || handle.lastOutputAt === null)
+    if (handle.readinessCandidateAt === null || handle.lastOutputAt === null)
       return false;
     const now = Date.now();
-    const hitCeiling = now - handle.firstContentAt >= READY_SETTLE_CEILING_MS;
+    const hitCeiling =
+      now - handle.readinessCandidateAt >= READY_SETTLE_CEILING_MS;
     const completedFrameSettled =
       handle.pendingReadinessFrame === null &&
       now - handle.lastOutputAt >= READY_SETTLE_MS;
@@ -1167,12 +1169,17 @@ export class SessionManager {
     const recent = this.recentReadinessOutput(handle);
     if (adapter.detectBlockingPrompt(recent)) handle.blockingPromptSeen = true;
     if (!handle.blockingPromptSeen) return;
+    // The ceiling applies only to a continuously non-blocking candidate. If a
+    // user leaves onboarding open for a minute, that elapsed minute must not
+    // make the first clean repaint after dismissal ready immediately.
+    handle.readinessCandidateAt = null;
 
     if (
       adapter.detectReadyPrompt(current) &&
       !adapter.detectBlockingPrompt(current)
     ) {
       handle.blockingPromptSeen = false;
+      handle.readinessCandidateAt = handle.lastOutputAt ?? Date.now();
       // Once the real composer is visible, older onboarding frames are no
       // longer part of the current screen and must not be re-latched later.
       handle.readinessHistory = current;
@@ -1183,8 +1190,11 @@ export class SessionManager {
     adapter: HarnessAdapter,
     handle: PtyHandle,
   ): boolean {
-    if (!adapter.detectReadyPrompt)
-      return this.hasRetainedBlockingPrompt(adapter, handle);
+    if (!adapter.detectReadyPrompt) {
+      const blocked = this.hasRetainedBlockingPrompt(adapter, handle);
+      if (blocked) handle.readinessCandidateAt = null;
+      return blocked;
+    }
     this.refreshImmediatePromptState(adapter, handle);
     return handle.blockingPromptSeen;
   }
@@ -1325,7 +1335,7 @@ export class SessionManager {
       pendingReadinessFrameHasContent: false,
       emitter,
       spawnedAt: Date.now(),
-      firstContentAt: null,
+      readinessCandidateAt: null,
       lastOutputAt: null,
       bracketedPaste: initialBracketedPasteState,
       exited,

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -143,27 +143,28 @@ const KILL_ESCALATION_MS = 2_000;
  *  to report the exit itself before synthesizing it from an OS-level check. */
 const KILL_ESCALATION_CONFIRM_MS = 500;
 /**
- * See `isReadyEnough()`: for a harness with `detectBlockingPrompt`, how long
- * to give the pty to render its first real frame before trusting a clean
- * scrollback (no known blocking prompt) as a genuine "no prompt showing"
- * rather than just "hasn't drawn anything yet".
+ * See `isReadyEnough()` / `armReadyFallback()`: for an immediate-fallback
+ * harness, how long to give the pty to render its first real frame before
+ * trusting a clean scrollback (no known blocking prompt) as a genuine "no
+ * prompt showing" rather than just "hasn't drawn anything yet".
  */
 const READY_SETTLE_MS = 700;
-/** See `isReadyEnough()`: how much of the tail of retained scrollback to
- *  scan for a blocking prompt — recent output only, not the full history a
- *  full-screen TUI never truly clears. Generous relative to one redraw
- *  frame (confirmed against a real capture: a single Codex trust-prompt
- *  frame is well under 2KB) without re-scanning unbounded history. */
+/** See `isReadyEnough()` / `armReadyFallback()`: how much of the tail of
+ *  retained scrollback to scan for a blocking prompt — recent output only,
+ *  not the full history a full-screen TUI never truly clears. Generous
+ *  relative to one redraw frame (confirmed against a real capture: a single
+ *  Codex trust-prompt frame is well under 2KB) without re-scanning unbounded
+ *  history. */
 const BLOCKING_PROMPT_SCAN_BYTES = 4_096;
 /**
- * See `armHookReadyFallback()`: how long after spawn a `readyFallback:
+ * See `armReadyFallback()`: how long after spawn a `readyFallback:
  * "hook-timeout"` harness may sit un-ready before the fallback flips it.
  * Generous on purpose: a healthy SessionStart hook lands in 1–3s, so 20s
  * only ever fires when the hook chain is genuinely broken (the Windows
  * node-resolution failure this exists for) — never racing a working hook.
  */
 const HOOK_READY_FALLBACK_MS = 20_000;
-/** Poll cadence for `armHookReadyFallback()` — coarse; nothing user-visible
+/** Poll cadence for `armReadyFallback()`'s hook-timeout mode — coarse; nothing user-visible
  *  rides on sub-second precision 20s after spawn. */
 const HOOK_READY_POLL_MS = 1_000;
 /**
@@ -901,10 +902,10 @@ export class SessionManager {
 
   /**
    * Marks a session's TUI as genuinely interactive — see `HarnessSession.ready`.
-   * Called from the ingest pipeline when a SessionStart(-equivalent) event
-   * is processed for this session (real hook for Claude Code, tailer-
-   * translated for Codex). Idempotent; a session that's exited or already
-   * ready is a silent no-op.
+   * Called either from the ingest pipeline when a SessionStart(-equivalent)
+   * event is processed for this session (real hook for Claude Code, tailer-
+   * translated for Codex), or from an adapter-declared readiness fallback.
+   * Idempotent; a session that's exited or already ready is a silent no-op.
    */
   setReady(id: string): void {
     const session = this.sessions.get(id);
@@ -1082,35 +1083,50 @@ export class SessionManager {
 
     pty.onExit(({ exitCode }) => this.markExited(session.id, handle, exitCode));
 
-    this.armHookReadyFallback(session.id, handle);
+    this.armReadyFallback(session.id, handle);
   }
 
   /**
-   * For a `readyFallback: "hook-timeout"` harness (Claude Code): rescue a
-   * session whose real readiness signal never arrives. `ready` is normally
-   * flipped by the SessionStart hook POSTing to /ingest — but that chain runs
-   * `node` through the agent's hook shell, and where it breaks (Windows: Git
-   * Bash resolves no `.cmd`, so a machine whose only node is a .cmd shim runs
-   * zero hooks) the session looked fine in the terminal while every held
-   * prompt was silently dropped after the SPA's timeout.
+   * Publishes adapter-declared fallback readiness so the SPA's held first
+   * prompt can be released even when the harness's real lifecycle signal
+   * cannot arrive yet (Codex) or never arrived (Claude Code with a broken
+   * SessionStart hook).
    *
-   * Conservative on purpose:
-   *  - fires no earlier than HOOK_READY_FALLBACK_MS after spawn — a healthy
-   *    hook (1–3s) always wins the race, so behaviour only changes on
-   *    machines where the hook is already broken;
+   * Both modes are conservative on purpose:
    *  - requires SOME output — a pty that hasn't drawn anything yet isn't an
-   *    interactive TUI missing its hook, it's still starting;
+   *    interactive TUI, it's still starting;
    *  - keeps waiting while a known blocking prompt (trust dialog, theme
    *    picker, login) is on screen, so the submit `\r` that follows readiness
    *    can never answer a dialog the user hasn't seen — once the user
    *    dismisses it, the next poll flips ready;
    *  - dies with the handle (exit clears the interval; a replaced handle is
    *    detected via the ptys map, same idempotency rule as markExited()).
+   *
+   * `"immediate"` (Codex) reuses the same settle window and scrollback rule
+   * as `isReadyEnough()`, but proactively calls `setReady()` after output is
+   * visible. That status event closes the first-prompt deadlock: Codex writes
+   * no rollout/session_meta before turn one, while the SPA waits for `ready`
+   * before submitting turn one. Only an EXPLICIT declaration arms this
+   * persistent state transition; detect-only legacy adapters retain their
+   * request-time `isReadyEnough()` compatibility path without being promoted.
+   *
+   * `"hook-timeout"` (Claude Code) retains its generous 20s delay: a healthy
+   * hook (1–3s) always wins the race, so behaviour only changes on machines
+   * where the hook is already broken.
    */
-  private armHookReadyFallback(id: string, handle: PtyHandle): void {
+  private armReadyFallback(id: string, handle: PtyHandle): void {
     const session = this.sessions.get(id);
     const adapter = session ? this.adapters[session.harness] : undefined;
-    if (adapter?.readyFallback !== "hook-timeout") return;
+    if (!adapter) return;
+    const mode = adapter.readyFallback;
+    if (mode !== "immediate" && mode !== "hook-timeout") return;
+    // An immediate promotion is only safe when the adapter can positively
+    // exclude its own known blocking screens. Hook-timeout preserves its
+    // existing optional-detector behaviour for third-party adapters.
+    if (mode === "immediate" && !adapter.detectBlockingPrompt) return;
+
+    const delayMs = mode === "immediate" ? READY_SETTLE_MS : HOOK_READY_FALLBACK_MS;
+    const pollMs = mode === "immediate" ? READY_POLL_MS : HOOK_READY_POLL_MS;
 
     const poll = setInterval(() => {
       const current = this.sessions.get(id);
@@ -1122,18 +1138,20 @@ export class SessionManager {
         clearInterval(poll);
         return;
       }
-      if (Date.now() - handle.spawnedAt < HOOK_READY_FALLBACK_MS) return;
+      if (Date.now() - handle.spawnedAt < delayMs) return;
       if (!handle.buffer) return;
       if (adapter.detectBlockingPrompt?.(handle.buffer.slice(-BLOCKING_PROMPT_SCAN_BYTES))) return;
       clearInterval(poll);
-      console.warn(
-        `[harness] session ${id}: SessionStart hook never reached /ingest after ${
-          HOOK_READY_FALLBACK_MS / 1000
-        }s — marking ready by fallback. The hook command may be failing on this machine ` +
-          `(is \`node\` resolvable from the agent's hook shell?).`,
-      );
+      if (mode === "hook-timeout") {
+        console.warn(
+          `[harness] session ${id}: SessionStart hook never reached /ingest after ${
+            HOOK_READY_FALLBACK_MS / 1000
+          }s — marking ready by fallback. The hook command may be failing on this machine ` +
+            `(is \`node\` resolvable from the agent's hook shell?).`,
+        );
+      }
       this.setReady(id);
-    }, HOOK_READY_POLL_MS);
+    }, pollMs);
     // Never the reason the process stays alive; tests with fake timers and
     // the real server both tear down via the exited hook below anyway.
     poll.unref?.();

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -186,12 +186,13 @@ export interface HarnessSession {
    * directory?") that isn't accepting real input yet. `ready` is the
    * stronger signal: this pty is actually interactive. Reset to `false` on
    * every fresh spawn (including resume) and only ever set by
-   * `SessionManager.setReady()` — see there for what flips it. Injecting
-   * input (macros, `/sessions/:id/input`) against a not-ready session
-   * queues briefly then fails loudly (`SessionNotReadyError`) rather than
-   * silently writing into a TUI that isn't listening; raw terminal
-   * keystrokes (`write()`) are deliberately never gated on this, since a
-   * human must always be able to answer the blocking prompt themselves.
+   * `SessionManager.setReady()` — either from the harness's real lifecycle
+   * signal or an explicitly-declared adapter fallback. Injecting input
+   * (macros, `/sessions/:id/input`) against a not-ready session queues briefly
+   * then fails loudly (`SessionNotReadyError`) rather than silently writing
+   * into a TUI that isn't listening; raw terminal keystrokes (`write()`) are
+   * deliberately never gated on this, since a human must always be able to
+   * answer the blocking prompt themselves.
    */
   ready: boolean;
 }
@@ -378,22 +379,24 @@ export interface HarnessAdapter {
   canResume(agentSessionId: string, cwd: string): Promise<boolean>;
   /**
    * Best-effort scrollback check for this harness's own known blocking
-   * prompts (e.g. "trust this directory?"), for harnesses whose real
-   * readiness signal (SessionStart-equivalent) can't be trusted to arrive
-   * before the very first input is worth injecting — see CodexAdapter's
-   * implementation for why. Optional: a harness whose readiness signal IS
-   * trustworthy standalone (Claude Code's SessionStart hook) should leave
-   * this unimplemented rather than have SessionManager fall back to a
-   * scrollback heuristic it doesn't need.
+   * prompts (e.g. trust, login, or onboarding screens). Used by declared
+   * readiness fallbacks so SessionManager never types into a prompt the user
+   * must answer; see CodexAdapter for the immediate-fallback case. Optional
+   * for adapters that never declare a fallback.
    */
   detectBlockingPrompt?(scrollback: string): boolean;
   /**
-   * How SessionManager may mark this harness ready WITHOUT its real readiness
-   * signal (SessionStart hook / tailer equivalent). Absent = never.
+   * How SessionManager may proactively mark this harness ready WITHOUT its
+   * real readiness signal (SessionStart hook / tailer equivalent). Absent =
+   * never publish fallback readiness; detect-only legacy adapters retain only
+   * their request-time `isReadyEnough` compatibility path.
    *
-   *  - `"immediate"` (Codex): `isReadyEnough` trusts a settled scrollback with
-   *    no blocking prompt right away — Codex's real signal cannot arrive
-   *    before the first injection needs it (see CodexAdapter).
+   *  - `"immediate"` (Codex): after the pty has produced output and settled,
+   *    SessionManager proactively publishes `ready` when no blocking prompt
+   *    is visible, releasing a held first prompt. `isReadyEnough` applies the
+   *    same settled-scrollback rule as a request-time race safeguard. Codex's
+   *    real signal cannot arrive before the first injection needs it (see
+   *    CodexAdapter).
    *  - `"hook-timeout"` (Claude Code): the hook is the primary signal, but a
    *    generously-timed fallback flips `ready` when it never arrives — the
    *    hook chain runs `node` through whatever shell Claude uses for hooks,

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -391,17 +391,25 @@ export interface HarnessAdapter {
    */
   detectBlockingPrompt?(terminalOutput: string): boolean;
   /**
+   * Best-effort positive match for this harness's empty interactive composer.
+   * Immediate fallbacks use it only after they previously recognized a
+   * blocking screen: a partial TUI repaint cannot erase that blocker latch;
+   * a positively identified composer can. Optional when the adapter's output
+   * is not diff-rendered or it never declares an immediate fallback.
+   */
+  detectReadyPrompt?(terminalOutput: string): boolean;
+  /**
    * How SessionManager may proactively mark this harness ready WITHOUT its
    * real readiness signal (SessionStart hook / tailer equivalent). Absent =
    * never publish fallback readiness; detect-only legacy adapters retain only
    * their request-time `isReadyEnough` compatibility path.
    *
-   *  - `"immediate"` (Codex): after the pty has produced output and settled,
-   *    SessionManager proactively publishes `ready` when no recognized
-   *    blocking prompt is visible, releasing a held first prompt.
-   *    `isReadyEnough` applies the same settled-frame rule as a request-
-   *    time race safeguard. Codex's real signal cannot arrive before the first
-   *    injection needs it (see CodexAdapter).
+   *  - `"immediate"` (Codex): after the pty has produced output and settled
+   *    (or reached a bounded liveness ceiling), SessionManager proactively
+   *    publishes `ready` when no recognized blocking prompt is visible,
+   *    releasing a held first prompt. `isReadyEnough` applies the same rule
+   *    as a request-time race safeguard. Codex's real signal cannot arrive
+   *    before the first injection needs it (see CodexAdapter).
    *  - `"hook-timeout"` (Claude Code): the hook is the primary signal, but a
    *    generously-timed fallback flips `ready` when it never arrives — the
    *    hook chain runs `node` through whatever shell Claude uses for hooks,

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -187,10 +187,13 @@ export interface HarnessSession {
    * stronger signal: this pty is actually interactive. Reset to `false` on
    * every fresh spawn (including resume) and only ever set by
    * `SessionManager.setReady()` — either from the harness's real lifecycle
-   * signal or an explicitly-declared adapter fallback. Injecting input
-   * (macros, `/sessions/:id/input`) against a not-ready session queues briefly
-   * then fails loudly (`SessionNotReadyError`) rather than silently writing
-   * into a TUI that isn't listening; raw terminal keystrokes (`write()`) are
+   * signal or an explicitly-declared adapter fallback. A fallback may publish
+   * readiness before the harness has created its first transcript/rollout;
+   * `ready` describes whether the TUI can receive input, not whether durable
+   * conversation metadata already exists. Injecting input (macros,
+   * `/sessions/:id/input`) against a not-ready session queues briefly then
+   * fails loudly (`SessionNotReadyError`) rather than silently writing into a
+   * TUI that isn't listening; raw terminal keystrokes (`write()`) are
    * deliberately never gated on this, since a human must always be able to
    * answer the blocking prompt themselves.
    */
@@ -378,13 +381,15 @@ export interface HarnessAdapter {
    */
   canResume(agentSessionId: string, cwd: string): Promise<boolean>;
   /**
-   * Best-effort scrollback check for this harness's own known blocking
-   * prompts (e.g. trust, login, or onboarding screens). Used by declared
-   * readiness fallbacks so SessionManager never types into a prompt the user
-   * must answer; see CodexAdapter for the immediate-fallback case. Optional
-   * for adapters that never declare a fallback.
+   * Best-effort check of recent content-bearing terminal output for this
+   * harness's own known blocking prompts (e.g. trust, login, or onboarding
+   * screens). Used by declared readiness fallbacks to avoid input while a
+   * screen the adapter recognizes is visible; it is not a generic terminal-
+   * state guarantee, so adapters are responsible for tracking stable copy
+   * from their startup flows. See CodexAdapter for the immediate-fallback
+   * case. Optional for adapters that never declare a fallback.
    */
-  detectBlockingPrompt?(scrollback: string): boolean;
+  detectBlockingPrompt?(terminalOutput: string): boolean;
   /**
    * How SessionManager may proactively mark this harness ready WITHOUT its
    * real readiness signal (SessionStart hook / tailer equivalent). Absent =
@@ -392,18 +397,18 @@ export interface HarnessAdapter {
    * their request-time `isReadyEnough` compatibility path.
    *
    *  - `"immediate"` (Codex): after the pty has produced output and settled,
-   *    SessionManager proactively publishes `ready` when no blocking prompt
-   *    is visible, releasing a held first prompt. `isReadyEnough` applies the
-   *    same settled-scrollback rule as a request-time race safeguard. Codex's
-   *    real signal cannot arrive before the first injection needs it (see
-   *    CodexAdapter).
+   *    SessionManager proactively publishes `ready` when no recognized
+   *    blocking prompt is visible, releasing a held first prompt.
+   *    `isReadyEnough` applies the same settled-frame rule as a request-
+   *    time race safeguard. Codex's real signal cannot arrive before the first
+   *    injection needs it (see CodexAdapter).
    *  - `"hook-timeout"` (Claude Code): the hook is the primary signal, but a
    *    generously-timed fallback flips `ready` when it never arrives — the
    *    hook chain runs `node` through whatever shell Claude uses for hooks,
    *    and on Windows machines where that resolution breaks, the alternative
-   *    was a held first prompt silently dropped. Requires
-   *    `detectBlockingPrompt` so the fallback never types into an unanswered
-   *    trust dialog.
+   *    was a held first prompt silently dropped. When supplied,
+   *    `detectBlockingPrompt` keeps this fallback waiting on blocking screens
+   *    the adapter recognizes.
    */
   readyFallback?: "immediate" | "hook-timeout";
   /**

--- a/packages/harness/web/e2e/new-session-composer.spec.ts
+++ b/packages/harness/web/e2e/new-session-composer.spec.ts
@@ -19,6 +19,16 @@ const lastInjectText = (page: Page): Promise<string> =>
       ).__HARNESS_TEST__?.lastInjectInput?.req?.text ?? "",
   );
 
+const injectCallCount = (page: Page): Promise<number> =>
+  page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __HARNESS_TEST__?: { injectInputCalls?: unknown[] };
+        }
+      ).__HARNESS_TEST__?.injectInputCalls?.length ?? 0,
+  );
+
 test.beforeEach(async ({ page }) => {
   await page.goto("/?seed=0");
   await expect(page.locator(".rail-workflows")).toBeVisible();
@@ -474,43 +484,73 @@ test("an upload failure rolls back, retains the queue, sends nothing, and retrie
   expect(createCount).toBe(2);
 });
 
-test("holds the prompt until the session is ready (Claude signed in), then sends it", async ({
-  page,
-}) => {
-  // Make the next session never reach ready on its own — the stand-in for a
-  // user still on Claude's login/onboarding screen, where SessionStart (and so
-  // session.ready) never fires until they finish signing in.
-  await page.addInitScript(() => {
-    (window as unknown as { __MOCK_WITHHOLD_READY__?: boolean }).__MOCK_WITHHOLD_READY__ = true;
+for (const agent of [
+  { id: "claude-code", label: "Claude Code" },
+  { id: "codex", label: "Codex" },
+] as const) {
+  test(`holds the prompt until ${agent.label} is ready, then sends it exactly once`, async ({
+    page,
+  }) => {
+    // Make the next session never reach ready on its own — the stand-in for a
+    // user still on an agent's login, trust, or onboarding screen.
+    await page.addInitScript(() => {
+      (window as unknown as { __MOCK_WITHHOLD_READY__?: boolean }).__MOCK_WITHHOLD_READY__ = true;
+    });
+    await page.goto("/?seed=0");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await page.getByTestId("rail-create-new").click();
+    if (agent.id === "codex") {
+      await page.getByTestId("composer-harness-select").click();
+      await page.getByTestId("composer-harness-option-codex").click();
+      await expect(page.getByTestId("composer-harness-select")).toContainText("Codex");
+    }
+    const prompt = `Summarise my ${agent.label} inbox every morning.`;
+    await page.getByTestId("composer-input").fill(prompt);
+    await page.getByTestId("composer-send").click();
+
+    // The session exists (workbench shown) but the prompt is HELD, not
+    // injected, because the session never became ready.
+    await expect(page.getByTestId("agent-view")).toBeVisible();
+    expect(await lastInjectText(page)).toBe("");
+    expect(await injectCallCount(page)).toBe(0);
+    const createdHarness = await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __HARNESS_TEST__?: { lastCreateSession?: { req?: { harness?: string } } };
+          }
+        ).__HARNESS_TEST__?.lastCreateSession?.req?.harness,
+    );
+    expect(createdHarness).toBe(agent.id);
+
+    // The provider-neutral hint points at terminal setup while preserving the
+    // original prompt.
+    await expect(page.getByTestId("toast")).toContainText(
+      /signing in or dismiss any trust or setup prompt/i,
+      { timeout: 8_000 },
+    );
+    expect(await lastInjectText(page)).toBe("");
+
+    // A readiness status releases the prompt. Repeating the status event must
+    // not inject the held intent a second time.
+    await page.evaluate(() =>
+      (
+        window as unknown as { __HARNESS_TEST__?: { promoteReady?: () => void } }
+      ).__HARNESS_TEST__?.promoteReady?.(),
+    );
+    await expect.poll(() => lastInjectText(page)).toContain(prompt);
+    await expect.poll(() => injectCallCount(page)).toBe(1);
+
+    await page.evaluate(() =>
+      (
+        window as unknown as { __HARNESS_TEST__?: { promoteReady?: () => void } }
+      ).__HARNESS_TEST__?.promoteReady?.(),
+    );
+    await page.waitForTimeout(500);
+    expect(await injectCallCount(page)).toBe(1);
   });
-  await page.goto("/?seed=0");
-  await expect(page.locator(".rail-workflows")).toBeVisible();
-
-  await page.getByTestId("rail-create-new").click();
-  await page.getByTestId("composer-input").fill("Summarise my inbox every morning.");
-  await page.getByTestId("composer-send").click();
-
-  // The session exists (workbench shown) but the prompt is HELD, not injected,
-  // because the session never became ready.
-  await expect(page.getByTestId("agent-view")).toBeVisible();
-  expect(await lastInjectText(page)).toBe("");
-
-  // A hint appears pointing the user at the terminal login; the prompt is still
-  // held while it shows.
-  await expect(page.getByTestId("toast")).toContainText(/sign in to claude/i, {
-    timeout: 8_000,
-  });
-  expect(await lastInjectText(page)).toBe("");
-
-  // The user finishes signing in → the session reports ready → the held prompt
-  // fires itself, carrying the original intent.
-  await page.evaluate(() =>
-    (
-      window as unknown as { __HARNESS_TEST__?: { promoteReady?: () => void } }
-    ).__HARNESS_TEST__?.promoteReady?.(),
-  );
-  await expect.poll(() => lastInjectText(page)).toContain("Summarise my inbox every morning.");
-});
+}
 
 test("a new session opens terminal-only; the canvas stays hidden until it has content", async ({
   page,

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -99,17 +99,18 @@ type RightTab = "canvas" | "steps" | "code";
 
 /**
  * How long a held initial prompt waits for the coding agent to become ready
- * (i.e. the user to finish signing in) before we give up and surface the
- * failure. The normal end of a hold is the session going ready (prompt sent)
- * or exiting — this is only a leak-guard for a login the user walks away from.
+ * (i.e. the user to finish any sign-in, trust, or onboarding step) before we
+ * give up and surface the failure. The normal end of a hold is the session
+ * going ready (prompt sent) or exiting — this is only a leak-guard for setup
+ * the user walks away from.
  */
 const HELD_PROMPT_TIMEOUT_MS = 10 * 60_000;
 
 /**
- * Grace before nudging the user toward the terminal login. A signed-in agent
- * reports ready within a beat, so its held prompt sends before this fires and
- * no hint shows; only a session still stuck (on the Claude login/onboarding
- * screen) survives the grace and surfaces the hint.
+ * Grace before nudging the user toward the terminal. A ready agent reports
+ * within a beat, so its held prompt sends before this fires and no hint shows;
+ * only a session still stuck on sign-in, trust, or onboarding survives the
+ * grace and surfaces the hint.
  */
 const HELD_PROMPT_HINT_DELAY_MS = 4_000;
 
@@ -283,10 +284,10 @@ export const App = (): JSX.Element => {
     [clearPending, harness.injectInput, harness.showToast],
   );
 
-  // Register a prompt to be sent once its session is ready (i.e. Claude is
-  // signed in). Sends immediately if already ready. While waiting, a delayed
-  // hint (only if the session is still not ready after a grace) points the
-  // user at the terminal login — so first-run intent is held, not lost.
+  // Register a prompt to be sent once its coding agent is ready. Sends
+  // immediately if already ready. While waiting, a delayed hint (only if the
+  // session is still not ready after a grace) points the user at terminal
+  // setup — so first-run intent is held, not lost.
   const sendPromptWhenReady = useCallback(
     (sessionId: string, prompt: string, failMessage: string): void => {
       clearPending(sessionId);
@@ -296,7 +297,7 @@ export const App = (): JSX.Element => {
       const hintTimer = window.setTimeout(() => {
         if (pendingPromptsRef.current.has(sessionId)) {
           harness.showToast(
-            "Sign in to Claude in the terminal — your prompt sends automatically once you're signed in.",
+            "Finish signing in or dismiss any trust or setup prompt in the terminal — your prompt sends automatically once the coding agent is ready.",
           );
         }
       }, HELD_PROMPT_HINT_DELAY_MS);

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -1057,9 +1057,9 @@ class MockApi implements HarnessApi {
       });
     };
     // Test-only: a session that never reaches ready on its own, so Playwright
-    // can exercise the hold-the-prompt-until-signed-in path (a not-logged-in
-    // Claude sits on its login screen and never fires SessionStart). The test
-    // fires readiness by hand via window.__HARNESS_TEST__.promoteReady().
+    // can exercise the hold-the-prompt-until-agent-ready path (for example,
+    // Claude login or Codex directory trust). The test fires readiness by hand
+    // via window.__HARNESS_TEST__.promoteReady().
     const win =
       typeof window === "undefined"
         ? undefined
@@ -1234,9 +1234,14 @@ class MockApi implements HarnessApi {
       }
       // Record the submission for Playwright to assert on — same pattern as
       // runMacro's lastMacroRun.
+      const previous =
+        (win.__HARNESS_TEST__?.injectInputCalls as
+          | Array<{ id: string; req: InjectInputRequest }>
+          | undefined) ?? [];
       win.__HARNESS_TEST__ = {
         ...(win.__HARNESS_TEST__ ?? {}),
         lastInjectInput: { id, req },
+        injectInputCalls: [...previous, { id, req }],
       };
     }
   }


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Agent Studio retains a new session's first prompt until the coding-agent TUI reports ready. Claude Code emits SessionStart before its first turn, but Codex does not create rollout/session metadata until after that turn. The UI therefore waited for a readiness signal that Codex could not produce until after the held prompt was injected.

## Summary and scope

- Proactively publish readiness for adapters declaring the immediate fallback once the PTY has emitted output, the settle window has elapsed, and no known blocking prompt is visible.
- Keep prompts held through trust/setup screens and stop fallback polling on real readiness, exit, or PTY replacement.
- Preserve Claude Code's SessionStart-first and 20-second broken-hook fallback behavior, plus legacy adapters' request-time compatibility path.
- Make the delayed setup hint provider-neutral and cover both Claude Code and Codex with exactly-once browser tests.
- Keep prompt delivery post-launch; no API, WebSocket, or CLI argument shape changes.

## Related work

Related issue or discussion: N/A — focused bug fix with a direct reproduction.

## Validation

```text
pnpm --filter @sapiom/harness exec vitest run src/core/session-manager.test.ts — 97 passed
pnpm --filter @sapiom/harness exec playwright test --config web/e2e/playwright.config.ts web/e2e/new-session-composer.spec.ts — 16 passed
pnpm --filter @sapiom/harness typecheck — passed
pnpm --filter @sapiom/harness build — passed
pnpm --filter @sapiom/harness lint — passed with one pre-existing unused-import warning in src/server/rest.test.ts
pnpm --filter @sapiom/harness test:perf — 4 passed
pnpm provider-copy:check — passed
pnpm terminology:check — passed
Live codex-cli 0.147.0 trusted-workspace smoke — reached running/ready without submitting a model prompt
pnpm --filter @sapiom/harness test — 2,100 passed; one unchanged chmod-based workspace-watcher test fails because this cloud sandbox can still read a mode-000 directory (reproduced in isolation)
```

### Tests and documentation

Added session-manager coverage for proactive readiness, output/settle gating, blocking prompts, duplicate signals, PTY replacement, and legacy adapters. Extended the composer Playwright suite across both providers and updated readiness contract documentation/JSDoc.

## Compatibility and release impact

- Breaking or externally visible changes: Codex prompts entered in the new-session composer now submit automatically once its TUI is ready. No breaking API or schema changes.
- Changeset: Added a patch changeset for @sapiom/harness.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

OpenAI Codex diagnosed the readiness deadlock, implemented the shared session-manager/UI/test changes, and drafted the changeset. The resulting diff was reviewed against the provider lifecycle, exercised with focused and package-level tests, built and typechecked, and smoke-tested against the installed Codex CLI.

## Checklist

- [x] I read CONTRIBUTING.md, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
