### PR TITLE
feat(harness): complete workspace agent inventory

### DIFF
--- a/.changeset/complete-workspace-agent-inventory.md
+++ b/.changeset/complete-workspace-agent-inventory.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Show every registry-known agent in its owning Agent Studio workspace graph, including local-only and disconnected agents, while preserving partial inventory with path-free warnings.

--- a/.changeset/complete-workspace-agent-inventory.md
+++ b/.changeset/complete-workspace-agent-inventory.md
@@ -1,5 +1,5 @@
 ---
-"@sapiom/harness": patch
+"@sapiom/harness": minor
 ---
 
 Show every registry-known agent in its owning Agent Studio workspace graph, including local-only and disconnected agents, while preserving partial inventory with path-free warnings.

--- a/packages/harness/src/core/definition-name.test.ts
+++ b/packages/harness/src/core/definition-name.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { resolveManifestName } from "./definition-name.js";
+import { inspectManifestName, resolveManifestName } from "./definition-name.js";
 
 /** A cached-extraction result shaped like canvas-cache's, with just the field
  *  under test populated. */
@@ -24,7 +24,9 @@ function extraction(manifestName: string) {
 describe("resolveManifestName", () => {
   it("returns the agent's declared manifest name", async () => {
     const extract = vi.fn().mockResolvedValue(extraction("order-triage"));
-    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBe("order-triage");
+    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBe(
+      "order-triage",
+    );
     expect(extract).toHaveBeenCalledWith("/proj/agent");
   });
 
@@ -36,16 +38,48 @@ describe("resolveManifestName", () => {
       cached: false,
       fingerprint: "0:0",
     });
-    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBeNull();
+    await expect(
+      resolveManifestName("/proj/agent", extract),
+    ).resolves.toBeNull();
   });
 
   it("returns null when extraction throws", async () => {
     const extract = vi.fn().mockRejectedValue(new Error("boom"));
-    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBeNull();
+    await expect(
+      resolveManifestName("/proj/agent", extract),
+    ).resolves.toBeNull();
   });
 
   it("returns null for a blank manifest name", async () => {
     const extract = vi.fn().mockResolvedValue(extraction("   "));
-    await expect(resolveManifestName("/proj/agent", extract)).resolves.toBeNull();
+    await expect(
+      resolveManifestName("/proj/agent", extract),
+    ).resolves.toBeNull();
+  });
+});
+
+describe("inspectManifestName", () => {
+  it("distinguishes an unnamed agent from a failed extraction", async () => {
+    const unnamed = vi.fn().mockResolvedValue(extraction("   "));
+    const failed = vi.fn().mockResolvedValue({
+      result: { ok: false as const, reason: "run npm install first" },
+      cached: false,
+      fingerprint: "0:0",
+    });
+
+    await expect(
+      inspectManifestName("/proj/unnamed", unnamed),
+    ).resolves.toEqual({ status: "absent" });
+    await expect(inspectManifestName("/proj/broken", failed)).resolves.toEqual({
+      status: "failed",
+    });
+  });
+
+  it("reports a thrown extraction as failed", async () => {
+    const extract = vi.fn().mockRejectedValue(new Error("boom"));
+
+    await expect(inspectManifestName("/proj/broken", extract)).resolves.toEqual(
+      { status: "failed" },
+    );
   });
 });

--- a/packages/harness/src/core/definition-name.ts
+++ b/packages/harness/src/core/definition-name.ts
@@ -14,16 +14,33 @@
  */
 import { extractWorkflowGraphCached } from "./canvas-cache.js";
 
+export type ManifestNameInspection =
+  | { status: "found"; name: string }
+  | { status: "absent" | "failed" };
+
+/**
+ * Inspect the declared manifest name while preserving the difference between
+ * a valid unnamed agent and an extraction failure. Inventory uses the richer
+ * result to avoid warning for the normal unnamed case.
+ */
+export async function inspectManifestName(
+  projectDir: string,
+  extract: typeof extractWorkflowGraphCached = extractWorkflowGraphCached,
+): Promise<ManifestNameInspection> {
+  try {
+    const { result } = await extract(projectDir);
+    if (!result.ok) return { status: "failed" };
+    const name = result.graph.manifestName.trim();
+    return name === "" ? { status: "absent" } : { status: "found", name };
+  } catch {
+    return { status: "failed" };
+  }
+}
+
 export async function resolveManifestName(
   projectDir: string,
   extract: typeof extractWorkflowGraphCached = extractWorkflowGraphCached,
 ): Promise<string | null> {
-  try {
-    const { result } = await extract(projectDir);
-    if (!result.ok) return null;
-    return result.graph.manifestName.trim() || null;
-  } catch {
-    // Extraction is best-effort here — a name is a nicety, a deploy is not.
-    return null;
-  }
+  const inspected = await inspectManifestName(projectDir, extract);
+  return inspected.status === "found" ? inspected.name : null;
 }

--- a/packages/harness/src/core/system-graph-inventory.test.ts
+++ b/packages/harness/src/core/system-graph-inventory.test.ts
@@ -5,6 +5,7 @@ import {
   HarnessRegistryInventoryProvider,
   type WorkspaceScope,
 } from "./system-graph-inventory.js";
+import type { ManifestNameInspection } from "./definition-name.js";
 
 const WORKSPACE = "/private/workspaces/acme";
 const SCOPE: WorkspaceScope = {
@@ -32,24 +33,28 @@ function provider(
   workflows: readonly WorkflowInfo[],
   options: {
     scopes?: { workspaceKey: string; cwd: string }[];
-    resolveManifestName?: (sourceRoot: string) => Promise<string | null>;
+    inspectManifestName?: (
+      sourceRoot: string,
+    ) => Promise<ManifestNameInspection>;
   } = {},
 ): HarnessRegistryInventoryProvider {
   return new HarnessRegistryInventoryProvider({
     listWorkflows: () => workflows,
     listWorkspaceScopes: () =>
       options.scopes ?? [{ workspaceKey: SCOPE.workspaceKey, cwd: SCOPE.root }],
-    ...(options.resolveManifestName
-      ? { resolveManifestName: options.resolveManifestName }
+    ...(options.inspectManifestName
+      ? { inspectManifestName: options.inspectManifestName }
       : {}),
   });
 }
 
 describe("HarnessRegistryInventoryProvider", () => {
   it("returns every registry-known agent regardless of deployment, source, or relationships", async () => {
-    const resolveManifestName = vi.fn(async (sourceRoot: string) => {
-      if (sourceRoot.endsWith("/growth")) return "growth-manifest";
-      return null;
+    const inspectManifestName = vi.fn(async (sourceRoot: string) => {
+      if (sourceRoot.endsWith("/growth")) {
+        return { status: "found" as const, name: "growth-manifest" };
+      }
+      return { status: "absent" as const };
     });
     const inventory = provider(
       [
@@ -63,7 +68,7 @@ describe("HarnessRegistryInventoryProvider", () => {
           path: `${WORKSPACE}-archive/outside`,
         },
       ],
-      { resolveManifestName },
+      { inspectManifestName },
     );
 
     await expect(inventory.listAgents(SCOPE)).resolves.toEqual({
@@ -93,52 +98,58 @@ describe("HarnessRegistryInventoryProvider", () => {
           sourceRoot: `${WORKSPACE}/research`,
         },
       ],
-      warnings: [
-        {
-          code: "inventory-extraction-failed",
-          agentKey: "local:reporting",
-          message:
-            "Could not inspect Reporting package; using its local identity.",
-        },
-      ],
+      warnings: [],
     });
-    expect(resolveManifestName).toHaveBeenCalledTimes(2);
-    expect(resolveManifestName).not.toHaveBeenCalledWith(
+    expect(inspectManifestName).toHaveBeenCalledTimes(2);
+    expect(inspectManifestName).not.toHaveBeenCalledWith(
       `${WORKSPACE}/research`,
     );
   });
 
-  it("resolves missing declared names concurrently and keeps partial results", async () => {
+  it("bounds manifest inspection concurrency and keeps partial results", async () => {
     let release!: () => void;
     const gate = new Promise<void>((resolve) => {
       release = resolve;
     });
     const started: string[] = [];
-    const resolveManifestName = vi.fn(async (sourceRoot: string) => {
+    const inspectManifestName = vi.fn(async (sourceRoot: string) => {
       started.push(sourceRoot);
       await gate;
       if (sourceRoot.endsWith("/broken")) {
+        return { status: "failed" as const };
+      }
+      if (sourceRoot.endsWith("/thrown")) {
         throw new Error(`unreadable ${sourceRoot}`);
       }
-      return sourceRoot.endsWith("/named") ? "declared-name" : null;
+      return sourceRoot.endsWith("/named")
+        ? { status: "found" as const, name: "declared-name" }
+        : { status: "absent" as const };
     });
     const inventoryPromise = provider(
       [
         workflow("Named", "named", null),
         workflow("Broken", "broken", null),
+        workflow("Thrown", "thrown", null),
         workflow("Fallback", "fallback", null),
+        workflow("Extra A", "extra-a", null),
+        workflow("Extra B", "extra-b", null),
       ],
-      { resolveManifestName },
+      { inspectManifestName },
     ).listAgents(SCOPE);
 
-    await vi.waitFor(() => expect(started).toHaveLength(3));
+    await vi.waitFor(() => expect(started).toHaveLength(4));
+    await Promise.resolve();
+    expect(started).toHaveLength(4);
     release();
     const result = await inventoryPromise;
 
     expect(result.agents.map((agent) => agent.agentKey)).toEqual([
       "declared-name",
       "local:broken",
+      "local:extra-a",
+      "local:extra-b",
       "local:fallback",
+      "local:thrown",
     ]);
     expect(result.warnings).toEqual([
       {
@@ -148,10 +159,11 @@ describe("HarnessRegistryInventoryProvider", () => {
       },
       {
         code: "inventory-extraction-failed",
-        agentKey: "local:fallback",
-        message: "Could not inspect Fallback; using its local identity.",
+        agentKey: "local:thrown",
+        message: "Could not inspect Thrown; using its local identity.",
       },
     ]);
+    expect(inspectManifestName).toHaveBeenCalledTimes(6);
     expect(JSON.stringify(result.warnings)).not.toContain(WORKSPACE);
   });
 

--- a/packages/harness/src/core/system-graph-inventory.test.ts
+++ b/packages/harness/src/core/system-graph-inventory.test.ts
@@ -102,6 +102,7 @@ describe("HarnessRegistryInventoryProvider", () => {
           sourceRoot: `${WORKSPACE}/research`,
         },
       ],
+      cacheable: true,
       warnings: [],
     });
     expect(inspectManifestName).toHaveBeenCalledTimes(2);
@@ -168,6 +169,7 @@ describe("HarnessRegistryInventoryProvider", () => {
       },
     ]);
     expect(inspectManifestName).toHaveBeenCalledTimes(6);
+    expect(result.cacheable).toBe(false);
     expect(JSON.stringify(result.warnings)).not.toContain(WORKSPACE);
   });
 
@@ -216,6 +218,7 @@ describe("HarnessRegistryInventoryProvider", () => {
       ["inventory-extraction-failed", "local:slow-e"],
     ]);
     expect(started).toHaveLength(5);
+    expect(result.cacheable).toBe(false);
 
     release();
     await Promise.resolve();
@@ -360,6 +363,7 @@ describe("HarnessRegistryInventoryProvider", () => {
 
     await expect(inventory.listAgents(SCOPE)).resolves.toMatchObject({
       agents: [{ agentKey: "research" }],
+      cacheable: false,
       warnings: [],
     });
   });

--- a/packages/harness/src/core/system-graph-inventory.test.ts
+++ b/packages/harness/src/core/system-graph-inventory.test.ts
@@ -36,6 +36,7 @@ function provider(
     inspectManifestName?: (
       sourceRoot: string,
     ) => Promise<ManifestNameInspection>;
+    manifestInspectionBudgetMs?: number;
   } = {},
 ): HarnessRegistryInventoryProvider {
   return new HarnessRegistryInventoryProvider({
@@ -44,6 +45,9 @@ function provider(
       options.scopes ?? [{ workspaceKey: SCOPE.workspaceKey, cwd: SCOPE.root }],
     ...(options.inspectManifestName
       ? { inspectManifestName: options.inspectManifestName }
+      : {}),
+    ...(options.manifestInspectionBudgetMs !== undefined
+      ? { manifestInspectionBudgetMs: options.manifestInspectionBudgetMs }
       : {}),
   });
 }
@@ -165,6 +169,58 @@ describe("HarnessRegistryInventoryProvider", () => {
     ]);
     expect(inspectManifestName).toHaveBeenCalledTimes(6);
     expect(JSON.stringify(result.warnings)).not.toContain(WORKSPACE);
+  });
+
+  it("returns partial inventory when the enrichment budget expires", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const started: string[] = [];
+    const inspectManifestName = vi.fn(async (sourceRoot: string) => {
+      started.push(sourceRoot);
+      if (sourceRoot.endsWith("/fast")) {
+        return { status: "found" as const, name: "fast-manifest" };
+      }
+      await gate;
+      return { status: "absent" as const };
+    });
+
+    const result = await provider(
+      [
+        workflow("Fast", "fast", null),
+        workflow("Slow A", "slow-a", null),
+        workflow("Slow B", "slow-b", null),
+        workflow("Slow C", "slow-c", null),
+        workflow("Slow D", "slow-d", null),
+        workflow("Slow E", "slow-e", null),
+      ],
+      { inspectManifestName, manifestInspectionBudgetMs: 20 },
+    ).listAgents(SCOPE);
+
+    expect(result.agents.map((agent) => agent.agentKey)).toEqual([
+      "fast-manifest",
+      "local:slow-a",
+      "local:slow-b",
+      "local:slow-c",
+      "local:slow-d",
+      "local:slow-e",
+    ]);
+    expect(
+      result.warnings.map(({ code, agentKey }) => [code, agentKey]),
+    ).toEqual([
+      ["inventory-extraction-failed", "local:slow-a"],
+      ["inventory-extraction-failed", "local:slow-b"],
+      ["inventory-extraction-failed", "local:slow-c"],
+      ["inventory-extraction-failed", "local:slow-d"],
+      ["inventory-extraction-failed", "local:slow-e"],
+    ]);
+    expect(started).toHaveLength(5);
+
+    release();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toHaveLength(5);
   });
 
   it("assigns each agent to its deepest known workspace", async () => {

--- a/packages/harness/src/core/system-graph-inventory.test.ts
+++ b/packages/harness/src/core/system-graph-inventory.test.ts
@@ -1,0 +1,311 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { WorkflowInfo } from "../shared/types.js";
+import {
+  HarnessRegistryInventoryProvider,
+  type WorkspaceScope,
+} from "./system-graph-inventory.js";
+
+const WORKSPACE = "/private/workspaces/acme";
+const SCOPE: WorkspaceScope = {
+  workspaceKey: "workspace-acme",
+  root: WORKSPACE,
+};
+
+function workflow(
+  name: string,
+  relativePath: string,
+  definitionSlug: string | null,
+  overrides: Partial<WorkflowInfo> = {},
+): WorkflowInfo {
+  return {
+    name,
+    path: `${WORKSPACE}/${relativePath}`,
+    definitionId: definitionSlug ? 1 : null,
+    definitionSlug,
+    source: "scan",
+    ...overrides,
+  };
+}
+
+function provider(
+  workflows: readonly WorkflowInfo[],
+  options: {
+    scopes?: { workspaceKey: string; cwd: string }[];
+    resolveManifestName?: (sourceRoot: string) => Promise<string | null>;
+  } = {},
+): HarnessRegistryInventoryProvider {
+  return new HarnessRegistryInventoryProvider({
+    listWorkflows: () => workflows,
+    listWorkspaceScopes: () =>
+      options.scopes ?? [{ workspaceKey: SCOPE.workspaceKey, cwd: SCOPE.root }],
+    ...(options.resolveManifestName
+      ? { resolveManifestName: options.resolveManifestName }
+      : {}),
+  });
+}
+
+describe("HarnessRegistryInventoryProvider", () => {
+  it("returns every registry-known agent regardless of deployment, source, or relationships", async () => {
+    const resolveManifestName = vi.fn(async (sourceRoot: string) => {
+      if (sourceRoot.endsWith("/growth")) return "growth-manifest";
+      return null;
+    });
+    const inventory = provider(
+      [
+        workflow("Research package", "research", "research", {
+          definitionId: 101,
+        }),
+        workflow("Growth package", "growth", null, { source: "connect" }),
+        workflow("Reporting package", "reporting", null),
+        {
+          ...workflow("Outside", "outside", "outside"),
+          path: `${WORKSPACE}-archive/outside`,
+        },
+      ],
+      { resolveManifestName },
+    );
+
+    await expect(inventory.listAgents(SCOPE)).resolves.toEqual({
+      agents: [
+        {
+          agentKey: "growth-manifest",
+          definitionId: null,
+          definitionSlug: null,
+          label: "Growth package",
+          resolutionAliases: ["growth-manifest"],
+          sourceRoot: `${WORKSPACE}/growth`,
+        },
+        {
+          agentKey: "local:reporting",
+          definitionId: null,
+          definitionSlug: null,
+          label: "Reporting package",
+          resolutionAliases: ["local:reporting"],
+          sourceRoot: `${WORKSPACE}/reporting`,
+        },
+        {
+          agentKey: "research",
+          definitionId: 101,
+          definitionSlug: "research",
+          label: "Research package",
+          resolutionAliases: ["research"],
+          sourceRoot: `${WORKSPACE}/research`,
+        },
+      ],
+      warnings: [
+        {
+          code: "inventory-extraction-failed",
+          agentKey: "local:reporting",
+          message:
+            "Could not inspect Reporting package; using its local identity.",
+        },
+      ],
+    });
+    expect(resolveManifestName).toHaveBeenCalledTimes(2);
+    expect(resolveManifestName).not.toHaveBeenCalledWith(
+      `${WORKSPACE}/research`,
+    );
+  });
+
+  it("resolves missing declared names concurrently and keeps partial results", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const started: string[] = [];
+    const resolveManifestName = vi.fn(async (sourceRoot: string) => {
+      started.push(sourceRoot);
+      await gate;
+      if (sourceRoot.endsWith("/broken")) {
+        throw new Error(`unreadable ${sourceRoot}`);
+      }
+      return sourceRoot.endsWith("/named") ? "declared-name" : null;
+    });
+    const inventoryPromise = provider(
+      [
+        workflow("Named", "named", null),
+        workflow("Broken", "broken", null),
+        workflow("Fallback", "fallback", null),
+      ],
+      { resolveManifestName },
+    ).listAgents(SCOPE);
+
+    await vi.waitFor(() => expect(started).toHaveLength(3));
+    release();
+    const result = await inventoryPromise;
+
+    expect(result.agents.map((agent) => agent.agentKey)).toEqual([
+      "declared-name",
+      "local:broken",
+      "local:fallback",
+    ]);
+    expect(result.warnings).toEqual([
+      {
+        code: "inventory-extraction-failed",
+        agentKey: "local:broken",
+        message: "Could not inspect Broken; using its local identity.",
+      },
+      {
+        code: "inventory-extraction-failed",
+        agentKey: "local:fallback",
+        message: "Could not inspect Fallback; using its local identity.",
+      },
+    ]);
+    expect(JSON.stringify(result.warnings)).not.toContain(WORKSPACE);
+  });
+
+  it("assigns each agent to its deepest known workspace", async () => {
+    const nestedRoot = `${WORKSPACE}/experiments`;
+    const scopes = [
+      { workspaceKey: SCOPE.workspaceKey, cwd: SCOPE.root },
+      { workspaceKey: "workspace-experiments", cwd: nestedRoot },
+    ];
+    const workflows = [
+      workflow("Root agent", "", "root-agent"),
+      workflow("Parent agent", "research", "research"),
+      workflow("Nested agent", "experiments/evaluator", "evaluator"),
+      {
+        ...workflow("Prefix sibling", "sibling", "sibling"),
+        path: `${WORKSPACE}-archive/sibling`,
+      },
+    ];
+
+    const parent = await provider(workflows, { scopes }).listAgents(SCOPE);
+    const nested = await provider(workflows, { scopes }).listAgents({
+      workspaceKey: "workspace-experiments",
+      root: nestedRoot,
+    });
+
+    expect(parent.agents.map((agent) => agent.agentKey)).toEqual([
+      "research",
+      "root-agent",
+    ]);
+    expect(nested.agents.map((agent) => agent.agentKey)).toEqual(["evaluator"]);
+  });
+
+  it("does not confuse same-basename roots or mixed Windows separators", async () => {
+    const windowsScope: WorkspaceScope = {
+      workspaceKey: "workspace-windows",
+      root: "C:\\Users\\Demo\\project",
+    };
+    const scopes = [
+      { workspaceKey: windowsScope.workspaceKey, cwd: windowsScope.root },
+      {
+        workspaceKey: "workspace-nested",
+        cwd: "C:/Users/Demo/project/experiments",
+      },
+      { workspaceKey: "workspace-other", cwd: "D:\\Other\\project" },
+    ];
+    const workflows: WorkflowInfo[] = [
+      {
+        ...workflow("Windows parent", "unused", "windows-parent"),
+        path: "c:/users/demo/project/main-agent",
+      },
+      {
+        ...workflow("Windows nested", "unused", "windows-nested"),
+        path: "C:\\Users\\Demo\\project\\experiments\\evaluator",
+      },
+      {
+        ...workflow("Prefix sibling", "unused", "prefix-sibling"),
+        path: "C:\\Users\\Demo\\project-old\\agent",
+      },
+      {
+        ...workflow("Other basename", "unused", "other"),
+        path: "D:\\Other\\project\\agent",
+      },
+    ];
+    const inventory = new HarnessRegistryInventoryProvider({
+      listWorkflows: () => workflows,
+      listWorkspaceScopes: () => scopes,
+    });
+
+    const result = await inventory.listAgents(windowsScope);
+
+    expect(result.agents.map((agent) => agent.agentKey)).toEqual([
+      "windows-parent",
+    ]);
+  });
+
+  it("preserves duplicate slugs with deterministic local identities and a warning", async () => {
+    const result = await provider([
+      workflow("First copy", "first", "shared"),
+      workflow("Second copy", "second", "shared", { source: "connect" }),
+    ]).listAgents(SCOPE);
+
+    expect(result.agents).toMatchObject([
+      {
+        agentKey: "local:first",
+        definitionSlug: "shared",
+        resolutionAliases: ["shared"],
+      },
+      {
+        agentKey: "local:second",
+        definitionSlug: "shared",
+        resolutionAliases: ["shared"],
+      },
+    ]);
+    expect(result.warnings).toEqual([
+      {
+        code: "duplicate-agent-key",
+        agentKey: "shared",
+        message: "Multiple agents use shared; kept each with a local identity.",
+      },
+    ]);
+    expect(JSON.stringify(result.warnings)).not.toContain(WORKSPACE);
+  });
+
+  it("keeps a duplicated local candidate ambiguous after suffixing its node ids", async () => {
+    const duplicate = workflow("Connected copy", "connected", null, {
+      source: "connect",
+    });
+
+    const result = await provider([duplicate, { ...duplicate }]).listAgents(
+      SCOPE,
+    );
+
+    expect(result.agents.map((agent) => agent.agentKey)).toEqual([
+      "local:connected",
+      "local:connected~2",
+    ]);
+    expect(result.agents.map((agent) => agent.resolutionAliases)).toEqual([
+      ["local:connected"],
+      ["local:connected"],
+    ]);
+    expect(result.warnings).toEqual([
+      {
+        code: "duplicate-agent-key",
+        agentKey: "local:connected",
+        message:
+          "Multiple agents use local:connected; kept each with a local identity.",
+      },
+    ]);
+  });
+
+  it("falls back to the selected scope if the read-only scope catalog is unavailable", async () => {
+    const inventory = new HarnessRegistryInventoryProvider({
+      listWorkflows: () => [workflow("Research", "research", "research")],
+      listWorkspaceScopes: async () => {
+        throw new Error("settings unavailable");
+      },
+    });
+
+    await expect(inventory.listAgents(SCOPE)).resolves.toMatchObject({
+      agents: [{ agentKey: "research" }],
+      warnings: [],
+    });
+  });
+
+  it("fails the provider call when the registry snapshot cannot be read", async () => {
+    const inventory = new HarnessRegistryInventoryProvider({
+      listWorkflows: async () => {
+        throw new Error("registry unavailable");
+      },
+      listWorkspaceScopes: () => [],
+    });
+
+    await expect(inventory.listAgents(SCOPE)).rejects.toThrow(
+      "registry unavailable",
+    );
+  });
+});

--- a/packages/harness/src/core/system-graph-inventory.ts
+++ b/packages/harness/src/core/system-graph-inventory.ts
@@ -57,30 +57,52 @@ export interface HarnessRegistryInventoryProviderOptions {
     | readonly WorkspaceScopeSummary[]
     | Promise<readonly WorkspaceScopeSummary[]>;
   inspectManifestName?: ManifestNameInspector;
+  /** Test seam; production keeps the default first-open latency budget. */
+  manifestInspectionBudgetMs?: number;
 }
 
 const MANIFEST_INSPECTION_CONCURRENCY = 4;
+// Individual extraction can wait 15 s; inventory must return well before that.
+const MANIFEST_INSPECTION_BUDGET_MS = 5_000;
 
-async function mapWithConcurrency<Input, Output>(
+async function mapWithDeadline<Input, Output>(
   values: readonly Input[],
   concurrency: number,
+  budgetMs: number,
   map: (value: Input) => Promise<Output>,
-): Promise<Output[]> {
-  const results = new Array<Output>(values.length);
+): Promise<Array<Output | undefined>> {
+  const results = new Array<Output | undefined>(values.length);
   let nextIndex = 0;
+  let deadlineReached = false;
   const worker = async (): Promise<void> => {
-    while (nextIndex < values.length) {
+    while (!deadlineReached && nextIndex < values.length) {
       const index = nextIndex;
       nextIndex += 1;
-      results[index] = await map(values[index]!);
+      try {
+        results[index] = await map(values[index]!);
+      } catch {
+        // The caller turns every unfinished/failed item into partial inventory.
+      }
     }
   };
-  await Promise.all(
+  const workers = Promise.all(
     Array.from({ length: Math.min(concurrency, values.length) }, async () =>
       worker(),
     ),
   );
-  return results;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<void>((resolve) => {
+    timer = setTimeout(() => {
+      deadlineReached = true;
+      resolve();
+    }, budgetMs);
+  });
+  await Promise.race([workers, deadline]);
+  if (!deadlineReached && timer) clearTimeout(timer);
+  // Already-started production inspections have their own 15 s timeout. Do
+  // not await them, and prevent workers from starting any more after the cap.
+  void workers;
+  return results.slice();
 }
 
 function isWindowsAbsolute(input: string): boolean {
@@ -217,7 +239,7 @@ function warningOrder(
  * V0 inventory adapter. WorkflowRegistry's scan/connect flows remain the only
  * writers; this provider receives snapshots and performs no discovery. The
  * injected manifest-name inspection may run cached extraction, so enrichment
- * is bounded to avoid unbounded child-process fan-out on a cold graph open.
+ * has both a concurrency cap and a wall-clock budget on a cold graph open.
  */
 export class HarnessRegistryInventoryProvider implements AgentInventoryProvider {
   constructor(
@@ -244,13 +266,22 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
         return owner?.workspaceKey === selectedScope.workspaceKey;
       });
 
-    const prepared = (
-      await mapWithConcurrency(
-        owned,
-        MANIFEST_INSPECTION_CONCURRENCY,
-        ({ workflow, sourceRoot }) =>
-          this.prepareAgent(selectedScope, workflow, sourceRoot),
-      )
+    const inspections = await mapWithDeadline(
+      owned,
+      MANIFEST_INSPECTION_CONCURRENCY,
+      this.options.manifestInspectionBudgetMs ?? MANIFEST_INSPECTION_BUDGET_MS,
+      ({ workflow, sourceRoot }) =>
+        this.prepareAgent(selectedScope, workflow, sourceRoot),
+    );
+    const prepared = Array.from(
+      { length: owned.length },
+      (_, index) =>
+        inspections[index] ??
+        this.prepareFallbackAgent(
+          selectedScope,
+          owned[index]!.workflow,
+          owned[index]!.sourceRoot,
+        ),
     ).sort(preparedOrder);
 
     const candidateCounts = new Map<AgentKey, number>();
@@ -402,6 +433,29 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
           (fallbackKey.slice("local:".length) || "Local agent"),
       ),
       resolutionAliases,
+      sourceRoot,
+    };
+  }
+
+  private prepareFallbackAgent(
+    scope: WorkspaceScope,
+    workflow: WorkflowInfo,
+    sourceRoot: string,
+  ): PreparedAgent {
+    const definitionSlug = normalizedAlias(workflow.definitionSlug);
+    const fallbackKey = workspaceRelativeLocalKey(scope.root, sourceRoot);
+    const candidateKey = definitionSlug ?? fallbackKey;
+    return {
+      candidateKey,
+      fallbackKey,
+      definitionId: workflow.definitionId,
+      definitionSlug,
+      extractionFailed: !definitionSlug,
+      label: safeLabel(
+        workflow.name,
+        definitionSlug ?? (fallbackKey.slice("local:".length) || "Local agent"),
+      ),
+      resolutionAliases: [candidateKey],
       sourceRoot,
     };
   }

--- a/packages/harness/src/core/system-graph-inventory.ts
+++ b/packages/harness/src/core/system-graph-inventory.ts
@@ -1,0 +1,374 @@
+import { realpathSync } from "node:fs";
+import * as path from "node:path";
+
+import type {
+  AgentKey,
+  GraphWarning,
+  WorkspaceKey,
+  WorkspaceScopeSummary,
+} from "../shared/system-graph.js";
+import type { WorkflowInfo } from "../shared/types.js";
+
+export interface WorkspaceScope {
+  workspaceKey: WorkspaceKey;
+  root: string;
+}
+
+export interface AgentInventoryItem {
+  agentKey: AgentKey;
+  definitionId: number | null;
+  definitionSlug: string | null;
+  label: string;
+  resolutionAliases: string[];
+  /** Internal filesystem evidence. Never serialize this into SystemGraph. */
+  sourceRoot: string;
+}
+
+export interface AgentInventoryWarning {
+  code: Extract<
+    GraphWarning["code"],
+    "duplicate-agent-key" | "inventory-extraction-failed"
+  >;
+  agentKey: AgentKey;
+  message: string;
+}
+
+export interface AgentInventoryResult {
+  agents: AgentInventoryItem[];
+  warnings: AgentInventoryWarning[];
+}
+
+/** Read-only boundary between Studio's current registry and graph projection. */
+export interface AgentInventoryProvider {
+  listAgents(scope: WorkspaceScope): Promise<AgentInventoryResult>;
+}
+
+type ManifestNameResolver = (sourceRoot: string) => Promise<string | null>;
+
+export interface HarnessRegistryInventoryProviderOptions {
+  listWorkflows: () =>
+    | readonly WorkflowInfo[]
+    | Promise<readonly WorkflowInfo[]>;
+  listWorkspaceScopes: () =>
+    | readonly WorkspaceScopeSummary[]
+    | Promise<readonly WorkspaceScopeSummary[]>;
+  resolveManifestName?: ManifestNameResolver;
+}
+
+function isWindowsAbsolute(input: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(input);
+}
+
+function pathApi(input: string): typeof path.posix {
+  return isWindowsAbsolute(input) ? path.win32 : path.posix;
+}
+
+/**
+ * Resolve with the input path's own flavor so mixed Windows separators remain
+ * comparable even when the test process (or a future remote host) is POSIX.
+ */
+export function canonicalGraphPath(input: string): string {
+  const windows = isWindowsAbsolute(input);
+  const api = pathApi(input);
+  const normalizedInput = windows ? input.replace(/\//g, "\\") : input;
+  const resolved = api.resolve(normalizedInput);
+  const matchesHost = windows === (process.platform === "win32");
+  if (!matchesHost) return resolved;
+  try {
+    return realpathSync.native(resolved);
+  } catch {
+    return resolved;
+  }
+}
+
+export function isWithinGraphPath(root: string, candidate: string): boolean {
+  if (isWindowsAbsolute(root) !== isWindowsAbsolute(candidate)) return false;
+  const api = pathApi(root);
+  const relative = api.relative(root, candidate);
+  return (
+    relative === "" ||
+    (relative !== ".." &&
+      !relative.startsWith(`..${api.sep}`) &&
+      !api.isAbsolute(relative))
+  );
+}
+
+function graphPathIdentity(input: string): string {
+  const canonical = canonicalGraphPath(input).replace(/\\/g, "/");
+  return isWindowsAbsolute(input) ? canonical.toLowerCase() : canonical;
+}
+
+function pathDepth(input: string): number {
+  return input.split(/[\\/]/).filter(Boolean).length;
+}
+
+function workspaceRelativeLocalKey(
+  scopeRoot: string,
+  sourceRoot: string,
+): AgentKey {
+  const api = pathApi(scopeRoot);
+  const relative = api.relative(scopeRoot, sourceRoot);
+  const local =
+    relative === ""
+      ? api.basename(sourceRoot) || "root"
+      : relative.split(api.sep).join("/");
+  return `local:${local}`;
+}
+
+function normalizedAlias(value: string | null): string | null {
+  const alias = value?.trim() ?? "";
+  if (
+    alias === "" ||
+    /[\0\r\n]/.test(alias) ||
+    alias.includes("/") ||
+    alias.includes("\\") ||
+    path.posix.isAbsolute(alias) ||
+    path.win32.isAbsolute(alias)
+  ) {
+    return null;
+  }
+  return alias;
+}
+
+function safeLabel(value: string, fallback: string): string {
+  const label = value.trim();
+  if (
+    label === "" ||
+    /[\0\r\n]/.test(label) ||
+    path.posix.isAbsolute(label) ||
+    path.win32.isAbsolute(label)
+  ) {
+    return fallback;
+  }
+  return label;
+}
+
+function uniqueAliases(values: Array<string | null>): string[] {
+  return [
+    ...new Set(values.filter((value): value is string => value !== null)),
+  ];
+}
+
+interface KnownScope {
+  depth: number;
+  workspaceKey: WorkspaceKey;
+  root: string;
+}
+
+interface PreparedAgent {
+  candidateKey: AgentKey;
+  fallbackKey: AgentKey;
+  definitionId: number | null;
+  definitionSlug: string | null;
+  extractionFailed: boolean;
+  label: string;
+  resolutionAliases: string[];
+  sourceRoot: string;
+}
+
+function preparedOrder(left: PreparedAgent, right: PreparedAgent): number {
+  return (
+    left.candidateKey.localeCompare(right.candidateKey) ||
+    left.sourceRoot.localeCompare(right.sourceRoot) ||
+    left.label.localeCompare(right.label)
+  );
+}
+
+function warningOrder(
+  left: AgentInventoryWarning,
+  right: AgentInventoryWarning,
+): number {
+  return (
+    left.code.localeCompare(right.code) ||
+    left.agentKey.localeCompare(right.agentKey) ||
+    left.message.localeCompare(right.message)
+  );
+}
+
+/**
+ * V0 inventory adapter. WorkflowRegistry's scan/connect flows remain the only
+ * writers; this provider receives snapshots and performs no discovery or I/O
+ * beyond the injected, cached manifest-name lookup.
+ */
+export class HarnessRegistryInventoryProvider implements AgentInventoryProvider {
+  constructor(
+    private readonly options: HarnessRegistryInventoryProviderOptions,
+  ) {}
+
+  async listAgents(scope: WorkspaceScope): Promise<AgentInventoryResult> {
+    // A registry read is the one operation whose failure makes inventory
+    // unavailable. Scope-catalog and per-agent enrichment failures degrade.
+    const workflows = await this.options.listWorkflows();
+    const selectedScope: WorkspaceScope = {
+      workspaceKey: scope.workspaceKey,
+      root: canonicalGraphPath(scope.root),
+    };
+    const knownScopes = await this.knownScopes(selectedScope);
+
+    const owned = workflows
+      .map((workflow) => ({
+        workflow,
+        sourceRoot: canonicalGraphPath(workflow.path),
+      }))
+      .filter(({ sourceRoot }) => {
+        const owner = this.ownerOf(sourceRoot, knownScopes);
+        return owner?.workspaceKey === selectedScope.workspaceKey;
+      });
+
+    const prepared = (
+      await Promise.all(
+        owned.map(({ workflow, sourceRoot }) =>
+          this.prepareAgent(selectedScope, workflow, sourceRoot),
+        ),
+      )
+    ).sort(preparedOrder);
+
+    const candidateCounts = new Map<AgentKey, number>();
+    for (const agent of prepared) {
+      candidateCounts.set(
+        agent.candidateKey,
+        (candidateCounts.get(agent.candidateKey) ?? 0) + 1,
+      );
+    }
+
+    const used = new Set<AgentKey>();
+    const assigned = prepared.map((agent) => {
+      const duplicate = (candidateCounts.get(agent.candidateKey) ?? 0) > 1;
+      let agentKey = duplicate ? agent.fallbackKey : agent.candidateKey;
+      if (used.has(agentKey)) agentKey = agent.fallbackKey;
+      let suffix = 2;
+      const base = agentKey;
+      while (used.has(agentKey)) {
+        agentKey = `${base}~${suffix}`;
+        suffix += 1;
+      }
+      used.add(agentKey);
+      return { agent, agentKey };
+    });
+
+    const warnings: AgentInventoryWarning[] = [];
+    for (const candidateKey of [...candidateCounts.keys()].sort()) {
+      if ((candidateCounts.get(candidateKey) ?? 0) < 2) continue;
+      warnings.push({
+        code: "duplicate-agent-key",
+        agentKey: candidateKey,
+        message: `Multiple agents use ${candidateKey}; kept each with a local identity.`,
+      });
+    }
+    for (const { agent, agentKey } of assigned) {
+      if (!agent.extractionFailed) continue;
+      warnings.push({
+        code: "inventory-extraction-failed",
+        agentKey,
+        message: `Could not inspect ${agent.label}; using its local identity.`,
+      });
+    }
+
+    const agents = assigned
+      .map(
+        ({ agent, agentKey }): AgentInventoryItem => ({
+          agentKey,
+          definitionId: agent.definitionId,
+          definitionSlug: agent.definitionSlug,
+          label: agent.label,
+          resolutionAliases: agent.resolutionAliases,
+          sourceRoot: agent.sourceRoot,
+        }),
+      )
+      .sort(
+        (left, right) =>
+          left.agentKey.localeCompare(right.agentKey) ||
+          left.sourceRoot.localeCompare(right.sourceRoot),
+      );
+
+    warnings.sort(warningOrder);
+    return { agents, warnings };
+  }
+
+  private async knownScopes(scope: WorkspaceScope): Promise<KnownScope[]> {
+    let summaries: readonly WorkspaceScopeSummary[] = [];
+    try {
+      summaries = await this.options.listWorkspaceScopes();
+    } catch {
+      // The selected scope is sufficient for a usable partial inventory. A
+      // later uncached graph request can recover once settings are readable.
+    }
+
+    const byRoot = new Map<string, KnownScope>();
+    for (const summary of summaries) {
+      const root = canonicalGraphPath(summary.cwd);
+      byRoot.set(graphPathIdentity(root), {
+        depth: pathDepth(root),
+        workspaceKey: summary.workspaceKey,
+        root,
+      });
+    }
+    // The resolved endpoint scope is authoritative when a catalog snapshot
+    // happens to contain an equivalent raw path with a stale key.
+    byRoot.set(graphPathIdentity(scope.root), {
+      ...scope,
+      depth: pathDepth(scope.root),
+    });
+    return [...byRoot.values()];
+  }
+
+  private ownerOf(
+    sourceRoot: string,
+    scopes: readonly KnownScope[],
+  ): KnownScope | null {
+    return (
+      scopes
+        .filter((scope) => isWithinGraphPath(scope.root, sourceRoot))
+        .sort(
+          (left, right) =>
+            right.depth - left.depth ||
+            right.root.length - left.root.length ||
+            left.workspaceKey.localeCompare(right.workspaceKey),
+        )[0] ?? null
+    );
+  }
+
+  private async prepareAgent(
+    scope: WorkspaceScope,
+    workflow: WorkflowInfo,
+    sourceRoot: string,
+  ): Promise<PreparedAgent> {
+    const definitionSlug = normalizedAlias(workflow.definitionSlug);
+    let manifestName: string | null = null;
+    let extractionFailed = false;
+    if (!definitionSlug && this.options.resolveManifestName) {
+      try {
+        manifestName = normalizedAlias(
+          await this.options.resolveManifestName(sourceRoot),
+        );
+        extractionFailed = manifestName === null;
+      } catch {
+        extractionFailed = true;
+      }
+    }
+
+    const fallbackKey = workspaceRelativeLocalKey(scope.root, sourceRoot);
+    const candidateKey = definitionSlug ?? manifestName ?? fallbackKey;
+    // Keep the pre-disambiguation candidate as an alias for every copy. When
+    // duplicate local fallbacks exist, a caller targeting that candidate must
+    // see ambiguity rather than silently resolving to the unsuffixed copy.
+    const resolutionAliases = uniqueAliases([
+      definitionSlug,
+      manifestName,
+      candidateKey,
+    ]);
+    return {
+      candidateKey,
+      fallbackKey,
+      definitionId: workflow.definitionId,
+      definitionSlug,
+      extractionFailed,
+      label: safeLabel(
+        workflow.name,
+        definitionSlug ?? manifestName ?? "Local agent",
+      ),
+      resolutionAliases,
+      sourceRoot,
+    };
+  }
+}

--- a/packages/harness/src/core/system-graph-inventory.ts
+++ b/packages/harness/src/core/system-graph-inventory.ts
@@ -37,6 +37,8 @@ export interface AgentInventoryWarning {
 
 export interface AgentInventoryResult {
   agents: AgentInventoryItem[];
+  /** False when a later graph open should retry degraded enrichment. */
+  cacheable: boolean;
   warnings: AgentInventoryWarning[];
 }
 
@@ -262,7 +264,7 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
         sourceRoot: canonicalGraphPath(workflow.path),
       }))
       .filter(({ sourceRoot }) => {
-        const owner = this.ownerOf(sourceRoot, knownScopes);
+        const owner = this.ownerOf(sourceRoot, knownScopes.scopes);
         return owner?.workspaceKey === selectedScope.workspaceKey;
       });
 
@@ -343,14 +345,24 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
       );
 
     warnings.sort(warningOrder);
-    return { agents, warnings };
+    return {
+      agents,
+      cacheable:
+        knownScopes.cacheable &&
+        prepared.every((agent) => !agent.extractionFailed),
+      warnings,
+    };
   }
 
-  private async knownScopes(scope: WorkspaceScope): Promise<KnownScope[]> {
+  private async knownScopes(
+    scope: WorkspaceScope,
+  ): Promise<{ cacheable: boolean; scopes: KnownScope[] }> {
     let summaries: readonly WorkspaceScopeSummary[] = [];
+    let cacheable = true;
     try {
       summaries = await this.options.listWorkspaceScopes();
     } catch {
+      cacheable = false;
       // The selected scope is sufficient for a usable partial inventory. A
       // later uncached graph request can recover once settings are readable.
     }
@@ -370,7 +382,7 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
       ...scope,
       depth: pathDepth(scope.root),
     });
-    return [...byRoot.values()];
+    return { cacheable, scopes: [...byRoot.values()] };
   }
 
   private ownerOf(

--- a/packages/harness/src/core/system-graph-inventory.ts
+++ b/packages/harness/src/core/system-graph-inventory.ts
@@ -8,6 +8,7 @@ import type {
   WorkspaceScopeSummary,
 } from "../shared/system-graph.js";
 import type { WorkflowInfo } from "../shared/types.js";
+import type { ManifestNameInspection } from "./definition-name.js";
 
 export interface WorkspaceScope {
   workspaceKey: WorkspaceKey;
@@ -16,6 +17,7 @@ export interface WorkspaceScope {
 
 export interface AgentInventoryItem {
   agentKey: AgentKey;
+  /** Internal deployment provenance. Never serialize this into SystemGraph. */
   definitionId: number | null;
   definitionSlug: string | null;
   label: string;
@@ -43,7 +45,9 @@ export interface AgentInventoryProvider {
   listAgents(scope: WorkspaceScope): Promise<AgentInventoryResult>;
 }
 
-type ManifestNameResolver = (sourceRoot: string) => Promise<string | null>;
+type ManifestNameInspector = (
+  sourceRoot: string,
+) => Promise<ManifestNameInspection>;
 
 export interface HarnessRegistryInventoryProviderOptions {
   listWorkflows: () =>
@@ -52,7 +56,31 @@ export interface HarnessRegistryInventoryProviderOptions {
   listWorkspaceScopes: () =>
     | readonly WorkspaceScopeSummary[]
     | Promise<readonly WorkspaceScopeSummary[]>;
-  resolveManifestName?: ManifestNameResolver;
+  inspectManifestName?: ManifestNameInspector;
+}
+
+const MANIFEST_INSPECTION_CONCURRENCY = 4;
+
+async function mapWithConcurrency<Input, Output>(
+  values: readonly Input[],
+  concurrency: number,
+  map: (value: Input) => Promise<Output>,
+): Promise<Output[]> {
+  const results = new Array<Output>(values.length);
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    while (nextIndex < values.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await map(values[index]!);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, async () =>
+      worker(),
+    ),
+  );
+  return results;
 }
 
 function isWindowsAbsolute(input: string): boolean {
@@ -102,7 +130,7 @@ function pathDepth(input: string): number {
   return input.split(/[\\/]/).filter(Boolean).length;
 }
 
-function workspaceRelativeLocalKey(
+export function workspaceRelativeLocalKey(
   scopeRoot: string,
   sourceRoot: string,
 ): AgentKey {
@@ -187,8 +215,9 @@ function warningOrder(
 
 /**
  * V0 inventory adapter. WorkflowRegistry's scan/connect flows remain the only
- * writers; this provider receives snapshots and performs no discovery or I/O
- * beyond the injected, cached manifest-name lookup.
+ * writers; this provider receives snapshots and performs no discovery. The
+ * injected manifest-name inspection may run cached extraction, so enrichment
+ * is bounded to avoid unbounded child-process fan-out on a cold graph open.
  */
 export class HarnessRegistryInventoryProvider implements AgentInventoryProvider {
   constructor(
@@ -216,10 +245,11 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
       });
 
     const prepared = (
-      await Promise.all(
-        owned.map(({ workflow, sourceRoot }) =>
+      await mapWithConcurrency(
+        owned,
+        MANIFEST_INSPECTION_CONCURRENCY,
+        ({ workflow, sourceRoot }) =>
           this.prepareAgent(selectedScope, workflow, sourceRoot),
-        ),
       )
     ).sort(preparedOrder);
 
@@ -336,12 +366,14 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
     const definitionSlug = normalizedAlias(workflow.definitionSlug);
     let manifestName: string | null = null;
     let extractionFailed = false;
-    if (!definitionSlug && this.options.resolveManifestName) {
+    if (!definitionSlug && this.options.inspectManifestName) {
       try {
-        manifestName = normalizedAlias(
-          await this.options.resolveManifestName(sourceRoot),
-        );
-        extractionFailed = manifestName === null;
+        const inspected = await this.options.inspectManifestName(sourceRoot);
+        if (inspected.status === "found") {
+          manifestName = normalizedAlias(inspected.name);
+        } else {
+          extractionFailed = inspected.status === "failed";
+        }
       } catch {
         extractionFailed = true;
       }
@@ -365,7 +397,9 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
       extractionFailed,
       label: safeLabel(
         workflow.name,
-        definitionSlug ?? manifestName ?? "Local agent",
+        definitionSlug ??
+          manifestName ??
+          (fallbackKey.slice("local:".length) || "Local agent"),
       ),
       resolutionAliases,
       sourceRoot,

--- a/packages/harness/src/core/system-graph-store.test.ts
+++ b/packages/harness/src/core/system-graph-store.test.ts
@@ -6,7 +6,10 @@ import type {
   SystemGraphBuildResult,
   WorkspaceScope,
 } from "./system-graph.js";
-import { SystemGraphStore } from "./system-graph-store.js";
+import {
+  SystemGraphStore,
+  type StoredSystemGraph,
+} from "./system-graph-store.js";
 
 const scope: WorkspaceScope = {
   workspaceKey: "workspace-one",
@@ -24,6 +27,10 @@ function buildResult(cacheable = true): SystemGraphBuildResult {
   return { cacheable, graph };
 }
 
+function storedResult(degraded = false): StoredSystemGraph {
+  return { graph, degraded };
+}
+
 describe("SystemGraphStore", () => {
   it("coalesces concurrent and sequential reads for an unchanged workspace", async () => {
     let resolveBuild!: (value: SystemGraphBuildResult) => void;
@@ -37,8 +44,8 @@ describe("SystemGraphStore", () => {
     const concurrent = store.get(scope);
     expect(first).toBe(concurrent);
     resolveBuild(buildResult());
-    await expect(first).resolves.toBe(graph);
-    await expect(store.get(scope)).resolves.toBe(graph);
+    await expect(first).resolves.toEqual(storedResult());
+    await expect(store.get(scope)).resolves.toEqual(storedResult());
     expect(builder.build).toHaveBeenCalledTimes(1);
   });
 
@@ -52,7 +59,7 @@ describe("SystemGraphStore", () => {
     const store = new SystemGraphStore(builder);
 
     await expect(store.get(scope)).rejects.toThrow("scan failed");
-    await expect(store.get(scope)).resolves.toBe(graph);
+    await expect(store.get(scope)).resolves.toEqual(storedResult());
     expect(builder.build).toHaveBeenCalledTimes(2);
   });
 
@@ -67,7 +74,7 @@ describe("SystemGraphStore", () => {
     expect(builder.build).toHaveBeenCalledTimes(2);
   });
 
-  it("coalesces but does not retain a degraded graph", async () => {
+  it("coalesces a degraded graph and allows one later re-enrichment", async () => {
     const build = vi
       .fn()
       .mockResolvedValueOnce(buildResult(false))
@@ -77,8 +84,51 @@ describe("SystemGraphStore", () => {
     const first = store.get(scope);
     const concurrent = store.get(scope);
     expect(first).toBe(concurrent);
-    await expect(first).resolves.toBe(graph);
-    await expect(store.get(scope)).resolves.toBe(graph);
+    await expect(first).resolves.toEqual(storedResult(true));
+    await expect(store.get(scope)).resolves.toEqual(storedResult());
     expect(build).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains the second degraded graph until explicit invalidation", async () => {
+    const build = vi.fn(async () => buildResult(false));
+    const store = new SystemGraphStore({ build });
+
+    await expect(store.get(scope)).resolves.toEqual(storedResult(true));
+    const second = store.get(scope);
+    await expect(second).resolves.toEqual(storedResult(true));
+    expect(store.get(scope)).toBe(second);
+    expect(build).toHaveBeenCalledTimes(2);
+
+    store.invalidate(scope.workspaceKey);
+    await expect(store.get(scope)).resolves.toEqual(storedResult(true));
+    expect(build).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not let an invalidated in-flight build consume the retry", async () => {
+    let resolveFirst!: (value: SystemGraphBuildResult) => void;
+    let resolveSecond!: (value: SystemGraphBuildResult) => void;
+    const firstBuild = new Promise<SystemGraphBuildResult>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const secondBuild = new Promise<SystemGraphBuildResult>((resolve) => {
+      resolveSecond = resolve;
+    });
+    const build = vi
+      .fn()
+      .mockReturnValueOnce(firstBuild)
+      .mockReturnValueOnce(secondBuild)
+      .mockResolvedValueOnce(buildResult());
+    const store = new SystemGraphStore({ build });
+
+    const stale = store.get(scope);
+    store.invalidate(scope.workspaceKey);
+    const current = store.get(scope);
+    resolveFirst(buildResult(false));
+    await stale;
+    resolveSecond(buildResult(false));
+    await current;
+
+    await expect(store.get(scope)).resolves.toEqual(storedResult());
+    expect(build).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/harness/src/core/system-graph-store.test.ts
+++ b/packages/harness/src/core/system-graph-store.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { SystemGraph } from "../shared/system-graph.js";
-import type { SystemGraphBuilder, WorkspaceScope } from "./system-graph.js";
+import type {
+  SystemGraphBuilder,
+  SystemGraphBuildResult,
+  WorkspaceScope,
+} from "./system-graph.js";
 import { SystemGraphStore } from "./system-graph-store.js";
 
 const scope: WorkspaceScope = {
@@ -16,10 +20,14 @@ const graph: SystemGraph = {
   warnings: [],
 };
 
+function buildResult(cacheable = true): SystemGraphBuildResult {
+  return { cacheable, graph };
+}
+
 describe("SystemGraphStore", () => {
   it("coalesces concurrent and sequential reads for an unchanged workspace", async () => {
-    let resolveBuild!: (value: SystemGraph) => void;
-    const pending = new Promise<SystemGraph>((resolve) => {
+    let resolveBuild!: (value: SystemGraphBuildResult) => void;
+    const pending = new Promise<SystemGraphBuildResult>((resolve) => {
       resolveBuild = resolve;
     });
     const builder: SystemGraphBuilder = { build: vi.fn(() => pending) };
@@ -28,7 +36,7 @@ describe("SystemGraphStore", () => {
     const first = store.get(scope);
     const concurrent = store.get(scope);
     expect(first).toBe(concurrent);
-    resolveBuild(graph);
+    resolveBuild(buildResult());
     await expect(first).resolves.toBe(graph);
     await expect(store.get(scope)).resolves.toBe(graph);
     expect(builder.build).toHaveBeenCalledTimes(1);
@@ -39,7 +47,7 @@ describe("SystemGraphStore", () => {
       build: vi
         .fn()
         .mockRejectedValueOnce(new Error("scan failed"))
-        .mockResolvedValueOnce(graph),
+        .mockResolvedValueOnce(buildResult()),
     };
     const store = new SystemGraphStore(builder);
 
@@ -49,11 +57,28 @@ describe("SystemGraphStore", () => {
   });
 
   it("supports explicit invalidation without coupling it to UI opens", async () => {
-    const builder: SystemGraphBuilder = { build: vi.fn(async () => graph) };
+    const builder: SystemGraphBuilder = {
+      build: vi.fn(async () => buildResult()),
+    };
     const store = new SystemGraphStore(builder);
     await store.get(scope);
     store.invalidate(scope.workspaceKey);
     await store.get(scope);
     expect(builder.build).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces but does not retain a degraded graph", async () => {
+    const build = vi
+      .fn()
+      .mockResolvedValueOnce(buildResult(false))
+      .mockResolvedValueOnce(buildResult());
+    const store = new SystemGraphStore({ build });
+
+    const first = store.get(scope);
+    const concurrent = store.get(scope);
+    expect(first).toBe(concurrent);
+    await expect(first).resolves.toBe(graph);
+    await expect(store.get(scope)).resolves.toBe(graph);
+    expect(build).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/harness/src/core/system-graph-store.ts
+++ b/packages/harness/src/core/system-graph-store.ts
@@ -1,24 +1,39 @@
 import type { SystemGraph, WorkspaceKey } from "../shared/system-graph.js";
 import type { SystemGraphBuilder, WorkspaceScope } from "./system-graph.js";
 
-/** Read-through cache. Promises coalesce concurrent opens, even when a
- * degraded result is intentionally evicted as soon as it resolves. */
+export interface StoredSystemGraph {
+  graph: SystemGraph;
+  degraded: boolean;
+}
+
+/** Read-through cache. Promises coalesce concurrent opens. A degraded first
+ * read gets one later re-enrichment; its second result is retained so a
+ * permanent inspection failure cannot charge every workspace open. */
 export class SystemGraphStore {
-  private readonly entries = new Map<WorkspaceKey, Promise<SystemGraph>>();
+  private readonly entries = new Map<
+    WorkspaceKey,
+    Promise<StoredSystemGraph>
+  >();
+  private readonly degradedRetries = new Set<WorkspaceKey>();
 
   constructor(private readonly builder: SystemGraphBuilder) {}
 
-  get(scope: WorkspaceScope): Promise<SystemGraph> {
+  get(scope: WorkspaceScope): Promise<StoredSystemGraph> {
     const existing = this.entries.get(scope.workspaceKey);
     if (existing) return existing;
 
-    let building: Promise<SystemGraph>;
+    let building: Promise<StoredSystemGraph>;
     try {
       building = this.builder.build(scope).then(({ cacheable, graph }) => {
-        if (!cacheable && this.entries.get(scope.workspaceKey) === building) {
-          this.entries.delete(scope.workspaceKey);
+        if (this.entries.get(scope.workspaceKey) === building) {
+          if (cacheable) {
+            this.degradedRetries.delete(scope.workspaceKey);
+          } else if (!this.degradedRetries.has(scope.workspaceKey)) {
+            this.degradedRetries.add(scope.workspaceKey);
+            this.entries.delete(scope.workspaceKey);
+          }
         }
-        return graph;
+        return { graph, degraded: !cacheable };
       });
     } catch (err) {
       building = Promise.reject(err);
@@ -34,9 +49,11 @@ export class SystemGraphStore {
 
   invalidate(workspaceKey: WorkspaceKey): void {
     this.entries.delete(workspaceKey);
+    this.degradedRetries.delete(workspaceKey);
   }
 
   clear(): void {
     this.entries.clear();
+    this.degradedRetries.clear();
   }
 }

--- a/packages/harness/src/core/system-graph-store.ts
+++ b/packages/harness/src/core/system-graph-store.ts
@@ -1,7 +1,8 @@
 import type { SystemGraph, WorkspaceKey } from "../shared/system-graph.js";
 import type { SystemGraphBuilder, WorkspaceScope } from "./system-graph.js";
 
-/** Process-lifetime read-through cache. Promises coalesce concurrent opens. */
+/** Read-through cache. Promises coalesce concurrent opens, even when a
+ * degraded result is intentionally evicted as soon as it resolves. */
 export class SystemGraphStore {
   private readonly entries = new Map<WorkspaceKey, Promise<SystemGraph>>();
 
@@ -13,7 +14,12 @@ export class SystemGraphStore {
 
     let building: Promise<SystemGraph>;
     try {
-      building = this.builder.build(scope);
+      building = this.builder.build(scope).then(({ cacheable, graph }) => {
+        if (!cacheable && this.entries.get(scope.workspaceKey) === building) {
+          this.entries.delete(scope.workspaceKey);
+        }
+        return graph;
+      });
     } catch (err) {
       building = Promise.reject(err);
     }

--- a/packages/harness/src/core/system-graph.test.ts
+++ b/packages/harness/src/core/system-graph.test.ts
@@ -31,6 +31,13 @@ function workflow(
   };
 }
 
+async function buildGraph(
+  builder: StaticSystemGraphBuilder,
+  scope: WorkspaceScope,
+) {
+  return (await builder.build(scope)).graph;
+}
+
 describe("LocalWorkspaceScopeCatalog", () => {
   it("gives a canonical root a stable opaque key and rejects unknown keys", async () => {
     const catalog = new LocalWorkspaceScopeCatalog(() => [
@@ -87,7 +94,10 @@ describe("StaticSystemGraphBuilder", () => {
       ],
     });
 
-    const graph = await new StaticSystemGraphBuilder(inventory).build(scope);
+    const graph = await buildGraph(
+      new StaticSystemGraphBuilder(inventory),
+      scope,
+    );
 
     expect(graph).toEqual({
       kind: "system",
@@ -131,6 +141,7 @@ describe("StaticSystemGraphBuilder", () => {
             sourceRoot: "/private/growth",
           },
         ],
+        cacheable: true,
         warnings: [],
       })),
     };
@@ -145,7 +156,8 @@ describe("StaticSystemGraphBuilder", () => {
         : [],
     );
 
-    const graph = await new StaticSystemGraphBuilder(inventory, detect).build(
+    const graph = await buildGraph(
+      new StaticSystemGraphBuilder(inventory, detect),
       scope,
     );
     expect(graph.edges).toHaveLength(1);
@@ -171,7 +183,8 @@ describe("StaticSystemGraphBuilder", () => {
       root.endsWith("caller") ? [{ slug: "shared", fromStepId: null }] : [],
     );
 
-    const graph = await new StaticSystemGraphBuilder(inventory, detect).build(
+    const graph = await buildGraph(
+      new StaticSystemGraphBuilder(inventory, detect),
       scope,
     );
 
@@ -234,14 +247,18 @@ describe("StaticSystemGraphBuilder", () => {
             sourceRoot: "/outside/private-agent",
           },
         ],
+        cacheable: true,
         warnings: [],
       })),
     };
 
-    const graph = await new StaticSystemGraphBuilder(
-      inventory,
-      vi.fn(async () => []),
-    ).build(scope);
+    const graph = await buildGraph(
+      new StaticSystemGraphBuilder(
+        inventory,
+        vi.fn(async () => []),
+      ),
+      scope,
+    );
 
     expect(graph.nodes).toHaveLength(4);
     expect(new Set(graph.nodes.map((node) => node.id)).size).toBe(4);
@@ -293,15 +310,19 @@ describe("StaticSystemGraphBuilder", () => {
             sourceRoot: "/private/research",
           },
         ],
+        cacheable: true,
         warnings: [],
       })),
     };
-    const graph = await new StaticSystemGraphBuilder(
-      inventory,
-      vi.fn(async () => {
-        throw new Error("boom at /private/research");
-      }),
-    ).build(scope);
+    const graph = await buildGraph(
+      new StaticSystemGraphBuilder(
+        inventory,
+        vi.fn(async () => {
+          throw new Error("boom at /private/research");
+        }),
+      ),
+      scope,
+    );
 
     expect(graph.warnings).toEqual([
       {
@@ -330,10 +351,13 @@ describe("StaticSystemGraphBuilder", () => {
       })),
     });
 
-    const graph = await new StaticSystemGraphBuilder(
-      inventory,
-      vi.fn(async () => []),
-    ).build(scope);
+    const graph = await buildGraph(
+      new StaticSystemGraphBuilder(
+        inventory,
+        vi.fn(async () => []),
+      ),
+      scope,
+    );
 
     expect(graph.nodes).toEqual([
       {
@@ -367,6 +391,7 @@ describe("StaticSystemGraphBuilder", () => {
             sourceRoot: "/private/reporting",
           },
         ],
+        cacheable: true,
         warnings: [
           {
             code: "inventory-extraction-failed" as const,
@@ -377,10 +402,13 @@ describe("StaticSystemGraphBuilder", () => {
       })),
     };
 
-    const graph = await new StaticSystemGraphBuilder(
-      inventory,
-      vi.fn(async () => []),
-    ).build(scope);
+    const graph = await buildGraph(
+      new StaticSystemGraphBuilder(
+        inventory,
+        vi.fn(async () => []),
+      ),
+      scope,
+    );
 
     expect(graph.nodes.map((node) => node.agentKey)).toEqual([
       "local:reporting",
@@ -395,5 +423,30 @@ describe("StaticSystemGraphBuilder", () => {
       },
     ]);
     expect(JSON.stringify(graph)).not.toContain("/private/");
+  });
+
+  it("keeps degraded cache policy outside the public graph contract", async () => {
+    const inventory: AgentInventoryProvider = {
+      listAgents: vi.fn(async () => ({
+        agents: [],
+        cacheable: false,
+        warnings: [],
+      })),
+    };
+
+    const built = await new StaticSystemGraphBuilder(
+      inventory,
+      vi.fn(async () => []),
+    ).build(scope);
+
+    expect(built.cacheable).toBe(false);
+    expect(built.graph).toEqual({
+      kind: "system",
+      scope: { kind: "working-tree", workspaceKey: scope.workspaceKey },
+      nodes: [],
+      edges: [],
+      warnings: [],
+    });
+    expect(built.graph).not.toHaveProperty("cacheable");
   });
 });

--- a/packages/harness/src/core/system-graph.test.ts
+++ b/packages/harness/src/core/system-graph.test.ts
@@ -4,10 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { WorkflowInfo } from "../shared/types.js";
 import {
+  HarnessRegistryInventoryProvider,
   LocalWorkspaceScopeCatalog,
   StaticSystemGraphBuilder,
-  WorkflowRegistryInventoryReader,
-  type LocalAgentInventoryReader,
+  type AgentInventoryProvider,
   type WorkspaceScope,
 } from "./system-graph.js";
 
@@ -70,37 +70,6 @@ describe("LocalWorkspaceScopeCatalog", () => {
   });
 });
 
-describe("WorkflowRegistryInventoryReader", () => {
-  it("filters to the workspace boundary and uses a package-relative fallback key", async () => {
-    const workflows = [
-      workflow("Research", "research", "research"),
-      workflow("Growth local", "growth", null),
-      {
-        ...workflow("Outside", "outside", "outside"),
-        path: `${FIXTURE}-elsewhere/outside`,
-      },
-    ];
-    const reader = new WorkflowRegistryInventoryReader(() => workflows);
-
-    await expect(
-      reader.list({ workspaceKey: "workspace-test", root: FIXTURE }),
-    ).resolves.toEqual([
-      {
-        agentKey: "local:growth",
-        definitionSlug: null,
-        label: "Growth local",
-        sourceRoot: path.join(FIXTURE, "growth"),
-      },
-      {
-        agentKey: "research",
-        definitionSlug: "research",
-        label: "Research",
-        sourceRoot: path.join(FIXTURE, "research"),
-      },
-    ]);
-  });
-});
-
 describe("StaticSystemGraphBuilder", () => {
   const scope: WorkspaceScope = {
     workspaceKey: "workspace-fixture",
@@ -108,12 +77,17 @@ describe("StaticSystemGraphBuilder", () => {
   };
 
   it("projects the literal Research -> Growth launch into the public contract", async () => {
-    const reader = new WorkflowRegistryInventoryReader(() => [
-      workflow("Research", "research", "research"),
-      workflow("Growth", "growth", "growth"),
-    ]);
+    const inventory = new HarnessRegistryInventoryProvider({
+      listWorkflows: () => [
+        workflow("Research", "research", "research"),
+        workflow("Growth", "growth", "growth"),
+      ],
+      listWorkspaceScopes: () => [
+        { workspaceKey: scope.workspaceKey, cwd: scope.root },
+      ],
+    });
 
-    const graph = await new StaticSystemGraphBuilder(reader).build(scope);
+    const graph = await new StaticSystemGraphBuilder(inventory).build(scope);
 
     expect(graph).toEqual({
       kind: "system",
@@ -137,21 +111,28 @@ describe("StaticSystemGraphBuilder", () => {
   });
 
   it("deduplicates edges, skips self-links, and reports unresolved targets deterministically", async () => {
-    const inventory: LocalAgentInventoryReader = {
-      list: vi.fn(async () => [
-        {
-          agentKey: "research",
-          definitionSlug: "research",
-          label: "Research",
-          sourceRoot: "/private/research",
-        },
-        {
-          agentKey: "growth",
-          definitionSlug: "growth",
-          label: "Growth",
-          sourceRoot: "/private/growth",
-        },
-      ]),
+    const inventory: AgentInventoryProvider = {
+      listAgents: vi.fn(async () => ({
+        agents: [
+          {
+            agentKey: "research",
+            definitionId: 1,
+            definitionSlug: "research",
+            label: "Research",
+            resolutionAliases: ["research"],
+            sourceRoot: "/private/research",
+          },
+          {
+            agentKey: "growth",
+            definitionId: 2,
+            definitionSlug: "growth",
+            label: "Growth",
+            resolutionAliases: ["growth"],
+            sourceRoot: "/private/growth",
+          },
+        ],
+        warnings: [],
+      })),
     };
     const detect = vi.fn(async (root: string) =>
       root.endsWith("research")
@@ -176,32 +157,18 @@ describe("StaticSystemGraphBuilder", () => {
   });
 
   it("keeps duplicate definition slugs as unique nodes and reports ambiguous launches", async () => {
-    const inventory: LocalAgentInventoryReader = {
-      list: vi.fn(async () => [
-        {
-          agentKey: "caller",
-          definitionSlug: "caller",
-          label: "Caller",
-          sourceRoot: path.join(FIXTURE, "caller"),
-        },
-        {
-          agentKey: "shared",
-          definitionSlug: "shared",
-          label: "First copy",
-          sourceRoot: path.join(FIXTURE, "growth"),
-        },
-        {
-          agentKey: "shared",
-          definitionSlug: "shared",
-          label: "Second copy",
-          sourceRoot: path.join(FIXTURE, "research"),
-        },
-      ]),
-    };
+    const inventory = new HarnessRegistryInventoryProvider({
+      listWorkflows: () => [
+        workflow("Caller", "caller", "caller"),
+        workflow("First copy", "growth", "shared"),
+        workflow("Second copy", "research", "shared"),
+      ],
+      listWorkspaceScopes: () => [
+        { workspaceKey: scope.workspaceKey, cwd: scope.root },
+      ],
+    });
     const detect = vi.fn(async (root: string) =>
-      root.endsWith("caller")
-        ? [{ slug: "shared", fromStepId: null }]
-        : [],
+      root.endsWith("caller") ? [{ slug: "shared", fromStepId: null }] : [],
     );
 
     const graph = await new StaticSystemGraphBuilder(inventory, detect).build(
@@ -217,6 +184,11 @@ describe("StaticSystemGraphBuilder", () => {
     expect(graph.edges).toEqual([]);
     expect(graph.warnings).toEqual([
       {
+        code: "duplicate-agent-key",
+        agentKey: "shared",
+        message: "Multiple agents use shared; kept each with a local identity.",
+      },
+      {
         code: "unresolved-target",
         agentKey: "caller",
         message: "Caller invokes ambiguous agent shared.",
@@ -226,15 +198,20 @@ describe("StaticSystemGraphBuilder", () => {
   });
 
   it("degrades a scanner failure into a path-free warning", async () => {
-    const inventory: LocalAgentInventoryReader = {
-      list: vi.fn(async () => [
-        {
-          agentKey: "research",
-          definitionSlug: "research",
-          label: "Research",
-          sourceRoot: "/private/research",
-        },
-      ]),
+    const inventory: AgentInventoryProvider = {
+      listAgents: vi.fn(async () => ({
+        agents: [
+          {
+            agentKey: "research",
+            definitionId: 1,
+            definitionSlug: "research",
+            label: "Research",
+            resolutionAliases: ["research"],
+            sourceRoot: "/private/research",
+          },
+        ],
+        warnings: [],
+      })),
     };
     const graph = await new StaticSystemGraphBuilder(
       inventory,
@@ -248,6 +225,93 @@ describe("StaticSystemGraphBuilder", () => {
         code: "projection-failed",
         agentKey: "research",
         message: "Could not inspect Research.",
+      },
+    ]);
+    expect(JSON.stringify(graph)).not.toContain("/private/");
+  });
+
+  it("keeps path-shaped registry and extraction values out of the public graph", async () => {
+    const inventory = new HarnessRegistryInventoryProvider({
+      listWorkflows: () => [
+        {
+          ...workflow(FIXTURE, "reporting", FIXTURE),
+          definitionId: null,
+        },
+      ],
+      listWorkspaceScopes: () => [
+        { workspaceKey: scope.workspaceKey, cwd: scope.root },
+      ],
+      resolveManifestName: vi.fn(async () => FIXTURE),
+    });
+
+    const graph = await new StaticSystemGraphBuilder(
+      inventory,
+      vi.fn(async () => []),
+    ).build(scope);
+
+    expect(graph.nodes).toEqual([
+      {
+        id: "agent:local:reporting",
+        agentKey: "local:reporting",
+        label: "Local agent",
+      },
+    ]);
+    expect(graph.warnings).toEqual([
+      {
+        code: "inventory-extraction-failed",
+        agentKey: "local:reporting",
+        message: "Could not inspect Local agent; using its local identity.",
+      },
+    ]);
+    expect(JSON.stringify(graph)).not.toContain(FIXTURE);
+  });
+
+  it("projects disconnected inventory nodes and merges inventory warnings", async () => {
+    const inventory: AgentInventoryProvider = {
+      listAgents: vi.fn(async () => ({
+        agents: [
+          {
+            agentKey: "research",
+            definitionId: 1,
+            definitionSlug: "research",
+            label: "Research",
+            resolutionAliases: ["research"],
+            sourceRoot: "/private/research",
+          },
+          {
+            agentKey: "local:reporting",
+            definitionId: null,
+            definitionSlug: null,
+            label: "Reporting",
+            resolutionAliases: [],
+            sourceRoot: "/private/reporting",
+          },
+        ],
+        warnings: [
+          {
+            code: "inventory-extraction-failed" as const,
+            agentKey: "local:reporting",
+            message: "Could not inspect Reporting; using its local identity.",
+          },
+        ],
+      })),
+    };
+
+    const graph = await new StaticSystemGraphBuilder(
+      inventory,
+      vi.fn(async () => []),
+    ).build(scope);
+
+    expect(graph.nodes.map((node) => node.agentKey)).toEqual([
+      "local:reporting",
+      "research",
+    ]);
+    expect(graph.edges).toEqual([]);
+    expect(graph.warnings).toEqual([
+      {
+        code: "inventory-extraction-failed",
+        agentKey: "local:reporting",
+        message: "Could not inspect Reporting; using its local identity.",
       },
     ]);
     expect(JSON.stringify(graph)).not.toContain("/private/");

--- a/packages/harness/src/core/system-graph.test.ts
+++ b/packages/harness/src/core/system-graph.test.ts
@@ -202,20 +202,28 @@ describe("StaticSystemGraphBuilder", () => {
       listAgents: vi.fn(async () => ({
         agents: [
           {
-            agentKey: "shared",
+            agentKey: "alpha",
             definitionId: null,
-            definitionSlug: "shared",
+            definitionSlug: "alpha",
             label: "/private/first",
-            resolutionAliases: ["shared"],
+            resolutionAliases: ["alpha"],
             sourceRoot: path.join(FIXTURE, "growth"),
           },
           {
-            agentKey: "shared",
+            agentKey: "alpha",
             definitionId: null,
-            definitionSlug: "shared",
+            definitionSlug: "alpha",
             label: "C:\\Users\\Demo\\second",
-            resolutionAliases: ["shared"],
+            resolutionAliases: ["alpha"],
             sourceRoot: path.join(FIXTURE, "research"),
+          },
+          {
+            agentKey: "local:growth",
+            definitionId: null,
+            definitionSlug: null,
+            label: "Caller",
+            resolutionAliases: ["local:growth"],
+            sourceRoot: path.join(FIXTURE, "caller"),
           },
           {
             agentKey: "/private/leaked-key",
@@ -235,23 +243,37 @@ describe("StaticSystemGraphBuilder", () => {
       vi.fn(async () => []),
     ).build(scope);
 
-    expect(graph.nodes).toHaveLength(3);
-    expect(new Set(graph.nodes.map((node) => node.id)).size).toBe(3);
-    expect(graph.nodes.map((node) => node.agentKey)).toEqual([
-      expect.stringMatching(/^local:[a-f0-9]{16}$/),
-      "local:growth",
-      "local:research",
-    ]);
-    expect(graph.nodes.map((node) => node.label)).toEqual([
-      expect.stringMatching(/^[a-f0-9]{16}$/),
-      "growth",
-      "research",
-    ]);
+    expect(graph.nodes).toHaveLength(4);
+    expect(new Set(graph.nodes.map((node) => node.id)).size).toBe(4);
+    const byKey = new Map(graph.nodes.map((node) => [node.agentKey, node]));
+    expect([...byKey.keys()]).toEqual(
+      expect.arrayContaining([
+        "local:caller",
+        "local:growth",
+        "local:research",
+      ]),
+    );
+    const hashedKey = [...byKey.keys()].find((key) =>
+      /^local:[a-f0-9]{16}$/.test(key),
+    );
+    expect(hashedKey).toBeDefined();
+    expect(byKey.get(hashedKey!)?.label).toBe(
+      hashedKey!.slice("local:".length),
+    );
+    expect(byKey.get("local:caller")?.label).toBe("Caller");
+    expect(byKey.get("local:growth")?.label).toBe("growth");
+    expect(byKey.get("local:research")?.label).toBe("research");
     expect(graph.warnings).toEqual([
       {
         code: "duplicate-agent-key",
-        agentKey: "shared",
-        message: "Multiple agents use shared; kept each with a local identity.",
+        agentKey: "alpha",
+        message: "Multiple agents use alpha; kept each with a local identity.",
+      },
+      {
+        code: "duplicate-agent-key",
+        agentKey: "local:growth",
+        message:
+          "Multiple agents use local:growth; kept each with a local identity.",
       },
     ]);
     expect(JSON.stringify(graph)).not.toContain("/private/");

--- a/packages/harness/src/core/system-graph.test.ts
+++ b/packages/harness/src/core/system-graph.test.ts
@@ -197,6 +197,67 @@ describe("StaticSystemGraphBuilder", () => {
     expect(JSON.stringify(graph)).not.toContain(FIXTURE);
   });
 
+  it("reasserts safe unique node identities for an arbitrary inventory provider", async () => {
+    const inventory: AgentInventoryProvider = {
+      listAgents: vi.fn(async () => ({
+        agents: [
+          {
+            agentKey: "shared",
+            definitionId: null,
+            definitionSlug: "shared",
+            label: "/private/first",
+            resolutionAliases: ["shared"],
+            sourceRoot: path.join(FIXTURE, "growth"),
+          },
+          {
+            agentKey: "shared",
+            definitionId: null,
+            definitionSlug: "shared",
+            label: "C:\\Users\\Demo\\second",
+            resolutionAliases: ["shared"],
+            sourceRoot: path.join(FIXTURE, "research"),
+          },
+          {
+            agentKey: "/private/leaked-key",
+            definitionId: null,
+            definitionSlug: null,
+            label: "/private/leaked-label",
+            resolutionAliases: ["/private/leaked-alias"],
+            sourceRoot: "/outside/private-agent",
+          },
+        ],
+        warnings: [],
+      })),
+    };
+
+    const graph = await new StaticSystemGraphBuilder(
+      inventory,
+      vi.fn(async () => []),
+    ).build(scope);
+
+    expect(graph.nodes).toHaveLength(3);
+    expect(new Set(graph.nodes.map((node) => node.id)).size).toBe(3);
+    expect(graph.nodes.map((node) => node.agentKey)).toEqual([
+      expect.stringMatching(/^local:[a-f0-9]{16}$/),
+      "local:growth",
+      "local:research",
+    ]);
+    expect(graph.nodes.map((node) => node.label)).toEqual([
+      expect.stringMatching(/^[a-f0-9]{16}$/),
+      "growth",
+      "research",
+    ]);
+    expect(graph.warnings).toEqual([
+      {
+        code: "duplicate-agent-key",
+        agentKey: "shared",
+        message: "Multiple agents use shared; kept each with a local identity.",
+      },
+    ]);
+    expect(JSON.stringify(graph)).not.toContain("/private/");
+    expect(JSON.stringify(graph)).not.toContain("C:\\Users");
+  });
+
   it("degrades a scanner failure into a path-free warning", async () => {
     const inventory: AgentInventoryProvider = {
       listAgents: vi.fn(async () => ({
@@ -241,7 +302,10 @@ describe("StaticSystemGraphBuilder", () => {
       listWorkspaceScopes: () => [
         { workspaceKey: scope.workspaceKey, cwd: scope.root },
       ],
-      resolveManifestName: vi.fn(async () => FIXTURE),
+      inspectManifestName: vi.fn(async () => ({
+        status: "found" as const,
+        name: FIXTURE,
+      })),
     });
 
     const graph = await new StaticSystemGraphBuilder(
@@ -253,16 +317,10 @@ describe("StaticSystemGraphBuilder", () => {
       {
         id: "agent:local:reporting",
         agentKey: "local:reporting",
-        label: "Local agent",
+        label: "reporting",
       },
     ]);
-    expect(graph.warnings).toEqual([
-      {
-        code: "inventory-extraction-failed",
-        agentKey: "local:reporting",
-        message: "Could not inspect Local agent; using its local identity.",
-      },
-    ]);
+    expect(graph.warnings).toEqual([]);
     expect(JSON.stringify(graph)).not.toContain(FIXTURE);
   });
 

--- a/packages/harness/src/core/system-graph.ts
+++ b/packages/harness/src/core/system-graph.ts
@@ -181,12 +181,22 @@ function normalizeInventory(
   }
 
   const used = new Set<AgentKey>();
+  const duplicateKeys = new Set(
+    [...counts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([candidateKey]) => candidateKey),
+  );
   const agents = prepared.map(({ agent, candidateKey, fallbackKey }) => {
     const duplicate = (counts.get(candidateKey) ?? 0) > 1;
     let agentKey = duplicate ? fallbackKey : candidateKey;
+    if (used.has(agentKey)) {
+      duplicateKeys.add(agentKey);
+      agentKey = fallbackKey;
+    }
     const base = agentKey;
     let suffix = 2;
     while (used.has(agentKey)) {
+      duplicateKeys.add(base);
       agentKey = `${base}~${suffix}`;
       suffix += 1;
     }
@@ -194,7 +204,10 @@ function normalizeInventory(
 
     const resolutionAliases = [
       ...new Set(
-        [...(duplicate ? [candidateKey] : []), ...agent.resolutionAliases]
+        [
+          ...(agentKey !== candidateKey ? [candidateKey] : []),
+          ...agent.resolutionAliases,
+        ]
           .map(safeAgentKey)
           .filter((alias): alias is AgentKey => alias !== null),
       ),
@@ -213,8 +226,7 @@ function normalizeInventory(
   );
 
   const warnings: GraphWarning[] = [];
-  for (const candidateKey of [...counts.keys()].sort()) {
-    if ((counts.get(candidateKey) ?? 0) < 2) continue;
+  for (const candidateKey of [...duplicateKeys].sort()) {
     warnings.push({
       code: "duplicate-agent-key",
       agentKey: candidateKey,

--- a/packages/harness/src/core/system-graph.ts
+++ b/packages/harness/src/core/system-graph.ts
@@ -1,6 +1,8 @@
 import { createHash } from "node:crypto";
+import * as path from "node:path";
 
 import type {
+  AgentKey,
   GraphWarning,
   SystemGraph,
   SystemGraphEdge,
@@ -10,9 +12,11 @@ import type {
 import { detectWorkflowLaunches } from "./canvas-interconnections.js";
 import {
   canonicalGraphPath,
+  isWithinGraphPath,
   type AgentInventoryItem,
   type AgentInventoryProvider,
   type WorkspaceScope,
+  workspaceRelativeLocalKey,
 } from "./system-graph-inventory.js";
 
 export { HarnessRegistryInventoryProvider } from "./system-graph-inventory.js";
@@ -86,6 +90,140 @@ function warningOrder(left: GraphWarning, right: GraphWarning): number {
   );
 }
 
+function fallbackAgentKey(scope: WorkspaceScope, sourceRoot: string): AgentKey {
+  const canonicalScope = canonicalGraphPath(scope.root);
+  const canonicalSource = canonicalGraphPath(sourceRoot);
+  if (isWithinGraphPath(canonicalScope, canonicalSource)) {
+    return workspaceRelativeLocalKey(canonicalScope, canonicalSource);
+  }
+  return `local:${createHash("sha256")
+    .update(canonicalSource)
+    .digest("hex")
+    .slice(0, 16)}`;
+}
+
+function safeAgentKey(value: string): AgentKey | null {
+  const key = value.trim();
+  if (
+    key === "" ||
+    /[\0\r\n]/.test(key) ||
+    path.posix.isAbsolute(key) ||
+    path.win32.isAbsolute(key) ||
+    key.includes("\\")
+  ) {
+    return null;
+  }
+  if (!key.startsWith("local:")) return key.includes("/") ? null : key;
+
+  const relative = key.slice("local:".length);
+  if (
+    relative === "" ||
+    path.posix.isAbsolute(relative) ||
+    path.win32.isAbsolute(relative) ||
+    relative
+      .split("/")
+      .some((segment) => segment === "" || segment === "." || segment === "..")
+  ) {
+    return null;
+  }
+  return key;
+}
+
+function safeLabel(value: string, agentKey: AgentKey): string {
+  const label = value.trim();
+  if (
+    label !== "" &&
+    !/[\0\r\n]/.test(label) &&
+    !path.posix.isAbsolute(label) &&
+    !path.win32.isAbsolute(label)
+  ) {
+    return label;
+  }
+  if (agentKey.startsWith("local:")) {
+    return agentKey.slice("local:".length) || "Local agent";
+  }
+  return agentKey;
+}
+
+interface PreparedInventoryItem {
+  agent: AgentInventoryItem;
+  candidateKey: AgentKey;
+  fallbackKey: AgentKey;
+}
+
+/**
+ * The provider contract promises safe unique keys, but projection is the last
+ * server-side boundary before serialization. Re-assert that invariant here so
+ * a future provider cannot make the browser reject the whole graph payload.
+ */
+function normalizeInventory(
+  scope: WorkspaceScope,
+  inventory: readonly AgentInventoryItem[],
+): { agents: AgentInventoryItem[]; warnings: GraphWarning[] } {
+  const prepared: PreparedInventoryItem[] = inventory
+    .map((agent) => {
+      const fallbackKey = fallbackAgentKey(scope, agent.sourceRoot);
+      return {
+        agent,
+        candidateKey: safeAgentKey(agent.agentKey) ?? fallbackKey,
+        fallbackKey,
+      };
+    })
+    .sort(
+      (left, right) =>
+        left.candidateKey.localeCompare(right.candidateKey) ||
+        left.agent.sourceRoot.localeCompare(right.agent.sourceRoot) ||
+        left.agent.label.localeCompare(right.agent.label),
+    );
+  const counts = new Map<AgentKey, number>();
+  for (const item of prepared) {
+    counts.set(item.candidateKey, (counts.get(item.candidateKey) ?? 0) + 1);
+  }
+
+  const used = new Set<AgentKey>();
+  const agents = prepared.map(({ agent, candidateKey, fallbackKey }) => {
+    const duplicate = (counts.get(candidateKey) ?? 0) > 1;
+    let agentKey = duplicate ? fallbackKey : candidateKey;
+    const base = agentKey;
+    let suffix = 2;
+    while (used.has(agentKey)) {
+      agentKey = `${base}~${suffix}`;
+      suffix += 1;
+    }
+    used.add(agentKey);
+
+    const resolutionAliases = [
+      ...new Set(
+        [...(duplicate ? [candidateKey] : []), ...agent.resolutionAliases]
+          .map(safeAgentKey)
+          .filter((alias): alias is AgentKey => alias !== null),
+      ),
+    ];
+    return {
+      ...agent,
+      agentKey,
+      label: safeLabel(agent.label, agentKey),
+      resolutionAliases,
+    };
+  });
+  agents.sort(
+    (left, right) =>
+      left.agentKey.localeCompare(right.agentKey) ||
+      left.sourceRoot.localeCompare(right.sourceRoot),
+  );
+
+  const warnings: GraphWarning[] = [];
+  for (const candidateKey of [...counts.keys()].sort()) {
+    if ((counts.get(candidateKey) ?? 0) < 2) continue;
+    warnings.push({
+      code: "duplicate-agent-key",
+      agentKey: candidateKey,
+      message: `Multiple agents use ${candidateKey}; kept each with a local identity.`,
+    });
+  }
+  return { agents, warnings };
+}
+
 export class StaticSystemGraphBuilder implements SystemGraphBuilder {
   constructor(
     private readonly inventory: AgentInventoryProvider,
@@ -94,11 +232,8 @@ export class StaticSystemGraphBuilder implements SystemGraphBuilder {
 
   async build(scope: WorkspaceScope): Promise<SystemGraph> {
     const inventory = await this.inventory.listAgents(scope);
-    const agents = [...inventory.agents].sort(
-      (left, right) =>
-        left.agentKey.localeCompare(right.agentKey) ||
-        left.sourceRoot.localeCompare(right.sourceRoot),
-    );
+    const normalized = normalizeInventory(scope, inventory.agents);
+    const agents = normalized.agents;
     const nodes = agents.map((agent) => ({
       id: `agent:${agent.agentKey}`,
       agentKey: agent.agentKey,
@@ -122,7 +257,10 @@ export class StaticSystemGraphBuilder implements SystemGraphBuilder {
     }
 
     const edges: SystemGraphEdge[] = [];
-    const warnings: GraphWarning[] = [...inventory.warnings];
+    const warnings: GraphWarning[] = [
+      ...inventory.warnings,
+      ...normalized.warnings,
+    ];
     const seenEdges = new Set<string>();
 
     // Source walks are independent. Run them together so first-open latency is
@@ -197,14 +335,21 @@ export class StaticSystemGraphBuilder implements SystemGraphBuilder {
       (left, right) =>
         left.from.localeCompare(right.from) || left.to.localeCompare(right.to),
     );
-    warnings.sort(warningOrder);
+    const uniqueWarnings = [
+      ...new Map(
+        warnings.map((warning) => [
+          `${warning.code}\0${warning.agentKey ?? ""}\0${warning.message}`,
+          warning,
+        ]),
+      ).values(),
+    ].sort(warningOrder);
 
     return {
       kind: "system",
       scope: { kind: "working-tree", workspaceKey: scope.workspaceKey },
       nodes,
       edges,
-      warnings,
+      warnings: uniqueWarnings,
     };
   }
 }

--- a/packages/harness/src/core/system-graph.ts
+++ b/packages/harness/src/core/system-graph.ts
@@ -37,7 +37,13 @@ export interface WorkspaceScopeCatalog extends WorkspaceScopeResolver {
 }
 
 export interface SystemGraphBuilder {
-  build(scope: WorkspaceScope): Promise<SystemGraph>;
+  build(scope: WorkspaceScope): Promise<SystemGraphBuildResult>;
+}
+
+export interface SystemGraphBuildResult {
+  /** Internal cache policy; only graph crosses the HTTP boundary. */
+  cacheable: boolean;
+  graph: SystemGraph;
 }
 
 type LaunchDetector = typeof detectWorkflowLaunches;
@@ -242,7 +248,7 @@ export class StaticSystemGraphBuilder implements SystemGraphBuilder {
     private readonly detectLaunches: LaunchDetector = detectWorkflowLaunches,
   ) {}
 
-  async build(scope: WorkspaceScope): Promise<SystemGraph> {
+  async build(scope: WorkspaceScope): Promise<SystemGraphBuildResult> {
     const inventory = await this.inventory.listAgents(scope);
     const normalized = normalizeInventory(scope, inventory.agents);
     const agents = normalized.agents;
@@ -357,11 +363,14 @@ export class StaticSystemGraphBuilder implements SystemGraphBuilder {
     ].sort(warningOrder);
 
     return {
-      kind: "system",
-      scope: { kind: "working-tree", workspaceKey: scope.workspaceKey },
-      nodes,
-      edges,
-      warnings: uniqueWarnings,
+      cacheable: inventory.cacheable,
+      graph: {
+        kind: "system",
+        scope: { kind: "working-tree", workspaceKey: scope.workspaceKey },
+        nodes,
+        edges,
+        warnings: uniqueWarnings,
+      },
     };
   }
 }

--- a/packages/harness/src/core/system-graph.ts
+++ b/packages/harness/src/core/system-graph.ts
@@ -1,29 +1,28 @@
 import { createHash } from "node:crypto";
-import { realpathSync } from "node:fs";
-import * as path from "node:path";
 
 import type {
-  AgentKey,
   GraphWarning,
   SystemGraph,
   SystemGraphEdge,
   WorkspaceKey,
   WorkspaceScopeSummary,
 } from "../shared/system-graph.js";
-import type { WorkflowInfo } from "../shared/types.js";
 import { detectWorkflowLaunches } from "./canvas-interconnections.js";
+import {
+  canonicalGraphPath,
+  type AgentInventoryItem,
+  type AgentInventoryProvider,
+  type WorkspaceScope,
+} from "./system-graph-inventory.js";
 
-export interface WorkspaceScope {
-  workspaceKey: WorkspaceKey;
-  root: string;
-}
-
-export interface LocalAgentInventoryItem {
-  agentKey: AgentKey;
-  definitionSlug: string | null;
-  label: string;
-  sourceRoot: string;
-}
+export { HarnessRegistryInventoryProvider } from "./system-graph-inventory.js";
+export type {
+  AgentInventoryItem,
+  AgentInventoryProvider,
+  AgentInventoryResult,
+  AgentInventoryWarning,
+  WorkspaceScope,
+} from "./system-graph-inventory.js";
 
 export interface WorkspaceScopeResolver {
   resolve(workspaceKey: WorkspaceKey): Promise<WorkspaceScope | null>;
@@ -33,35 +32,14 @@ export interface WorkspaceScopeCatalog extends WorkspaceScopeResolver {
   list(): Promise<WorkspaceScopeSummary[]>;
 }
 
-export interface LocalAgentInventoryReader {
-  list(scope: WorkspaceScope): Promise<LocalAgentInventoryItem[]>;
-}
-
 export interface SystemGraphBuilder {
   build(scope: WorkspaceScope): Promise<SystemGraph>;
 }
 
 type LaunchDetector = typeof detectWorkflowLaunches;
 
-function canonicalRoot(root: string): string {
-  const resolved = path.resolve(root);
-  try {
-    return realpathSync.native(resolved);
-  } catch {
-    return resolved;
-  }
-}
-
 function workspaceKeyForRoot(root: string): WorkspaceKey {
   return `workspace-${createHash("sha256").update(root).digest("hex").slice(0, 16)}`;
-}
-
-function isWithin(root: string, candidate: string): boolean {
-  const relative = path.relative(root, candidate);
-  return (
-    relative === "" ||
-    (!relative.startsWith("..") && !path.isAbsolute(relative))
-  );
 }
 
 /**
@@ -78,7 +56,7 @@ export class LocalWorkspaceScopeCatalog implements WorkspaceScopeCatalog {
   async list(): Promise<WorkspaceScopeSummary[]> {
     const byRoot = new Map<string, WorkspaceScopeSummary>();
     for (const root of await this.listRoots()) {
-      const canonical = canonicalRoot(root);
+      const canonical = canonicalGraphPath(root);
       byRoot.set(canonical, {
         workspaceKey: workspaceKeyForRoot(canonical),
         cwd: root,
@@ -91,42 +69,12 @@ export class LocalWorkspaceScopeCatalog implements WorkspaceScopeCatalog {
 
   async resolve(workspaceKey: WorkspaceKey): Promise<WorkspaceScope | null> {
     for (const root of await this.listRoots()) {
-      const canonical = canonicalRoot(root);
+      const canonical = canonicalGraphPath(root);
       if (workspaceKeyForRoot(canonical) === workspaceKey) {
         return { workspaceKey, root: canonical };
       }
     }
     return null;
-  }
-}
-
-export class WorkflowRegistryInventoryReader implements LocalAgentInventoryReader {
-  constructor(private readonly listWorkflows: () => readonly WorkflowInfo[]) {}
-
-  async list(scope: WorkspaceScope): Promise<LocalAgentInventoryItem[]> {
-    const items = this.listWorkflows()
-      .map((workflow): LocalAgentInventoryItem | null => {
-        const sourceRoot = canonicalRoot(workflow.path);
-        if (!isWithin(scope.root, sourceRoot)) return null;
-        const relative = path
-          .relative(scope.root, sourceRoot)
-          .split(path.sep)
-          .join("/");
-        const localKey = relative || path.basename(sourceRoot) || "root";
-        return {
-          agentKey: workflow.definitionSlug ?? `local:${localKey}`,
-          definitionSlug: workflow.definitionSlug,
-          label: workflow.name,
-          sourceRoot,
-        };
-      })
-      .filter((item): item is LocalAgentInventoryItem => item !== null);
-
-    return items.sort(
-      (left, right) =>
-        left.agentKey.localeCompare(right.agentKey) ||
-        left.sourceRoot.localeCompare(right.sourceRoot),
-    );
   }
 }
 
@@ -138,94 +86,43 @@ function warningOrder(left: GraphWarning, right: GraphWarning): number {
   );
 }
 
-function fallbackAgentKey(scope: WorkspaceScope, sourceRoot: string): AgentKey {
-  const relative = path.relative(scope.root, sourceRoot);
-  if (
-    relative !== "" &&
-    !relative.startsWith("..") &&
-    !path.isAbsolute(relative)
-  ) {
-    return `local:${relative.split(path.sep).join("/")}`;
-  }
-  // Injected inventory adapters may supply a root outside the selected scope.
-  // Keep the fallback path-free while still making its identity deterministic.
-  return `local:${createHash("sha256")
-    .update(sourceRoot)
-    .digest("hex")
-    .slice(0, 16)}`;
-}
-
-/**
- * A copied agent can retain another folder's definition slug. Keep both nodes
- * visible with stable local identities instead of emitting a wire payload the
- * browser must reject for duplicate node ids.
- */
-function disambiguateAgentKeys(
-  scope: WorkspaceScope,
-  inventory: readonly LocalAgentInventoryItem[],
-): LocalAgentInventoryItem[] {
-  const counts = new Map<AgentKey, number>();
-  for (const agent of inventory) {
-    counts.set(agent.agentKey, (counts.get(agent.agentKey) ?? 0) + 1);
-  }
-
-  const used = new Set<AgentKey>();
-  return [...inventory]
-    .sort(
-      (left, right) =>
-        left.agentKey.localeCompare(right.agentKey) ||
-        left.sourceRoot.localeCompare(right.sourceRoot),
-    )
-    .map((agent) => {
-      const localKey = fallbackAgentKey(scope, agent.sourceRoot);
-      const preferred = (counts.get(agent.agentKey) ?? 0) > 1
-        ? localKey
-        : agent.agentKey;
-      let agentKey = preferred;
-      let suffix = 2;
-      while (used.has(agentKey)) {
-        agentKey = `${localKey}~${suffix}`;
-        suffix += 1;
-      }
-      used.add(agentKey);
-      return agentKey === agent.agentKey ? agent : { ...agent, agentKey };
-    });
-}
-
 export class StaticSystemGraphBuilder implements SystemGraphBuilder {
   constructor(
-    private readonly inventory: LocalAgentInventoryReader,
+    private readonly inventory: AgentInventoryProvider,
     private readonly detectLaunches: LaunchDetector = detectWorkflowLaunches,
   ) {}
 
   async build(scope: WorkspaceScope): Promise<SystemGraph> {
-    const agents = disambiguateAgentKeys(
-      scope,
-      await this.inventory.list(scope),
+    const inventory = await this.inventory.listAgents(scope);
+    const agents = [...inventory.agents].sort(
+      (left, right) =>
+        left.agentKey.localeCompare(right.agentKey) ||
+        left.sourceRoot.localeCompare(right.sourceRoot),
     );
     const nodes = agents.map((agent) => ({
       id: `agent:${agent.agentKey}`,
       agentKey: agent.agentKey,
       label: agent.label,
     }));
-    const byTarget = new Map<string, LocalAgentInventoryItem[]>();
-    const registerTarget = (
-      key: string,
-      agent: LocalAgentInventoryItem,
-    ): void => {
+    const byTarget = new Map<string, AgentInventoryItem[]>();
+    const registerTarget = (key: string, agent: AgentInventoryItem): void => {
       const candidates = byTarget.get(key) ?? [];
-      if (!candidates.some((candidate) => candidate.agentKey === agent.agentKey)) {
+      if (
+        !candidates.some((candidate) => candidate.agentKey === agent.agentKey)
+      ) {
         candidates.push(agent);
         byTarget.set(key, candidates);
       }
     };
     for (const agent of agents) {
       registerTarget(agent.agentKey, agent);
-      if (agent.definitionSlug) registerTarget(agent.definitionSlug, agent);
+      for (const alias of agent.resolutionAliases) {
+        registerTarget(alias, agent);
+      }
     }
 
     const edges: SystemGraphEdge[] = [];
-    const warnings: GraphWarning[] = [];
+    const warnings: GraphWarning[] = [...inventory.warnings];
     const seenEdges = new Set<string>();
 
     // Source walks are independent. Run them together so first-open latency is
@@ -257,13 +154,18 @@ export class StaticSystemGraphBuilder implements SystemGraphBuilder {
       for (const launch of launches) {
         const candidates = byTarget.get(launch.slug) ?? [];
         if (candidates.length !== 1) {
+          const target = /^[A-Za-z0-9@_.:-]+$/.test(launch.slug)
+            ? launch.slug
+            : null;
           warnings.push({
             code: "unresolved-target",
             agentKey: caller.agentKey,
             message:
               candidates.length === 0
-                ? `${caller.label} invokes unknown agent ${launch.slug}.`
-                : `${caller.label} invokes ambiguous agent ${launch.slug}.`,
+                ? target
+                  ? `${caller.label} invokes unknown agent ${target}.`
+                  : `${caller.label} invokes an invalid agent target.`
+                : `${caller.label} invokes ambiguous agent ${target ?? "target"}.`,
           });
           continue;
         }

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -107,7 +107,7 @@ import {
   createDefinitionSlugResolver,
   resolveAgentsBaseUrl,
 } from "../core/definition-slug-resolver.js";
-import { resolveManifestName } from "../core/definition-name.js";
+import { inspectManifestName, resolveManifestName } from "../core/definition-name.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { createApiKeyProvider } from "../core/api-key-provider.js";
 import { createRestRouter } from "./rest.js";
@@ -748,7 +748,7 @@ export const startServer = async (
       new HarnessRegistryInventoryProvider({
         listWorkflows: () => workflowsCache,
         listWorkspaceScopes: () => workspaceScopeCatalog.list(),
-        resolveManifestName,
+        inspectManifestName,
       }),
     ),
   );

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -97,9 +97,9 @@ import { ensureCanvasTemplate } from "../core/canvas-template.js";
 import { renderCanvasForSession } from "../core/canvas-render.js";
 import { invalidateExtractionCache } from "../core/canvas-cache.js";
 import {
+  HarnessRegistryInventoryProvider,
   LocalWorkspaceScopeCatalog,
   StaticSystemGraphBuilder,
-  WorkflowRegistryInventoryReader,
 } from "../core/system-graph.js";
 import { SystemGraphStore } from "../core/system-graph-store.js";
 import { sweepNdjson } from "../core/collector/store-retention.js";
@@ -745,7 +745,11 @@ export const startServer = async (
   ]);
   const systemGraphStore = new SystemGraphStore(
     new StaticSystemGraphBuilder(
-      new WorkflowRegistryInventoryReader(() => workflowsCache),
+      new HarnessRegistryInventoryProvider({
+        listWorkflows: () => workflowsCache,
+        listWorkspaceScopes: () => workspaceScopeCatalog.list(),
+        resolveManifestName,
+      }),
     ),
   );
 

--- a/packages/harness/src/server/system-graph.test.ts
+++ b/packages/harness/src/server/system-graph.test.ts
@@ -7,7 +7,10 @@ import type {
   SystemGraphBuilder,
   WorkspaceScopeResolver,
 } from "../core/system-graph.js";
-import type { SystemGraph } from "../shared/system-graph.js";
+import {
+  SYSTEM_GRAPH_CACHE_HEADER,
+  type SystemGraph,
+} from "../shared/system-graph.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { createSystemGraphRouter } from "./system-graph.js";
 
@@ -40,7 +43,7 @@ describe("createSystemGraphRouter", () => {
     server = undefined;
   });
 
-  function start() {
+  function start(cacheable = true) {
     const scopeResolver: WorkspaceScopeResolver = {
       resolve: vi.fn(async (key: string) =>
         key === workspaceKey
@@ -49,7 +52,7 @@ describe("createSystemGraphRouter", () => {
       ),
     };
     const builder: SystemGraphBuilder = {
-      build: vi.fn(async () => ({ cacheable: true, graph })),
+      build: vi.fn(async () => ({ cacheable, graph })),
     };
     const app = express();
     app.use("/api", createBootTokenMiddleware("test-token"));
@@ -82,9 +85,27 @@ describe("createSystemGraphRouter", () => {
     });
 
     expect(first.status).toBe(200);
+    expect(first.headers.get(SYSTEM_GRAPH_CACHE_HEADER)).toBe("complete");
     expect(await first.json()).toEqual(graph);
     expect(second.status).toBe(200);
     expect(builder.build).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports degradation and bounds re-enrichment to one later request", async () => {
+    const { baseUrl, builder } = start(false);
+    const route = `${baseUrl}/api/workspaces/${workspaceKey}/system-graph`;
+    const request = () =>
+      fetch(route, { headers: { "X-Harness-Token": "test-token" } });
+
+    const first = await request();
+    const second = await request();
+    const third = await request();
+
+    expect(first.headers.get(SYSTEM_GRAPH_CACHE_HEADER)).toBe("degraded");
+    expect(second.headers.get(SYSTEM_GRAPH_CACHE_HEADER)).toBe("degraded");
+    expect(third.headers.get(SYSTEM_GRAPH_CACHE_HEADER)).toBe("degraded");
+    expect(await third.json()).toEqual(graph);
+    expect(builder.build).toHaveBeenCalledTimes(2);
   });
 
   it("rejects an unknown opaque workspace key without scanning", async () => {

--- a/packages/harness/src/server/system-graph.test.ts
+++ b/packages/harness/src/server/system-graph.test.ts
@@ -48,7 +48,9 @@ describe("createSystemGraphRouter", () => {
           : null,
       ),
     };
-    const builder: SystemGraphBuilder = { build: vi.fn(async () => graph) };
+    const builder: SystemGraphBuilder = {
+      build: vi.fn(async () => ({ cacheable: true, graph })),
+    };
     const app = express();
     app.use("/api", createBootTokenMiddleware("test-token"));
     app.use(

--- a/packages/harness/src/server/system-graph.ts
+++ b/packages/harness/src/server/system-graph.ts
@@ -2,6 +2,10 @@ import { Router } from "express";
 
 import type { WorkspaceScopeResolver } from "../core/system-graph.js";
 import type { SystemGraphStore } from "../core/system-graph-store.js";
+import {
+  SYSTEM_GRAPH_CACHE_HEADER,
+  type SystemGraphCacheStatus,
+} from "../shared/system-graph.js";
 
 export interface SystemGraphRouterOptions {
   scopeResolver: WorkspaceScopeResolver;
@@ -25,7 +29,11 @@ export function createSystemGraphRouter(
           res.status(404).json({ error: "Workspace not found" });
           return;
         }
-        res.json(await options.store.get(scope));
+        const result = await options.store.get(scope);
+        const cacheStatus: SystemGraphCacheStatus = result.degraded
+          ? "degraded"
+          : "complete";
+        res.set(SYSTEM_GRAPH_CACHE_HEADER, cacheStatus).json(result.graph);
       } catch (err) {
         next(err);
       }

--- a/packages/harness/src/shared/system-graph.ts
+++ b/packages/harness/src/shared/system-graph.ts
@@ -27,7 +27,12 @@ export interface SystemGraphEdge {
 }
 
 export interface GraphWarning {
-  code: "unresolved-target" | "duplicate-edge" | "projection-failed";
+  code:
+    | "unresolved-target"
+    | "duplicate-edge"
+    | "projection-failed"
+    | "duplicate-agent-key"
+    | "inventory-extraction-failed";
   message: string;
   agentKey?: AgentKey;
 }

--- a/packages/harness/src/shared/system-graph.ts
+++ b/packages/harness/src/shared/system-graph.ts
@@ -6,6 +6,10 @@
 export type WorkspaceKey = string;
 export type AgentKey = string;
 
+/** Internal HTTP metadata; it is deliberately not part of SystemGraph JSON. */
+export const SYSTEM_GRAPH_CACHE_HEADER = "X-Sapiom-System-Graph-Cache";
+export type SystemGraphCacheStatus = "complete" | "degraded";
+
 export interface WorkspaceScopeSummary {
   workspaceKey: WorkspaceKey;
   /** Used only to join the existing workspace-folder projection in AppState. */

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -373,6 +373,10 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await expect(page.getByTestId("system-graph-node-growth")).toContainText(
       "Growth",
     );
+    // Inventory nodes do not need an incoming or outgoing relationship.
+    await expect(page.getByTestId("system-graph-node-reporting")).toContainText(
+      "Reporting",
+    );
     await expect(
       page.getByTestId("system-graph-edge-agent:research-agent:growth"),
     ).toContainText("invokes · static · async");

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -499,6 +499,42 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
       .toBe(2);
   });
 
+  test("a degraded workspace projection retries once on a later open", async ({ page }) => {
+    await page.evaluate(() => {
+      (window as unknown as {
+        __MOCK_SYSTEM_GRAPH_DEGRADED_REMAINING__?: number;
+      }).__MOCK_SYSTEM_GRAPH_DEGRADED_REMAINING__ = 2;
+    });
+
+    const openGraph = async () => {
+      await page.getByTestId("workspace-select-acme-app").click();
+      await expect(page.getByTestId("system-graph-canvas")).toBeVisible();
+    };
+    const openAgent = async () => {
+      await page
+        .getByTestId("workflow-leasing")
+        .locator(".workflow-item-trigger")
+        .click();
+      await expect(page.getByTestId("system-graph-canvas")).toHaveCount(0);
+    };
+    const requestCount = () =>
+      page.evaluate(
+        () =>
+          ((window as unknown as {
+            __HARNESS_TEST__?: { systemGraphRequests?: string[] };
+          }).__HARNESS_TEST__?.systemGraphRequests ?? []).length,
+      );
+
+    await openGraph();
+    await expect.poll(requestCount).toBe(1);
+    await openAgent();
+    await openGraph();
+    await expect.poll(requestCount).toBe(2);
+    await openAgent();
+    await openGraph();
+    await expect.poll(requestCount).toBe(2);
+  });
+
   test("switching sessions makes the canvas follow the new session's content", async ({ page }) => {
     // Zone 3 keys off the active session. sess-boot ships a bundled doc (board);
     // the second leasing session ships none — so the canvas pane OPENS for the

--- a/packages/harness/web/src/components/SystemGraphCanvas.tsx
+++ b/packages/harness/web/src/components/SystemGraphCanvas.tsx
@@ -4,27 +4,15 @@ import type { SystemGraph, WorkspaceKey } from "@shared/system-graph";
 
 import type { HarnessApi } from "../lib/api";
 import { orderSystemGraphNodes } from "../lib/system-graph";
+import { createSystemGraphLoader } from "../lib/system-graph-loader";
 import { EmptyState } from "./EmptyState";
 
 /**
- * V0 mirrors the server's process-lifetime snapshot in the browser tab.
- * SAP-2904 owns source-driven invalidation and user-visible freshness states.
+ * V0 mirrors the server's process-lifetime snapshot in the browser tab, with
+ * one later-open retry for a degraded projection. SAP-2904 owns source-driven
+ * invalidation and user-visible freshness states.
  */
-const requests = new Map<WorkspaceKey, Promise<SystemGraph>>();
-
-function loadSystemGraph(
-  api: HarnessApi,
-  workspaceKey: WorkspaceKey,
-): Promise<SystemGraph> {
-  const existing = requests.get(workspaceKey);
-  if (existing) return existing;
-  const request = api.getSystemGraph(workspaceKey);
-  requests.set(workspaceKey, request);
-  void request.catch(() => {
-    if (requests.get(workspaceKey) === request) requests.delete(workspaceKey);
-  });
-  return request;
-}
+const loadSystemGraph = createSystemGraphLoader();
 
 interface SystemGraphCanvasProps {
   workspaceKey: WorkspaceKey;

--- a/packages/harness/web/src/lib/api.test.ts
+++ b/packages/harness/web/src/lib/api.test.ts
@@ -1,12 +1,59 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { SYSTEM_GRAPH_CACHE_HEADER } from "@shared/system-graph";
 
 import {
+  createApi,
+  isMockMode,
   parseNdjsonLine,
   progressiveLeasingRun,
   PROGRESSIVE_STEP_MS,
   terminalDeployEvent,
   type DeployStreamEvent,
 } from "./api";
+
+describe("RealApi.getSystemGraph", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns transport degradation metadata outside the graph JSON", async () => {
+    if (isMockMode()) return;
+    const graph = {
+      kind: "system",
+      scope: { kind: "working-tree", workspaceKey: "workspace-test" },
+      nodes: [],
+      edges: [],
+      warnings: [],
+    };
+    vi.stubGlobal("window", {
+      __HARNESS__: { token: "test-token" },
+      location: { search: "" },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify(graph), {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            [SYSTEM_GRAPH_CACHE_HEADER]: "degraded",
+          },
+        }),
+      ),
+    );
+
+    await expect(createApi().getSystemGraph("workspace-test")).resolves.toEqual(
+      { graph, degraded: true },
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/workspaces/workspace-test/system-graph",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-Harness-Token": "test-token" }),
+      }),
+    );
+  });
+});
 
 describe("progressiveLeasingRun", () => {
   const at = (elapsed: number) => progressiveLeasingRun("exec-mock-prod-1", elapsed);

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -1081,6 +1081,11 @@ class MockApi implements HarnessApi {
       nodes: [
         { id: "agent:growth", agentKey: "growth", label: "Growth" },
         {
+          id: "agent:reporting",
+          agentKey: "reporting",
+          label: "Reporting",
+        },
+        {
           id: "agent:research",
           agentKey: "research",
           label: "Research",

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -30,16 +30,19 @@ import type {
   WorkflowInputContractResponse,
   WorkflowInfo,
 } from "@shared/types";
-import type {
-  SystemGraph,
-  WorkspaceKey,
-  WorkspaceScopeSummary,
+import {
+  SYSTEM_GRAPH_CACHE_HEADER,
+  type SystemGraphCacheStatus,
+  type SystemGraph,
+  type WorkspaceKey,
+  type WorkspaceScopeSummary,
 } from "@shared/system-graph";
 
 import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
 
 import { getTheme } from "./theme";
 import { parseSystemGraph } from "./system-graph";
+import type { SystemGraphLoadResult } from "./system-graph-loader";
 
 import {
   MOCK_ACCOUNT_PLAN,
@@ -269,7 +272,7 @@ export interface HarnessApi {
   authStatus(): Promise<AuthStatusResponse>;
   getState(): Promise<AppState>;
   /** Static local dependency projection for one server-issued workspace key. */
-  getSystemGraph(workspaceKey: WorkspaceKey): Promise<SystemGraph>;
+  getSystemGraph(workspaceKey: WorkspaceKey): Promise<SystemGraphLoadResult>;
   createSession(req: CreateSessionRequest): Promise<HarnessSession>;
   attachFile(id: string, req: AttachFileRequest): Promise<AttachFileResponse>;
   listSessions(): Promise<HarnessSession[]>;
@@ -375,7 +378,7 @@ class RealApi implements HarnessApi {
     return this.request<AuthStatusResponse>("/api/auth/status");
   }
 
-  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+  private async response(path: string, init?: RequestInit): Promise<Response> {
     const res = await fetch(path, {
       ...init,
       headers: {
@@ -405,6 +408,11 @@ class RealApi implements HarnessApi {
         reason,
       );
     }
+    return res;
+  }
+
+  private async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const res = await this.response(path, init);
     if (res.status === 204) return undefined as T;
     return (await res.json()) as T;
   }
@@ -413,16 +421,20 @@ class RealApi implements HarnessApi {
     return this.request<AppState>("/api/state");
   }
 
-  async getSystemGraph(workspaceKey: WorkspaceKey): Promise<SystemGraph> {
-    const graph = parseSystemGraph(
-      await this.request<unknown>(
-        `/api/workspaces/${encodeURIComponent(workspaceKey)}/system-graph`,
-      ),
+  async getSystemGraph(
+    workspaceKey: WorkspaceKey,
+  ): Promise<SystemGraphLoadResult> {
+    const response = await this.response(
+      `/api/workspaces/${encodeURIComponent(workspaceKey)}/system-graph`,
     );
+    const graph = parseSystemGraph((await response.json()) as unknown);
     if (graph.scope.workspaceKey !== workspaceKey) {
       throw new Error("Invalid system graph response");
     }
-    return graph;
+    const cacheStatus = response.headers.get(
+      SYSTEM_GRAPH_CACHE_HEADER,
+    ) as SystemGraphCacheStatus | null;
+    return { graph, degraded: cacheStatus === "degraded" };
   }
 
   createSession(req: CreateSessionRequest): Promise<HarnessSession> {
@@ -1049,15 +1061,19 @@ class MockApi implements HarnessApi {
     };
   }
 
-  async getSystemGraph(workspaceKey: WorkspaceKey): Promise<SystemGraph> {
+  async getSystemGraph(
+    workspaceKey: WorkspaceKey,
+  ): Promise<SystemGraphLoadResult> {
     await delay(180);
     if (!this.workspaceScopes().some((scope) => scope.workspaceKey === workspaceKey)) {
       throw new ApiError(404, "Workspace not found", "Workspace not found");
     }
+    let degraded = false;
     if (typeof window !== "undefined") {
       const win = window as unknown as {
         __HARNESS_TEST__?: Record<string, unknown>;
         __MOCK_SYSTEM_GRAPH_FAIL_ONCE__?: boolean;
+        __MOCK_SYSTEM_GRAPH_DEGRADED_REMAINING__?: number;
       };
       const previous =
         (win.__HARNESS_TEST__?.systemGraphRequests as WorkspaceKey[] | undefined) ??
@@ -1074,8 +1090,14 @@ class MockApi implements HarnessApi {
           "System graph projection failed",
         );
       }
+      const degradedRemaining =
+        win.__MOCK_SYSTEM_GRAPH_DEGRADED_REMAINING__ ?? 0;
+      degraded = degradedRemaining > 0;
+      if (degraded) {
+        win.__MOCK_SYSTEM_GRAPH_DEGRADED_REMAINING__ = degradedRemaining - 1;
+      }
     }
-    return {
+    const graph: SystemGraph = {
       kind: "system",
       scope: { kind: "working-tree", workspaceKey },
       nodes: [
@@ -1102,6 +1124,7 @@ class MockApi implements HarnessApi {
       ],
       warnings: [],
     };
+    return { graph, degraded };
   }
 
   async createSession(req: CreateSessionRequest): Promise<HarnessSession> {

--- a/packages/harness/web/src/lib/system-graph-loader.test.ts
+++ b/packages/harness/web/src/lib/system-graph-loader.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SystemGraph, WorkspaceKey } from "@shared/system-graph";
+
+import {
+  createSystemGraphLoader,
+  type SystemGraphSource,
+} from "./system-graph-loader";
+
+const workspaceKey: WorkspaceKey = "workspace-test";
+const graph: SystemGraph = {
+  kind: "system",
+  scope: { kind: "working-tree", workspaceKey },
+  nodes: [],
+  edges: [],
+  warnings: [],
+};
+
+describe("createSystemGraphLoader", () => {
+  it("coalesces requests and retains a complete graph", async () => {
+    const getSystemGraph = vi.fn(async () => ({ graph, degraded: false }));
+    const load = createSystemGraphLoader();
+    const source: SystemGraphSource = { getSystemGraph };
+
+    const first = load(source, workspaceKey);
+    expect(load(source, workspaceKey)).toBe(first);
+    await expect(first).resolves.toBe(graph);
+    expect(load(source, workspaceKey)).toBe(first);
+    expect(getSystemGraph).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows one later-open retry and retains a second degraded graph", async () => {
+    const getSystemGraph = vi.fn(async () => ({ graph, degraded: true }));
+    const load = createSystemGraphLoader();
+    const source: SystemGraphSource = { getSystemGraph };
+
+    const first = load(source, workspaceKey);
+    expect(load(source, workspaceKey)).toBe(first);
+    await expect(first).resolves.toBe(graph);
+
+    const second = load(source, workspaceKey);
+    await expect(second).resolves.toBe(graph);
+    expect(load(source, workspaceKey)).toBe(second);
+    expect(getSystemGraph).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a rejected request without consuming the degraded retry", async () => {
+    const getSystemGraph = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("scan failed"))
+      .mockResolvedValueOnce({ graph, degraded: false });
+    const load = createSystemGraphLoader();
+    const source: SystemGraphSource = { getSystemGraph };
+
+    await expect(load(source, workspaceKey)).rejects.toThrow("scan failed");
+    await expect(load(source, workspaceKey)).resolves.toBe(graph);
+    expect(getSystemGraph).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/harness/web/src/lib/system-graph-loader.ts
+++ b/packages/harness/web/src/lib/system-graph-loader.ts
@@ -1,0 +1,42 @@
+import type { SystemGraph, WorkspaceKey } from "@shared/system-graph";
+
+export interface SystemGraphLoadResult {
+  graph: SystemGraph;
+  degraded: boolean;
+}
+
+export interface SystemGraphSource {
+  getSystemGraph(workspaceKey: WorkspaceKey): Promise<SystemGraphLoadResult>;
+}
+
+/** Process-lifetime browser cache with one later-open retry for degradation. */
+export function createSystemGraphLoader(): (
+  source: SystemGraphSource,
+  workspaceKey: WorkspaceKey,
+) => Promise<SystemGraph> {
+  const requests = new Map<WorkspaceKey, Promise<SystemGraph>>();
+  const degradedRetries = new Set<WorkspaceKey>();
+
+  return (source, workspaceKey) => {
+    const existing = requests.get(workspaceKey);
+    if (existing) return existing;
+
+    let request: Promise<SystemGraph>;
+    request = source.getSystemGraph(workspaceKey).then((result) => {
+      if (result.degraded && !degradedRetries.has(workspaceKey)) {
+        degradedRetries.add(workspaceKey);
+        if (requests.get(workspaceKey) === request) {
+          requests.delete(workspaceKey);
+        }
+      }
+      return result.graph;
+    });
+    requests.set(workspaceKey, request);
+    void request.catch(() => {
+      if (requests.get(workspaceKey) === request) {
+        requests.delete(workspaceKey);
+      }
+    });
+    return request;
+  };
+}

--- a/packages/harness/web/src/lib/system-graph.test.ts
+++ b/packages/harness/web/src/lib/system-graph.test.ts
@@ -26,6 +26,23 @@ describe("parseSystemGraph", () => {
     expect(parseSystemGraph(valid)).toEqual(valid);
   });
 
+  it("accepts typed duplicate and partial-inventory warnings", () => {
+    const warnings = [
+      {
+        code: "duplicate-agent-key",
+        agentKey: "shared",
+        message: "Multiple agents use shared.",
+      },
+      {
+        code: "inventory-extraction-failed",
+        agentKey: "local:reporting",
+        message: "Could not inspect Reporting; using its local identity.",
+      },
+    ];
+
+    expect(parseSystemGraph({ ...valid, warnings }).warnings).toEqual(warnings);
+  });
+
   it("rejects an edge whose endpoint is absent", () => {
     expect(() =>
       parseSystemGraph({
@@ -40,6 +57,15 @@ describe("parseSystemGraph", () => {
       parseSystemGraph({ ...valid, root: "/private/workspace" }),
     ).toThrow();
     expect(() => parseSystemGraph({ ...valid, kind: "canvas" })).toThrow();
+  });
+
+  it("rejects unknown warning codes", () => {
+    expect(() =>
+      parseSystemGraph({
+        ...valid,
+        warnings: [{ code: "inventory-broken", message: "Nope" }],
+      }),
+    ).toThrow("Invalid system graph response");
   });
 });
 

--- a/packages/harness/web/src/lib/system-graph.ts
+++ b/packages/harness/web/src/lib/system-graph.ts
@@ -58,6 +58,8 @@ const WARNING_CODES = new Set<GraphWarning["code"]>([
   "unresolved-target",
   "duplicate-edge",
   "projection-failed",
+  "duplicate-agent-key",
+  "inventory-extraction-failed",
 ]);
 
 function parseWarning(value: unknown): GraphWarning | null {


### PR DESCRIPTION
## Summary

Complete SAP-2902 by replacing the walking skeleton's array reader with a read-only agent inventory provider. Every registry-known agent owned by the selected workspace now reaches the graph, including local-only, manually connected, disconnected, duplicated, and partially extractable agents.

## Changes

- add a read-only `AgentInventoryProvider` and Harness registry adapter
- assign each agent to the deepest known containing workspace
- apply V0 identity precedence: definition slug, cached manifest name, workspace-relative fallback
- distinguish an absent manifest name from a failed inspection
- preserve duplicate identities with deterministic, path-free local node keys and typed ambiguity warnings
- cap manifest enrichment at four concurrent inspections and five seconds wall-clock, retaining partial inventory at the deadline
- carry inventory cacheability through the internal builder/store boundary without adding metadata to public graph JSON
- allow exactly one later re-enrichment of a degraded projection, then retain the second result across both server and browser caches
- merge typed, path-free inventory warnings into the public graph and accept them in the strict browser parser
- exercise disconnected inventory and bounded degraded retries through Agent Studio's mock browser flow
- add a minor Harness Changeset

## Testing

- [x] `pnpm --filter @sapiom/harness build`
- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `pnpm --filter @sapiom/harness lint` (0 errors; one pre-existing warning in `rest.test.ts`)
- [x] 59 selected inventory/projector/store/endpoint/client tests
- [x] 2,154 Harness unit/integration tests outside `workspace-watcher.test.ts`
- [x] Harness performance suite (4 tests)
- [x] 4 targeted Playwright workspace-graph scenarios
- [x] targeted Prettier check for the normalized touched files
- [x] `pnpm terminology:check`
- [x] `pnpm changeset status`
- [x] `git diff --check`

The cloud sandbox cannot make a chmod-000 fixture unreadable, so the one permission-specific workspace-watcher test fails here; the same failure reproduces unchanged on the SAP-2901 worktree. PR #712's GitHub CI is green, where that test runs under the normal runner filesystem.

## Follow-up boundary

V0 performs one bounded later-open retry when enrichment is degraded. SAP-2904 owns source-driven invalidation/refresh and user-visible warning details; this PR keeps the existing warning-count presentation.

## Screenshots/Demos

Not applicable; this changes inventory and cache correctness without changing graph presentation.

## Related

- Closes: SAP-2902
- Stacked on #712 (SAP-2901)

## Checklist

- [x] Code follows project conventions
- [x] No graph payload exposes absolute filesystem paths
- [x] Inventory reads do not scan, connect, deploy, or persist
- [x] Public graph JSON is unchanged by retry metadata
- [x] Self-reviewed
- [x] Changeset included
