### PR TITLE
feat(ui): add sibling Agent Studio session tabs

### DIFF
--- a/.changeset/fresh-sibling-session-tabs.md
+++ b/.changeset/fresh-sibling-session-tabs.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Start fresh same-folder Claude Code or Codex conversations from browser-style session tabs in Agent Studio.

--- a/packages/harness/web/e2e/portable-continue.spec.ts
+++ b/packages/harness/web/e2e/portable-continue.spec.ts
@@ -81,9 +81,9 @@ test("continuing it opens a NEW session rather than resuming the old one", async
   // A real fresh id is present — `/.+/` proves the attribute EXISTS and is
   // non-empty (a bare not-"" also passes when the attribute is absent).
   await expect(context).toHaveAttribute("data-session-id", /.+/);
-  // The old session is not what came back — it never appears as a live session
-  // (no active context on it, no switch chip for it).
-  await expect(page.getByTestId("session-switch-sess-pricing")).toHaveCount(0);
+  // The old session is not what came back — exited sessions never appear in
+  // the live tab strip.
+  await expect(page.getByTestId("session-tab-sess-pricing")).toHaveCount(0);
   // And no failure toast: this path never attempts the resume that would 409.
   await expect(page.getByTestId("toast")).toHaveCount(0);
 });

--- a/packages/harness/web/e2e/session-tabs.spec.ts
+++ b/packages/harness/web/e2e/session-tabs.spec.ts
@@ -1,0 +1,318 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+interface SessionTestState {
+  createSessionCalls?: Array<{
+    req?: Record<string, unknown> & { cwd?: string; harness?: string };
+  }>;
+  lastCreateSession?: {
+    req?: Record<string, unknown> & { cwd?: string; harness?: string };
+  };
+  bindWorkflowCalls?: Array<{
+    req?: { sessionId?: string; workflowPath?: string | null };
+  }>;
+  lastBindWorkflow?: {
+    req?: { sessionId?: string; workflowPath?: string | null };
+  };
+  publish?: (message: unknown) => void;
+}
+
+const testState = (page: Page): Promise<SessionTestState> =>
+  page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __HARNESS_TEST__?: SessionTestState;
+        }
+      ).__HARNESS_TEST__ ?? {},
+  );
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/?seed=0");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+  await expect(page.getByTestId("session-context")).toHaveAttribute(
+    "data-session-id",
+    "sess-boot",
+  );
+});
+
+test("renders oldest-first accessible tabs with provider tooltips", async ({
+  page,
+}) => {
+  const tablist = page.getByRole("tablist", { name: "Sessions" });
+  const tabs = tablist.getByRole("tab");
+
+  await expect(tabs).toHaveCount(2);
+  await expect(tabs.nth(0)).toHaveText("acme-app");
+  await expect(tabs.nth(0)).toHaveAttribute("aria-selected", "true");
+  await expect(tabs.nth(0)).toHaveAttribute("title", "acme-app · Claude Code");
+  await expect(tabs.nth(1)).toHaveText("acme-app 2");
+  await expect(tabs.nth(1)).toHaveAttribute("aria-selected", "false");
+  await expect(tabs.nth(1)).toHaveAttribute("title", "acme-app 2 · Codex");
+  await expect(page.getByTestId("session-tab-new")).toHaveAttribute(
+    "aria-label",
+    "New session on leasing",
+  );
+});
+
+test("starts a fresh Claude sibling in the same folder and binding", async ({
+  page,
+}) => {
+  const newSession = page.getByTestId("session-tab-new");
+  await newSession.click();
+  await expect(newSession).toHaveAttribute("aria-busy", "true");
+
+  await expect(
+    page.getByRole("tablist", { name: "Sessions" }).getByRole("tab"),
+  ).toHaveCount(3);
+  await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
+  await expect(page.getByTestId("session-context-title")).toHaveText(
+    "acme-app 3",
+  );
+
+  await expect
+    .poll(async () => (await testState(page)).lastCreateSession?.req)
+    .toMatchObject({
+      cwd: "/Users/demo/acme-app",
+      harness: "claude-code",
+    });
+  const create = (await testState(page)).lastCreateSession?.req ?? {};
+  expect(create).not.toHaveProperty("prompt");
+  expect(create).not.toHaveProperty("rehydrateFrom");
+  expect(create).not.toHaveProperty("agentSessionId");
+
+  await expect
+    .poll(async () => (await testState(page)).lastBindWorkflow?.req)
+    .toMatchObject({ workflowPath: "/Users/demo/acme-app/leasing" });
+  await expect(newSession).toHaveAttribute("aria-busy", "false");
+  await expect(page.getByTestId("session-tab-sess-boot")).toBeVisible();
+  await expect(page.getByTestId("session-tab-sess-leasing-2")).toBeVisible();
+});
+
+test("inherits Codex from the selected source tab", async ({ page }) => {
+  await page.getByTestId("session-tab-main-sess-leasing-2").click();
+  await expect(page.getByTestId("session-context")).toHaveAttribute(
+    "data-session-id",
+    "sess-leasing-2",
+  );
+
+  await page.getByTestId("session-tab-new").click();
+  await expect
+    .poll(async () => (await testState(page)).lastCreateSession?.req)
+    .toMatchObject({
+      cwd: "/Users/demo/acme-app",
+      harness: "codex",
+    });
+  await expect
+    .poll(
+      async () => (await testState(page)).lastBindWorkflow?.req?.workflowPath,
+    )
+    .toBe("/Users/demo/acme-app/leasing");
+});
+
+test("guards rapid same-frame clicks with one create request", async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    const button = document.querySelector<HTMLButtonElement>(
+      "[data-testid='session-tab-new']",
+    );
+    button?.click();
+    button?.click();
+  });
+
+  await expect
+    .poll(async () => (await testState(page)).createSessionCalls?.length ?? 0)
+    .toBe(1);
+  await expect(
+    page.getByRole("tablist", { name: "Sessions" }).getByRole("tab"),
+  ).toHaveCount(3);
+});
+
+test("creates an unbound sibling without issuing a bind request", async ({
+  page,
+}) => {
+  await page.getByTestId("workspace-focus-scratch").click();
+  await expect(page.getByTestId("session-context")).toHaveAttribute(
+    "data-session-id",
+    "sess-bg",
+  );
+
+  await page.getByTestId("session-tab-new").click();
+  await expect
+    .poll(async () => (await testState(page)).lastCreateSession?.req)
+    .toMatchObject({
+      cwd: "/Users/demo/scratch",
+      harness: "claude-code",
+    });
+  await expect
+    .poll(async () => (await testState(page)).createSessionCalls?.length ?? 0)
+    .toBe(1);
+  expect((await testState(page)).bindWorkflowCalls ?? []).toHaveLength(0);
+  await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
+});
+
+test("creation failure restores the source tab and shows the scoped error", async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __MOCK_CREATE_SESSION_FAIL_ONCE__?: boolean;
+      }
+    ).__MOCK_CREATE_SESSION_FAIL_ONCE__ = true;
+  });
+
+  await page.getByTestId("session-tab-new").click();
+  await expect(page.getByTestId("toast")).toContainText(
+    "Couldn't start the session.",
+  );
+  await expect(page.getByTestId("session-context")).toHaveAttribute(
+    "data-session-id",
+    "sess-boot",
+  );
+  await expect(
+    page.getByRole("tablist", { name: "Sessions" }).getByRole("tab"),
+  ).toHaveCount(2);
+  await expect(page.getByTestId("session-tab-new")).toHaveAttribute(
+    "aria-busy",
+    "false",
+  );
+});
+
+test("binding failure keeps the new session active and unbound", async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    (
+      window as unknown as {
+        __MOCK_BIND_WORKFLOW_FAIL_ONCE__?: boolean;
+      }
+    ).__MOCK_BIND_WORKFLOW_FAIL_ONCE__ = true;
+  });
+
+  await page.getByTestId("session-tab-new").click();
+  await expect(page.getByTestId("toast")).toContainText(
+    "Session started, but couldn't attach it to leasing.",
+  );
+  await expect(page.getByTestId("session-context")).toHaveAttribute(
+    "data-session-id",
+    /^sess-mock-/,
+  );
+  await expect(page.getByTestId("session-workflow-chip")).toHaveCount(0);
+  await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
+  await expect
+    .poll(async () => (await testState(page)).bindWorkflowCalls?.length ?? 0)
+    .toBe(1);
+});
+
+test("an exited active session can start fresh with its provider and binding", async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    const publish = (
+      window as unknown as {
+        __HARNESS_TEST__?: SessionTestState;
+      }
+    ).__HARNESS_TEST__?.publish;
+    publish?.({
+      type: "session.status",
+      session: {
+        id: "sess-boot",
+        agentSessionId: null,
+        boundWorkflowPath: "/Users/demo/acme-app/leasing",
+        harness: "claude-code",
+        cwd: "/Users/demo/acme-app",
+        title: "acme-app",
+        status: "exited",
+        createdAt: new Date(Date.now() - 60_000).toISOString(),
+        lastActiveAt: new Date().toISOString(),
+        exitCode: 0,
+        ready: false,
+      },
+    });
+  });
+
+  await expect(page.getByTestId("dead-session-pane")).toBeVisible();
+  await expect(page.getByTestId("session-tabs")).toHaveCount(0);
+  await expect(page.getByTestId("session-tab-new")).toBeVisible();
+  await page.getByTestId("session-tab-new").click();
+
+  await expect
+    .poll(async () => (await testState(page)).lastCreateSession?.req)
+    .toMatchObject({
+      cwd: "/Users/demo/acme-app",
+      harness: "claude-code",
+    });
+  await expect
+    .poll(
+      async () => (await testState(page)).lastBindWorkflow?.req?.workflowPath,
+    )
+    .toBe("/Users/demo/acme-app/leasing");
+  await expect(page.getByTestId("dead-session-pane")).toHaveCount(0);
+});
+
+test("switching tabs dismisses active-session menu state", async ({ page }) => {
+  await page.getByTestId("session-menu").click();
+  await expect(page.getByTestId("session-menu-popover")).toBeVisible();
+
+  await page.keyboard.press("Meta+2");
+  await expect(page.getByTestId("session-menu-popover")).toHaveCount(0);
+  await expect(
+    page.getByTestId("session-tab-main-sess-leasing-2"),
+  ).toHaveAttribute("aria-selected", "true");
+});
+
+test("long tab sets scroll internally while + and actions remain reachable", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 560, height: 800 });
+  await page.evaluate(() => {
+    const publish = (
+      window as unknown as {
+        __HARNESS_TEST__?: SessionTestState;
+      }
+    ).__HARNESS_TEST__?.publish;
+    for (let index = 0; index < 8; index += 1) {
+      publish?.({
+        type: "session.status",
+        session: {
+          id: `sess-overflow-${index}`,
+          agentSessionId: null,
+          boundWorkflowPath: "/Users/demo/acme-app/leasing",
+          harness: index % 2 === 0 ? "claude-code" : "codex",
+          cwd: "/Users/demo/acme-app",
+          title: `Investigate overflow scenario ${index + 1}`,
+          status: "running",
+          createdAt: new Date(Date.now() + index * 1_000).toISOString(),
+          lastActiveAt: new Date().toISOString(),
+          ready: true,
+        },
+      });
+    }
+  });
+
+  const list = page.locator(".session-tabs-list");
+  await expect(
+    page.getByRole("tablist", { name: "Sessions" }).getByRole("tab"),
+  ).toHaveCount(10);
+  await expect(page.getByTestId("session-tab-new")).toBeVisible();
+  expect(
+    await list.evaluate((element) => element.scrollWidth > element.clientWidth),
+  ).toBe(true);
+
+  await page.getByTestId("session-tab-new").click();
+  await expect(page.getByTestId("session-context")).toHaveAttribute(
+    "data-session-id",
+    /^sess-mock-/,
+  );
+  const activeTabIsContained = await page
+    .locator(".session-tab.is-active")
+    .evaluate((tab) => {
+      const tabRect = tab.getBoundingClientRect();
+      const listRect = tab.parentElement!.getBoundingClientRect();
+      return tabRect.left >= listRect.left && tabRect.right <= listRect.right;
+    });
+  expect(activeTabIsContained).toBe(true);
+  await expect(page.getByTestId("session-tab-new")).toBeInViewport();
+});

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -135,13 +135,9 @@ test("auto-selects the running boot session on initial load", async ({ page }) =
   await expect(page.locator(".terminal-empty")).toHaveCount(0);
   const header = page.getByTestId("session-context");
   await expect(header).toHaveAttribute("data-session-id", "sess-boot");
-  // The active session is the options dropdown (session-menu); its dot carries
-  // the status. (A background session's switch chip has its own dot, so scope
-  // to the active menu.)
-  await expect(header.getByTestId("session-menu").locator(".session-dot")).toHaveAttribute(
-    "data-status",
-    "running",
-  );
+  await expect(
+    page.getByTestId("session-tab-sess-boot").locator(".session-dot"),
+  ).toHaveAttribute("data-status", "running");
 });
 
 test("session header: compact identity (name only; path in the tooltip); New session opens from the rail's history menu", async ({
@@ -149,9 +145,9 @@ test("session header: compact identity (name only; path in the tooltip); New ses
 }) => {
   const header = page.getByTestId("session-context");
   const title = header.getByTestId("session-context-title");
-  // A folder-default session is labelled by its bound AGENT (leasing), not the
-  // workspace folder — the rail already names the workspace.
-  await expect(title).toContainText("leasing");
+  // Browser-style sessions use the established session-name contract rather
+  // than replacing the folder default with the bound agent's name.
+  await expect(title).toHaveText("acme-app");
   // The full path never renders inline (it would bleed) — it lives in the
   // session menu's hover tooltip alongside the workspace label.
   await expect(header).not.toContainText("/Users/demo/acme-app");
@@ -192,7 +188,7 @@ test("the active session shows a busy pulse that clears once output goes quiet",
       harnessSessionId: "sess-boot",
     });
   });
-  const busy = page.getByTestId("session-busy");
+  const busy = page.getByTestId("session-tab-busy-sess-boot");
   await expect(busy).toBeVisible({ timeout: 5_000 });
   await page.screenshot({ path: "web/e2e/screenshots/session-tab-busy.png" });
 
@@ -232,7 +228,7 @@ test("Overview opens the introduction, and Escape returns to the session behind 
   await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-boot");
 });
 
-test("creation IA: Add existing agents opens the detection dialog; the tab strip + opens the composer", async ({
+test("creation IA: Add existing agents opens detection; the tab + starts a sibling directly", async ({
   page,
 }) => {
   // Adding what already exists is ONE detection-driven dialog — no doors, no
@@ -246,13 +242,15 @@ test("creation IA: Add existing agents opens the detection dialog; the tab strip
   await page.keyboard.press("Escape");
   await expect(modal).toHaveCount(0);
 
-  // Creating something NEW lives in the composer: the session bar's + opens it,
-  // not a dialog and not a silent direct add.
-  const newBtn = page.getByTestId("session-new");
-  await expect(newBtn).toHaveAttribute("aria-label", "New session");
+  // The workbench + means another conversation in this folder. The rail's
+  // Create new remains the composer entry for a new project/agent.
+  const newBtn = page.getByTestId("session-tab-new");
+  await expect(newBtn).toHaveAttribute("aria-label", "New session on leasing");
   await newBtn.click();
-  await expect(page.getByTestId("new-session-composer")).toBeVisible();
-  await expect(page.getByTestId("composer-input")).toBeVisible();
+  await expect(page.getByTestId("session-tabs").getByRole("tab")).toHaveCount(
+    3,
+  );
+  await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
   await expect(page.locator(".modal-start")).toHaveCount(0);
 });
 
@@ -330,21 +328,24 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await page.screenshot({ path: "web/e2e/screenshots/rail-explorer.png", fullPage: true });
   });
 
-  test("focusing an agent with sessions shows the active session and a switcher menu", async ({ page }) => {
-    // Leasing is focused on load and carries two live sessions. The bar shows a
-    // single selector (sess-boot); switching lives in its ⌄ menu, which lists
-    // both sessions with the active one checked.
+  test("focusing an agent with sessions shows visible browser-style tabs", async ({
+    page,
+  }) => {
+    // Leasing is focused on load and carries two live sessions, oldest first.
     const header = page.getByTestId("session-context");
     await expect(header).toHaveAttribute("data-session-id", "sess-boot");
+    const tabs = page.getByTestId("session-tabs").getByRole("tab");
+    await expect(tabs).toHaveCount(2);
+    await expect(tabs.nth(0)).toHaveText("acme-app");
+    await expect(tabs.nth(0)).toHaveAttribute("aria-selected", "true");
+    await expect(tabs.nth(1)).toHaveText("acme-app 2");
+    await expect(tabs.nth(1)).toHaveAttribute("aria-selected", "false");
     await expect(page.getByTestId("session-menu")).toBeVisible();
-    await page.getByTestId("session-menu").click();
-    await expect(page.locator(".session-switch-item")).toHaveCount(2);
-    await expect(page.getByTestId("session-switch-sess-leasing-2")).toBeVisible();
-    await expect(page.getByTestId("session-switch-sess-boot")).toHaveAttribute("aria-checked", "true");
-    await page.keyboard.press("Escape");
-    // A + to add another session is always available.
-    await expect(page.getByTestId("session-new")).toBeVisible();
-    await page.screenshot({ path: "web/e2e/screenshots/session-tab-strip.png", fullPage: true });
+    await expect(page.getByTestId("session-tab-new")).toBeVisible();
+    await page.screenshot({
+      path: "web/e2e/screenshots/session-tab-strip.png",
+      fullPage: true,
+    });
   });
 
   test("switching sessions makes the canvas follow the new session's content", async ({ page }) => {
@@ -357,27 +358,34 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await expect(page.locator(".right-pane")).not.toHaveClass(/is-collapsed/);
 
     // Switch to the empty session — nothing to show, so the canvas hides.
-    await page.getByTestId("session-menu").click();
-    await page.getByTestId("session-switch-sess-leasing-2").click();
-    await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-leasing-2");
+    await page.getByTestId("session-tab-main-sess-leasing-2").click();
+    await expect(page.getByTestId("session-context")).toHaveAttribute(
+      "data-session-id",
+      "sess-leasing-2",
+    );
     await expect(page.locator(".right-pane")).toHaveClass(/is-collapsed/);
 
     // Switch back to the populated session — the canvas opens again.
-    await page.getByTestId("session-menu").click();
-    await page.getByTestId("session-switch-sess-boot").click();
-    await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-boot");
+    await page.getByTestId("session-tab-main-sess-boot").click();
+    await expect(page.getByTestId("session-context")).toHaveAttribute(
+      "data-session-id",
+      "sess-boot",
+    );
     await expect(page.locator(".right-pane")).not.toHaveClass(/is-collapsed/);
     await expect(page.locator(".canvas-iframe")).toBeVisible();
   });
 
-  test("the + opens the composer to start a new session", async ({ page }) => {
-    // The + is the New-session entry: it opens the composer-first home rather
-    // than silently spawning a session, so a new agent starts from an outcome.
-    await page.getByTestId("session-new").click();
-    await expect(page.getByTestId("new-session-composer")).toBeVisible();
-    await expect(page.getByTestId("composer-input")).toBeVisible();
-    // Leasing stays the focused agent behind the composer.
-    await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-focused/);
+  test("the + starts a fresh same-folder session without opening the composer", async ({
+    page,
+  }) => {
+    await page.getByTestId("session-tab-new").click();
+    await expect(page.getByTestId("session-tabs").getByRole("tab")).toHaveCount(
+      3,
+    );
+    await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
+    await expect(page.getByTestId("workflow-leasing")).toHaveClass(
+      /is-focused/,
+    );
   });
 
   test("ending the active session confirms, then falls back to another session", async ({ page }) => {
@@ -390,22 +398,25 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await expect(confirm).toBeVisible();
     await expect(confirm).toContainText("kills the live terminal");
 
-    // Keep cancels — nothing dies, both sessions remain in the switcher.
+    // Keep cancels — nothing dies, both live tabs remain.
     await page.getByRole("button", { name: "Keep session" }).click();
     await expect(confirm).toHaveCount(0);
-    await page.getByTestId("session-menu").click();
-    await expect(page.locator(".session-switch-item")).toHaveCount(2);
-    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("session-tabs").getByRole("tab")).toHaveCount(
+      2,
+    );
 
     // Confirming ends the active session; the workbench falls back to the other
-    // leasing session, now active and the only one left in the switcher.
+    // leasing session, now active and the only live tab left.
     await page.getByTestId("session-menu").click();
     await page.getByTestId("session-end-btn").click();
     await page.getByTestId("end-session-confirm-btn").click();
-    await expect(page.getByTestId("session-context")).toHaveAttribute("data-session-id", "sess-leasing-2");
-    await page.getByTestId("session-menu").click();
-    await expect(page.locator(".session-switch-item")).toHaveCount(1);
-    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("session-context")).toHaveAttribute(
+      "data-session-id",
+      "sess-leasing-2",
+    );
+    await expect(page.getByTestId("session-tabs").getByRole("tab")).toHaveCount(
+      1,
+    );
     // Leasing stays focused throughout — ending a session never moves the rail.
     await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-focused/);
   });
@@ -418,7 +429,7 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await expect(page.getByTestId("workflow-rfq")).toHaveClass(/is-focused/);
     // No session controls render for an agent with no live session.
     await expect(page.getByTestId("session-menu")).toHaveCount(0);
-    await expect(page.getByTestId("session-new")).toHaveCount(0);
+    await expect(page.getByTestId("session-tab-new")).toHaveCount(0);
 
     const start = page.getByTestId("open-agent-empty");
     await expect(start).toContainText("No running session for rfq");
@@ -438,12 +449,15 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
 
     // Start runs the create+bind path in rfq's OWN folder (never borrowing the
     // acme-app session), and the workbench goes live with the terminal. The
-    // bound agent (rfq) labels the active session.
+    // The session uses its folder-derived default label.
     await page.getByTestId("open-agent-start-session").click();
-    await expect(page.getByTestId("session-context-title")).toHaveText("rfq");
+    await expect(page.getByTestId("session-context-title")).toHaveText(
+      "rfq-agent",
+    );
     await expect(page.locator(".harness-terminal")).toBeVisible();
-    // The new session is the only one on this agent — no switch chips.
-    await expect(page.locator(".session-switch")).toHaveCount(0);
+    await expect(page.getByTestId("session-tabs").getByRole("tab")).toHaveCount(
+      1,
+    );
   });
 
   test("the mapping invariant: focused agent == active tab's agent == right-panel subject", async ({
@@ -451,16 +465,24 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
   }) => {
     // On load: rail focuses leasing, the active tab is bound to leasing, and
     // the right pane renders leasing's board.
-    await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-focused/);
-    await expect(page.getByTestId("session-context-title")).toContainText("leasing");
+    await expect(page.getByTestId("workflow-leasing")).toHaveClass(
+      /is-focused/,
+    );
+    await expect(page.getByTestId("session-context-title")).toHaveText(
+      "acme-app",
+    );
     await expect(page.locator(".canvas-iframe")).toBeVisible();
 
     // Focus rfq and start its session: all four move together to rfq.
     await page.getByTestId("workflow-rfq").locator(".workflow-item-trigger").click();
     await page.getByTestId("open-agent-start-session").click();
     await expect(page.getByTestId("workflow-rfq")).toHaveClass(/is-focused/);
-    await expect(page.getByTestId("workflow-leasing")).not.toHaveClass(/is-focused/);
-    await expect(page.getByTestId("session-context-title")).toContainText("rfq");
+    await expect(page.getByTestId("workflow-leasing")).not.toHaveClass(
+      /is-focused/,
+    );
+    await expect(page.getByTestId("session-context-title")).toHaveText(
+      "rfq-agent",
+    );
     // Still exactly one filled row.
     await expect(
       page.locator(".rail-list .workflow-item.is-focused, .rail-list .workspace-row.is-selected"),
@@ -484,18 +506,20 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await expect(page.getByTestId("session-context-title")).toHaveText("Leasing revamp");
   });
 
-  test("the boot session's default binding surfaces as its agent label on load", async ({ page }) => {
-    // Fixture: sess-boot is pre-bound to leasing, so the active session reads
-    // "leasing" (its agent) without any interaction — useful for anyone
-    // eyeballing mock mode, not just tests.
+  test("the boot session keeps its folder-derived session label on load", async ({
+    page,
+  }) => {
     const title = page.getByTestId("session-context-title");
     await expect(title).toBeVisible();
-    await expect(title).toHaveText("leasing");
+    await expect(title).toHaveText("acme-app");
   });
 
-  test("the binding is per-session: an exited session under review keeps its own title, not the agent binding", async ({ page }) => {
-    // The live boot session is bound to leasing, so the header reads the agent.
-    await expect(page.getByTestId("session-context-title")).toHaveText("leasing");
+  test("the binding is per-session: an exited session under review keeps its own title, not the agent binding", async ({
+    page,
+  }) => {
+    await expect(page.getByTestId("session-context-title")).toHaveText(
+      "acme-app",
+    );
 
     // Select an exited session that never had anything bound (from the merged
     // past-sessions list) — it opens as a dead session reviewed under its own
@@ -598,7 +622,9 @@ test("a past-session row opens the dead-session pane first; Resume is the explic
   // The resumed session is unbound and now lives as the active session in the
   // workbench; sessions are not a rail concern, so no session rows in the rail.
   await expect(page.locator("[data-testid^='rail-session-']")).toHaveCount(0);
-  await expect(header.getByTestId("session-menu")).toContainText("Build the leasing pipeline");
+  await expect(header.getByTestId("session-context-title")).toContainText(
+    "Build the leasing pipeline",
+  );
 });
 
 test("the sessions menu is ONE merged past-sessions list with status tags and rich meta", async ({ page }) => {

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -5,10 +5,9 @@
  *  1. LEFT RAIL — an explorer of what exists on disk: workspace folders and
  *     the agents (sapiom.json) inside them. Clicking an agent FOCUSES it. No
  *     sessions live here.
- *  2. MAIN PANEL — the workbench for the focused agent: a session tab strip
- *     (one tab per live session belonging to the agent) above the session
- *     bar, terminal, and action bar. Session switching lives in the tab
- *     strip; the session bar is the active session's identity header.
+ *  2. MAIN PANEL — the workbench for the focused agent: browser-style live
+ *     session tabs inside the shared header, then the conversation/terminal.
+ *     Session switching and same-folder session creation live in that strip.
  *  3. RIGHT PANEL — projections of the ACTIVE session's bound agent (Canvas |
  *     Steps | Code), session-keyed. The canvas stays mounted behind CSS when
  *     another tab is active so a running Visualize enrichment (and the
@@ -169,10 +168,14 @@ export const App = (): JSX.Element => {
     },
     [harness.getWorkflowInputContract],
   );
-  // The composer-first "new session" home. `composing` is explicit New-session
-  // intent (Create new / the +); the home also shows whenever nothing else
-  // claims the centre pane (first run, or every session closed).
+  // The composer-first "new session" home. `composing` is explicit rail
+  // Create-new intent; the workbench tab + starts a sibling directly instead.
+  // The home also shows whenever nothing else claims the centre pane.
   const [composing, setComposing] = useState(false);
+  // The tab + is a one-at-a-time create/bind transaction. State renders the
+  // pending affordance; the ref closes React's same-frame double-click window.
+  const [siblingSessionPending, setSiblingSessionPending] = useState(false);
+  const siblingSessionPendingRef = useRef(false);
   // The focused agent (or bare-scaffold folder) path — the rail's single
   // selection and the main panel's tab-strip subject. The active tab's
   // session is harness.activeSessionId.
@@ -866,10 +869,57 @@ export const App = (): JSX.Element => {
     sendScaffoldPrompt(session, cwd, idea);
   };
 
-  // The tab strip's + and the empty state's Start: begin ANOTHER session on the
-  // focused agent. It lands in the agent's workspace (an existing tab's cwd if
-  // one exists, else the agent's own folder), binds there, and focus stays on
-  // the agent so the new session joins its tab strip.
+  // The workbench tab + starts a fresh coding-agent process beside the active
+  // session. Folder, provider, and optional agent binding carry over; prompt,
+  // transcript, resume identity, and rehydration deliberately do not.
+  const handleStartSiblingSession = (source: HarnessSession): void => {
+    if (siblingSessionPendingRef.current) return;
+
+    siblingSessionPendingRef.current = true;
+    setSiblingSessionPending(true);
+    const focusBeforeCreate = focusedAgentPath;
+    const workflowPath = boundWorkflowPathOf(source);
+    const workflowName = workflowPath
+      ? (state.workflows.find((workflow) =>
+          samePath(workflow.path, workflowPath),
+        )?.name ?? basenameOf(workflowPath))
+      : null;
+
+    void (async () => {
+      try {
+        const session = await createSessionAt(source.cwd, source.harness);
+        if (!workflowPath) {
+          setFocusedAgentPath(source.cwd);
+          return;
+        }
+
+        try {
+          await harness.bindWorkflow(session.id, workflowPath);
+          setFocusedAgentPath(workflowPath);
+        } catch {
+          // Creation already succeeded. Keep that independent process alive
+          // and visible as an unbound folder session rather than rolling it
+          // back because the secondary binding write failed.
+          setFocusedAgentPath(source.cwd);
+          harness.showToast(
+            `Session started, but couldn't attach it to ${workflowName ?? "the agent"}.`,
+          );
+        }
+      } catch {
+        // createSessionAt focuses the requested cwd optimistically. Restore
+        // the source exactly when no new session was created.
+        setFocusedAgentPath(focusBeforeCreate ?? workflowPath ?? source.cwd);
+        harness.setActiveSessionId(source.id);
+        harness.showToast("Couldn't start the session.");
+      } finally {
+        siblingSessionPendingRef.current = false;
+        setSiblingSessionPending(false);
+      }
+    })();
+  };
+
+  // The focused-agent empty state's Start creates the first session. This is
+  // distinct from the tab + because there is no source provider to inherit.
   const handleStartSessionForAgent = (workflow: WorkflowInfo): void => {
     void (async () => {
       const owner = liveSessionsForFocus(state.sessions, workflow.path)[0];
@@ -1510,37 +1560,32 @@ export const App = (): JSX.Element => {
               onRenameSession={renameSession}
               boundWorkflowName={boundWorkflow?.name ?? null}
               sessions={showWorkbench ? focusTabs : []}
+              busySessionIds={harness.busySessionIds}
               onSelectSession={selectTab}
-              labelOf={(session) => {
-                // Sessions of the focused agent share its workspace folder, so
-                // labelling them by that folder is redundant (the rail already
-                // names the workspace). A session still on its folder default is
-                // labelled by its AGENT instead, numbering extras; a real
-                // rename/title passes through untouched.
-                const display = sessionDisplayName(session, state.sessions, sessionNames);
-                const folder = basenameOf(session.cwd);
-                // Folder-default forms ONLY: the bare basename, or "<basename> N"
-                // the dedup appends to repeats. A real rename or transcript title
-                // that merely begins with the basename (e.g. "leasing draft")
-                // must pass through — matching `startsWith("leasing ")` would have
-                // silently replaced it with the agent name.
-                const suffix = display.startsWith(`${folder} `) ? display.slice(folder.length + 1) : "";
-                const isFolderDefault = display === folder || /^\d+$/.test(suffix);
-                if (!isFolderDefault || !focusedWorkflow) return display;
-                const idx = focusTabs.findIndex((s) => s.id === session.id);
-                return idx > 0 ? `${focusedWorkflow.name} ${idx + 1}` : focusedWorkflow.name;
-              }}
-              busy={activeSession != null && harness.busySessionIds.has(activeSession.id)}
+              labelOf={(session) =>
+                sessionDisplayName(session, state.sessions, sessionNames)
+              }
+              busy={
+                activeSession != null &&
+                harness.busySessionIds.has(activeSession.id)
+              }
               onCloseSession={(id) => void harness.closeSession(id)}
               onOpenInEditor={openInEditor}
               editorLabel={editorLabel(harness.settings?.editor)}
               onToast={harness.showToast}
               onExpandRail={railCollapsed ? () => setRailCollapsed(false) : null}
               onExpandRight={rightCollapsed ? expandRightPane : null}
-              onNewSession={() => setComposing(true)}
-              /* The agent action cluster shares the one session bar — no
-                 separate tab lane or action row. Switching sessions moves to
-                 the rail / ⌘K / history. */
+              subjectName={
+                focusedWorkflow?.name ??
+                (activeSession ? basenameOf(activeSession.cwd) : null)
+              }
+              newSessionPending={siblingSessionPending}
+              onNewSession={
+                activeSession
+                  ? () => handleStartSiblingSession(activeSession)
+                  : null
+              }
+              /* The agent action cluster shares the same row as the tabs. */
               actions={
                 showWorkbench && activeSession && boundWorkflow ? (
                   <SessionStepsBar

--- a/packages/harness/web/src/components/EndSessionConfirm.tsx
+++ b/packages/harness/web/src/components/EndSessionConfirm.tsx
@@ -6,9 +6,8 @@ import { Icon } from "./Icon";
 
 /**
  * The one confirm dialog before a live session ends — ending it kills a real
- * PTY, so it never happens on a bare click. Shared by the session bar's ⋯
- * menu (the active session) and the tab strip's × (any tab), so the copy and
- * the safe-default focus never drift between the two entry points.
+ * PTY, so it never happens on a bare click. It is opened from the active
+ * session tab's options menu.
  *
  * Dismisses like every other layer: Escape and a backdrop click both
  * mean "Keep session", and Escape hands focus back to the control the flow
@@ -21,7 +20,7 @@ export function EndSessionConfirm({
 }: {
   onCancel: () => void;
   onConfirm: () => void;
-  /** Focus returns here on Escape (the ⋯ button or the tab's × that opened it). */
+  /** Focus returns here on Escape. */
   triggerRef?: RefObject<HTMLElement | null>;
 }): JSX.Element {
   const confirmRef = useRef<HTMLDivElement>(null);

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -1,13 +1,14 @@
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { JSX, ReactNode } from "react";
 import type { HarnessSession } from "@shared/types";
 
-import { HARNESS_LABELS, formatRelativeTime } from "../lib/history-meta";
+import { HARNESS_LABELS } from "../lib/history-meta";
 import { basenameOf } from "../lib/paths";
 import type { ToastTone } from "../lib/toast";
 import { AnchoredPopover } from "./AnchoredPopover";
 import { EndSessionConfirm } from "./EndSessionConfirm";
 import { Icon } from "./Icon";
+import { SessionTabs } from "./SessionTabs";
 import { trackingAttrs } from "../lib/analytics/tracking-attrs";
 
 /** The workspace a session belongs to is its directory's basename — the
@@ -15,6 +16,8 @@ import { trackingAttrs } from "../lib/analytics/tracking-attrs";
 function workspaceLabelOf(path: string): string {
   return basenameOf(path);
 }
+
+const EMPTY_BUSY_SESSION_IDS: ReadonlySet<string> = new Set();
 
 interface SessionBarProps {
   /** The main panel is showing the Overview/intro, not a session. */
@@ -53,23 +56,27 @@ interface SessionBarProps {
   onToast: (message: string, tone?: ToastTone) => void;
   /** The agent action cluster (globe/Test/Run/Deploy), right-anchored. */
   actions?: ReactNode;
-  /** Start a new session (the + at the end of the queue). */
+  /** Start a sibling session (the + pinned after the live-session tabs). */
   onNewSession?: (() => void) | null;
-  /** The focused agent's live sessions, for the inline switcher. */
+  /** Disables fresh-session creation until its create/bind transaction settles. */
+  newSessionPending?: boolean;
+  /** Agent name (or bare folder name) used by the new-session affordance. */
+  subjectName?: string | null;
+  /** The focused agent/folder's live sessions, rendered oldest first as tabs. */
   sessions?: HarnessSession[];
-  /** Switch the active session (clicking another session's chip). */
+  /** Live output state for every visible session, including background tabs. */
+  busySessionIds?: ReadonlySet<string>;
+  /** Switch the active session (clicking another session's tab). */
   onSelectSession?: ((id: string) => void) | null;
-  /** Display name for a session chip (rename > title > folder). */
+  /** Display name for a tab (rename > title > folder). */
   labelOf?: (session: HarnessSession) => string;
 }
 
 /**
- * The single main-panel header. It carries, on one horizontally-scrollable row:
- * the session QUEUE on the left (the current session as an options dropdown —
- * its title ⌄ opens Copy path / Rename / Open in editor / End session — then
- * the focused agent's OTHER live sessions as switch chips, then a + to add one),
- * and the agent ACTIONS on the right. No harness glyph, no separate tab lane,
- * no standalone ⋯ menu: identity, switching, and actions read as one bar.
+ * The single main-panel header. Live sessions for the focused agent/folder are
+ * browser-style tabs on the left, followed by a pinned + for a fresh sibling.
+ * The active tab owns Copy path / Rename / Open in editor / End session through
+ * its caret, while agent actions remain right-anchored on the same row.
  */
 export function SessionBar({
   overviewMode = false,
@@ -90,7 +97,10 @@ export function SessionBar({
   onToast,
   actions = null,
   onNewSession = null,
+  newSessionPending = false,
+  subjectName = null,
   sessions = [],
+  busySessionIds = EMPTY_BUSY_SESSION_IDS,
   onSelectSession = null,
   labelOf,
 }: SessionBarProps): JSX.Element {
@@ -104,10 +114,11 @@ export function SessionBar({
     if (activeSession) onRenameSession(activeSession.id, renameDraft);
     setRenaming(false);
   };
-
-  const others = activeSession ? sessions.filter((s) => s.id !== activeSession.id) : [];
-  // The switcher lists every live session of this agent, active one first.
-  const orderedSessions = activeSession ? [activeSession, ...others] : [];
+  useEffect(() => {
+    setMenuOpen(false);
+    setRenaming(false);
+    setConfirmingClose(false);
+  }, [activeSession?.id]);
 
   return (
     <div className="session-bar" {...trackingAttrs({ surface: "session_bar" })}>
@@ -185,181 +196,185 @@ export function SessionBar({
               </span>
             </button>
           ) : null
+        ) : activeSession &&
+          activeSession.status !== "exited" &&
+          sessions.length > 0 &&
+          onSelectSession &&
+          onNewSession &&
+          labelOf ? (
+          <SessionTabs
+            sessions={sessions}
+            activeSessionId={activeSession.id}
+            busySessionIds={busySessionIds}
+            labelOf={labelOf}
+            subjectName={subjectName ?? workspaceLabelOf(activeSession.cwd)}
+            onSelect={onSelectSession}
+            onNew={onNewSession}
+            newSessionPending={newSessionPending}
+            menuOpen={menuOpen}
+            onToggleMenu={() => setMenuOpen((open) => !open)}
+            menuTriggerRef={menuTriggerRef}
+            menuTooltip={`${HARNESS_LABELS[activeSession.harness]} · ${workspaceLabelOf(activeSession.cwd)} · ${activeSession.cwd}`}
+            renaming={renaming}
+            renameDraft={renameDraft}
+            onRenameDraftChange={setRenameDraft}
+            onCommitRename={commitRename}
+            onCancelRename={() => setRenaming(false)}
+          />
         ) : activeSession ? (
-          <>
-            {/* Current session: the options dropdown (title ⌄). */}
-            <div className="session-current-wrap">
-              {renaming ? (
-                <input
-                  className="group-name-input session-rename-input session-context-rename"
-                  data-testid="session-rename-input"
-                  value={renameDraft}
-                  autoFocus
-                  onFocus={(e) => e.currentTarget.select()}
-                  onChange={(e) => setRenameDraft(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") commitRename();
-                    if (e.key === "Escape") setRenaming(false);
-                  }}
-                  onBlur={commitRename}
-                />
-              ) : (
-                <button
-                  ref={menuTriggerRef}
-                  className="session-current session-title-trigger"
-                  data-testid="session-menu"
-                  aria-haspopup="menu"
-                  aria-expanded={menuOpen}
-                  data-tooltip={`${HARNESS_LABELS[activeSession.harness]} · ${workspaceLabelOf(activeSession.cwd)} · ${activeSession.cwd}`}
-                  onClick={() => setMenuOpen((v) => !v)}
-                  // The tooltip embeds the absolute cwd (OS username included).
-                  {...trackingAttrs({ object: "session" })}
-                >
-                  {busy ? (
-                    <span className="session-busy" data-testid="session-busy" aria-hidden="true" />
-                  ) : (
-                    <span className="session-dot" data-status={activeSession.status} />
-                  )}
-                  <span className="session-context-title" data-testid="session-context-title">
-                    {labelOf ? labelOf(activeSession) : (sessionName ?? activeSession.title)}
-                  </span>
-                  <Icon name="ChevronDown" size={13} />
-                </button>
-              )}
-              <AnchoredPopover
-                open={menuOpen}
-                anchorRef={menuTriggerRef}
-                onDismiss={closeMenu}
-                placement="down-start"
-                className="session-menu"
-                role="menu"
-                testid="session-menu-popover"
+          /* An exited session is historical context, not a live tab. Keep its
+             compact title/menu while still allowing a fresh sibling below. */
+          <div className="session-current-wrap">
+            {renaming ? (
+              <input
+                className="group-name-input session-rename-input session-context-rename"
+                data-testid="session-rename-input"
+                value={renameDraft}
+                autoFocus
+                onFocus={(event) => event.currentTarget.select()}
+                onChange={(event) => setRenameDraft(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") commitRename();
+                  if (event.key === "Escape") setRenaming(false);
+                }}
+                onBlur={commitRename}
+              />
+            ) : (
+              <button
+                ref={menuTriggerRef}
+                type="button"
+                className="session-current session-title-trigger"
+                data-testid="session-menu"
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                data-tooltip={`${HARNESS_LABELS[activeSession.harness]} · ${workspaceLabelOf(activeSession.cwd)} · ${activeSession.cwd}`}
+                onClick={() => setMenuOpen((open) => !open)}
+                {...trackingAttrs({ object: "session" })}
               >
-                {/* Switcher: every live session of this agent, the active one
-                    checked. Picking a row switches; the actions below act on the
-                    current session. One place to select or act — no inline chips
-                    crowding the bar. */}
-                <div className="session-menu-section">Sessions</div>
-                {orderedSessions.map((s) => {
-                  const isActive = s.id === activeSession.id;
-                  return (
-                    <button
-                      key={s.id}
-                      role="menuitemradio"
-                      aria-checked={isActive}
-                      className={"profile-menu-item session-switch-item" + (isActive ? " is-selected" : "")}
-                      data-testid={`session-switch-${s.id}`}
-                      onClick={() => {
-                        if (!isActive) onSelectSession?.(s.id);
-                        closeMenu();
-                      }}
-                    >
-                      <span className="session-dot" data-status={s.status} />
-                      <span className="session-switch-label">{labelOf ? labelOf(s) : s.title}</span>
-                      <span className="session-switch-meta">{formatRelativeTime(s.lastActiveAt)}</span>
-                      {isActive && <Icon name="Check" size={13} />}
-                    </button>
-                  );
-                })}
-                {onNewSession && (
-                  <button
-                    role="menuitem"
-                    className="profile-menu-item session-menu-new"
-                    data-testid="session-new-menu"
-                    onClick={() => {
-                      onNewSession();
-                      closeMenu();
-                    }}
-                  >
-                    <Icon name="Plus" size={13} />
-                    New session
-                  </button>
+                {busy ? (
+                  <span
+                    className="session-busy"
+                    data-testid="session-busy"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <span
+                    className="session-dot"
+                    data-status={activeSession.status}
+                    aria-hidden="true"
+                  />
                 )}
-
-                <div className="session-menu-divider" role="separator" />
-
-                {/* Which agent's Canvas this session drives — moved off the bar
-                    into the menu, where it reads as metadata, not a session. */}
-                {boundWorkflowName && (
-                  <div className="session-menu-bound" data-testid="session-workflow-chip">
-                    Bound to <strong>{boundWorkflowName}</strong> · shown in Canvas
-                  </div>
-                )}
-
-                <button
-                  role="menuitem"
-                  className="profile-menu-item"
-                  onClick={() => {
-                    void navigator.clipboard
-                      ?.writeText(activeSession.cwd)
-                      .then(() => onToast("Path copied.", "success"))
-                      .catch(() => onToast("Couldn't copy the path."));
-                    closeMenu();
-                  }}
+                <span
+                  className="session-context-title"
+                  data-testid="session-context-title"
                 >
-                  <Icon name="Copy" size={13} />
-                  Copy path
-                </button>
-                <button
-                  role="menuitem"
-                  className="profile-menu-item"
-                  data-testid="session-rename"
-                  onClick={() => {
-                    setRenameDraft(sessionName ?? activeSession.title);
-                    setRenaming(true);
-                    closeMenu();
-                  }}
-                >
-                  <Icon name="Pencil" size={13} />
-                  Rename session
-                </button>
-                <button
-                  role="menuitem"
-                  className="profile-menu-item"
-                  data-testid="session-open-editor"
-                  onClick={() => {
-                    onOpenInEditor(activeSession.cwd);
-                    closeMenu();
-                  }}
-                >
-                  <Icon name="Code" size={13} />
-                  Open in {editorLabel}
-                </button>
-                {activeSession.status !== "exited" && (
-                  <button
-                    role="menuitem"
-                    className="profile-menu-item session-menu-danger"
-                    data-testid="session-end-btn"
-                    onClick={() => {
-                      closeMenu();
-                      setConfirmingClose(true);
-                    }}
-                  >
-                    <Icon name="X" size={13} />
-                    End session…
-                  </button>
-                )}
-              </AnchoredPopover>
-            </div>
-          </>
+                  {labelOf
+                    ? labelOf(activeSession)
+                    : (sessionName ?? activeSession.title)}
+                </span>
+                <Icon name="ChevronDown" size={13} />
+              </button>
+            )}
+          </div>
         ) : (
           <span className="session-context-none">No active session</span>
         )}
       </div>
 
-      {/* + : add a session — OUTSIDE the scrollable queue so it stays visible
-          however long the session list grows. */}
-      {/* No "new session" + while the composer IS the new-session screen — it's
-          redundant there. Only alongside a live session. */}
-      {onNewSession && activeSession && !composing && (
+      {activeSession && (
+        <AnchoredPopover
+          open={menuOpen}
+          anchorRef={menuTriggerRef}
+          onDismiss={closeMenu}
+          placement="down-start"
+          className="session-menu"
+          role="menu"
+          testid="session-menu-popover"
+        >
+          {boundWorkflowName && (
+            <div
+              className="session-menu-bound"
+              data-testid="session-workflow-chip"
+            >
+              Bound to <strong>{boundWorkflowName}</strong> · shown in Canvas
+            </div>
+          )}
+
+          <button
+            role="menuitem"
+            className="profile-menu-item"
+            onClick={() => {
+              void navigator.clipboard
+                ?.writeText(activeSession.cwd)
+                .then(() => onToast("Path copied.", "success"))
+                .catch(() => onToast("Couldn't copy the path."));
+              closeMenu();
+            }}
+          >
+            <Icon name="Copy" size={13} />
+            Copy path
+          </button>
+          <button
+            role="menuitem"
+            className="profile-menu-item"
+            data-testid="session-rename"
+            onClick={() => {
+              setRenameDraft(sessionName ?? activeSession.title);
+              setRenaming(true);
+              closeMenu();
+            }}
+          >
+            <Icon name="Pencil" size={13} />
+            Rename session
+          </button>
+          <button
+            role="menuitem"
+            className="profile-menu-item"
+            data-testid="session-open-editor"
+            onClick={() => {
+              onOpenInEditor(activeSession.cwd);
+              closeMenu();
+            }}
+          >
+            <Icon name="Code" size={13} />
+            Open in {editorLabel}
+          </button>
+          {activeSession.status !== "exited" && (
+            <button
+              role="menuitem"
+              className="profile-menu-item session-menu-danger"
+              data-testid="session-end-btn"
+              onClick={() => {
+                closeMenu();
+                setConfirmingClose(true);
+              }}
+            >
+              <Icon name="X" size={13} />
+              End session…
+            </button>
+          )}
+        </AnchoredPopover>
+      )}
+
+      {/* Ended sessions do not join the live strip, but their + still starts a
+          fresh session from the same folder/provider/binding. Live-session +
+          is pinned inside SessionTabs, outside its scrolling list. */}
+      {onNewSession && activeSession?.status === "exited" && !composing && (
         <button
-          className="session-new"
-          data-testid="session-new"
-          aria-label="New session"
-          data-tooltip="New session"
+          type="button"
+          className="theme-toggle session-tab-new"
+          data-testid="session-tab-new"
+          aria-label={`New session on ${subjectName ?? workspaceLabelOf(activeSession.cwd)}`}
+          aria-busy={newSessionPending}
+          data-tooltip={`New session on ${subjectName ?? workspaceLabelOf(activeSession.cwd)}`}
+          disabled={newSessionPending}
           onClick={onNewSession}
         >
-          <Icon name="Plus" size={15} />
+          {newSessionPending ? (
+            <span className="session-busy" aria-hidden="true" />
+          ) : (
+            <Icon name="Plus" size={14} />
+          )}
         </button>
       )}
 

--- a/packages/harness/web/src/components/SessionTabs.tsx
+++ b/packages/harness/web/src/components/SessionTabs.tsx
@@ -1,0 +1,185 @@
+import { useEffect, useRef } from "react";
+import type { JSX, RefObject } from "react";
+import type { HarnessSession } from "@shared/types";
+
+import { trackingAttrs } from "../lib/analytics/tracking-attrs";
+import { HARNESS_LABELS } from "../lib/history-meta";
+import { Icon } from "./Icon";
+
+interface SessionTabsProps {
+  sessions: HarnessSession[];
+  activeSessionId: string | null;
+  busySessionIds: ReadonlySet<string>;
+  labelOf: (session: HarnessSession) => string;
+  subjectName: string;
+  onSelect: (id: string) => void;
+  onNew: () => void;
+  newSessionPending: boolean;
+  menuOpen: boolean;
+  onToggleMenu: () => void;
+  menuTriggerRef: RefObject<HTMLButtonElement | null>;
+  menuTooltip?: string;
+  renaming: boolean;
+  renameDraft: string;
+  onRenameDraftChange: (value: string) => void;
+  onCommitRename: () => void;
+  onCancelRename: () => void;
+}
+
+/**
+ * Browser-style live-session switching for the focused agent or folder.
+ *
+ * The rail remains the project explorer. This strip owns session selection
+ * and fresh same-folder creation; destructive session actions remain behind
+ * the active tab's options menu rather than becoming per-tab close buttons.
+ */
+export function SessionTabs({
+  sessions,
+  activeSessionId,
+  busySessionIds,
+  labelOf,
+  subjectName,
+  onSelect,
+  onNew,
+  newSessionPending,
+  menuOpen,
+  onToggleMenu,
+  menuTriggerRef,
+  menuTooltip,
+  renaming,
+  renameDraft,
+  onRenameDraftChange,
+  onCommitRename,
+  onCancelRename,
+}: SessionTabsProps): JSX.Element {
+  const activeTabRef = useRef<HTMLDivElement>(null);
+  const cancelRenameOnBlurRef = useRef(false);
+
+  // A newly created session appends to the oldest-first list. Keep its tab in
+  // view without moving the page or introducing a second header row.
+  useEffect(() => {
+    activeTabRef.current?.scrollIntoView({
+      block: "nearest",
+      inline: "nearest",
+    });
+  }, [activeSessionId, sessions.length]);
+
+  return (
+    <div className="session-tabs" data-testid="session-tabs">
+      <div className="session-tabs-list" role="tablist" aria-label="Sessions">
+        {sessions.map((session) => {
+          const active = session.id === activeSessionId;
+          const label = labelOf(session);
+          const provider = HARNESS_LABELS[session.harness];
+          const showRename = active && renaming;
+
+          return (
+            <div
+              ref={active ? activeTabRef : undefined}
+              key={session.id}
+              className={`session-tab${active ? " is-active" : ""}`}
+              data-testid={`session-tab-${session.id}`}
+            >
+              {showRename ? (
+                <input
+                  className="group-name-input session-rename-input session-tab-rename"
+                  data-testid="session-rename-input"
+                  aria-label="Rename session"
+                  value={renameDraft}
+                  autoFocus
+                  onFocus={(event) => {
+                    cancelRenameOnBlurRef.current = false;
+                    event.currentTarget.select();
+                  }}
+                  onChange={(event) => onRenameDraftChange(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") onCommitRename();
+                    if (event.key === "Escape") {
+                      cancelRenameOnBlurRef.current = true;
+                      onCancelRename();
+                    }
+                  }}
+                  onBlur={() => {
+                    if (cancelRenameOnBlurRef.current) {
+                      cancelRenameOnBlurRef.current = false;
+                      return;
+                    }
+                    onCommitRename();
+                  }}
+                />
+              ) : (
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  className="session-tab-main"
+                  data-testid={`session-tab-main-${session.id}`}
+                  title={`${label} · ${provider}`}
+                  data-tooltip={`${label} · ${provider}`}
+                  onClick={() => onSelect(session.id)}
+                >
+                  {busySessionIds.has(session.id) ? (
+                    <span
+                      className="session-busy"
+                      data-testid={`session-tab-busy-${session.id}`}
+                      aria-hidden="true"
+                    />
+                  ) : (
+                    <span
+                      className="session-dot"
+                      data-status={session.status}
+                      aria-hidden="true"
+                    />
+                  )}
+                  <span
+                    className="session-tab-label"
+                    data-testid={active ? "session-context-title" : undefined}
+                  >
+                    {label}
+                  </span>
+                </button>
+              )}
+
+              {active && !showRename && (
+                <button
+                  ref={menuTriggerRef}
+                  type="button"
+                  className="theme-toggle session-tab-menu"
+                  data-testid="session-menu"
+                  aria-label="Session options"
+                  aria-haspopup="menu"
+                  aria-expanded={menuOpen}
+                  data-tooltip={menuTooltip}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onToggleMenu();
+                  }}
+                  {...trackingAttrs({ object: "session" })}
+                >
+                  <Icon name="ChevronDown" size={12} />
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <button
+        type="button"
+        className="theme-toggle session-tab-new"
+        data-testid="session-tab-new"
+        aria-label={`New session on ${subjectName}`}
+        aria-busy={newSessionPending}
+        data-tooltip={`New session on ${subjectName}`}
+        disabled={newSessionPending}
+        onClick={onNew}
+      >
+        {newSessionPending ? (
+          <span className="session-busy" aria-hidden="true" />
+        ) : (
+          <Icon name="Plus" size={14} />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -1005,6 +1005,7 @@ class MockApi implements HarnessApi {
     if (typeof window !== "undefined") {
       const win = window as unknown as {
         __HARNESS_TEST__?: Record<string, unknown>;
+        __MOCK_CREATE_SESSION_FAIL_ONCE__?: boolean;
       };
       const previous =
         (win.__HARNESS_TEST__?.createSessionCalls as unknown[] | undefined) ??
@@ -1014,6 +1015,10 @@ class MockApi implements HarnessApi {
         lastCreateSession: { req },
         createSessionCalls: [...previous, { req }],
       };
+      if (win.__MOCK_CREATE_SESSION_FAIL_ONCE__) {
+        win.__MOCK_CREATE_SESSION_FAIL_ONCE__ = false;
+        throw new Error("mock: couldn't create session");
+      }
     }
     const session: HarnessSession = {
       id: `sess-mock-${this.sessions.length + 1}`,
@@ -1431,6 +1436,25 @@ class MockApi implements HarnessApi {
     workflowPath: string | null,
   ): Promise<HarnessSession> {
     await delay(150);
+    if (typeof window !== "undefined") {
+      const win = window as unknown as {
+        __HARNESS_TEST__?: Record<string, unknown>;
+        __MOCK_BIND_WORKFLOW_FAIL_ONCE__?: boolean;
+      };
+      const previous =
+        (win.__HARNESS_TEST__?.bindWorkflowCalls as unknown[] | undefined) ??
+        [];
+      const req = { sessionId, workflowPath };
+      win.__HARNESS_TEST__ = {
+        ...(win.__HARNESS_TEST__ ?? {}),
+        lastBindWorkflow: { req },
+        bindWorkflowCalls: [...previous, { req }],
+      };
+      if (win.__MOCK_BIND_WORKFLOW_FAIL_ONCE__) {
+        win.__MOCK_BIND_WORKFLOW_FAIL_ONCE__ = false;
+        throw new Error("mock: couldn't bind session");
+      }
+    }
     const existing = this.sessions.find((session) => session.id === sessionId);
     if (!existing) throw new Error(`mock: no session to bind for ${sessionId}`);
     const bound: HarnessSession = {

--- a/packages/harness/web/src/lib/mock-data.ts
+++ b/packages/harness/web/src/lib/mock-data.ts
@@ -406,7 +406,9 @@ export const MOCK_SESSIONS: HarnessSession[] = [
     // its tab carries the busy pulse shortly after load — the pulse only means
     // anything on a tab you are not already looking at.
     boundWorkflowPath: "/Users/demo/acme-app/leasing",
-    harness: "claude-code",
+    // Mixed-provider siblings prove the tab + inherits the selected session's
+    // adapter rather than defaulting every new conversation to Claude Code.
+    harness: "codex",
     cwd: MOCK_LAUNCH_DIR,
     title: "acme-app",
     status: "running",
@@ -1087,4 +1089,3 @@ export const MOCK_SETTINGS: HarnessSettings = {
   // LLM call the user never asked for.
   rollingSummary: false,
 };
-

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -680,7 +680,6 @@ input {
    -------------------------------------------------------------------------- */
 .theme-toggle,
 .macro-icon-btn,
-.session-new,
 .dir-picker-up,
 .composer-attach,
 .composer-send {
@@ -701,7 +700,6 @@ input {
    flex row must never stretch or squeeze a glyph button — it is a square or
    it is nothing. */
 .workspace-row-action,
-.session-tab-close,
 .deploy-status-dismiss,
 .plan-card-menu-btn,
 .toast-dismiss {
@@ -2515,24 +2513,16 @@ button.rail-footer-card:hover {
   }
 }
 
-/* The session queue: a horizontally-scrollable row of the current session (an
-   options dropdown), the agent's other live sessions (switch chips), and a + to
-   add one. It grows to fill the bar and scrolls under pressure, so every session
-   stays reachable without a second lane. */
+/* The session queue owns the header's flexible left side. Live-session
+   overflow is handled inside .session-tabs-list, keeping the trailing + fixed
+   and the action cluster reachable without a second header row. */
 .session-queue {
   display: flex;
   align-items: center;
   gap: var(--sp1);
   flex: 1;
   min-width: 0;
-  overflow-x: auto;
-  scrollbar-width: none;
-  /* A right-edge fade signals there is more of the queue to scroll to when it
-     overflows; over a queue that fits, it fades only empty space. */
-  mask-image: linear-gradient(to right, #000 calc(100% - var(--sp4)), transparent);
-}
-.session-queue::-webkit-scrollbar {
-  display: none;
+  overflow: hidden;
 }
 
 .session-current-wrap {
@@ -2540,10 +2530,8 @@ button.rail-footer-card:hover {
   flex: 0 0 auto;
 }
 
-/* Each session in the queue is a compact chip. The current one carries the ⌄
-   options dropdown and a selected wash; the others switch on click. */
-.session-current,
-.session-switch {
+/* Static/ended session identity when a live tab strip does not apply. */
+.session-current {
   display: inline-flex;
   align-items: center;
   gap: var(--sp2);
@@ -2591,48 +2579,9 @@ button.rail-footer-card:hover {
   cursor: default;
 }
 
-.session-switch {
-  color: var(--text-dim);
-  cursor: pointer;
-}
-.session-switch:hover {
-  background: var(--surface-hover);
-  color: var(--text);
-}
-.session-switch-label {
-  max-width: 16ch;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.session-title-trigger:focus-visible,
-.session-switch:focus-visible,
-.session-new:focus-visible {
+.session-title-trigger:focus-visible {
   outline: 2px solid var(--focus);
   outline-offset: 1px;
-}
-
-/* + at the end of the queue: a quiet ghost icon button. */
-.session-new {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  width: var(--control-h-xs);
-  height: var(--control-h-xs);
-  border: 1px solid transparent;
-  border-radius: var(--radius);
-  background: transparent;
-  color: var(--text-dim);
-  cursor: pointer;
-  transition:
-    background-color var(--transition-fast),
-    color var(--transition-fast);
-}
-.session-new:hover {
-  background: var(--surface-hover);
-  color: var(--text);
 }
 
 /* The title is the primary claim: it never shrinks below its content until
@@ -2679,49 +2628,6 @@ button.rail-footer-card:hover {
 .session-menu-danger:hover:not(:disabled) {
   color: var(--red-text);
   background: color-mix(in srgb, var(--red) 12%, transparent);
-}
-
-/* Session switcher inside the current-session menu ------------------------
-   The ⌄ on the current session opens a titled list of the agent's live
-   sessions (active one checked) plus this session's actions — one place to
-   pick a session or act on it, so the bar itself stays a single clean pill. */
-.session-menu-section {
-  padding: var(--sp2) var(--sp2) var(--sp1);
-  font-size: var(--type-micro);
-  font-weight: 650;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--text-faint);
-}
-
-/* Rows reuse .profile-menu-item; the active one carries the app's standard
-   "you are here" selected wash. The label grows; time trails, right-aligned. */
-.session-switch-item .session-switch-label {
-  flex: 1 1 auto;
-  max-width: none;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: var(--text);
-}
-
-.session-switch-item.is-selected {
-  background: var(--active-shade);
-  color: var(--text);
-}
-
-.session-switch-meta {
-  margin-left: auto;
-  padding-left: var(--sp2);
-  font-family: var(--font-mono);
-  font-variant-numeric: tabular-nums;
-  font-size: var(--type-meta);
-  color: var(--text-faint);
-}
-
-.session-menu-divider {
-  height: 1px;
-  margin: var(--sp1) 0;
-  background: var(--ui-line);
 }
 
 /* Bound-agent line: which agent's Canvas this session drives. Quiet metadata,
@@ -2810,68 +2716,70 @@ button.rail-footer-card:hover {
 
 /* Session tab strip -------------------------------------------------------
 
-   One tab per live session belonging to the FOCUSED agent. Sits
-   directly under the session bar; session switching lives here. The strip
-   scrolls horizontally under pressure so the panes never widen past their
-   grid track. */
+   Browser-style tabs live INSIDE .session-bar. Only the list scrolls; the +
+   stays pinned beside it and the action cluster remains outside this flex
+   item. Ending a session stays in the active tab's options menu. */
 .session-tabs {
   display: flex;
   align-items: center;
   gap: var(--sp1);
-  flex: 0 0 auto;
+  flex: 1;
   min-width: 0;
-  padding: var(--sp1) var(--pane-pad-x);
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-1);
+}
+
+.session-tabs-list {
+  display: flex;
+  align-items: center;
+  gap: var(--sp1);
+  flex: 1;
+  min-width: 0;
   overflow-x: auto;
   scrollbar-width: none;
 }
 
-.session-tabs::-webkit-scrollbar {
+.session-tabs-list::-webkit-scrollbar {
   display: none;
 }
 
-/* One tab: a main select button + a trailing × close. The tab reads selected
-   with a filled surface and a hairline; the resting tab is quiet. */
+/* One tab: a main select button plus the active tab's options caret. */
 .session-tab {
   display: inline-flex;
   align-items: center;
   flex: 0 0 auto;
-  max-width: 220px;
-  height: 28px;
-  border-radius: var(--radius-md);
-  border: 1px solid transparent;
-  color: var(--text-dim);
+  max-width: 24ch;
+  height: var(--control-h-xs);
+  border-radius: var(--radius);
+  color: var(--text-faint);
   transition:
     background-color var(--transition-fast),
-    border-color var(--transition-fast),
     color var(--transition-fast);
 }
 
 .session-tab:hover {
-  background: var(--bg-hover);
-  color: var(--text);
+  background: var(--surface-hover);
+  color: var(--text-dim);
 }
 
 .session-tab.is-active {
   background: var(--active-shade);
-  border-color: var(--ui-line);
   color: var(--text);
 }
 
 .session-tab-main {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--sp2);
+  flex: 1 1 auto;
   min-width: 0;
   height: 100%;
   padding: 0 var(--sp1) 0 var(--sp2);
-  border: none;
+  border: 0;
   background: transparent;
-  border-radius: var(--radius-md) 0 0 var(--radius-md);
+  border-radius: var(--radius) 0 0 var(--radius);
   color: inherit;
   font-size: var(--type-label);
   text-align: left;
+  cursor: pointer;
 }
 
 .session-tab-main:focus-visible {
@@ -2879,13 +2787,8 @@ button.rail-footer-card:hover {
   outline-offset: -2px;
 }
 
-.session-tab-main > svg {
-  flex: 0 0 auto;
-  color: var(--text-faint);
-}
-
-.session-tab.is-active .session-tab-main > svg {
-  color: var(--brand);
+.session-tab.is-active .session-tab-main {
+  padding-right: 0;
 }
 
 .session-tab-label {
@@ -2895,107 +2798,38 @@ button.rail-footer-card:hover {
   white-space: nowrap;
 }
 
-/* Live/starting/exited dot — same 7px trailing mark the session bar uses. */
-.session-tab-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
+/* The caret belongs to the selected tab, and rotates while its menu is open. */
+.session-tab-menu {
   flex: 0 0 auto;
-  background: var(--text-faint);
+  color: inherit;
 }
 
-.session-tab-dot[data-status="running"] {
-  background: var(--green);
+.session-tab-menu[aria-expanded="true"] svg {
+  transform: rotate(180deg);
 }
 
-.session-tab-dot[data-status="starting"] {
-  background: var(--amber);
+.session-tab-rename {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+  margin: 0 var(--sp1);
+  padding: 0 var(--sp1);
 }
 
-/* Busy pulse (output in the last ~3s) — replaces the dot on a background tab
-   so activity you are not looking at still reads. */
-.session-tab-busy {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  flex: 0 0 auto;
-  background: var(--accent);
-  animation: session-tab-busy-pulse 1.2s ease-in-out infinite;
-}
-
-.session-tab-close {
-  margin-right: 4px;
-  border: none;
-  background: transparent;
-  border-radius: var(--radius-sm);
+.session-tab-new:disabled {
   color: var(--text-faint);
-  opacity: 0;
-  transition:
-    opacity var(--transition-fast),
-    background-color var(--transition-fast),
-    color var(--transition-fast);
+  cursor: wait;
 }
 
-/* The × reveals on tab hover/focus and stays visible on the active tab so the
-   current session is always closable without a hunt. */
-.session-tab:hover .session-tab-close,
-.session-tab.is-active .session-tab-close,
-.session-tab-close:focus-visible {
-  opacity: 1;
-}
-
-.session-tab-close:hover {
-  background: color-mix(in srgb, var(--red) 14%, transparent);
-  color: var(--red-text);
-}
-
-.session-tab-close:active {
-  background: color-mix(in srgb, var(--red) 22%, transparent);
-}
-
-.session-tab-close:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: -2px;
-}
-
-/* Trailing + : open another session on the focused agent. */
-.session-tab-new {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  width: 26px;
-  height: 26px;
-  border: none;
+.session-tab-new:disabled:hover {
   background: transparent;
-  border-radius: var(--radius-md);
-  color: var(--text-faint);
-  transition:
-    background-color var(--transition-fast),
-    color var(--transition-fast);
-}
-
-.session-tab-new:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-}
-
-.session-tab-new:active {
-  background: var(--surface-inset);
-}
-
-.session-tab-new:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: -2px;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .session-tab,
-  .session-tab-close,
-  .session-tab-new {
+  .session-tab {
     transition: none;
   }
-  .session-tab-busy {
+  .session-busy {
     animation: none;
   }
 }


### PR DESCRIPTION
## Summary

Replace the Agent Studio chat-header `+` composer detour with fresh sibling sessions and expose live conversations for the focused agent/folder as browser-style tabs. New sessions inherit only the source folder, Claude Code/Codex adapter, and optional workflow binding.

## Changes

- add accessible, oldest-first session tabs with provider/status tooltips, an active-tab menu, inline rename, keyboard selection, overflow scrolling, and a pinned creation affordance
- create same-folder siblings with a synchronous duplicate guard and pending state, without prompt, resume, transcript, or rehydration context
- preserve successfully created sessions when workflow binding fails and preserve the source state when creation fails
- support fresh creation from exited sessions while leaving the rail Create New action on the full composer
- add deterministic mock failure/request recording, mixed Claude/Codex fixtures, E2E regressions, and an `@sapiom/harness` patch changeset

## Motivation

The header control reads as “new chat” but previously opened global agent creation. This makes subsequent independent conversations in one working tree immediate and aligns production with the approved Agent Studio tab design.

## Testing

- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `pnpm --filter @sapiom/harness build`
- [x] 2,111 unit tests across 140 files
- [x] isolated performance suite: 4/4
- [x] `pnpm --filter @sapiom/harness test:ui`: 330/330
- [ ] `src/core/workspace-watcher.test.ts` unreadable-directory assertion (this sandbox does not enforce `chmod 000`; unrelated to this UI diff)

## Screenshots / Demos

The browser-style tab strip and narrow-width overflow are exercised by Playwright. The generated headless screenshot artifact is intentionally gitignored and is not attached.

## Related

Closes: SAP-2891

## Breaking Changes

None.

## Checklist

- [x] Code follows project guidelines
- [x] No hardcoded secrets
- [x] Self-reviewed
- [x] Linear ticket linked
- [x] Changeset added
