### PR TITLE
fix(examples): simplify fintech radar inputs

### DIFF
--- a/examples/fintech-exec-radar/README.md
+++ b/examples/fintech-exec-radar/README.md
@@ -50,21 +50,21 @@ plan ──▶ budgetBlocked                                (call ceiling)
 
 ```json
 {
-  "companies": ["Example Fintech A", "Example Fintech B", "Example Fintech C"],
+  "deliverTo": "you@example.com",
+  "companies": ["Example Bank", "Sample Payments", "Demo Capital"],
   "signals": ["exec_moves", "funding", "hiring"],
   "window": "7d",
   "maxScrapesPerCompany": 3,
   "maxCapabilityCalls": 160,
-  "deliverTo": "you@example.com",
   "dryRun": true
 }
 ```
 
-The built-in watchlist contains 15 fictional placeholders and previews without
-spending. Replace it with the companies you track, then set `dryRun: false` for a
-live run. Input is deduplicated, and a plan with more than 15 unique companies
-fails before fan-out instead of silently dropping coverage. A live run using the
-unchanged fictional defaults is also rejected before any capability call. `window` adds a
+The run form puts optional email delivery first, requires the companies you
+actually track, and keeps tuning controls under optional fields. The first run
+previews without spending; set `dryRun: false` only after reviewing its call
+envelope. Input is deduplicated, and a plan with more than 15 unique companies
+fails before fan-out instead of silently dropping coverage. `window` adds a
 recency phrase to each search query; it is a provider hint, not an enforced date
 filter, so older results can still appear. The three signals are:
 

--- a/examples/fintech-exec-radar/index.test.mjs
+++ b/examples/fintech-exec-radar/index.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
+import { zodToJsonSchema } from "@sapiom/agent";
 import { EmailHttpError } from "@sapiom/tools";
 
 import { agent } from "./index.ts";
@@ -89,6 +90,21 @@ async function acknowledgeReportedItems(context, child) {
     context,
   );
 }
+
+test("entry contract leads with delivery and only requires a watchlist", () => {
+  const schema = zodToJsonSchema(agent.steps.plan.inputSchema);
+
+  assert.equal(Object.keys(schema.properties)[0], "deliverTo");
+  assert.equal(schema.properties.deliverTo.type, "string");
+  assert.equal(schema.properties.deliverTo.default, "");
+  assert.equal(schema.properties.deliverTo.format, "email-or-empty");
+  assert.equal(typeof schema.properties.deliverTo.pattern, "string");
+  assert.equal(schema.properties.window.default, "7d");
+  assert.equal(schema.properties.maxScrapesPerCompany.default, 3);
+  assert.equal(schema.properties.maxCapabilityCalls.default, 160);
+  assert.equal(schema.properties.dryRun.default, true);
+  assert.deepEqual(schema.required, ["companies"]);
+});
 
 test("three failed children still produce a 12-of-15 sourced digest", async () => {
   const companies = Array.from(
@@ -388,23 +404,20 @@ test("plan previews exact costs and blocks only above the configured ceiling", a
   );
   assert.equal(allowed.stepName, "fanOut");
 
-  const fictionalLiveRun = await agent.steps.plan.run(
+  const missingCompanies = await agent.steps.plan.run(
     {
-      ...baseInput,
-      companies: Array.from(
-        { length: 15 },
-        (_, index) => `Example Fintech ${String.fromCharCode(65 + index)}`,
-      ).reverse(),
+      signals: ["exec_moves", "funding", "hiring"],
+      window: "7d",
+      maxScrapesPerCompany: 3,
       maxCapabilityCalls: 160,
+      childDefinition: "fintech-exec-radar-test",
+      runDate: "2026-08-26",
       dryRun: false,
     },
     context,
   );
-  assert.equal(fictionalLiveRun.kind, "fail");
-  assert.match(
-    fictionalLiveRun.reason,
-    /replace the fictional default companies/,
-  );
+  assert.equal(missingCompanies.kind, "fail");
+  assert.match(missingCompanies.reason, /companies must contain/);
 });
 
 test("plan rejects explicit empty arrays and dedupes slug-equivalent names", async () => {
@@ -445,6 +458,20 @@ test("plan rejects explicit empty arrays and dedupes slug-equivalent names", asy
   assert.equal(deduped.stepName, "planned");
   assert.deepEqual(deduped.input.companies, ["Example Bank"]);
   assert.equal(deduped.input.estimate.companies, 1);
+
+  const rawOverLimitButUniqueWithinLimit = await agent.steps.plan.run(
+    {
+      ...baseInput,
+      maxCapabilityCalls: 160,
+      companies: [
+        ...Array.from({ length: 15 }, (_, index) => `Company ${index}`),
+        "company-0",
+      ],
+    },
+    context,
+  );
+  assert.equal(rawOverLimitButUniqueWithinLimit.stepName, "planned");
+  assert.equal(rawOverLimitButUniqueWithinLimit.input.companies.length, 15);
 
   const internationalNames = await agent.steps.plan.run(
     {

--- a/examples/fintech-exec-radar/index.ts
+++ b/examples/fintech-exec-radar/index.ts
@@ -25,24 +25,6 @@ import { z } from "zod/v4";
  */
 
 // ------------------------------------------------------------------- config
-const DEFAULT_COMPANIES = [
-  "Example Fintech A",
-  "Example Fintech B",
-  "Example Fintech C",
-  "Example Fintech D",
-  "Example Fintech E",
-  "Example Fintech F",
-  "Example Fintech G",
-  "Example Fintech H",
-  "Example Fintech I",
-  "Example Fintech J",
-  "Example Fintech K",
-  "Example Fintech L",
-  "Example Fintech M",
-  "Example Fintech N",
-  "Example Fintech O",
-] as const;
-
 const DEFAULT_SIGNALS = ["exec_moves", "funding", "hiring"] as const;
 const MAX_COMPANIES = 15;
 const MAX_SCRAPES_PER_COMPANY = 3;
@@ -55,6 +37,7 @@ const MEMORY_NAMESPACE_PREFIX = "fintech-exec-radar";
 const MEMORY_RECORD_MARKER = "reported_source_url_keys";
 const OBSERVATION_RECORD_MARKER = "fintech_radar_observation_snapshot";
 const RANK_OUTPUT_NAME = "rank_fintech_radar_items";
+const EMAIL_OR_EMPTY_PATTERN = new RegExp(`(?:^$|${z.regexes.email.source})`);
 const RANK_OUTPUT_SCHEMA = {
   type: "object",
   additionalProperties: false,
@@ -192,7 +175,6 @@ type Ctx = AgentExecutionContext<Shared>;
 
 // ------------------------------------------------------------------ helpers
 function normalizeCompanies(input: unknown): string[] {
-  if (input === undefined) return [...DEFAULT_COMPANIES];
   const values = Array.isArray(input) ? input : [];
   const bySlug = new Map<string, string>();
   for (const value of values) {
@@ -218,14 +200,6 @@ function normalizeSignals(input: unknown): Signal[] {
     ),
   ];
   return cleaned;
-}
-
-function isDefaultCompanyList(companies: string[]): boolean {
-  if (companies.length !== DEFAULT_COMPANIES.length) return false;
-  const supplied = new Set(companies.map(companyKey));
-  return DEFAULT_COMPANIES.every((company) =>
-    supplied.has(companyKey(company)),
-  );
 }
 
 function clampInteger(
@@ -768,19 +742,25 @@ async function commitReportedKeys(
 
 // ------------------------------------------------------------------- schema
 const entryInput = z.object({
+  deliverTo: z
+    .stringFormat("email-or-empty", EMAIL_OR_EMPTY_PATTERN)
+    .default("")
+    .optional()
+    .describe("Recipient email. Leave empty to return the digest inline only."),
   companies: z
     .array(z.string())
-    .default([...DEFAULT_COMPANIES])
     .describe(
       `Companies to track; deduped, with at most ${MAX_COMPANIES} unique names.`,
     ),
   signals: z
     .array(z.enum(DEFAULT_SIGNALS))
     .default([...DEFAULT_SIGNALS])
+    .optional()
     .describe("Signals to track: executive moves, funding, and hiring."),
   window: z
     .enum(["1d", "7d", "30d"])
     .default("7d")
+    .optional()
     .describe(
       "Recency hint included in every search query; the provider may return older results.",
     ),
@@ -790,22 +770,21 @@ const entryInput = z.object({
     .min(0)
     .max(MAX_SCRAPES_PER_COMPANY)
     .default(MAX_SCRAPES_PER_COMPANY)
+    .optional()
     .describe("Maximum article pages read per company across all signals."),
   maxCapabilityCalls: z
     .number()
     .int()
     .min(1)
     .default(DEFAULT_MAX_CAPABILITY_CALLS)
+    .optional()
     .describe(
       "Hard structural ceiling; the run blocks before fan-out if its maximum call envelope exceeds this number.",
     ),
-  deliverTo: z
-    .union([z.literal(""), z.email()])
-    .default("")
-    .describe("Recipient email. Leave empty to return the digest inline only."),
   dryRun: z
     .boolean()
     .default(true)
+    .optional()
     .describe(
       "Preview the resolved plan and maximum call envelope without spending. Set false to run live.",
     ),
@@ -816,6 +795,7 @@ const entryInput = z.object({
   mode: z
     .enum(["coordinate", "research"])
     .default("coordinate")
+    .optional()
     .describe(
       "Internal role. Coordinators dispatch one research child per company.",
     ),
@@ -922,12 +902,6 @@ const plan = defineStep({
         runDate,
         invalid: false,
       });
-    }
-
-    if (!dryRun && isDefaultCompanyList(companies)) {
-      return fail(
-        "replace the fictional default companies before starting a live run",
-      );
     }
 
     const estimate = costEnvelope(

--- a/examples/fintech-exec-radar/template.json
+++ b/examples/fintech-exec-radar/template.json
@@ -12,74 +12,15 @@
     "Funding watchlist",
     "Hiring-signal brief"
   ],
-  "notes": "Click **Use this template** and Sapiom builds and deploys it for you; open it on the **Agents** page and run it.\n\nWith no input it previews 15 fictional placeholders without invoking any capability. Replace `companies` with the companies you track, choose any of the three `signals`, then set `dryRun: false` for a live run; a live run using the unchanged fictional defaults is rejected before any capability call. Set `deliverTo` only when you want a real email. Email delivery reuses the account's first existing sender inbox, or creates a Fintech Exec Radar inbox when none exists. The preview returns the exact maximum call counts. Current dollar pricing comes from Sapiom's signed-in capability catalog rather than copied constants; account spending rules enforce dollar limits, while `maxCapabilityCalls` is this agent's structural hard stop.\n\nAttach a weekly cron trigger to the deployed agent for a standing radar. Precise headcount, LinkedIn scraping, paywall bypassing, CRM write-back, and a custom watchlist UI are deliberately outside v1.",
+  "notes": "Click **Use this template** and Sapiom builds and deploys it for you; open it on the **Agents** page and run it.\n\nStart with **Deliver to**: enter an email for delivery, or leave it empty to receive the digest in the run result. Then enter the companies you actually track. Signals, recency, article reads, the call ceiling, and preview mode are optional and have safe defaults. The first run previews the exact maximum call counts without invoking a capability. Set `dryRun: false` only after reviewing that plan. Email delivery reuses the account's first existing sender inbox, or creates a Fintech Exec Radar inbox when none exists. Current dollar pricing comes from Sapiom's signed-in capability catalog rather than copied constants; account spending rules enforce dollar limits, while `maxCapabilityCalls` is this agent's structural hard stop.\n\nAttach a weekly cron trigger to the deployed agent for a standing radar. Precise headcount, LinkedIn scraping, paywall bypassing, CRM write-back, and a custom watchlist UI are deliberately outside v1.",
   "settings": [
     {
-      "path": "companies",
-      "label": "Companies to track",
-      "description": "One independent child run per company; deduped, with plans over 15 unique names rejected before fan-out.",
-      "type": "string[]",
-      "default": [
-        "Example Fintech A",
-        "Example Fintech B",
-        "Example Fintech C",
-        "Example Fintech D",
-        "Example Fintech E",
-        "Example Fintech F",
-        "Example Fintech G",
-        "Example Fintech H",
-        "Example Fintech I",
-        "Example Fintech J",
-        "Example Fintech K",
-        "Example Fintech L",
-        "Example Fintech M",
-        "Example Fintech N",
-        "Example Fintech O"
-      ]
-    },
-    {
-      "path": "window",
-      "label": "Search recency hint",
-      "description": "Adds 1d, 7d, or 30d wording to each query; the search provider may return older results.",
-      "type": "string",
-      "default": "7d",
-      "example": "7d"
-    },
-    {
-      "path": "signals",
-      "label": "Signals to track",
-      "description": "Choose one or more of exec_moves, funding, and hiring.",
-      "type": "string[]",
-      "default": ["exec_moves", "funding", "hiring"]
-    },
-    {
-      "path": "maxScrapesPerCompany",
-      "label": "Article reads per company",
-      "description": "Maximum article pages read across all signals for one company.",
-      "type": "number",
-      "default": 3
-    },
-    {
-      "path": "maxCapabilityCalls",
-      "label": "Maximum capability calls",
-      "description": "Blocks before fan-out when the plan's exact maximum call envelope exceeds this value.",
-      "type": "number",
-      "default": 160
-    },
-    {
       "path": "deliverTo",
-      "label": "Email the digest to",
+      "label": "Deliver to",
       "description": "Leave empty to return the digest inline only.",
       "type": "email",
       "default": "",
       "example": "you@yourcompany.com"
-    },
-    {
-      "path": "dryRun",
-      "label": "Preview without spending",
-      "description": "Enabled by default. Disable only after replacing the fictional company placeholders.",
-      "type": "boolean",
-      "default": true
     }
   ],
   "defaultInput": {},
@@ -87,11 +28,7 @@
     {
       "title": "Preview a three-company radar without spending",
       "input": {
-        "companies": [
-          "Example Fintech A",
-          "Example Fintech B",
-          "Example Fintech C"
-        ],
+        "companies": ["Example Bank", "Sample Payments", "Demo Capital"],
         "signals": ["exec_moves", "funding", "hiring"],
         "window": "7d",
         "maxScrapesPerCompany": 3,
@@ -100,11 +37,7 @@
       "output": {
         "dryRun": true,
         "dispatched": false,
-        "companies": [
-          "Example Fintech A",
-          "Example Fintech B",
-          "Example Fintech C"
-        ],
+        "companies": ["Example Bank", "Sample Payments", "Demo Capital"],
         "estimate": {
           "companies": 3,
           "signalsPerCompany": 3,
@@ -123,13 +56,5 @@
         }
       }
     }
-  ],
-  "zeroSetup": {
-    "terminalState": "completed",
-    "expect": [
-      { "path": "dryRun", "assert": "equals", "value": true },
-      { "path": "dispatched", "assert": "equals", "value": false }
-    ],
-    "narrative": "Previews an exact call envelope for 15 fictional company placeholders without spending; replace them with the companies you track and disable dryRun for a live sourced digest."
-  }
+  ]
 }

--- a/examples/registry.json
+++ b/examples/registry.json
@@ -367,10 +367,9 @@
         }
       ],
       "setup": {
-        "runsWithNoSetup": true,
+        "runsWithNoSetup": false,
         "connectionCount": 0,
-        "settingCount": 7,
-        "degradedWithoutSetup": "Previews an exact call envelope for 15 fictional company placeholders without spending; replace them with the companies you track and disable dryRun for a live sourced digest."
+        "settingCount": 1
       }
     },
     {


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The Fintech Exec Radar run form promoted seven defaulted settings into one long always-visible form, rendered the delivery address as a JSON textarea, and prefilled a fictional company list that a user had to replace before a useful live run.

## Summary and scope

- Put `deliverTo` first in the entry contract and expose it as a scalar field labeled **Deliver to**, while retaining empty-or-valid-email schema validation.
- Require users to enter the companies they actually track; no real organization is published as a default and an unattended live run cannot spend against an untouched watchlist.
- Keep signals, recency, scrape count, call limits, and preview mode optional while preserving their safe schema defaults.
- Promote only delivery plus the required watchlist, reducing the manifest settings projection from seven fields to one.
- Add a regression test for entry-field order, email validation, required watchlist, and safe optional defaults; update the template manifest, registry projection, and README.

This does not change research, fan-out, ranking, delivery, persistence, or deduplication behavior.

## Related work

Related issue or discussion: Follow-up to #709 and direct maintainer feedback on the generated run form.

## Validation

```text
npm run typecheck (example) — passed
npm test (example) — 18/18 passed
npm run format:check (example) — passed
pnpm examples:check — passed (12 templates)
pnpm examples:check:test — 155/155 passed
pnpm lint — passed with pre-existing warnings only
pnpm build && pnpm typecheck — passed
sapiom_dev_agents_check — 7 steps, no warnings; deliverTo is first, companies is the only required field, and optional defaults are present
sapiom_dev_agents_run_local {companies:["Example Bank"]} — completed as an 11-call no-spend preview; no unused stubs or stub warnings
```

### Tests and documentation

Added emitted-schema and post-deduplication regression coverage, and updated the example README, template guidance, and sample input/output.

## Compatibility and release impact

- Breaking or externally visible changes: The example now requires an explicit company watchlist. Existing customized inputs remain accepted; omitted tuning fields resolve to the same runtime defaults.
- Changeset: N/A — this changes a gallery example and its manifest, not a published package.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

OpenAI Codex inspected the generated form behavior, implemented the schema/default simplification, updated tests and documentation, and ran the validation listed above. The diff and emitted agent manifest were manually reviewed before submission.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
