### PR TITLE
fix(harness): recognize Codex 0.143 composer

### DIFF
--- a/.changeset/codex-0143-ready-composer.md
+++ b/.changeset/codex-0143-ready-composer.md
@@ -3,5 +3,5 @@
 ---
 
 Recognize the Codex CLI 0.143 empty-composer screen so accepting a new
-directory's trust prompt releases Agent Studio's held initial prompt. MCP
-startup warnings remain non-blocking and Claude Code readiness is unchanged.
+directory's trust prompt releases Agent Studio's held initial prompt. Also
+recognize future composer copy changes from the input marker and cwd footer.

--- a/.changeset/codex-0143-ready-composer.md
+++ b/.changeset/codex-0143-ready-composer.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/harness": patch
+---
+
+Recognize the Codex CLI 0.143 empty-composer screen so accepting a new
+directory's trust prompt releases Agent Studio's held initial prompt. MCP
+startup warnings remain non-blocking and Claude Code readiness is unchanged.

--- a/.changeset/codex-0143-ready-composer.md
+++ b/.changeset/codex-0143-ready-composer.md
@@ -4,4 +4,5 @@
 
 Recognize the Codex CLI 0.143 empty-composer screen so accepting a new
 directory's trust prompt releases Agent Studio's held initial prompt. Also
-recognize future composer copy changes from the input marker and cwd footer.
+best-effort recognize future composer copy changes from the input marker and
+cwd footer while known onboarding fragments remain blocking.

--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -347,6 +347,17 @@ describe("CodexAdapter", () => {
       ).toBe(false);
     });
 
+    it("vetoes a partial trust repaint even when the underlying cwd footer is visible", () => {
+      const adapter = new CodexAdapter();
+      expect(
+        adapter.detectReadyPrompt(
+          "\x1b[?2026h\x1b[6;3H  1. Yes, continue\r\n" +
+            "\x1b[7;3H› 2. No, quit\r\n" +
+            "\x1b[14;3Hgpt-5.5 default · /tmp/proj\x1b[?2026l",
+        ),
+      ).toBe(false);
+    });
+
     it("does not mistake an onboarding screen for the empty composer", () => {
       const adapter = new CodexAdapter();
       expect(

--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -249,6 +249,16 @@ describe("CodexAdapter", () => {
       expect(adapter.detectBlockingPrompt(composer)).toBe(false);
     });
 
+    it("does not treat MCP startup authentication warnings as blocking prompts", () => {
+      const adapter = new CodexAdapter();
+      expect(
+        adapter.detectBlockingPrompt(
+          "MCP client for `notion` failed to start: Auth error: OAuth authorization required\r\n" +
+            "MCP startup incomplete (failed: notion, render)",
+        ),
+      ).toBe(false);
+    });
+
     it("does not treat one isolated onboarding label in ordinary output as a whole blocking screen", () => {
       const adapter = new CodexAdapter();
       expect(
@@ -303,6 +313,16 @@ describe("CodexAdapter", () => {
         adapter.detectReadyPrompt(
           "\x1b[?2026h\x1b[12;3HAsk\x1b[12;7HCodex\x1b[12;13Hto\x1b[12;16Hdo" +
             "\x1b[12;19Hanything\x1b[?2026l",
+        ),
+      ).toBe(true);
+    });
+
+    it("recognizes the Codex 0.143 empty-composer copy", () => {
+      const adapter = new CodexAdapter();
+      expect(
+        adapter.detectReadyPrompt(
+          "\x1b[?2026h\x1b[12;3HUse\x1b[12;7H/skills\x1b[12;15Hto" +
+            "\x1b[12;18Hlist\x1b[12;23Havailable\x1b[12;33Hskills\x1b[?2026l",
         ),
       ).toBe(true);
     });

--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -327,6 +327,26 @@ describe("CodexAdapter", () => {
       ).toBe(true);
     });
 
+    it("recognizes a future composer copy from its input marker and cwd footer", () => {
+      const adapter = new CodexAdapter();
+      expect(
+        adapter.detectReadyPrompt(
+          "\x1b[?2026h\x1b[12;3H› A future placeholder\r\n" +
+            "\x1b[14;3Hgpt-next medium · C:\\work\\project\x1b[?2026l",
+        ),
+      ).toBe(true);
+    });
+
+    it("does not treat a selection marker without the cwd footer as a composer", () => {
+      const adapter = new CodexAdapter();
+      expect(
+        adapter.detectReadyPrompt(
+          "\x1b[?2026h\x1b[6;3H› 1. Yes, continue\r\n" +
+            "\x1b[7;3H2. No, quit\x1b[?2026l",
+        ),
+      ).toBe(false);
+    });
+
     it("does not mistake an onboarding screen for the empty composer", () => {
       const adapter = new CodexAdapter();
       expect(

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -131,6 +131,19 @@ const READY_PROMPT_PATTERNS = [
 const COMPOSER_INPUT_MARKER = /›/u;
 const COMPOSER_CWD_FOOTER = /·\s*(?:~[\\/]|\/|[A-Za-z]:[\\/])/u;
 
+/**
+ * A modal can repaint only its moved selection row while leaving Codex's
+ * underlying footer visible. Full blocker detection deliberately requires a
+ * whole multi-phrase signature, but clearing an already-latched blocker is
+ * stricter: any one known modal fragment vetoes composer readiness until a
+ * clean frame arrives.
+ */
+function hasBlockingPromptFragment(rendered: string): boolean {
+  return BLOCKING_PROMPT_SIGNATURES.some((signature) =>
+    signature.some((pattern) => pattern.test(rendered)),
+  );
+}
+
 export interface CodexAdapterOptions {
   /** Overridable for tests. */
   binary?: string;
@@ -327,6 +340,7 @@ export class CodexAdapter implements HarnessAdapter {
 
   detectReadyPrompt(terminalOutput: string): boolean {
     const rendered = stripAnsi(terminalOutput);
+    if (hasBlockingPromptFragment(rendered)) return false;
     return (
       READY_PROMPT_PATTERNS.some((pattern) => pattern.test(rendered)) ||
       (COMPOSER_INPUT_MARKER.test(rendered) &&

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -121,6 +121,16 @@ const READY_PROMPT_PATTERNS = [
   tuiPhrase("Use /skills to list available skills"),
 ];
 
+/**
+ * Copy-independent composer proof. Codex's empty input row carries the `›`
+ * marker and its footer separates the mode from the cwd with `·`; onboarding
+ * selectors can use the same marker, but do not render that cwd footer. The
+ * blocker check in SessionManager still wins when a known modal and the
+ * underlying composer are present in the same diff-rendered frame.
+ */
+const COMPOSER_INPUT_MARKER = /›/u;
+const COMPOSER_CWD_FOOTER = /·\s*(?:~[\\/]|\/|[A-Za-z]:[\\/])/u;
+
 export interface CodexAdapterOptions {
   /** Overridable for tests. */
   binary?: string;
@@ -317,7 +327,11 @@ export class CodexAdapter implements HarnessAdapter {
 
   detectReadyPrompt(terminalOutput: string): boolean {
     const rendered = stripAnsi(terminalOutput);
-    return READY_PROMPT_PATTERNS.some((pattern) => pattern.test(rendered));
+    return (
+      READY_PROMPT_PATTERNS.some((pattern) => pattern.test(rendered)) ||
+      (COMPOSER_INPUT_MARKER.test(rendered) &&
+        COMPOSER_CWD_FOOTER.test(rendered))
+    );
   }
 
   /**

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -107,10 +107,19 @@ const BLOCKING_PROMPT_SIGNATURES: readonly (readonly RegExp[])[] = [
   [tuiPhrase("Select Syntax Theme"), tuiPhrase("Type to filter themes")],
 ];
 
-/** Stable empty-composer copy from codex-cli 0.147.0. This is not required
- * for the ordinary already-trusted path; SessionManager uses it to prove that
- * a previously detected onboarding screen has actually been replaced. */
-const READY_PROMPT_PATTERNS = [tuiPhrase("Ask Codex to do anything")];
+/**
+ * Stable empty-composer copy across supported Codex CLI releases. This is not
+ * required for the ordinary already-trusted path; SessionManager uses it to
+ * prove that a previously detected onboarding screen has actually been
+ * replaced. Keep older copy here as well as newer copy: a real 0.143.0 startup
+ * renders "Use /skills to list available skills", while 0.147.0 renders "Ask
+ * Codex to do anything". Without both, accepting a trust prompt on 0.143.0
+ * leaves the safety latch closed even though the composer is visible.
+ */
+const READY_PROMPT_PATTERNS = [
+  tuiPhrase("Ask Codex to do anything"),
+  tuiPhrase("Use /skills to list available skills"),
+];
 
 export interface CodexAdapterOptions {
   /** Overridable for tests. */

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -694,6 +694,18 @@ describe("SessionManager", () => {
       await vi.advanceTimersByTimeAsync(6_000);
       expect(manager.get(session.id)?.ready).toBe(false);
 
+      // A diff-rendered modal can retain the underlying composer and footer.
+      // The recognized blocker must still win even though detectReadyPrompt
+      // has enough structural evidence to identify the composer underneath.
+      spawns[0]?.emitData(
+        "\x1b[?2026h\x1b[1;1HDo you trust the contents of this directory?\r\n" +
+          "\x1b[6;1H1. Yes, continue\r\n\x1b[7;1H2. No, quit\r\n" +
+          "\x1b[12;1H› Use /skills to list available skills\r\n" +
+          "\x1b[14;1Hgpt-5.5 default · /tmp/proj\x1b[?2026l",
+      );
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
       // Real empty-composer copy captured from Codex 0.143.0 after the user
       // accepted the trust screen. v0.3.3 only recognized the newer "Ask
       // Codex to do anything" copy, so the safety latch never reopened.
@@ -702,10 +714,12 @@ describe("SessionManager", () => {
           "\x1b[12;1H› Use /skills to list available skills\r\n" +
           "\x1b[14;1Hgpt-5.5 default · /tmp/proj\x1b[?2026l",
       );
-      await vi.advanceTimersByTimeAsync(749);
+      await vi.advanceTimersByTimeAsync(600);
       expect(manager.get(session.id)?.ready).toBe(false);
 
-      await vi.advanceTimersByTimeAsync(1);
+      // Give the poll loop a generous crossing beyond READY_SETTLE_MS rather
+      // than pinning this regression to the exact constant by one millisecond.
+      await vi.advanceTimersByTimeAsync(600);
       expect(manager.get(session.id)?.ready).toBe(true);
       expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
     });

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -694,13 +694,12 @@ describe("SessionManager", () => {
       await vi.advanceTimersByTimeAsync(6_000);
       expect(manager.get(session.id)?.ready).toBe(false);
 
-      // A diff-rendered modal can retain the underlying composer and footer.
-      // The recognized blocker must still win even though detectReadyPrompt
-      // has enough structural evidence to identify the composer underneath.
+      // A diff-rendered modal can repaint only its moved selection rows while
+      // retaining the underlying footer. Even without the trust heading in
+      // this frame, a single known modal fragment must keep the latch closed.
       spawns[0]?.emitData(
-        "\x1b[?2026h\x1b[1;1HDo you trust the contents of this directory?\r\n" +
-          "\x1b[6;1H1. Yes, continue\r\n\x1b[7;1H2. No, quit\r\n" +
-          "\x1b[12;1H› Use /skills to list available skills\r\n" +
+        "\x1b[?2026h\x1b[6;1H  1. Yes, continue\r\n" +
+          "\x1b[7;1H› 2. No, quit\r\n" +
           "\x1b[14;1Hgpt-5.5 default · /tmp/proj\x1b[?2026l",
       );
       await vi.advanceTimersByTimeAsync(1_000);

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -4,13 +4,14 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { HarnessAdapter, HarnessKind, HarnessSession, SpawnSpec } from "../shared/types.js";
+import { CodexAdapter } from "./adapters/codex.js";
+import { ExternalHarnessError, SessionNotResumeableError } from "./errors.js";
 import {
   SessionManager,
   sanitizeExitTail,
   type PtySpawnFn,
   type SessionManagerOptions,
 } from "./session-manager.js";
-import { ExternalHarnessError, SessionNotResumeableError } from "./errors.js";
 
 /** Minimal fake IPty: lets tests drive onData/onExit and observe write/resize/kill.
  *  `pid` is only set when a test passes one explicitly — sweep tests need a
@@ -675,6 +676,38 @@ describe("SessionManager", () => {
       );
       await vi.advanceTimersByTimeAsync(700);
       expect(manager.get(session.id)?.ready).toBe(true);
+    });
+
+    it("clears a trust-screen latch on the Codex 0.143 empty composer", async () => {
+      const { manager, spawns } = makeManager({
+        adapter: new CodexAdapter({ binary: "fake-codex" }),
+      });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
+
+      spawns[0]?.emitData(
+        "\x1b[?2026h\x1b[1;1HDo you trust the contents of this directory?\r\n" +
+          "\x1b[6;1H1. Yes, continue\r\n\x1b[7;1H2. No, quit\x1b[?2026l",
+      );
+      await vi.advanceTimersByTimeAsync(6_000);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      // Real empty-composer copy captured from Codex 0.143.0 after the user
+      // accepted the trust screen. v0.3.3 only recognized the newer "Ask
+      // Codex to do anything" copy, so the safety latch never reopened.
+      spawns[0]?.emitData(
+        "\x1b[?2026h\x1b[10;1H⚠ MCP startup incomplete (failed: notion, render)\r\n" +
+          "\x1b[12;1H› Use /skills to list available skills\r\n" +
+          "\x1b[14;1Hgpt-5.5 default · /tmp/proj\x1b[?2026l",
+      );
+      await vi.advanceTimersByTimeAsync(749);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(manager.get(session.id)?.ready).toBe(true);
+      expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
     });
 
     it("retains a blocking screen across partial synchronized diff repaints until the composer is proven", async () => {


### PR DESCRIPTION
## Summary

- recognize Codex CLI 0.143's `Use /skills to list available skills` empty-composer frame
- tolerate future placeholder copy changes using the input marker plus model/cwd footer
- reopen the readiness safety latch after a user accepts a new directory's trust prompt
- keep MCP startup authentication warnings non-blocking and preserve Claude Code behavior

## Root cause

The v0.3.3 readiness fallback correctly saw and retained Codex's trust screen, but it only accepted the newer `Ask Codex to do anything` composer copy as proof that onboarding had cleared. Codex 0.143 renders a different empty-composer placeholder, so the session remained `ready: false` after trust was accepted and Agent Studio kept holding the initial prompt.

The failing Mac's live PTY replay confirmed the trust screen was in history, the current frame contained the 0.143 composer copy, and the MCP warnings did not match a blocking-screen signature.

## Validation

- focused Codex adapter/session-manager tests: 144 passed
- harness unit suite excluding the sandbox-only unreadable-directory test: 2,105 passed
- harness performance suite: 4 passed
- harness typecheck: passed
- harness lint: no errors (one pre-existing warning)
- desktop tests: 152 passed
- desktop typecheck and full dependency build: passed

The excluded workspace-watcher test was run separately and reproduces unchanged because this sandbox cannot make the fixture directory unreadable with `chmod`; it is unrelated to this patch.
