### PR TITLE
feat(tools): forward caller-supplied idempotencyKey on media generation

### DIFF
--- a/.changeset/media-gen-idempotency-key.md
+++ b/.changeset/media-gen-idempotency-key.md
@@ -2,4 +2,4 @@
 "@sapiom/tools": minor
 ---
 
-`contentGeneration.images` / `contentGeneration.video`: `ImageCreateInput` and `VideoCreateInput` gain an optional `idempotencyKey` — a caller-supplied cross-call idempotency key (arbitrary string ≤255) forwarded verbatim as a top-level request field. A repeat with the same key (per tenant) returns the existing generation instead of launching a new one, matching `agents.run` semantics. The SDK only forwards it — across the sync `create` and async `launch` paths, image and video; the platform validates and deduplicates (SAP-2578 / E7 phase 3).
+`contentGeneration.images` / `contentGeneration.video`: `ImageCreateInput` and `VideoCreateInput` gain an optional `idempotencyKey` — a caller-supplied cross-call idempotency key (arbitrary string ≤255, not a UUID) forwarded verbatim as a top-level request field. A repeat with the same key (per tenant) returns the existing generation instead of launching a new one, matching `agents.run` semantics. The SDK only forwards it — across the sync `create` and async `launch` paths, image and video; the platform validates and deduplicates (SAP-2578 / E7 phase 3).

--- a/.changeset/media-gen-idempotency-key.md
+++ b/.changeset/media-gen-idempotency-key.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": minor
+---
+
+`contentGeneration.images` / `contentGeneration.video`: `ImageCreateInput` and `VideoCreateInput` gain an optional `idempotencyKey` — a caller-supplied cross-call idempotency key (arbitrary string ≤255) forwarded verbatim as a top-level request field. A repeat with the same key (per tenant) returns the existing generation instead of launching a new one, matching `agents.run` semantics. The SDK only forwards it — across the sync `create` and async `launch` paths, image and video; the platform validates and deduplicates (SAP-2578 / E7 phase 3).

--- a/packages/tools/src/content-generation/README.md
+++ b/packages/tools/src/content-generation/README.md
@@ -185,7 +185,7 @@ Shared:
 - `storage` (optional) — persist outputs; `{ visibility: "private" | "public" }`.
 - `idempotencyKey` (optional) — cross-call idempotency key; a repeat with the same
   key (per tenant) returns the existing generation instead of a new one, like
-  `agents.run`. Arbitrary string ≤255.
+  `agents.run`. Arbitrary string ≤255 (not a UUID).
 - `passthrough` (optional) — escape hatch for a raw provider knob the neutral
   vocabulary doesn't cover; merged last, so it overrides the neutral fields.
 - `numImages` / `params` — **deprecated**, still honored; superseded by `count` /

--- a/packages/tools/src/content-generation/README.md
+++ b/packages/tools/src/content-generation/README.md
@@ -183,6 +183,9 @@ Shared:
 - `model` (optional) — a semantic alias (e.g. `"flux-fast"`, `"veo3-fast"`);
   defaults to a fast model. Most callers omit it.
 - `storage` (optional) — persist outputs; `{ visibility: "private" | "public" }`.
+- `idempotencyKey` (optional) — cross-call idempotency key; a repeat with the same
+  key (per tenant) returns the existing generation instead of a new one, like
+  `agents.run`. Arbitrary string ≤255.
 - `passthrough` (optional) — escape hatch for a raw provider knob the neutral
   vocabulary doesn't cover; merged last, so it overrides the neutral fields.
 - `numImages` / `params` — **deprecated**, still honored; superseded by `count` /

--- a/packages/tools/src/content-generation/index.spec.ts
+++ b/packages/tools/src/content-generation/index.spec.ts
@@ -1466,6 +1466,97 @@ describe("neutral params (E4/SAP-2579)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// E7 phase 3 (SAP-2578) — caller-supplied idempotencyKey reaches the request
+// body (cross-call dedup lives on the platform; the SDK is a verbatim passthrough,
+// so the only contract to prove is that the allow-list doesn't drop the field).
+// ---------------------------------------------------------------------------
+
+describe("idempotencyKey passthrough (E7 phase 3 / SAP-2578)", () => {
+  it("createImage forwards idempotencyKey as a top-level body field", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({ images: [] })]);
+
+    await createImage(
+      { prompt: "x", idempotencyKey: "dedupe-abc-123" },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      idempotencyKey: "dedupe-abc-123",
+    });
+  });
+
+  it("createVideo forwards idempotencyKey as a top-level body field", async () => {
+    const { transport, calls } = makeTransport([
+      (c) =>
+        c.init.method === "POST"
+          ? jsonResponse({ requestId: "r", responseUrl: `${BASE}/queue/r` })
+          : null,
+      (c) =>
+        c.init.method === "GET"
+          ? jsonResponse({ video: { url: "https://media/v.mp4" } })
+          : null,
+    ]);
+
+    await createVideo(
+      { prompt: "x", idempotencyKey: "dedupe-vid-9", pollIntervalMs: 1 },
+      transport,
+      BASE,
+    );
+
+    // pollIntervalMs is a client-side control and stays off the wire; idempotencyKey rides top-level.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      idempotencyKey: "dedupe-vid-9",
+    });
+  });
+
+  it("launchImage + launchVideo forward idempotencyKey alongside their dispatch shape", async () => {
+    const img = makeLaunchTransport(
+      { requestId: "i", responseUrl: `${BASE}/queue/i` },
+      { images: [{ url: "u" }] },
+    );
+    await launchImage(
+      { prompt: "x", idempotencyKey: "dedupe-img-launch" },
+      img.transport,
+      BASE,
+    );
+    expect(JSON.parse(img.calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      dispatch: "async",
+      idempotencyKey: "dedupe-img-launch",
+    });
+
+    const vid = makeLaunchTransport(
+      { requestId: "v", responseUrl: `${BASE}/queue/v` },
+      { video: { url: "u" } },
+    );
+    await launchVideo(
+      { prompt: "x", idempotencyKey: "dedupe-vid-launch" },
+      vid.transport,
+      BASE,
+    );
+    expect(JSON.parse(vid.calls[0]!.init.body as string)).toEqual({
+      prompt: "x",
+      idempotencyKey: "dedupe-vid-launch",
+    });
+  });
+
+  it("drops an explicit null idempotencyKey (JS caller) instead of sending it", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({ images: [] })]);
+
+    await createImage(
+      { prompt: "x", idempotencyKey: null as unknown as undefined },
+      transport,
+      BASE,
+    );
+
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({ prompt: "x" });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // toVideoResumePayload()
 // ---------------------------------------------------------------------------
 

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -127,7 +127,7 @@ export interface ImageCreateInput {
 
   /**
    * Optional cross-call idempotency key: a repeat with the same key (per tenant) returns the
-   * existing generation instead of a new one, matching `agents.run`. Arbitrary string ≤255.
+   * existing generation instead of a new one, matching `agents.run`. Arbitrary string ≤255 (not a UUID).
    * Forwarded verbatim — the platform validates and deduplicates; the SDK adds no logic.
    */
   idempotencyKey?: string;
@@ -699,7 +699,7 @@ export interface VideoCreateInput {
 
   /**
    * Optional cross-call idempotency key: a repeat with the same key (per tenant) returns the
-   * existing generation instead of a new one, matching `agents.run`. Arbitrary string ≤255.
+   * existing generation instead of a new one, matching `agents.run`. Arbitrary string ≤255 (not a UUID).
    * Forwarded verbatim — the platform validates and deduplicates; the SDK adds no logic.
    */
   idempotencyKey?: string;

--- a/packages/tools/src/content-generation/index.ts
+++ b/packages/tools/src/content-generation/index.ts
@@ -125,6 +125,13 @@ export interface ImageCreateInput {
    */
   model?: string;
 
+  /**
+   * Optional cross-call idempotency key: a repeat with the same key (per tenant) returns the
+   * existing generation instead of a new one, matching `agents.run`. Arbitrary string ≤255.
+   * Forwarded verbatim — the platform validates and deduplicates; the SDK adds no logic.
+   */
+  idempotencyKey?: string;
+
   // ── Neutral params (E4/SAP-2579). Validated against the resolved model's capabilities BEFORE
   // payment and mapped to its provider wire keys; an unsupported one → 400 `unsupported_param`
   // (never silently dropped). Omit ⇒ the provider default. See {@link AspectRatio} et al.
@@ -376,6 +383,9 @@ export async function createImage(
   const body: Record<string, unknown> = { prompt: input.prompt };
   if (input.model != null) body.model = input.model;
   if (input.storage) body.storage = input.storage;
+  // Request-level control (like `model`/`storage`), not a neutral media param: forwarded
+  // verbatim for the platform to validate + dedup. `!= null` drops an explicit JS `null`.
+  if (input.idempotencyKey != null) body.idempotencyKey = input.idempotencyKey;
   applyMediaParams(body, input as unknown as Record<string, unknown>, IMAGE_PARAM_KEYS);
 
   const raw = await capabilityCall<RawImageResult>(
@@ -557,6 +567,9 @@ export async function launchImage(
   };
   if (input.model != null) body.model = input.model;
   if (input.storage) body.storage = input.storage;
+  // Request-level control (like `model`/`storage`), not a neutral media param: forwarded
+  // verbatim for the platform to validate + dedup. `!= null` drops an explicit JS `null`.
+  if (input.idempotencyKey != null) body.idempotencyKey = input.idempotencyKey;
   applyMediaParams(body, input as unknown as Record<string, unknown>, IMAGE_PARAM_KEYS);
 
   const handle = await capabilityCall<ImageDispatchResponse>(
@@ -683,6 +696,13 @@ export interface VideoCreateInput {
    * @example "veo3-fast"
    */
   model?: LiteralUnion<KnownVideoModel>;
+
+  /**
+   * Optional cross-call idempotency key: a repeat with the same key (per tenant) returns the
+   * existing generation instead of a new one, matching `agents.run`. Arbitrary string ≤255.
+   * Forwarded verbatim — the platform validates and deduplicates; the SDK adds no logic.
+   */
+  idempotencyKey?: string;
 
   // ── Neutral params (E4/SAP-2579) — same contract as {@link ImageCreateInput}: validated against
   // the resolved model's capabilities BEFORE payment, mapped to its provider wire keys; an
@@ -882,6 +902,9 @@ export async function createVideo(
   const body: Record<string, unknown> = { prompt: input.prompt };
   if (input.model != null) body.model = input.model;
   if (input.storage) body.storage = input.storage;
+  // Request-level control (like `model`/`storage`), not a neutral media param: forwarded
+  // verbatim for the platform to validate + dedup. `!= null` drops an explicit JS `null`.
+  if (input.idempotencyKey != null) body.idempotencyKey = input.idempotencyKey;
   applyMediaParams(body, input as unknown as Record<string, unknown>, VIDEO_PARAM_KEYS);
 
   // Submit through the capability router — the video capability's adapter always
@@ -1062,6 +1085,9 @@ export async function launchVideo(
   const body: Record<string, unknown> = { prompt: input.prompt };
   if (input.model != null) body.model = input.model;
   if (input.storage) body.storage = input.storage;
+  // Request-level control (like `model`/`storage`), not a neutral media param: forwarded
+  // verbatim for the platform to validate + dedup. `!= null` drops an explicit JS `null`.
+  if (input.idempotencyKey != null) body.idempotencyKey = input.idempotencyKey;
   applyMediaParams(body, input as unknown as Record<string, unknown>, VIDEO_PARAM_KEYS);
 
   const handle = await capabilityCall<VideoDispatchResponse>(


### PR DESCRIPTION
## Primary change type

<!-- Select exactly one primary type. -->

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The backend landed E7 phase 3 (SAP-2578, sapiom/Sapiom#4584): media generation
(`content.generation.images` / `content.generation.video`) now accepts a
caller-supplied `idempotencyKey` on `ImageCreateRequest` / `VideoCreateRequest`,
validates it (non-empty string ≤255, not a UUID), and deduplicates cross-call —
a repeat with the same key (per tenant) returns the existing generation instead
of launching a new one, matching `agents.run` semantics.

The SDK half was missing: `@sapiom/tools` did not expose the field, so a caller
had no way to pass it and get retry-safe, dedup'd media generation.

## Summary and scope

Exposes `idempotencyKey` on the SDK and forwards it verbatim to the wire.

- Add `idempotencyKey?: string` to `ImageCreateInput` and `VideoCreateInput`
  (`packages/tools/src/content-generation/index.ts`), documented from the
  backend contract and modelled on the existing `agents.run` (`AgentRunSpec`)
  field rather than inventing new naming.
- Thread it to the request body on all four construction sites — `createImage`,
  `launchImage`, `createVideo`, `launchVideo` — placed alongside the sibling
  request-level controls (`model`/`storage`) and **before** the
  `applyMediaParams` allow-list, so `IMAGE_PARAM_KEYS`/`VIDEO_PARAM_KEYS` can't
  drop it. Guarded with `!= null` (drops an explicit JS `null`, mirroring the
  neighbours). The `images`/`video` namespaces and `createClient()` delegate to
  these four — no other path builds a request body.
- Document the field in the module README's "Shared" input-params list.

Out of scope: no SDK-side validation or dedup logic — this is a pure
passthrough; the platform validates (non-empty ≤255, not a UUID) and
deduplicates.

## Related work

Related issue or discussion: SAP-2578 (E7 — Retry safety and idempotency);
backend contract in sapiom/Sapiom#4584.

## Validation

```text
# pnpm --filter @sapiom/tools typecheck — pass (clean)
# pnpm --filter @sapiom/tools exec eslint src/content-generation — pass (no findings)
# pnpm --filter @sapiom/tools build — pass
# pnpm --filter @sapiom/tools exec jest src/content-generation — pass (101 tests, 4 new)
# node .context/idempotency-demo.mjs — PASS (idempotencyKey reaches the request body on all 4 paths, via built package + real createClient)
# pnpm provider-copy:check — pass (74 files)
# pnpm terminology:check — pass (422 files)
# pnpm exec changeset status — @sapiom/tools 0.31.0 -> 0.32.0 (minor); agent/agent-core/sandbox-preview auto-patched
```

### Tests and documentation

Added a "idempotencyKey passthrough (E7 phase 3 / SAP-2578)" test block in
`index.spec.ts` asserting the caller-supplied key lands in the parsed request
body for `createImage`, `createVideo`, `launchImage`, `launchVideo`, plus a
null-drop case. Documented the field via JSDoc on both input types and a bullet
in the content-generation module README.

## Compatibility and release impact

- Breaking or externally visible changes: None — a new optional, additive input
  field; existing callers compile and behave unchanged.
- Changeset: Added — `.changeset/media-gen-idempotency-key.md` (`@sapiom/tools`
  minor); the `workspace:^` dependents (`@sapiom/agent`, `@sapiom/agent-core`,
  `@sapiom/sandbox-preview`) auto-patch per `updateInternalDependencies: patch`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

AI assistance (Claude Code): drafted the SDK passthrough, the tests, the
changeset, and this PR body. Verified by running the tools typecheck, lint,
build, and jest suite (101 passing), a standalone end-to-end demo against the
built package proving the key reaches the wire on all four paths, and a
multi-agent adversarial review of the diff (which caught the missing README
entry, now fixed).

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
