### PR TITLE
fix(tools): widen ModelRunOutcome.costUsd to number | null (SAP-2811)

### DIFF
--- a/.changeset/widen-model-run-cost-usd.md
+++ b/.changeset/widen-model-run-cost-usd.md
@@ -13,9 +13,5 @@ Under `strictNullChecks`, code that does arithmetic on or formats
 or skip the row). Read-only and logging code is unaffected, and nothing changes
 at runtime for a run that does report an estimate.
 
-Both delivery paths land the same encoding: a polled result and a step resumed
-via `pauseUntilSignal` both give you `null` — never `undefined`, never a
-fabricated `0` — when no estimate was reported.
-
 `costUsd` is an estimate, not a billed amount; don't reconcile invoices against
 it.

--- a/.changeset/widen-model-run-cost-usd.md
+++ b/.changeset/widen-model-run-cost-usd.md
@@ -1,0 +1,24 @@
+---
+"@sapiom/tools": minor
+---
+
+`ModelRunOutcome.costUsd` is now `number | null` — the type told a lie.
+
+The platform already sends `cost_usd: null` on a bounded set of runs, where the
+stored estimate came from a source it will not stand behind and the honest
+figure is unrecoverable. The published type said `number`, so a strict consumer
+could do `outcome.costUsd.toFixed(2)` on a value that was `null` at runtime.
+The mapper now lands a wire `null`, a missing key, and a malformed value all on
+`null` — one encoding, never a fabricated `0` that would read as "this run was
+free".
+
+**Strictness impact:** under `strictNullChecks`, code that does arithmetic on or
+formats `result.costUsd` will now fail to compile until it guards —
+`outcome.costUsd ?? 0`, or skip the row. That is the point: the runtime `null`
+was already reaching those call sites. Code that only reads or logs the value is
+unaffected.
+
+Worth guarding rather than defaulting: `costUsd` is a size×lane **estimate**,
+not the amount you are billed. Billed cost belongs to the metering rail (plan
+allowance + priced overage), and this field is deprecated as an authoritative
+dollar figure.

--- a/.changeset/widen-model-run-cost-usd.md
+++ b/.changeset/widen-model-run-cost-usd.md
@@ -2,23 +2,20 @@
 "@sapiom/tools": minor
 ---
 
-`ModelRunOutcome.costUsd` is now `number | null` — the type told a lie.
+**Breaking (type-level):** `ModelRunOutcome.costUsd` is now `number | null`.
 
-The platform already sends `cost_usd: null` on a bounded set of runs, where the
-stored estimate came from a source it will not stand behind and the honest
-figure is unrecoverable. The published type said `number`, so a strict consumer
-could do `outcome.costUsd.toFixed(2)` on a value that was `null` at runtime.
-The mapper now lands a wire `null`, a missing key, and a malformed value all on
-`null` — one encoding, never a fabricated `0` that would read as "this run was
-free".
+The platform doesn't report a cost estimate for every run, so `costUsd` could
+already arrive as `null` at runtime — the published type said `number` and left
+no room for it.
 
-**Strictness impact:** under `strictNullChecks`, code that does arithmetic on or
-formats `result.costUsd` will now fail to compile until it guards —
-`outcome.costUsd ?? 0`, or skip the row. That is the point: the runtime `null`
-was already reaching those call sites. Code that only reads or logs the value is
-unaffected.
+Under `strictNullChecks`, code that does arithmetic on or formats
+`result.costUsd` now fails to compile until it guards (`outcome.costUsd ?? 0`,
+or skip the row). Read-only and logging code is unaffected, and nothing changes
+at runtime for a run that does report an estimate.
 
-Worth guarding rather than defaulting: `costUsd` is a size×lane **estimate**,
-not the amount you are billed. Billed cost belongs to the metering rail (plan
-allowance + priced overage), and this field is deprecated as an authoritative
-dollar figure.
+Both delivery paths land the same encoding: a polled result and a step resumed
+via `pauseUntilSignal` both give you `null` — never `undefined`, never a
+fabricated `0` — when no estimate was reported.
+
+`costUsd` is an estimate, not a billed amount; don't reconcile invoices against
+it.

--- a/packages/harness/src/server/rehydrate-session.test.ts
+++ b/packages/harness/src/server/rehydrate-session.test.ts
@@ -99,11 +99,6 @@ describe("portable continue — rehydrating a fresh session", () => {
       agentSessionId: PRIOR_AGENT_SESSION,
       harness,
     };
-    // Keep fixtures inside the event store's 30-day retention window. A fixed
-    // date makes this wiring test race the boot-time retention sweep once that
-    // date ages out: direct creates can read the events before the sweep while
-    // the HTTP request below sometimes loses them first.
-    const startedAt = Date.now() - 10 * 60_000;
     const at = (minutes: number): string =>
       new Date(startedAt + minutes * 60_000).toISOString();
     const event = (

--- a/packages/harness/src/server/rehydrate-session.test.ts
+++ b/packages/harness/src/server/rehydrate-session.test.ts
@@ -94,8 +94,13 @@ describe("portable continue — rehydrating a fresh session", () => {
       agentSessionId: PRIOR_AGENT_SESSION,
       harness,
     };
+    // Keep fixtures inside the event store's 30-day retention window. A fixed
+    // date makes this wiring test race the boot-time retention sweep once that
+    // date ages out: direct creates can read the events before the sweep while
+    // the HTTP request below sometimes loses them first.
+    const startedAt = Date.now() - 10 * 60_000;
     const at = (minutes: number): string =>
-      `2026-07-27T10:${String(minutes).padStart(2, "0")}:00.000Z`;
+      new Date(startedAt + minutes * 60_000).toISOString();
     const event = (
       n: number,
       type: AnalyticsEventType,

--- a/packages/tools/src/models/index.ts
+++ b/packages/tools/src/models/index.ts
@@ -520,14 +520,12 @@ export interface ModelRunOutcome {
   warnings?: string[];
   durationMs: number;
   /**
-   * The run's size×lane cost ESTIMATE in USD — never a provider-priced figure, and
-   * NOT the amount you are billed. The billed amount lives on the metering rail
-   * (plan allowance + priced overage); treat this as a rough signal only.
+   * Rough cost estimate for the run, in USD — an estimate, NOT the amount you
+   * are billed. Don't reconcile invoices or gate spend against it.
    *
-   * `null` means the platform declined to report an estimate rather than resurface
-   * one it can't stand behind (a narrow set of legacy rows). Guard before
-   * arithmetic — `outcome.costUsd ?? 0`, or skip the row — and never render a
-   * fabricated `0` for an undisclosed cost.
+   * `null` when the platform doesn't report an estimate for a run. Guard before
+   * arithmetic (`outcome.costUsd ?? 0`, or skip the row): `null` means "not
+   * reported", never "this run was free".
    */
   costUsd: number | null;
   usage: CodingRunUsage;
@@ -602,6 +600,12 @@ export const modelRunResultSchema = {
       const warnings = normalizeWarnings(r.warnings);
       if (warnings) r.warnings = warnings;
       else delete r.warnings;
+      // Same cost encoding as the polled path (mapModelResult). The server
+      // feeds both paths from one projection, so this is belt-and-braces
+      // rather than a divergence today — but a `number | null` field must
+      // never hand a resumed step `undefined`, which is what a missing key
+      // would otherwise do.
+      r.costUsd = typeof r.costUsd === "number" ? r.costUsd : null;
     }
     return value as ModelRunResultPayload;
   },
@@ -619,7 +623,7 @@ interface ModelWireResult {
   /** Present only when the run has warnings (e.g. an unhonored `model` pin); guarded at map time. */
   warnings?: string[];
   duration_ms: number;
-  /** Nullable on the wire: the platform sends `null` rather than an estimate it can't stand behind. */
+  /** Nullable on the wire: the platform doesn't report an estimate for every run. */
   cost_usd?: number | null;
   usage?: {
     input_tokens?: number;

--- a/packages/tools/src/models/index.ts
+++ b/packages/tools/src/models/index.ts
@@ -519,7 +519,17 @@ export interface ModelRunOutcome {
    */
   warnings?: string[];
   durationMs: number;
-  costUsd: number;
+  /**
+   * The run's size×lane cost ESTIMATE in USD — never a provider-priced figure, and
+   * NOT the amount you are billed. The billed amount lives on the metering rail
+   * (plan allowance + priced overage); treat this as a rough signal only.
+   *
+   * `null` means the platform declined to report an estimate rather than resurface
+   * one it can't stand behind (a narrow set of legacy rows). Guard before
+   * arithmetic — `outcome.costUsd ?? 0`, or skip the row — and never render a
+   * fabricated `0` for an undisclosed cost.
+   */
+  costUsd: number | null;
   usage: CodingRunUsage;
 }
 
@@ -609,7 +619,8 @@ interface ModelWireResult {
   /** Present only when the run has warnings (e.g. an unhonored `model` pin); guarded at map time. */
   warnings?: string[];
   duration_ms: number;
-  cost_usd: number;
+  /** Nullable on the wire: the platform sends `null` rather than an estimate it can't stand behind. */
+  cost_usd?: number | null;
   usage?: {
     input_tokens?: number;
     output_tokens?: number;
@@ -642,7 +653,10 @@ function mapModelResult(r: ModelWireResult | null | undefined): ModelRunOutcome 
     servedClass: r.served_class ?? null,
     lane: r.lane ?? null,
     durationMs: r.duration_ms,
-    costUsd: r.cost_usd,
+    // ONE encoding of "no cost estimate": a wire `null`, a missing key, and a
+    // malformed value all land on `null` — never a fabricated `0`, which a
+    // consumer would read as "this run was free".
+    costUsd: typeof r.cost_usd === "number" ? r.cost_usd : null,
     // Passthrough via the shared guard (`normalizeWarnings`): the key is
     // absent unless at least one string warning survives — a wire `[]`, a
     // non-array, or an all-junk array maps to absent, matching the documented

--- a/packages/tools/src/models/run-launch.spec.ts
+++ b/packages/tools/src/models/run-launch.spec.ts
@@ -77,8 +77,8 @@ describe("agent.run — terminal result mapping", () => {
   });
 
   it("ONE encoding of 'no cost estimate' — null for a wire null, a missing key, or a malformed value", async () => {
-    // The platform sends `cost_usd: null` rather than resurface an estimate it
-    // can't stand behind. A fabricated `0` would read as "this run was free".
+    // A fabricated `0` for an omitted estimate would read as "this run was
+    // free", so every unreported or invalid encoding lands on `null`.
     const wireResult = (cost?: unknown) => ({
       success: true,
       stop_reason: "end_turn",

--- a/packages/tools/src/models/run-launch.spec.ts
+++ b/packages/tools/src/models/run-launch.spec.ts
@@ -76,6 +76,34 @@ describe("agent.run — terminal result mapping", () => {
     expect(result.result?.usage.inputTokens).toBe(10);
   });
 
+  it("ONE encoding of 'no cost estimate' — null for a wire null, a missing key, or a malformed value", async () => {
+    // The platform sends `cost_usd: null` rather than resurface an estimate it
+    // can't stand behind. A fabricated `0` would read as "this run was free".
+    const wireResult = (cost?: unknown) => ({
+      success: true,
+      stop_reason: "end_turn",
+      turns: 1,
+      model_used: null,
+      duration_ms: 1200,
+      ...(cost !== undefined ? { cost_usd: cost } : {}),
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+    const runWith = async (cost?: unknown) => {
+      const sapiom = createClient({ apiKey: "k", fetch: fakeFetch({ wireResult: wireResult(cost) }) });
+      return (await sapiom.models.run({ prompt: "say OK" })).result?.costUsd;
+    };
+
+    // Wire `null` — the legacy-row case the published type used to deny.
+    expect(await runWith(null)).toBeNull();
+    // Missing key → null, not `undefined` leaking into a `number | null` field.
+    expect(await runWith()).toBeNull();
+    // Not a number → null, never a string leaking through.
+    expect(await runWith("0.001")).toBeNull();
+    // A real estimate still comes through — including a genuine zero.
+    expect(await runWith(0.001)).toBe(0.001);
+    expect(await runWith(0)).toBe(0);
+  });
+
   it("maps the serving disclosure (servedClass/lane) when the server reports it", async () => {
     const sapiom = createClient({
       apiKey: "k",

--- a/packages/tools/src/models/run-launch.spec.ts
+++ b/packages/tools/src/models/run-launch.spec.ts
@@ -184,6 +184,36 @@ describe("agent.run — terminal result mapping", () => {
     expect(await runWith([1, "warn-a", null])).toEqual(["warn-a"]);
   });
 
+  it("the resume payload gets the SAME cost encoding (modelRunResultSchema normalizes)", () => {
+    // The resumed-step path doesn't go through mapModelResult, so `parse` has to
+    // land the same encoding: a `number | null` field must never hand a resumed
+    // step `undefined`.
+    const payload = (cost?: unknown) => ({
+      runId: "run-abc",
+      status: "completed",
+      output: "OK",
+      result: {
+        success: true,
+        stopReason: "end_turn",
+        turns: 1,
+        modelUsed: null,
+        durationMs: 1200,
+        ...(cost !== undefined ? { costUsd: cost } : {}),
+        usage: { inputTokens: 10, outputTokens: 5, cacheReadTokens: 0, cacheCreateTokens: 0, thinkingTokens: 0 },
+      },
+      error: null,
+    });
+
+    // What the server actually sends for an unreported estimate.
+    expect(modelRunResultSchema.parse(payload(null)).result?.costUsd).toBeNull();
+    // Missing key → null, not `undefined` under a `number | null` type.
+    expect(modelRunResultSchema.parse(payload()).result?.costUsd).toBeNull();
+    expect(modelRunResultSchema.parse(payload("0.001")).result?.costUsd).toBeNull();
+    // A real estimate survives — including a genuine zero.
+    expect(modelRunResultSchema.parse(payload(0.001)).result?.costUsd).toBe(0.001);
+    expect(modelRunResultSchema.parse(payload(0)).result?.costUsd).toBe(0);
+  });
+
   it("the resume payload gets the SAME warnings encoding (modelRunResultSchema normalizes)", async () => {
     // A step resumed via pauseUntilSignal receives the server-serialized
     // payload through modelRunResultSchema.parse, not mapModelResult — the


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

`ModelRunOutcome.costUsd` is published as `number`, but the platform already
sends `cost_usd: null` on a bounded set of runs — rows whose stored estimate
came from a source it will not stand behind, where the honest pre-disclosure
figure is unrecoverable and an explicit null beats resurfacing the wrong number
(server-side guard: sapiom/Sapiom#4504, `AgentRunResultView.costUsd` is already
`number | null` there).

So a strict consumer doing `outcome.costUsd.toFixed(2)` hits a runtime `null`
the type says cannot exist. This was found during the SDK ergonomics work
(#682) and deliberately left alone in that PR — widening is exactly the kind of
type change an additive-only pass rules out, so it was flagged in the PR body
for a minor instead. This is that minor.

## Summary and scope

- `ModelRunOutcome.costUsd: number` → `number | null`, with JSDoc stating the
  consumer-facing contract: it's an **estimate**, not the billed amount, and
  `null` means "not reported" rather than "free".
- `ModelWireResult.cost_usd` → `number | null` and optional, matching what the
  server serializes.
- `mapModelResult` lands a wire `null`, a missing key, and a malformed value all
  on `null` — one encoding, mirroring how this file already normalizes
  `warnings`. A fabricated `0` would read to a consumer as "this run was free",
  which is worse than an honest absence. A genuine `0` still passes through.
- `modelRunResultSchema.parse` applies the same coercion when a consumer
  validates a resume payload (added in review). The schema is opt-in boundary
  hardening; it does not claim every unparsed resume payload is normalized.
- Changeset (`@sapiom/tools`, minor) labelled `**Breaking (type-level):**`,
  matching how this package's CHANGELOG already marks compile-breaking changes
  shipped at minor.

**Out of scope:** the deprecation itself. No `@deprecated` tag is added — the
field has no replacement in the SDK surface, and striking it through in every
consumer's editor with nothing to migrate to would be worse than silence.
Retiring it belongs with the release that gives consumers something else to
use. `CodingRunOutcome` is untouched — coding runs never carried a `cost_usd`
key at all.

## Related work

Related issue or discussion: SAP-2811. Follows sapiom-js#682 (which flagged this
mismatch) and sapiom/Sapiom#4504 (the server-side `servedModel` stale-row guard
that produces the null).

## Validation

```text
# command — result
pnpm build                                                  — clean (all packages)
pnpm typecheck                                              — clean, exit 0
pnpm lint                                                   — clean, exit 0 (only pre-existing warnings)
npx jest --maxWorkers=1 src/models/{run-launch,resume-payload,launch}.spec.ts
                                                            — 3 suites, 32 tests passed
pnpm provider-copy:check                                    — passed (74 audited files)
Node 20 rehydrate-session stress loop                        — 10/10 passed; current main's equivalent fix merged
```

### Tests and documentation

Two cases in `run-launch.spec.ts`, one per delivery path (`ONE encoding of 'no
cost estimate'` for the polled path, and the matching resume-payload case next
to its `warnings` sibling) — each covers a wire `null`, a missing key, and a
non-number, and confirms a real estimate (including a genuine `0`) still comes
through. Docs: the JSDoc on `costUsd` is
the user-facing documentation for this change; no README changes needed
(`packages/tools/src/models/README.md` does not enumerate outcome fields).

## Compatibility and release impact

- Breaking or externally visible changes: **Type-level only, no runtime change
  for callers.** Under `strictNullChecks`, code that does arithmetic on or
  formats `result.costUsd` now fails to compile until it guards
  (`outcome.costUsd ?? 0`, or skip the row). That is the point — the runtime
  `null` was already reaching those call sites. Read/log-only code is
  unaffected. Shipped as a **minor**, per the ticket.
- Changeset: Added — `.changeset/widen-model-run-cost-usd.md` (`@sapiom/tools`,
  minor), labelled `**Breaking (type-level):**`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Written with Claude Code and OpenAI Codex. Claude Code read the server-side
`toResultView` guard, made the type and mapper edits, and wrote the model tests.
Codex diagnosed the Node 20 failure as an expired retention fixture, confirmed
the equivalent fix had landed on main, merged it, applied follow-up review
wording, and reran the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.