### PR TITLE
fix(harness): teach omit-model in the Studio prompt, and guard the right direction

### DIFF
--- a/.changeset/harness-prompt-omit-model.md
+++ b/.changeset/harness-prompt-omit-model.md
@@ -2,4 +2,4 @@
 "@sapiom/harness": patch
 ---
 
-Studio's coding-agent system prompt now says to omit `model` outright instead of offering a label pin, matching the authoring skill, the MCP instructions, and the call-surface guide.
+Studio's coding-agent system prompt now says to omit `model`, states that `smart` is a no-op, and keeps size labels as the deliberate choice — matching the authoring skill, the MCP instructions, and the call-surface guide.

--- a/.changeset/harness-prompt-omit-model.md
+++ b/.changeset/harness-prompt-omit-model.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Studio's coding-agent system prompt now says to omit `model` outright instead of offering a label pin, matching the authoring skill, the MCP instructions, and the call-surface guide.

--- a/.changeset/tools-jsdoc-omit-model.md
+++ b/.changeset/tools-jsdoc-omit-model.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/tools": patch
+---
+
+`model` JSDoc on the llm and models specs no longer suggests pinning `smart` — it is the default, so pinning it does nothing. The hover text now says to omit `model`, and to pass a size label only when picking a class deliberately.

--- a/packages/harness/src/core/inject/system-prompt.test.ts
+++ b/packages/harness/src/core/inject/system-prompt.test.ts
@@ -34,7 +34,14 @@ describe("generateSystemPromptFile", () => {
     expect(content).toContain("ctx.sapiom.llm.run");
     expect(content).toContain("ctx.sapiom.models.run");
     expect(content).toContain("ctx.sapiom.agents.run");
-    expect(content).toContain("pin the `smart` label");
+    // Omit-only is the advice. This assertion used to require the OPPOSITE
+    // ("pin the `smart` label"), which pinned a no-op into the highest-authority
+    // teaching surface and made correcting it fail CI — see the eval finding in
+    // the PR body. Guard the direction the rule actually points, matching
+    // agent-core's skill-sync content guard.
+    expect(content).toContain("Omit `model` entirely");
+    expect(content.toLowerCase()).not.toContain("pin the `smart`");
+    expect(content.toLowerCase()).not.toContain("if you must pin");
     // Structured/forced-tool output has no `text` block — the reply lives in the
     // `tool_use` block's input. Reading only `type === 'text'` there returns
     // `undefined` and invites exactly the string-parsing fallback this rule bans.

--- a/packages/harness/src/core/inject/system-prompt.test.ts
+++ b/packages/harness/src/core/inject/system-prompt.test.ts
@@ -34,14 +34,23 @@ describe("generateSystemPromptFile", () => {
     expect(content).toContain("ctx.sapiom.llm.run");
     expect(content).toContain("ctx.sapiom.models.run");
     expect(content).toContain("ctx.sapiom.agents.run");
-    // Omit-only is the advice. This assertion used to require the OPPOSITE
-    // ("pin the `smart` label"), which pinned a no-op into the highest-authority
-    // teaching surface and made correcting it fail CI — see the eval finding in
-    // the PR body. Guard the direction the rule actually points, matching
-    // agent-core's skill-sync content guard.
+    // Omit-only is the advice, and `smart` specifically is the no-op (it IS the
+    // default) — NOT labels in general: `small`/`medium`/`large` select a billing
+    // class deliberately. This assertion used to require the OPPOSITE ("pin the
+    // `smart` label"), which pinned a no-op into the highest-authority teaching
+    // surface and made correcting it fail CI. Guard the direction the rule points,
+    // matching agent-core's skill-sync content guard.
     expect(content).toContain("Omit `model` entirely");
-    expect(content.toLowerCase()).not.toContain("pin the `smart`");
-    expect(content.toLowerCase()).not.toContain("if you must pin");
+    expect(content).toMatch(/`smart` is already the default/i);
+    // Reject a reintroduction however it is worded. A literal substring check is
+    // what let this drift in the first place, so guard two shapes:
+    //   (a) "pin" and `smart` in the same sentence, either order —
+    //       "or pin the `smart` label", "pass `smart` if you need to pin explicitly"
+    //   (b) `smart` offered as a value to supply — "use `smart`", "set model to smart"
+    expect(content).not.toMatch(/\bpin\w*\b[^.]*smart|smart[^.]*\bpin\w*\b/i);
+    expect(content).not.toMatch(
+      /\b(?:pass|use|set|specify|choose|select)\b[^.]{0,30}`?"?smart/i,
+    );
     // Structured/forced-tool output has no `text` block — the reply lives in the
     // `tool_use` block's input. Reading only `type === 'text'` there returns
     // `undefined` and invites exactly the string-parsing fallback this rule bans.

--- a/packages/harness/src/profiles/default.ts
+++ b/packages/harness/src/profiles/default.ts
@@ -27,8 +27,9 @@ platform-driven multi-turn loop → \`ctx.sapiom.models.run\` (never for a
 one-shot — it overthinks); dispatching a deployed agent by slug →
 \`ctx.sapiom.agents.run\`. Structured output = tool-use/schema output — read
 the \`tool_use\` block's input, never string-parse; a plain-text reply reads
-only \`type === 'text'\` blocks. Omit \`model\`
-(recommended) or pin the \`smart\` label; raw provider ids are never
+only \`type === 'text'\` blocks. **Omit \`model\` entirely** — the platform
+routes it, and pinning a label buys nothing the default doesn't already
+give you; raw provider ids are never
 honored. Results disclose the served class + lane. Debugging a run: the
 Run Inspector, or the per-step I/O endpoint documented in the guide.
 Guide: https://docs.sapiom.ai/guides/choose-a-call-surface.

--- a/packages/harness/src/profiles/default.ts
+++ b/packages/harness/src/profiles/default.ts
@@ -28,8 +28,9 @@ one-shot — it overthinks); dispatching a deployed agent by slug →
 \`ctx.sapiom.agents.run\`. Structured output = tool-use/schema output — read
 the \`tool_use\` block's input, never string-parse; a plain-text reply reads
 only \`type === 'text'\` blocks. **Omit \`model\` entirely** — the platform
-routes it, and pinning a label buys nothing the default doesn't already
-give you; raw provider ids are never
+routes it, and \`smart\` is already the default, so naming it changes
+nothing. Reach for \`small\`/\`medium\`/\`large\` only to choose a class
+deliberately. Raw provider ids are never
 honored. Results disclose the served class + lane. Debugging a run: the
 Run Inspector, or the per-step I/O endpoint documented in the guide.
 Guide: https://docs.sapiom.ai/guides/choose-a-call-surface.

--- a/packages/tools/src/llm/index.ts
+++ b/packages/tools/src/llm/index.ts
@@ -106,7 +106,8 @@ export interface LlmRunSpec {
    * Routing label (e.g. `"smart"`, `"small"`, `"medium"`, `"large"`). The
    * gateway resolves it against its configured label set — a raw provider
    * model id is never honored. Omit to let the gateway choose (the
-   * recommended default); pass `"smart"` if you need to pin explicitly.
+   * recommended default). `"smart"` IS that default, so pinning it is a no-op;
+   * pass `"small"`/`"medium"`/`"large"` only to pick a billing class deliberately.
    */
   model?: RoutingLabel;
   /**
@@ -151,7 +152,8 @@ export interface LlmSubmitSpec {
    * Routing label (e.g. `"smart"`, `"small"`, `"medium"`, `"large"`). The
    * gateway resolves it against its configured label set — a raw provider
    * model id is never honored. Omit to let the gateway choose (the
-   * recommended default); pass `"smart"` if you need to pin explicitly.
+   * recommended default). `"smart"` IS that default, so pinning it is a no-op;
+   * pass `"small"`/`"medium"`/`"large"` only to pick a billing class deliberately.
    */
   model?: RoutingLabel;
   /**

--- a/packages/tools/src/models/index.ts
+++ b/packages/tools/src/models/index.ts
@@ -66,7 +66,8 @@ export interface CodingRunSpec {
    * Routing label for the coding agent's LLM calls (e.g. `"smart"`). The
    * platform resolves it against its configured label set — a raw provider
    * model id is never honored. Omit to let the platform choose (the
-   * recommended default); pass `"smart"` if you need to pin explicitly.
+   * recommended default). `"smart"` IS that default, so pinning it is a no-op;
+   * pass `"small"`/`"medium"`/`"large"` only to pick a billing class deliberately.
    */
   model?: ModelLabel;
 }
@@ -484,7 +485,8 @@ export interface ModelRunSpec {
    * is never honored. An unrecognized value is never silently dropped: the
    * run routes via the platform default and the platform reports it in the
    * result's `warnings` (SAP-2765). Omit to let the platform choose (the
-   * recommended default); pass `"smart"` if you need to pin explicitly.
+   * recommended default). `"smart"` IS that default, so pinning it is a no-op;
+   * pass `"small"`/`"medium"`/`"large"` only to pick a billing class deliberately.
    */
   model?: ModelLabel;
   /** Max output tokens per turn. */


### PR DESCRIPTION
## What was wrong

The Studio coding-agent system prompt said:

> Omit `model` (recommended) or pin the `smart` label; raw provider ids are never honored.

The label pin is a **no-op** — it is already the default — so the prompt taught authors to write a line of code that changes nothing. Every other surface that states this rule had already dropped that advice:

| Surface | pin-a-label advice |
|---|---|
| `agent-core` authoring skill | dropped |
| `@sapiom/mcp` instructions (and the served copy) | dropped |
| call-surface guide | dropped |
| **harness system prompt** | **still present** — fixed here |
| **`@sapiom/tools` JSDoc (4 sites, ships in `.d.ts`)** | **still present** — fixed here (review round 1) |

Corrected in review round 1: the original table omitted `@sapiom/tools`, because the inventory grep searched for `pin the \`smart\`` / `if you must pin` and the tools phrasing is `pass \`"smart"\` if you need to pin explicitly`. The highest-read-volume surface was invisible to the search that produced the table — the same class of failure as the drift itself.

The prompt is the highest-authority surface — it is injected into every Studio session, ahead of the skill and the MCP instructions.

## Why it survived several fix rounds

`packages/harness/src/core/inject/system-prompt.test.ts` asserted the wrong direction:

```ts
expect(content).toContain("pin the `smart` label");
```

So correcting the prompt would have failed CI, while `agent-core`'s `skill-sync.test.ts` asserts the opposite for the canonical skill:

```ts
expect(canonical.toLowerCase()).not.toContain("if you must pin");
```

Two guards in one repo, pinning contradictory versions of the same rule. That is the actual defect — the stale prompt text is just its symptom. The test's own comment claimed it was "kept in sync with the MCP instructions", a sync no mechanism enforced.

## How it surfaced

A clean-room harness eval (six scenarios against the released teaching stack, judged per-criterion). The reproducibility scenario asked the subject to pin a raw provider model id. It correctly refused the raw id and correctly explained that pinning does not buy reproducibility — then recommended pinning the label anyway, because the system prompt told it to. That scenario had already failed a previous run for the same advice coming from the guide; the guide was fixed, the prompt was not.

## The change

- **`packages/harness/src/profiles/default.ts`** — say **omit `model` entirely**, and state why a pin buys nothing, rather than presenting it as a second valid option.
- **`packages/harness/src/core/inject/system-prompt.test.ts`** — assert `Omit \`model\` entirely` is present and that pin-a-label phrasings are absent, so the guard now points the same way as `agent-core`'s. A future correction to this rule will no longer be blocked by its own test.
- Changeset: `@sapiom/harness` patch.

No behaviour change beyond prompt copy; no exported API touched.

## Testing

```
npx vitest run src/core/inject/system-prompt.test.ts   →  4 passed
```

`packages/harness` full suite is unchanged against the base commit — 25 files / 22 tests failing both before and after this change (all pre-existing, in `canvas-render` and friends). `pnpm typecheck` in this package reports 52 pre-existing errors from unbuilt workspace deps; none in either file touched here. `pnpm lint` reports one pre-existing unused-import warning in an unrelated test.

## Follow-up worth doing separately

The rule now lives in ~11 authored places across three repos, and only one group of them (the three MCP instruction copies) has a drift guard. A cross-surface content check — one test that asserts the rule's key claims agree across the prompt, the skill, and the instructions — would have caught this in CI instead of in an eval three fix-rounds later. Related: serving the Studio prompt from the backend rather than shipping it npm-upgrade-bound (SAP-2810), which is what let this drift persist unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FB4ZTXuSgMJcUeLQ8LMQLL

