### PR TITLE
feat(harness): render full workspace dependency graphs

### DIFF
--- a/.changeset/workspace-graph-layout.md
+++ b/.changeset/workspace-graph-layout.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": minor
+---
+
+Render workspace dependency graphs as full-main Agent Studio destinations with deterministic non-linear layout, routed invocation modes, stable per-workspace pan and zoom controls, and exact agent-card navigation.

--- a/packages/harness/src/core/system-graph-inventory.ts
+++ b/packages/harness/src/core/system-graph-inventory.ts
@@ -1,14 +1,17 @@
 import { realpathSync } from "node:fs";
 import * as path from "node:path";
 
-import type {
-  AgentKey,
-  GraphWarning,
-  WorkspaceKey,
-  WorkspaceScopeSummary,
+import {
+  workspaceRelativeLocalKey,
+  type AgentKey,
+  type GraphWarning,
+  type WorkspaceKey,
+  type WorkspaceScopeSummary,
 } from "../shared/system-graph.js";
 import type { WorkflowInfo } from "../shared/types.js";
 import type { ManifestNameInspection } from "./definition-name.js";
+
+export { workspaceRelativeLocalKey } from "../shared/system-graph.js";
 
 export interface WorkspaceScope {
   workspaceKey: WorkspaceKey;
@@ -154,19 +157,6 @@ function pathDepth(input: string): number {
   return input.split(/[\\/]/).filter(Boolean).length;
 }
 
-export function workspaceRelativeLocalKey(
-  scopeRoot: string,
-  sourceRoot: string,
-): AgentKey {
-  const api = pathApi(scopeRoot);
-  const relative = api.relative(scopeRoot, sourceRoot);
-  const local =
-    relative === ""
-      ? api.basename(sourceRoot) || "root"
-      : relative.split(api.sep).join("/");
-  return `local:${local}`;
-}
-
 function normalizedAlias(value: string | null): string | null {
   const alias = value?.trim() ?? "";
   if (
@@ -266,23 +256,34 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
       .filter(({ sourceRoot }) => {
         const owner = this.ownerOf(sourceRoot, knownScopes.scopes);
         return owner?.workspaceKey === selectedScope.workspaceKey;
+      })
+      .map(({ workflow, sourceRoot }) => {
+        const fallbackKey =
+          workspaceRelativeLocalKey(
+            knownScopes.navigationRoot,
+            workflow.path,
+          ) ?? workspaceRelativeLocalKey(selectedScope.root, sourceRoot);
+        if (!fallbackKey) {
+          throw new Error("Owned system graph path had no local identity");
+        }
+        return { workflow, sourceRoot, fallbackKey };
       });
 
     const inspections = await mapWithDeadline(
       owned,
       MANIFEST_INSPECTION_CONCURRENCY,
       this.options.manifestInspectionBudgetMs ?? MANIFEST_INSPECTION_BUDGET_MS,
-      ({ workflow, sourceRoot }) =>
-        this.prepareAgent(selectedScope, workflow, sourceRoot),
+      ({ workflow, sourceRoot, fallbackKey }) =>
+        this.prepareAgent(workflow, sourceRoot, fallbackKey),
     );
     const prepared = Array.from(
       { length: owned.length },
       (_, index) =>
         inspections[index] ??
         this.prepareFallbackAgent(
-          selectedScope,
           owned[index]!.workflow,
           owned[index]!.sourceRoot,
+          owned[index]!.fallbackKey,
         ),
     ).sort(preparedOrder);
 
@@ -354,11 +355,14 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
     };
   }
 
-  private async knownScopes(
-    scope: WorkspaceScope,
-  ): Promise<{ cacheable: boolean; scopes: KnownScope[] }> {
+  private async knownScopes(scope: WorkspaceScope): Promise<{
+    cacheable: boolean;
+    navigationRoot: string;
+    scopes: KnownScope[];
+  }> {
     let summaries: readonly WorkspaceScopeSummary[] = [];
     let cacheable = true;
+    let navigationRoot = scope.root;
     try {
       summaries = await this.options.listWorkspaceScopes();
     } catch {
@@ -370,6 +374,14 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
     const byRoot = new Map<string, KnownScope>();
     for (const summary of summaries) {
       const root = canonicalGraphPath(summary.cwd);
+      if (
+        summary.workspaceKey === scope.workspaceKey &&
+        graphPathIdentity(root) === graphPathIdentity(scope.root)
+      ) {
+        // Local keys describe the registry path the browser already knows,
+        // while canonical paths remain authoritative for ownership and scans.
+        navigationRoot = summary.cwd;
+      }
       byRoot.set(graphPathIdentity(root), {
         depth: pathDepth(root),
         workspaceKey: summary.workspaceKey,
@@ -382,7 +394,7 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
       ...scope,
       depth: pathDepth(scope.root),
     });
-    return { cacheable, scopes: [...byRoot.values()] };
+    return { cacheable, navigationRoot, scopes: [...byRoot.values()] };
   }
 
   private ownerOf(
@@ -402,9 +414,9 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
   }
 
   private async prepareAgent(
-    scope: WorkspaceScope,
     workflow: WorkflowInfo,
     sourceRoot: string,
+    fallbackKey: AgentKey,
   ): Promise<PreparedAgent> {
     const definitionSlug = normalizedAlias(workflow.definitionSlug);
     let manifestName: string | null = null;
@@ -422,7 +434,6 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
       }
     }
 
-    const fallbackKey = workspaceRelativeLocalKey(scope.root, sourceRoot);
     const candidateKey = definitionSlug ?? manifestName ?? fallbackKey;
     // Keep the pre-disambiguation candidate as an alias for every copy. When
     // duplicate local fallbacks exist, a caller targeting that candidate must
@@ -450,12 +461,11 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
   }
 
   private prepareFallbackAgent(
-    scope: WorkspaceScope,
     workflow: WorkflowInfo,
     sourceRoot: string,
+    fallbackKey: AgentKey,
   ): PreparedAgent {
     const definitionSlug = normalizedAlias(workflow.definitionSlug);
-    const fallbackKey = workspaceRelativeLocalKey(scope.root, sourceRoot);
     const candidateKey = definitionSlug ?? fallbackKey;
     return {
       candidateKey,

--- a/packages/harness/src/core/system-graph.ts
+++ b/packages/harness/src/core/system-graph.ts
@@ -9,13 +9,13 @@ import type {
   WorkspaceKey,
   WorkspaceScopeSummary,
 } from "../shared/system-graph.js";
+import { workspaceRelativeLocalKey } from "../shared/system-graph.js";
 import {
   canonicalGraphPath,
   isWithinGraphPath,
   type AgentInventoryItem,
   type AgentInventoryProvider,
   type WorkspaceScope,
-  workspaceRelativeLocalKey,
 } from "./system-graph-inventory.js";
 import {
   SourceAgentRelationshipProvider,
@@ -109,7 +109,8 @@ function fallbackAgentKey(scope: WorkspaceScope, sourceRoot: string): AgentKey {
   const canonicalScope = canonicalGraphPath(scope.root);
   const canonicalSource = canonicalGraphPath(sourceRoot);
   if (isWithinGraphPath(canonicalScope, canonicalSource)) {
-    return workspaceRelativeLocalKey(canonicalScope, canonicalSource);
+    const localKey = workspaceRelativeLocalKey(canonicalScope, canonicalSource);
+    if (localKey) return localKey;
   }
   return `local:${createHash("sha256")
     .update(canonicalSource)

--- a/packages/harness/src/shared/system-graph.ts
+++ b/packages/harness/src/shared/system-graph.ts
@@ -6,6 +6,94 @@
 export type WorkspaceKey = string;
 export type AgentKey = string;
 
+interface ParsedGraphPath {
+  caseInsensitive: boolean;
+  root: string;
+  segments: string[];
+}
+
+function normalizedGraphSegments(value: string): string[] | null {
+  const segments: string[] = [];
+  for (const segment of value.split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (segments.length === 0) return null;
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  return segments;
+}
+
+/**
+ * Parse the absolute POSIX, drive-letter, and UNC paths that can cross the
+ * Harness HTTP boundary without importing Node's `path` module into the SPA.
+ */
+function parseGraphPath(input: string): ParsedGraphPath | null {
+  const normalized = input.replace(/\\/g, "/");
+  const drive = /^([A-Za-z]):\//.exec(normalized);
+  if (drive) {
+    const segments = normalizedGraphSegments(normalized.slice(drive[0].length));
+    return segments
+      ? {
+          caseInsensitive: true,
+          root: `drive:${drive[1]!.toLowerCase()}`,
+          segments,
+        }
+      : null;
+  }
+  if (normalized.startsWith("//")) {
+    const parts = normalizedGraphSegments(normalized.slice(2));
+    if (!parts || parts.length < 2) return null;
+    return {
+      caseInsensitive: true,
+      root: `unc:${parts[0]!.toLowerCase()}/${parts[1]!.toLowerCase()}`,
+      segments: parts.slice(2),
+    };
+  }
+  if (!normalized.startsWith("/")) return null;
+  const segments = normalizedGraphSegments(normalized.slice(1));
+  return segments
+    ? { caseInsensitive: false, root: "posix:/", segments }
+    : null;
+}
+
+/**
+ * The one browser/server rule for a workspace-relative local AgentKey.
+ * Callers receive null when the source is not inside the supplied scope.
+ */
+export function workspaceRelativeLocalKey(
+  scopeRoot: string,
+  sourceRoot: string,
+): AgentKey | null {
+  const scope = parseGraphPath(scopeRoot);
+  const source = parseGraphPath(sourceRoot);
+  if (
+    !scope ||
+    !source ||
+    scope.root !== source.root ||
+    scope.caseInsensitive !== source.caseInsensitive ||
+    scope.segments.length > source.segments.length
+  ) {
+    return null;
+  }
+  const equal = (left: string, right: string): boolean =>
+    scope.caseInsensitive
+      ? left.toLowerCase() === right.toLowerCase()
+      : left === right;
+  if (
+    scope.segments.some(
+      (segment, index) => !equal(segment, source.segments[index]!),
+    )
+  ) {
+    return null;
+  }
+  const relative = source.segments.slice(scope.segments.length);
+  const local = relative.join("/") || source.segments.at(-1) || "root";
+  return `local:${local}`;
+}
+
 /** Internal HTTP metadata; it is deliberately not part of SystemGraph JSON. */
 export const SYSTEM_GRAPH_CACHE_HEADER = "X-Sapiom-System-Graph-Cache";
 export type SystemGraphCacheStatus = "complete" | "degraded";

--- a/packages/harness/src/shared/system-graph.ts
+++ b/packages/harness/src/shared/system-graph.ts
@@ -54,7 +54,3 @@ export interface SystemGraph {
   edges: SystemGraphEdge[];
   warnings: GraphWarning[];
 }
-
-export type CanvasSubject =
-  | { kind: "workspace"; workspaceKey: WorkspaceKey }
-  | { kind: "agent"; workflowPath: string; sessionId: string | null };

--- a/packages/harness/web/e2e/mobile.spec.ts
+++ b/packages/harness/web/e2e/mobile.spec.ts
@@ -87,3 +87,40 @@ test("right pane opens as a bottom sheet and dismisses from its own collapse con
   // Hidden, not unmounted — the keep-alive contract holds on mobile too.
   await expect(pane).toHaveCount(1);
 });
+
+test("a workspace graph is the main destination, never the right bottom sheet", async ({
+  page,
+}) => {
+  await page.getByTestId("rail-expand").click();
+  await page.getByTestId("workspace-select-acme-app").click();
+
+  const graph = page.getByTestId("workspace-graph-view");
+  await expect(graph).toBeVisible();
+  await expect(page.locator(".rail-workflows")).toHaveCount(0);
+  await expect(page.getByTestId("right-sheet-scrim")).toHaveCount(0);
+  await expect(page.locator(".right-pane")).toBeHidden();
+  await expect(page.locator(".right-pane")).toHaveCount(1);
+  await expect(page.locator(".center-pane")).toBeHidden();
+  await expect(page.locator(".center-pane")).toHaveCount(1);
+
+  const bounds = await graph.boundingBox();
+  expect(bounds?.x).toBe(0);
+  expect(bounds?.width).toBe(375);
+  expect((bounds?.y ?? 0) + (bounds?.height ?? 0)).toBe(812);
+
+  const controls = await page.getByTestId("system-graph-controls").boundingBox();
+  expect((controls?.x ?? -1) + (controls?.width ?? 0)).toBeLessThanOrEqual(375);
+  expect((controls?.y ?? -1) + (controls?.height ?? 0)).toBeLessThanOrEqual(812);
+  const overflow = await page.evaluate(() => {
+    const element = document.scrollingElement as HTMLElement;
+    return element.scrollWidth - element.clientWidth;
+  });
+  expect(overflow).toBe(0);
+  await page.screenshot({
+    path: "web/e2e/screenshots/mobile-workspace-graph.png",
+  });
+
+  await page.getByTestId("system-graph-node-leasing").click();
+  await expect(graph).toHaveCount(0);
+  await expect(page.locator(".center-pane")).toBeVisible();
+});

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -348,7 +348,7 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     });
   });
 
-  test("a folder label opens its cached workspace graph while the chevron only folds children", async ({
+  test("a folder label opens a full-main cached workspace graph while preserving the agent view", async ({
     page,
   }) => {
     const sessionContext = page.getByTestId("session-context");
@@ -359,14 +359,41 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await expect(page.locator(".harness-terminal")).toBeVisible();
     await expect(page.getByTestId("workflow-leasing")).toBeVisible();
 
-    // The label owns graph selection; it does not fold the folder or navigate
-    // the active terminal/session.
+    // The right-pane arrangement is agent state, not workspace-graph state.
+    // Leave it on Steps and prove the folder destination does not rewrite it.
+    await page.getByTestId("right-tab-steps").click();
+    await expect(page.getByTestId("right-tab-steps")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    // The label owns graph selection; it does not fold the folder, navigate
+    // the session, or mount the graph in the right sidebar.
     await page.getByTestId("workspace-select-acme-app").click();
     await expect(page.getByTestId("workspace-group-acme-app")).toHaveClass(
       /is-selected/,
     );
     await expect(page.getByTestId("workflow-leasing")).toBeVisible();
+    await expect(page.getByTestId("workspace-graph-view")).toBeVisible();
     await expect(page.getByTestId("system-graph-canvas")).toBeVisible();
+    await expect(page.locator(".center-pane")).toBeHidden();
+    await expect(page.locator(".center-pane")).toHaveCount(1);
+    await expect(page.locator(".right-pane")).toBeHidden();
+    await expect(page.locator(".right-pane")).toHaveCount(1);
+    await expect(page.locator(".harness-terminal")).toBeHidden();
+    await expect(page.locator(".harness-terminal")).toHaveCount(1);
+    await expect(page.locator(".canvas-iframe")).toBeHidden();
+    await expect(page.locator(".canvas-iframe")).toHaveCount(1);
+
+    const destinationBounds = await page
+      .getByTestId("workspace-graph-view")
+      .boundingBox();
+    const appBounds = await page.locator(".app").boundingBox();
+    expect(destinationBounds).toEqual(appBounds);
+
+    await expect(page.getByTestId("system-graph-node-leasing")).toContainText(
+      "Leasing",
+    );
     await expect(page.getByTestId("system-graph-node-research")).toContainText(
       "Research",
     );
@@ -377,23 +404,61 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await expect(page.getByTestId("system-graph-node-reporting")).toContainText(
       "Reporting",
     );
+    await expect(page.getByTestId("system-graph-node-standalone")).toContainText(
+      "Standalone",
+    );
     await expect(
       page.getByTestId("system-graph-edge-agent:research-agent:growth"),
-    ).toContainText("invokes · static · blocking + async");
-    await expect(page.getByTestId("right-tab-canvas")).toHaveAttribute(
-      "aria-selected",
-      "true",
+    ).toContainText("blocking + async");
+    await expect(
+      page
+        .getByTestId("system-graph-edge-agent:research-agent:growth")
+        .locator("path"),
+    ).toHaveClass(/is-combined/);
+    await expect(
+      page
+        .getByTestId("system-graph-edge-agent:research-agent:growth")
+        .locator("path"),
+    ).toHaveCSS("stroke-dasharray", "none");
+    await expect(
+      page
+        .getByTestId("system-graph-edge-agent:research-agent:leasing")
+        .locator("path"),
+    ).toHaveClass(/is-async/);
+    await expect(
+      page
+        .getByTestId("system-graph-edge-agent:reporting-agent:leasing")
+        .locator("path"),
+    ).toHaveClass(/is-blocking/);
+    await expect(page.getByTestId("system-graph-node-leasing")).toHaveAttribute(
+      "type",
+      "button",
     );
-    await expect(page.getByTestId("right-tab-steps")).toBeDisabled();
-    await expect(page.getByTestId("right-tab-code")).toBeDisabled();
+    await expect(page.locator(".system-graph-node-meta").first()).toHaveText(
+      "agent",
+    );
+    await expect(
+      page.getByTestId("system-graph-canvas").getByText(/failed|running|cost/i),
+    ).toHaveCount(0);
+    await expect(page.getByTestId("system-graph-legend")).toHaveCount(0);
     await expect(sessionContext).toHaveAttribute(
       "data-session-id",
       "sess-boot",
     );
-    await expect(page.locator(".harness-terminal")).toBeVisible();
+    await page.screenshot({
+      path: "web/e2e/screenshots/workspace-graph-full.png",
+      fullPage: true,
+    });
+    await toggleTheme(page);
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    await page.screenshot({
+      path: "web/e2e/screenshots/workspace-graph-full-dark.png",
+      fullPage: true,
+    });
+    await toggleTheme(page);
 
     // The dedicated disclosure is independent: folding keeps the selected
-    // graph and the terminal exactly where they are.
+    // graph and hidden agent surfaces exactly where they are.
     await page.getByTestId("workspace-disclosure-acme-app").click();
     await expect(page.getByTestId("workflow-leasing")).toHaveCount(0);
     await expect(page.getByTestId("system-graph-canvas")).toBeVisible();
@@ -418,19 +483,85 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
       )
       .toBe(1);
 
-    // An agent row restores the ordinary per-agent/session Canvas contract.
-    await page
-      .getByTestId("workflow-leasing")
-      .locator(".workflow-item-trigger")
-      .click();
+    // A navigable graph card uses the ordinary agent-focus path and restores
+    // the exact terminal/session/right-tab arrangement that was underneath.
+    await page.getByTestId("system-graph-node-leasing").click();
     await expect(page.getByTestId("system-graph-canvas")).toHaveCount(0);
-    await expect(page.locator(".canvas-iframe")).toBeVisible();
+    await expect(page.locator(".harness-terminal")).toBeVisible();
     await expect(page.getByTestId("workflow-leasing")).toHaveClass(
       /is-focused/,
     );
     await expect(sessionContext).toHaveAttribute(
       "data-session-id",
       "sess-boot",
+    );
+    await expect(page.getByTestId("right-tab-steps")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+  });
+
+  test("workspace graph view controls pan, zoom, reset, fit, and restore per workspace", async ({
+    page,
+  }) => {
+    await page.getByTestId("workspace-select-acme-app").click();
+    const subject = page.getByTestId("system-graph-subject");
+    const reset = page.getByTestId("system-graph-zoom-reset");
+    const initialTransform = await subject.evaluate(
+      (element) => (element as HTMLElement).style.transform,
+    );
+    const initialZoom = Number((await reset.innerText()).replace("%", ""));
+
+    await page.getByTestId("system-graph-zoom-in").click();
+    await expect
+      .poll(async () => Number((await reset.innerText()).replace("%", "")))
+      .toBeGreaterThan(initialZoom);
+
+    const viewport = page.getByTestId("system-graph-viewport");
+    const box = await viewport.boundingBox();
+    if (!box) throw new Error("Missing system graph viewport bounds");
+    await page.mouse.move(box.x + box.width / 3, box.y + box.height / 3);
+    const beforeWheel = Number((await reset.innerText()).replace("%", ""));
+    await page.mouse.wheel(0, -120);
+    await expect
+      .poll(async () => Number((await reset.innerText()).replace("%", "")))
+      .toBeGreaterThan(beforeWheel);
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(
+      box.x + box.width / 2 + 60,
+      box.y + box.height / 2 + 35,
+    );
+    await page.mouse.up();
+    await expect
+      .poll(() =>
+        subject.evaluate((element) => (element as HTMLElement).style.transform),
+      )
+      .not.toBe(initialTransform);
+
+    await reset.click();
+    await expect(reset).toHaveText("100%");
+    await page.getByTestId("system-graph-fit").click();
+    const fittedTransform = await subject.evaluate(
+      (element) => (element as HTMLElement).style.transform,
+    );
+    await page.getByTestId("system-graph-zoom-in").click();
+    await viewport.dblclick({ position: { x: 8, y: 8 } });
+    await expect
+      .poll(() =>
+        subject.evaluate((element) => (element as HTMLElement).style.transform),
+      )
+      .toBe(fittedTransform);
+
+    await page
+      .getByTestId("workflow-leasing")
+      .locator(".workflow-item-trigger")
+      .click();
+    await page.getByTestId("workspace-select-acme-app").click();
+    await expect(page.getByTestId("system-graph-subject")).toHaveAttribute(
+      "style",
+      new RegExp(fittedTransform.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
     );
   });
 
@@ -451,8 +582,11 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
 
     await expect(page.getByTestId("system-graph-canvas")).toBeVisible();
     await expect(page.getByTestId("system-graph-node-research")).toBeVisible();
-    // Selecting the right-pane projection does not displace the center's
-    // no-session agent state.
+    // The graph is session-independent. The no-session agent view stays
+    // mounted underneath and returns unchanged when its card is selected.
+    await expect(page.getByTestId("open-agent-empty")).toBeHidden();
+    await expect(page.getByTestId("open-agent-empty")).toHaveCount(1);
+    await page.getByTestId("system-graph-node-leasing").click();
     await expect(page.getByTestId("open-agent-empty")).toContainText(
       "No running session for leasing",
     );

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -565,6 +565,98 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     );
   });
 
+  test("workspace graph keyboard navigation reveals focus and rejects a blank saved view", async ({
+    page,
+  }) => {
+    await page.getByTestId("workspace-select-acme-app").click();
+    const viewport = page.getByTestId("system-graph-viewport");
+    const subject = page.getByTestId("system-graph-subject");
+    const reset = page.getByTestId("system-graph-zoom-reset");
+    const viewportBounds = await viewport.boundingBox();
+    if (!viewportBounds) throw new Error("Missing system graph viewport bounds");
+
+    await viewport.focus();
+    await expect(viewport).toBeFocused();
+    const beforeKeyboardPan = await subject.evaluate(
+      (element) => (element as HTMLElement).style.transform,
+    );
+    await page.keyboard.press("ArrowRight");
+    await expect
+      .poll(() =>
+        subject.evaluate((element) => (element as HTMLElement).style.transform),
+      )
+      .not.toBe(beforeKeyboardPan);
+    await reset.click();
+
+    const panGraphOffscreen = async () => {
+      await page.mouse.move(viewportBounds.x + 8, viewportBounds.y + 8);
+      await page.mouse.down();
+      await page.mouse.move(
+        viewportBounds.x + viewportBounds.width + 2_000,
+        viewportBounds.y + viewportBounds.height + 2_000,
+      );
+      await page.mouse.up();
+      await expect
+        .poll(async () => {
+          const [viewportBox, subjectBox] = await Promise.all([
+            viewport.boundingBox(),
+            subject.boundingBox(),
+          ]);
+          if (!viewportBox || !subjectBox) return false;
+          return (
+            subjectBox.x >= viewportBox.x + viewportBox.width ||
+            subjectBox.x + subjectBox.width <= viewportBox.x ||
+            subjectBox.y >= viewportBox.y + viewportBox.height ||
+            subjectBox.y + subjectBox.height <= viewportBox.y
+          );
+        })
+        .toBe(true);
+    };
+
+    // Tabbing from the viewport to an offscreen card must pan that card back
+    // into view before its visible focus ring is shown.
+    await panGraphOffscreen();
+    await viewport.focus();
+    await page.keyboard.press("Tab");
+    const focusedCard = page.locator("button.system-graph-node").first();
+    await expect(focusedCard).toBeFocused();
+    const focusedBounds = await focusedCard.boundingBox();
+    if (!focusedBounds) throw new Error("Missing focused graph card bounds");
+    expect(focusedBounds.x).toBeGreaterThanOrEqual(viewportBounds.x + 16);
+    expect(focusedBounds.y).toBeGreaterThanOrEqual(viewportBounds.y + 16);
+    expect(focusedBounds.x + focusedBounds.width).toBeLessThanOrEqual(
+      viewportBounds.x + viewportBounds.width - 16,
+    );
+    expect(focusedBounds.y + focusedBounds.height).toBeLessThanOrEqual(
+      viewportBounds.y + viewportBounds.height - 16,
+    );
+
+    // A user may still pan beyond the subject while exploring. Reopening that
+    // workspace rejects the non-intersecting snapshot and auto-fits again.
+    await panGraphOffscreen();
+    await page
+      .getByTestId("workflow-leasing")
+      .locator(".workflow-item-trigger")
+      .click();
+    await page.getByTestId("workspace-select-acme-app").click();
+    const restoredBounds = await page
+      .getByTestId("system-graph-node-research")
+      .boundingBox();
+    if (!restoredBounds) throw new Error("Missing restored graph card bounds");
+    expect(restoredBounds.x + restoredBounds.width).toBeGreaterThan(
+      viewportBounds.x,
+    );
+    expect(restoredBounds.x).toBeLessThan(
+      viewportBounds.x + viewportBounds.width,
+    );
+    expect(restoredBounds.y + restoredBounds.height).toBeGreaterThan(
+      viewportBounds.y,
+    );
+    expect(restoredBounds.y).toBeLessThan(
+      viewportBounds.y + viewportBounds.height,
+    );
+  });
+
   test("a persisted workspace graph is viewable with no active session", async ({
     page,
   }) => {

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -9,13 +9,13 @@
  *     session tabs inside the shared header, then the conversation/terminal.
  *     Session switching and same-folder session creation live in that strip.
  *  3. RIGHT PANEL — projections of the ACTIVE session's bound agent (Canvas |
- *     Steps | Code), or a folder-selected workspace dependency graph. The
- *     canvas stays mounted behind CSS when another tab is active so a running
- *     Visualize enrichment is never disturbed by a tab flip.
+ *     Steps | Code). The canvas stays mounted behind CSS when another tab is
+ *     active so a running Visualize enrichment is never disturbed by a tab
+ *     flip.
  *
- * The ordinary mapping invariant is: rail focused agent == tab strip's agent
- * == active tab's bound agent == right panel's subject. Selecting a workspace
- * temporarily changes only the last term; the center and session stay put.
+ * A workspace folder opens its dependency graph as a full main destination.
+ * The center and right agent panes stay mounted and inert behind that
+ * destination, so returning to an agent restores the exact prior view.
  */
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { JSX } from "react";
@@ -27,7 +27,7 @@ import type {
   WorkflowInfo,
   WorkflowInputContractResponse,
 } from "@shared/types";
-import type { CanvasSubject, WorkspaceKey } from "@shared/system-graph";
+import type { WorkspaceKey } from "@shared/system-graph";
 
 import { CanvasPane } from "./components/CanvasPane";
 import { CodePanel } from "./components/CodePanel";
@@ -47,6 +47,7 @@ import { TooltipLayer } from "./components/TooltipLayer";
 import { NewSessionComposer } from "./components/NewSessionComposer";
 import { OverviewModal } from "./components/OverviewModal";
 import { WorkflowsRail } from "./components/WorkflowsRail";
+import { WorkspaceGraphView } from "./components/WorkspaceGraphView";
 import { boundWorkflowPathOf } from "./lib/api";
 import { classifyConnectivity, useConnectivity } from "./lib/connectivity";
 import { historyDirs } from "./lib/history-meta";
@@ -182,8 +183,8 @@ export const App = (): JSX.Element => {
   // selection and the main panel's tab-strip subject. The active tab's
   // session is harness.activeSessionId.
   const [focusedAgentPath, setFocusedAgentPath] = useState<string | null>(null);
-  // Folder selection owns only the right Canvas. It deliberately does not
-  // mutate focusedAgentPath or activeSessionId, so the terminal never jumps.
+  // Folder selection opens a full-main graph destination. It deliberately
+  // does not mutate the focused agent, active session, or either agent pane.
   const [selectedWorkspaceKey, setSelectedWorkspaceKey] =
     useState<WorkspaceKey | null>(null);
   // "Open in Studio" deep links (sapiom://agent/<id>). The applier is a ref
@@ -754,9 +755,16 @@ export const App = (): JSX.Element => {
   const showComposer =
     !showReview && !showDead && (composing || (!showAgentEmpty && !showWorkbench));
   const showWorkspaceGraph = selectedWorkspaceKey != null;
-  // The composer still owns the center when there is no live session, but a
-  // folder graph remains independently viewable beside it.
   const rightPaneSuppressedByComposer = showComposer && !showWorkspaceGraph;
+  const workspaceScopes = state.workspaceScopes ?? [];
+  const selectedWorkspaceScope = selectedWorkspaceKey
+    ? (workspaceScopes.find(
+        (scope) => scope.workspaceKey === selectedWorkspaceKey,
+      ) ?? null)
+    : null;
+  const selectedWorkspaceName = selectedWorkspaceScope
+    ? basenameOf(selectedWorkspaceScope.cwd)
+    : "Workspace";
   // A live session to return to when the composer was opened over the workbench.
   const composerCanCancel =
     composing && activeSession != null && activeSession.status !== "exited";
@@ -782,14 +790,6 @@ export const App = (): JSX.Element => {
         harness.lastDeployErrorFor(rightPaneWorkflow.path),
       )
     : null;
-  const canvasSubject: CanvasSubject = showWorkspaceGraph
-    ? { kind: "workspace", workspaceKey: selectedWorkspaceKey }
-    : {
-        kind: "agent",
-        workflowPath: rightPaneWorkflow?.path ?? focusedAgentPath ?? "",
-        sessionId: harness.activeSessionId,
-      };
-
   // Run inspection for the active session.
   const selectedObservedRun = harness.activeSessionId
     ? (harness.runsBySession.get(harness.activeSessionId) ?? null)
@@ -820,13 +820,8 @@ export const App = (): JSX.Element => {
 
   const handleSelectWorkspace = (workspaceKey: WorkspaceKey): void => {
     setSelectedWorkspaceKey(workspaceKey);
-    setRightTab("canvas");
-    setCanvasExpanded(false);
-    setRightCollapsed(false);
-    // Templates is the one full-width destination that suppresses both panes;
-    // selecting a folder returns to the unchanged workbench/composer center so
-    // the requested graph can actually be seen.
     setTemplatesOpen(false);
+    setOverviewOpen(false);
     closeMobileDrawer();
   };
 
@@ -1538,10 +1533,14 @@ export const App = (): JSX.Element => {
             // stand in for the workbench — `.is-browsing` hides the panes for
             // either.
             (templatesOpen ? " is-browsing" : "") +
+            (showWorkspaceGraph ? " is-workspace-graph" : "") +
             // The workbench animates the canvas column open/closed (see
             // .app.canvas-animated). Off while browsing / composing / mobile,
             // where the single-column switch should be instant.
-            (!templatesOpen && !isMobile && !rightPaneSuppressedByComposer
+            (!templatesOpen &&
+              !showWorkspaceGraph &&
+              !isMobile &&
+              !rightPaneSuppressedByComposer
               ? " canvas-animated"
               : "") +
             // Present only DURING an open/close slide: it pins the pane content
@@ -1558,7 +1557,10 @@ export const App = (): JSX.Element => {
               // Browsing and the composer home take the whole width: a
               // two-column card grid inside half the shell is the letterbox this
               // view exists to escape, and the composer has no canvas yet.
-              templatesOpen || isMobile || rightPaneSuppressedByComposer
+              templatesOpen ||
+              showWorkspaceGraph ||
+              isMobile ||
+              rightPaneSuppressedByComposer
                 ? "minmax(0, 1fr)"
                 : // Two tracks always, so the canvas column can animate to 0 on
                   // collapse — the pane (and its left-edge shadow) slides shut,
@@ -1592,7 +1594,26 @@ export const App = (): JSX.Element => {
             />
           )}
 
-          <div className="center-pane">
+          {showWorkspaceGraph && selectedWorkspaceKey && (
+            <WorkspaceGraphView
+              key={selectedWorkspaceKey}
+              workspaceKey={selectedWorkspaceKey}
+              workspaceName={selectedWorkspaceName}
+              api={harness.api}
+              workflows={state.workflows}
+              workspaceScopes={workspaceScopes}
+              onOpenAgent={handleFocusAgent}
+              onExpandRail={
+                railCollapsed ? () => setRailCollapsed(false) : undefined
+              }
+            />
+          )}
+
+          <div
+            className="center-pane"
+            inert={showWorkspaceGraph ? true : undefined}
+            aria-hidden={showWorkspaceGraph || undefined}
+          >
             <SessionBar
               openedAgentName={noSessionAgentName}
               reviewTitle={reviewSummary ? reviewSummary.title : null}
@@ -1764,7 +1785,7 @@ export const App = (): JSX.Element => {
             />
           )}
 
-          {isMobile && !rightCollapsed && (
+          {isMobile && !showWorkspaceGraph && !rightCollapsed && (
             <div
               className="shell-scrim"
               data-testid="right-sheet-scrim"
@@ -1784,6 +1805,8 @@ export const App = (): JSX.Element => {
                 ? " is-collapsed"
                 : "")
             }
+            inert={showWorkspaceGraph ? true : undefined}
+            aria-hidden={showWorkspaceGraph || undefined}
           >
             <div className="right-pane-tabs" role="tablist" aria-label="Right pane">
               <button
@@ -1800,7 +1823,6 @@ export const App = (): JSX.Element => {
                 role="tab"
                 aria-selected={rightTab === "steps"}
                 className={"right-pane-tab" + (rightTab === "steps" ? " is-active" : "")}
-                disabled={showWorkspaceGraph}
                 onClick={() => setRightTab("steps")}
                 data-testid="right-tab-steps"
               >
@@ -1811,7 +1833,6 @@ export const App = (): JSX.Element => {
                 role="tab"
                 aria-selected={rightTab === "code"}
                 className={"right-pane-tab" + (rightTab === "code" ? " is-active" : "")}
-                disabled={showWorkspaceGraph}
                 onClick={() => {
                   setRightTab("code");
                   setCodePanelEverShown(true);
@@ -1824,8 +1845,7 @@ export const App = (): JSX.Element => {
               <div className="right-pane-corner">
                 {/* Cloud-status pill → dashboard. The board has no subheader,
                     so the link/build state lives here in the tab bar. */}
-                {!showWorkspaceGraph &&
-                  rightTab === "canvas" &&
+                {rightTab === "canvas" &&
                   rightPaneWorkflow?.definitionId != null && (
                     <a
                       className="status-tag status-tag-action workflow-deployed-tag right-pane-deployed"
@@ -1848,8 +1868,7 @@ export const App = (): JSX.Element => {
                     </a>
                   )}
                 {/* Canvas expand / Steps Focus sits beside the panel toggle. */}
-                {!showWorkspaceGraph &&
-                  (rightTab === "canvas" || rightTab === "steps") && (
+                {(rightTab === "canvas" || rightTab === "steps") && (
                   <button
                     className="theme-toggle"
                     data-testid="canvas-expand"
@@ -1878,8 +1897,6 @@ export const App = (): JSX.Element => {
               data-testid="right-panel-canvas"
             >
               <CanvasPane
-                subject={canvasSubject}
-                api={harness.api}
                 sessionId={harness.activeSessionId}
                 lastMessage={harness.lastMessage}
                 boundWorkflow={rightPaneWorkflow}
@@ -1887,8 +1904,9 @@ export const App = (): JSX.Element => {
                 overviewActive={showComposer}
                 sessionExited={showDead}
                 onCanvasState={(hasContent) => {
-                  // A workspace graph owns this surface independently. Late
-                  // probes from the still-mounted agent canvas must not fold it.
+                  // A full-main workspace graph leaves this agent probe mounted;
+                  // it must not mutate the hidden pane while that destination
+                  // is open.
                   if (showWorkspaceGraph) return;
                   // The pane follows the active session's board: open it whenever
                   // the session has one, close it when it doesn't. This fires on

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { JSX } from "react";
 import type { BackgroundTask, BusMessage, MacroDef, RunView, WorkflowInfo } from "@shared/types";
-import type { CanvasSubject } from "@shared/system-graph";
 
-import { isMockMode, type HarnessApi } from "../lib/api";
+import { isMockMode } from "../lib/api";
 import { MOCK_CANVAS_OVERVIEWS, hasMockCanvasDoc } from "../lib/mock-data";
 import { getTheme, subscribeTheme } from "../lib/theme";
 import { type CanvasGraph, formatGraphCounts, parseCanvasGraph } from "../lib/canvas-graph";
@@ -19,7 +18,6 @@ import { EmptyState } from "./EmptyState";
 import { Icon } from "./Icon";
 import { WorkflowActionsHeader } from "./WorkflowActionsHeader";
 import { RunWorkspace } from "./RunWorkspace";
-import { SystemGraphCanvas } from "./SystemGraphCanvas";
 import { track as trackProduct } from "../lib/analytics/events";
 import { trackingAttrs } from "../lib/analytics/tracking-attrs";
 
@@ -32,10 +30,6 @@ const ACTIVITY_LINES_SHOWN = 8;
 const FRAME_LOAD_TIMEOUT_MS = 4000;
 
 interface CanvasPaneProps {
-  /** Explicit owner of the Canvas surface. Workspace subjects use the local
-   * system-graph contract; agent subjects retain the session canvas below. */
-  subject: CanvasSubject;
-  api: HarnessApi;
   sessionId: string | null;
   lastMessage: BusMessage | null;
   boundWorkflow: WorkflowInfo | null;
@@ -128,8 +122,6 @@ function isLegendItem(value: unknown): value is CanvasLegendItem {
 }
 
 export function CanvasPane({
-  subject,
-  api,
   sessionId,
   lastMessage,
   boundWorkflow,
@@ -786,18 +778,6 @@ export function CanvasPane({
   // GitHub's 404 page rendered inside the pane.
   const sessionHasServableDoc = sessionId != null && (!isMockMode() || hasMockCanvasDoc(sessionId));
   const showsContent = hasGeneratedContent && sessionHasServableDoc;
-
-  // Keep every hook above unconditional so switching the right-pane subject
-  // never violates React's hook ordering. A workspace owns only this Canvas
-  // projection; the mounted session and center pane remain untouched.
-  if (subject.kind === "workspace") {
-    return (
-      <aside className="canvas-pane" {...trackingAttrs({ surface: "canvas" })}>
-        <SystemGraphCanvas workspaceKey={subject.workspaceKey} api={api} />
-      </aside>
-    );
-  }
-
 
   // The observability header for the Steps surface: a deploy landing (if one is
   // in flight/just landed) and the run summary card (if a run has been

--- a/packages/harness/web/src/components/SystemGraphCanvas.tsx
+++ b/packages/harness/web/src/components/SystemGraphCanvas.tsx
@@ -10,6 +10,7 @@ import {
 import type {
   CSSProperties,
   JSX,
+  KeyboardEvent as ReactKeyboardEvent,
   PointerEvent as ReactPointerEvent,
 } from "react";
 import type { AgentKey, SystemGraph, WorkspaceKey } from "@shared/system-graph";
@@ -17,6 +18,7 @@ import type { AgentKey, SystemGraph, WorkspaceKey } from "@shared/system-graph";
 import {
   layoutSystemGraph,
   systemGraphNodeById,
+  type SystemGraphLayoutNode,
 } from "../lib/system-graph-layout";
 import {
   SYSTEM_GRAPH_DEFAULT_MIN_ZOOM,
@@ -25,8 +27,12 @@ import {
   clampSystemGraphZoom,
   createSystemGraphViewportStore,
   fitSystemGraphView,
+  panSystemGraphViewWithKeyboard,
   resetSystemGraphView,
+  revealSystemGraphRect,
+  systemGraphViewIntersectsViewport,
   wheelSystemGraphView,
+  type SystemGraphArrowKey,
   type SystemGraphView,
 } from "../lib/system-graph-viewport";
 import { trackingAttrs } from "../lib/analytics/tracking-attrs";
@@ -71,9 +77,8 @@ export function SystemGraphCanvas({
   }, [graph]);
   const layout = computed.layout;
   const graphNodes = useMemo(() => systemGraphNodeById(graph), [graph]);
-  const saved = viewportStore.get(workspaceKey);
   const [view, setView] = useState<SystemGraphView>(
-    saved?.view ?? resetSystemGraphView(),
+    () => viewportStore.get(workspaceKey) ?? resetSystemGraphView(),
   );
   const [minZoom, setMinZoom] = useState(SYSTEM_GRAPH_DEFAULT_MIN_ZOOM);
   const [panning, setPanning] = useState(false);
@@ -89,17 +94,14 @@ export function SystemGraphCanvas({
     ): void => {
       setView((current) => {
         const resolved = typeof next === "function" ? next(current) : next;
-        viewportStore.set(workspaceKey, {
-          view: resolved,
-          autoFitted: true,
-        });
+        viewportStore.set(workspaceKey, resolved);
         return resolved;
       });
     },
     [workspaceKey],
   );
 
-  const readFit = useCallback(() => {
+  const readViewportFit = useCallback(() => {
     const viewport = viewportRef.current;
     if (!viewport || !layout) return null;
     const rect = viewport.getBoundingClientRect();
@@ -107,42 +109,53 @@ export function SystemGraphCanvas({
     const rootFontSize = Number.parseFloat(
       getComputedStyle(document.documentElement).fontSize,
     );
-    return fitSystemGraphView(
-      layout.bounds,
-      { width: rect.width, height: rect.height },
-      Number.isFinite(rootFontSize) ? rootFontSize : 16,
-    );
+    const viewportSize = { width: rect.width, height: rect.height };
+    return {
+      fit: fitSystemGraphView(
+        layout.bounds,
+        viewportSize,
+        Number.isFinite(rootFontSize) ? rootFontSize : 16,
+      ),
+      viewport: viewportSize,
+    };
   }, [layout]);
 
   const fitView = useCallback((): void => {
-    const fit = readFit();
-    if (!fit) return;
+    const measured = readViewportFit();
+    if (!measured) return;
+    const { fit } = measured;
     setMinZoom(fit.minZoom);
     commitView({ zoom: fit.zoom, x: fit.x, y: fit.y });
-  }, [commitView, readFit]);
+  }, [commitView, readViewportFit]);
 
   useLayoutEffect(() => {
     const viewport = viewportRef.current;
     if (!viewport || !layout) return;
     const syncFloor = (): void => {
-      const fit = readFit();
-      if (fit) setMinZoom(fit.minZoom);
+      const measured = readViewportFit();
+      if (measured) setMinZoom(measured.fit.minZoom);
     };
     const existing = viewportStore.get(workspaceKey);
-    const fit = readFit();
-    if (fit) {
+    const measured = readViewportFit();
+    if (measured) {
+      const { fit, viewport: viewportSize } = measured;
       setMinZoom(fit.minZoom);
-      if (existing?.autoFitted) {
-        setView(existing.view);
+      if (
+        existing &&
+        systemGraphViewIntersectsViewport(
+          existing,
+          layout.bounds,
+          viewportSize,
+          layout.nodes,
+        )
+      ) {
+        setView(existing);
       } else {
         // The system-map reference never enlarges a small graph on arrival;
         // explicit Fit may zoom up later. Containment wins when 100% crops.
         const initial = { ...fit, zoom: Math.min(1, fit.zoom) };
         const initialView = { zoom: initial.zoom, x: 0, y: 0 };
-        viewportStore.set(workspaceKey, {
-          view: initialView,
-          autoFitted: true,
-        });
+        viewportStore.set(workspaceKey, initialView);
         setView(initialView);
       }
     }
@@ -150,7 +163,7 @@ export function SystemGraphCanvas({
     const observer = new ResizeObserver(syncFloor);
     observer.observe(viewport);
     return () => observer.disconnect();
-  }, [layout, readFit, workspaceKey]);
+  }, [layout, readViewportFit, workspaceKey]);
 
   useEffect(() => {
     const viewport = viewportRef.current;
@@ -220,6 +233,22 @@ export function SystemGraphCanvas({
     });
   };
 
+  const handleKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>): void => {
+    if (event.target !== event.currentTarget) return;
+    if (
+      event.key !== "ArrowLeft" &&
+      event.key !== "ArrowRight" &&
+      event.key !== "ArrowUp" &&
+      event.key !== "ArrowDown"
+    ) {
+      return;
+    }
+    event.preventDefault();
+    commitView((current) =>
+      panSystemGraphViewWithKeyboard(current, event.key as SystemGraphArrowKey),
+    );
+  };
+
   if (computed.failed || !layout) {
     return (
       <EmptyState
@@ -232,12 +261,31 @@ export function SystemGraphCanvas({
     );
   }
 
+  const revealNode = (node: SystemGraphLayoutNode): void => {
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const rect = viewport.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return;
+    commitView((current) =>
+      revealSystemGraphRect(
+        current,
+        layout.bounds,
+        { width: rect.width, height: rect.height },
+        node,
+      ),
+    );
+  };
+
   return (
     <div className="system-graph-canvas" data-testid="system-graph-canvas">
       <div
         ref={viewportRef}
         className={"system-graph-viewport" + (panning ? " is-panning" : "")}
         data-testid="system-graph-viewport"
+        role="region"
+        aria-label="Workspace dependency graph. Use arrow keys to pan."
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={finishPan}
@@ -335,6 +383,7 @@ export function SystemGraphCanvas({
                 style={style}
                 title={graphNode.label}
                 aria-label={`Open ${graphNode.label}`}
+                onFocus={() => revealNode(placed)}
                 onClick={() => onOpenAgent(graphNode.agentKey)}
                 {...trackingAttrs({ object: "agent" })}
               >

--- a/packages/harness/web/src/components/SystemGraphCanvas.tsx
+++ b/packages/harness/web/src/components/SystemGraphCanvas.tsx
@@ -1,194 +1,425 @@
-import { useEffect, useState } from "react";
-import type { JSX } from "react";
-import type { SystemGraph, WorkspaceKey } from "@shared/system-graph";
-
-import type { HarnessApi } from "../lib/api";
 import {
-  groupSystemGraphEdges,
-  orderSystemGraphNodes,
-} from "../lib/system-graph";
-import { createSystemGraphLoader } from "../lib/system-graph-loader";
-import { EmptyState } from "./EmptyState";
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type {
+  CSSProperties,
+  JSX,
+  PointerEvent as ReactPointerEvent,
+} from "react";
+import type { AgentKey, SystemGraph, WorkspaceKey } from "@shared/system-graph";
 
-/**
- * V0 mirrors the server's process-lifetime snapshot in the browser tab, with
- * one later-open retry for a degraded projection. SAP-2904 owns source-driven
- * invalidation and user-visible freshness states.
- */
-const loadSystemGraph = createSystemGraphLoader();
+import {
+  layoutSystemGraph,
+  systemGraphNodeById,
+} from "../lib/system-graph-layout";
+import {
+  SYSTEM_GRAPH_DEFAULT_MIN_ZOOM,
+  SYSTEM_GRAPH_MAX_ZOOM,
+  SYSTEM_GRAPH_ZOOM_STEP,
+  clampSystemGraphZoom,
+  createSystemGraphViewportStore,
+  fitSystemGraphView,
+  resetSystemGraphView,
+  wheelSystemGraphView,
+  type SystemGraphView,
+} from "../lib/system-graph-viewport";
+import { trackingAttrs } from "../lib/analytics/tracking-attrs";
+import { EmptyState } from "./EmptyState";
+import { Icon } from "./Icon";
+
+const viewportStore = createSystemGraphViewportStore();
+const PAN_THRESHOLD = 3;
 
 interface SystemGraphCanvasProps {
+  graph: SystemGraph;
   workspaceKey: WorkspaceKey;
-  api: HarnessApi;
+  navigableAgentKeys: ReadonlySet<AgentKey>;
+  onOpenAgent: (agentKey: AgentKey) => void;
+}
+
+interface DragState {
+  pointerId: number;
+  startClientX: number;
+  startClientY: number;
+  startView: SystemGraphView;
+  moved: boolean;
+}
+
+function edgeModeClass(modes: readonly string[]): string {
+  if (modes.length === 2) return "is-combined";
+  return modes[0] === "async" ? "is-async" : "is-blocking";
 }
 
 export function SystemGraphCanvas({
+  graph,
   workspaceKey,
-  api,
+  navigableAgentKeys,
+  onOpenAgent,
 }: SystemGraphCanvasProps): JSX.Element {
-  const [graph, setGraph] = useState<SystemGraph | null>(null);
-  const [error, setError] = useState(false);
-  const [attempt, setAttempt] = useState(0);
+  const computed = useMemo(() => {
+    try {
+      return { layout: layoutSystemGraph(graph), failed: false } as const;
+    } catch {
+      return { layout: null, failed: true } as const;
+    }
+  }, [graph]);
+  const layout = computed.layout;
+  const graphNodes = useMemo(() => systemGraphNodeById(graph), [graph]);
+  const saved = viewportStore.get(workspaceKey);
+  const [view, setView] = useState<SystemGraphView>(
+    saved?.view ?? resetSystemGraphView(),
+  );
+  const [minZoom, setMinZoom] = useState(SYSTEM_GRAPH_DEFAULT_MIN_ZOOM);
+  const [panning, setPanning] = useState(false);
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const dragRef = useRef<DragState | null>(null);
+  const viewRef = useRef(view);
+  viewRef.current = view;
+  const markerId = `system-graph-arrow-${useId().replace(/:/g, "")}`;
+
+  const commitView = useCallback(
+    (
+      next: SystemGraphView | ((current: SystemGraphView) => SystemGraphView),
+    ): void => {
+      setView((current) => {
+        const resolved = typeof next === "function" ? next(current) : next;
+        viewportStore.set(workspaceKey, {
+          view: resolved,
+          autoFitted: true,
+        });
+        return resolved;
+      });
+    },
+    [workspaceKey],
+  );
+
+  const readFit = useCallback(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || !layout) return null;
+    const rect = viewport.getBoundingClientRect();
+    if (rect.width <= 0 || rect.height <= 0) return null;
+    const rootFontSize = Number.parseFloat(
+      getComputedStyle(document.documentElement).fontSize,
+    );
+    return fitSystemGraphView(
+      layout.bounds,
+      { width: rect.width, height: rect.height },
+      Number.isFinite(rootFontSize) ? rootFontSize : 16,
+    );
+  }, [layout]);
+
+  const fitView = useCallback((): void => {
+    const fit = readFit();
+    if (!fit) return;
+    setMinZoom(fit.minZoom);
+    commitView({ zoom: fit.zoom, x: fit.x, y: fit.y });
+  }, [commitView, readFit]);
+
+  useLayoutEffect(() => {
+    const viewport = viewportRef.current;
+    if (!viewport || !layout) return;
+    const syncFloor = (): void => {
+      const fit = readFit();
+      if (fit) setMinZoom(fit.minZoom);
+    };
+    const existing = viewportStore.get(workspaceKey);
+    const fit = readFit();
+    if (fit) {
+      setMinZoom(fit.minZoom);
+      if (existing?.autoFitted) {
+        setView(existing.view);
+      } else {
+        // The system-map reference never enlarges a small graph on arrival;
+        // explicit Fit may zoom up later. Containment wins when 100% crops.
+        const initial = { ...fit, zoom: Math.min(1, fit.zoom) };
+        const initialView = { zoom: initial.zoom, x: 0, y: 0 };
+        viewportStore.set(workspaceKey, {
+          view: initialView,
+          autoFitted: true,
+        });
+        setView(initialView);
+      }
+    }
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(syncFloor);
+    observer.observe(viewport);
+    return () => observer.disconnect();
+  }, [layout, readFit, workspaceKey]);
 
   useEffect(() => {
-    let active = true;
-    setGraph(null);
-    setError(false);
-    void loadSystemGraph(api, workspaceKey).then(
-      (next) => {
-        if (active) setGraph(next);
-      },
-      () => {
-        if (active) setError(true);
-      },
-    );
-    return () => {
-      active = false;
+    const viewport = viewportRef.current;
+    if (!viewport) return;
+    const onWheel = (event: WheelEvent): void => {
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest(".system-graph-controls")
+      ) {
+        return;
+      }
+      event.preventDefault();
+      const rect = viewport.getBoundingClientRect();
+      const pointer = {
+        x: event.clientX - (rect.left + rect.width / 2),
+        y: event.clientY - (rect.top + rect.height / 2),
+      };
+      commitView((current) =>
+        wheelSystemGraphView(current, event.deltaY, pointer, minZoom),
+      );
     };
-  }, [api, workspaceKey, attempt]);
+    viewport.addEventListener("wheel", onWheel, { passive: false });
+    return () => viewport.removeEventListener("wheel", onWheel);
+  }, [commitView, minZoom]);
 
-  if (error) {
+  const finishPan = (event: ReactPointerEvent<HTMLDivElement>): void => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId);
+    }
+    dragRef.current = null;
+    setPanning(false);
+  };
+
+  const handlePointerDown = (
+    event: ReactPointerEvent<HTMLDivElement>,
+  ): void => {
+    if (event.button !== 0) return;
+    const target = event.target;
+    if (target instanceof Element && target.closest("button, a")) return;
+    dragRef.current = {
+      pointerId: event.pointerId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startView: viewRef.current,
+      moved: false,
+    };
+    event.currentTarget.setPointerCapture(event.pointerId);
+  };
+
+  const handlePointerMove = (
+    event: ReactPointerEvent<HTMLDivElement>,
+  ): void => {
+    const drag = dragRef.current;
+    if (!drag || drag.pointerId !== event.pointerId) return;
+    const dx = event.clientX - drag.startClientX;
+    const dy = event.clientY - drag.startClientY;
+    if (!drag.moved && Math.hypot(dx, dy) < PAN_THRESHOLD) return;
+    drag.moved = true;
+    setPanning(true);
+    commitView({
+      ...drag.startView,
+      x: drag.startView.x + dx,
+      y: drag.startView.y + dy,
+    });
+  };
+
+  if (computed.failed || !layout) {
     return (
       <EmptyState
-        className="canvas-empty system-graph-state"
-        testId="system-graph-error"
+        className="system-graph-state"
+        testId="system-graph-layout-error"
         icon="TriangleAlert"
-        title="Couldn't load this workspace graph"
-        body="The local projection failed. Retry the filesystem scan."
-        cta={
-          <button
-            className="btn-primary"
-            onClick={() => setAttempt((value) => value + 1)}
-          >
-            Retry
-          </button>
-        }
+        title="Couldn't lay out this workspace graph"
+        body="The local graph was malformed, so Studio stopped before rendering unsafe geometry."
       />
     );
   }
-
-  if (!graph) {
-    return (
-      <div
-        className="canvas-loading system-graph-state"
-        data-testid="system-graph-loading"
-      >
-        <span className="canvas-task-spinner" aria-hidden="true" />
-        <p className="canvas-empty-hint">Loading workspace graph…</p>
-      </div>
-    );
-  }
-
-  if (graph.nodes.length === 0) {
-    return (
-      <EmptyState
-        className="canvas-empty system-graph-state"
-        testId="system-graph-empty"
-        icon="Frame"
-        title="No agents in this workspace"
-        body="Agent projects discovered inside this folder will appear here."
-      />
-    );
-  }
-
-  const width = 420;
-  const cardWidth = 240;
-  const cardHeight = 72;
-  const cardX = (width - cardWidth) / 2;
-  const top = 44;
-  const gap = 76;
-  const orderedNodes = orderSystemGraphNodes(graph);
-  const visibleEdges = groupSystemGraphEdges(graph.edges);
-  const positions = new Map(
-    orderedNodes.map((node, index) => [
-      node.id,
-      { x: cardX, y: top + index * (cardHeight + gap) },
-    ]),
-  );
-  const height = Math.max(
-    320,
-    top * 2 + graph.nodes.length * cardHeight + (graph.nodes.length - 1) * gap,
-  );
 
   return (
     <div className="system-graph-canvas" data-testid="system-graph-canvas">
-      <div className="system-graph-heading">
-        <span>Workspace dependencies</span>
-        <span>{graph.nodes.length} agents</span>
-      </div>
-      <div className="system-graph-scroll">
-        <svg
-          className="system-graph-svg"
-          viewBox={`0 0 ${width} ${height}`}
-          role="img"
+      <div
+        ref={viewportRef}
+        className={"system-graph-viewport" + (panning ? " is-panning" : "")}
+        data-testid="system-graph-viewport"
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={finishPan}
+        onPointerCancel={finishPan}
+        onDoubleClick={(event) => {
+          const target = event.target;
+          if (
+            !(target instanceof Element) ||
+            !target.closest(".system-graph-node, button, a")
+          ) {
+            fitView();
+          }
+        }}
+      >
+        <div
+          className="system-graph-subject"
+          data-testid="system-graph-subject"
+          data-semantic-zoom={view.zoom < 0.55 ? "far" : "near"}
+          style={
+            {
+              width: layout.bounds.width,
+              height: layout.bounds.height,
+              transform: `translate(-50%, -50%) translate(${view.x}px, ${view.y}px) scale(${view.zoom})`,
+            } satisfies CSSProperties
+          }
+          role="group"
           aria-label="Workspace dependency graph"
         >
-          <defs>
-            <marker
-              id="system-graph-arrow"
-              markerWidth="8"
-              markerHeight="8"
-              refX="7"
-              refY="4"
-              orient="auto"
-              markerUnits="strokeWidth"
-            >
-              <path d="M 0 0 L 8 4 L 0 8 z" className="system-graph-arrow" />
-            </marker>
-          </defs>
-
-          {visibleEdges.map((edge) => {
-            const from = positions.get(edge.from);
-            const to = positions.get(edge.to);
-            if (!from || !to) return null;
-            const startX = from.x + cardWidth / 2;
-            const startY = from.y + cardHeight;
-            const endX = to.x + cardWidth / 2;
-            const endY = to.y;
-            const middleY = (startY + endY) / 2;
-            return (
+          <svg
+            className="system-graph-edges"
+            width={layout.bounds.width}
+            height={layout.bounds.height}
+            viewBox={`0 0 ${layout.bounds.width} ${layout.bounds.height}`}
+            aria-hidden="true"
+          >
+            <defs>
+              <marker
+                id={markerId}
+                markerWidth="8"
+                markerHeight="8"
+                refX="7"
+                refY="4"
+                orient="auto"
+                markerUnits="strokeWidth"
+              >
+                <path d="M 0 0 L 8 4 L 0 8 z" className="system-graph-arrow" />
+              </marker>
+            </defs>
+            {layout.edges.map((edge) => (
               <g
-                key={`${edge.from}-${edge.to}`}
+                key={JSON.stringify([edge.from, edge.to])}
                 data-testid={`system-graph-edge-${edge.from}-${edge.to}`}
               >
                 <path
-                  className="system-graph-edge"
-                  d={`M ${startX} ${startY} C ${startX} ${middleY}, ${endX} ${middleY}, ${endX} ${endY - 8}`}
-                  markerEnd="url(#system-graph-arrow)"
+                  className={`system-graph-edge ${edgeModeClass(edge.modes)}`}
+                  d={edge.path}
+                  markerEnd={`url(#${markerId})`}
                 />
                 <text
                   className="system-graph-edge-label"
-                  x={startX + 12}
-                  y={middleY + 4}
+                  x={edge.labelX}
+                  y={edge.labelY}
+                  textAnchor="middle"
                 >
-                  {`invokes · static · ${edge.modes.join(" + ")}`}
+                  {edge.label}
                 </text>
               </g>
-            );
-          })}
+            ))}
+          </svg>
 
-          {orderedNodes.map((node) => {
-            const position = positions.get(node.id)!;
-            return (
-              <g
-                key={node.id}
-                className="system-graph-node"
-                data-testid={`system-graph-node-${node.agentKey}`}
-                transform={`translate(${position.x} ${position.y})`}
+          {layout.nodes.map((placed) => {
+            const graphNode = graphNodes.get(placed.id)!;
+            const navigable = navigableAgentKeys.has(graphNode.agentKey);
+            const style = {
+              left: placed.x,
+              top: placed.y,
+              width: placed.width,
+              height: placed.height,
+            } satisfies CSSProperties;
+            const contents = (
+              <>
+                <span className="system-graph-node-label">
+                  {graphNode.label}
+                </span>
+                <span className="system-graph-node-meta">agent</span>
+              </>
+            );
+            return navigable ? (
+              <button
+                key={placed.id}
+                type="button"
+                className="system-graph-node is-navigable"
+                data-testid={`system-graph-node-${graphNode.agentKey}`}
+                data-agent-key={graphNode.agentKey}
+                style={style}
+                title={graphNode.label}
+                aria-label={`Open ${graphNode.label}`}
+                onClick={() => onOpenAgent(graphNode.agentKey)}
+                {...trackingAttrs({ object: "agent" })}
               >
-                <rect width={cardWidth} height={cardHeight} rx="10" />
-                <circle cx="24" cy="25" r="5" />
-                <text className="system-graph-node-label" x="40" y="30">
-                  {node.label}
-                </text>
-                <text className="system-graph-node-meta" x="40" y="50">
-                  agent
-                </text>
-              </g>
+                {contents}
+              </button>
+            ) : (
+              <div
+                key={placed.id}
+                className="system-graph-node"
+                data-testid={`system-graph-node-${graphNode.agentKey}`}
+                data-agent-key={graphNode.agentKey}
+                style={style}
+                title={graphNode.label}
+                {...trackingAttrs({ object: "agent" })}
+              >
+                {contents}
+              </div>
             );
           })}
-        </svg>
+        </div>
+
+        <div
+          className="system-graph-controls"
+          data-testid="system-graph-controls"
+          role="group"
+          aria-label="Workspace graph view controls"
+        >
+          <button
+            type="button"
+            className="theme-toggle"
+            data-testid="system-graph-zoom-out"
+            aria-label="Zoom out"
+            disabled={view.zoom <= minZoom}
+            onClick={() =>
+              commitView((current) => ({
+                ...current,
+                zoom: clampSystemGraphZoom(
+                  current.zoom - SYSTEM_GRAPH_ZOOM_STEP,
+                  minZoom,
+                ),
+              }))
+            }
+          >
+            <Icon name="ZoomOut" size={14} />
+          </button>
+          <button
+            type="button"
+            className="theme-toggle system-graph-zoom-reset"
+            data-testid="system-graph-zoom-reset"
+            aria-label="Reset workspace graph view to 100%"
+            disabled={view.zoom === 1 && view.x === 0 && view.y === 0}
+            onClick={() => commitView(resetSystemGraphView())}
+          >
+            {Math.round(view.zoom * 100)}%
+          </button>
+          <button
+            type="button"
+            className="theme-toggle"
+            data-testid="system-graph-zoom-in"
+            aria-label="Zoom in"
+            disabled={view.zoom >= SYSTEM_GRAPH_MAX_ZOOM}
+            onClick={() =>
+              commitView((current) => ({
+                ...current,
+                zoom: clampSystemGraphZoom(
+                  current.zoom + SYSTEM_GRAPH_ZOOM_STEP,
+                  minZoom,
+                ),
+              }))
+            }
+          >
+            <Icon name="ZoomIn" size={14} />
+          </button>
+          <button
+            type="button"
+            className="theme-toggle"
+            data-testid="system-graph-fit"
+            aria-label="Fit workspace graph to view"
+            onClick={fitView}
+          >
+            <Icon name="Frame" size={14} />
+          </button>
+        </div>
       </div>
+
       {graph.warnings.length > 0 && (
         <p className="system-graph-warning" data-testid="system-graph-warning">
           {graph.warnings.length} static projection{" "}

--- a/packages/harness/web/src/components/WorkspaceGraphView.tsx
+++ b/packages/harness/web/src/components/WorkspaceGraphView.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useMemo, useState } from "react";
+import type { JSX } from "react";
+import type {
+  AgentKey,
+  SystemGraph,
+  WorkspaceKey,
+  WorkspaceScopeSummary,
+} from "@shared/system-graph";
+import type { WorkflowInfo } from "@shared/types";
+
+import type { HarnessApi } from "../lib/api";
+import { createSystemGraphLoader } from "../lib/system-graph-loader";
+import { mapSystemGraphNavigation } from "../lib/system-graph-navigation";
+import { trackingAttrs } from "../lib/analytics/tracking-attrs";
+import { EmptyState } from "./EmptyState";
+import { Icon } from "./Icon";
+import { SystemGraphCanvas } from "./SystemGraphCanvas";
+
+/**
+ * V0 mirrors the server's process-lifetime snapshot in the browser tab, with
+ * one later-open retry for a degraded projection. SAP-2904 owns source-driven
+ * invalidation and user-visible freshness states.
+ */
+const loadSystemGraph = createSystemGraphLoader();
+
+interface WorkspaceGraphViewProps {
+  workspaceKey: WorkspaceKey;
+  workspaceName: string;
+  api: HarnessApi;
+  workflows: readonly WorkflowInfo[];
+  workspaceScopes: readonly WorkspaceScopeSummary[];
+  onOpenAgent: (path: string) => void;
+  onExpandRail?: () => void;
+}
+
+export function WorkspaceGraphView({
+  workspaceKey,
+  workspaceName,
+  api,
+  workflows,
+  workspaceScopes,
+  onOpenAgent,
+  onExpandRail,
+}: WorkspaceGraphViewProps): JSX.Element {
+  const [graph, setGraph] = useState<SystemGraph | null>(null);
+  const [error, setError] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    setGraph(null);
+    setError(false);
+    void loadSystemGraph(api, workspaceKey).then(
+      (next) => {
+        if (active) setGraph(next);
+      },
+      () => {
+        if (active) setError(true);
+      },
+    );
+    return () => {
+      active = false;
+    };
+  }, [api, workspaceKey, attempt]);
+
+  const navigation = useMemo(
+    () =>
+      graph
+        ? mapSystemGraphNavigation(
+            graph.nodes,
+            workspaceKey,
+            workflows,
+            workspaceScopes,
+          )
+        : new Map<AgentKey, WorkflowInfo>(),
+    [graph, workspaceKey, workflows, workspaceScopes],
+  );
+
+  return (
+    <section
+      className="workspace-graph-view"
+      data-testid="workspace-graph-view"
+      aria-label="Workspace dependencies"
+    >
+      <header className="workspace-graph-bar">
+        {onExpandRail && (
+          <button
+            type="button"
+            className="theme-toggle"
+            data-testid="workspace-graph-rail-expand"
+            aria-label="Expand workspace panel"
+            onClick={onExpandRail}
+          >
+            <Icon name="PanelLeftOpen" size={15} />
+          </button>
+        )}
+        <Icon name="Folder" size={15} />
+        <span
+          className="workspace-graph-title"
+          title={workspaceName}
+          {...trackingAttrs({ object: "workspace" })}
+        >
+          {workspaceName}
+        </span>
+      </header>
+
+      <div className="workspace-graph-body">
+        {error ? (
+          <EmptyState
+            className="system-graph-state"
+            testId="system-graph-error"
+            icon="TriangleAlert"
+            title="Couldn't load this workspace graph"
+            body="The local projection failed. Retry the filesystem scan."
+            cta={
+              <button
+                type="button"
+                className="btn-primary"
+                onClick={() => setAttempt((value) => value + 1)}
+              >
+                Retry
+              </button>
+            }
+          />
+        ) : !graph ? (
+          <div
+            className="canvas-loading system-graph-state"
+            data-testid="system-graph-loading"
+          >
+            <span className="canvas-task-spinner" aria-hidden="true" />
+            <p className="canvas-empty-hint">Loading workspace graph…</p>
+          </div>
+        ) : graph.nodes.length === 0 ? (
+          <EmptyState
+            className="system-graph-state"
+            testId="system-graph-empty"
+            icon="Frame"
+            title="No agents in this workspace"
+            body="Agent projects discovered inside this folder will appear here."
+          />
+        ) : (
+          <SystemGraphCanvas
+            graph={graph}
+            workspaceKey={workspaceKey}
+            navigableAgentKeys={new Set(navigation.keys())}
+            onOpenAgent={(agentKey) => {
+              const workflow = navigation.get(agentKey);
+              if (workflow) onOpenAgent(workflow.path);
+            }}
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -1102,6 +1102,7 @@ class MockApi implements HarnessApi {
       scope: { kind: "working-tree", workspaceKey },
       nodes: [
         { id: "agent:growth", agentKey: "growth", label: "Growth" },
+        { id: "agent:leasing", agentKey: "leasing", label: "Leasing" },
         {
           id: "agent:reporting",
           agentKey: "reporting",
@@ -1111,6 +1112,11 @@ class MockApi implements HarnessApi {
           id: "agent:research",
           agentKey: "research",
           label: "Research",
+        },
+        {
+          id: "agent:standalone",
+          agentKey: "standalone",
+          label: "Standalone",
         },
       ],
       edges: [
@@ -1127,6 +1133,27 @@ class MockApi implements HarnessApi {
           kind: "invokes",
           basis: "static",
           mode: "async",
+        },
+        {
+          from: "agent:research",
+          to: "agent:leasing",
+          kind: "invokes",
+          basis: "static",
+          mode: "async",
+        },
+        {
+          from: "agent:growth",
+          to: "agent:research",
+          kind: "invokes",
+          basis: "static",
+          mode: "async",
+        },
+        {
+          from: "agent:reporting",
+          to: "agent:leasing",
+          kind: "invokes",
+          basis: "static",
+          mode: "blocking",
         },
       ],
       warnings: [],

--- a/packages/harness/web/src/lib/system-graph-layout.test.ts
+++ b/packages/harness/web/src/lib/system-graph-layout.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, it } from "vitest";
+import type {
+  AgentInvocationMode,
+  SystemGraph,
+  SystemGraphEdge,
+} from "@shared/system-graph";
+
+import {
+  SYSTEM_GRAPH_NODE_HEIGHT,
+  SYSTEM_GRAPH_NODE_WIDTH,
+  layoutSystemGraph,
+  type SystemGraphLayout,
+} from "./system-graph-layout";
+
+const node = (id: string) => ({ id, agentKey: id, label: id.toUpperCase() });
+const edge = (
+  from: string,
+  to: string,
+  mode: AgentInvocationMode = "blocking",
+): SystemGraphEdge => ({ from, to, kind: "invokes", basis: "static", mode });
+
+function graph(nodeIds: string[], edges: SystemGraphEdge[]): SystemGraph {
+  return {
+    kind: "system",
+    scope: { kind: "working-tree", workspaceKey: "workspace-test" },
+    nodes: nodeIds.map(node),
+    edges,
+    warnings: [],
+  };
+}
+
+function byId(layout: SystemGraphLayout, id: string) {
+  const placed = layout.nodes.find((candidate) => candidate.id === id);
+  if (!placed) throw new Error(`Missing layout node ${id}`);
+  return placed;
+}
+
+function rectanglesOverlap(
+  left: { x: number; y: number; width: number; height: number },
+  right: { x: number; y: number; width: number; height: number },
+): boolean {
+  return !(
+    left.x + left.width <= right.x ||
+    right.x + right.width <= left.x ||
+    left.y + left.height <= right.y ||
+    right.y + right.height <= left.y
+  );
+}
+
+function expectNodesNotToOverlap(layout: SystemGraphLayout): void {
+  for (let left = 0; left < layout.nodes.length; left += 1) {
+    for (let right = left + 1; right < layout.nodes.length; right += 1) {
+      expect(
+        rectanglesOverlap(layout.nodes[left]!, layout.nodes[right]!),
+        `${layout.nodes[left]!.id} overlaps ${layout.nodes[right]!.id}`,
+      ).toBe(false);
+    }
+  }
+}
+
+function expectEdgesNotToCrossCards(layout: SystemGraphLayout): void {
+  for (const routed of layout.edges) {
+    for (let index = 1; index < routed.points.length; index += 1) {
+      const start = routed.points[index - 1]!;
+      const end = routed.points[index]!;
+      for (const placed of layout.nodes) {
+        const crossesHorizontalInterior =
+          start.y === end.y &&
+          start.y > placed.y &&
+          start.y < placed.y + placed.height &&
+          Math.max(start.x, end.x) > placed.x &&
+          Math.min(start.x, end.x) < placed.x + placed.width;
+        const crossesVerticalInterior =
+          start.x === end.x &&
+          start.x > placed.x &&
+          start.x < placed.x + placed.width &&
+          Math.max(start.y, end.y) > placed.y &&
+          Math.min(start.y, end.y) < placed.y + placed.height;
+        expect(
+          crossesHorizontalInterior || crossesVerticalInterior,
+          `${routed.from} -> ${routed.to} crosses ${placed.id}`,
+        ).toBe(false);
+      }
+    }
+  }
+}
+
+describe("layoutSystemGraph", () => {
+  it("ranks a direct chain strictly from left to right", () => {
+    const layout = layoutSystemGraph(
+      graph(["c", "a", "b"], [edge("a", "b"), edge("b", "c")]),
+    );
+
+    expect(byId(layout, "a").x).toBeLessThan(byId(layout, "b").x);
+    expect(byId(layout, "b").x).toBeLessThan(byId(layout, "c").x);
+  });
+
+  it("keeps fan-out targets together and fan-in targets after every caller", () => {
+    const fanOut = layoutSystemGraph(
+      graph(
+        ["source", "left", "right"],
+        [edge("source", "left"), edge("source", "right", "async")],
+      ),
+    );
+    expect(byId(fanOut, "left").x).toBe(byId(fanOut, "right").x);
+    expect(byId(fanOut, "source").x).toBeLessThan(byId(fanOut, "left").x);
+
+    const fanIn = layoutSystemGraph(
+      graph(
+        ["target", "left", "right"],
+        [edge("left", "target"), edge("right", "target")],
+      ),
+    );
+    expect(byId(fanIn, "target").x).toBeGreaterThan(byId(fanIn, "left").x);
+    expect(byId(fanIn, "target").x).toBeGreaterThan(byId(fanIn, "right").x);
+  });
+
+  it("condenses cycles, routes their return edges, and ranks downstream SCCs later", () => {
+    const layout = layoutSystemGraph(
+      graph(
+        ["a", "b", "c", "downstream"],
+        [
+          edge("a", "b"),
+          edge("b", "c", "async"),
+          edge("c", "a"),
+          edge("c", "downstream"),
+        ],
+      ),
+    );
+
+    expect(byId(layout, "a").x).toBe(byId(layout, "b").x);
+    expect(byId(layout, "b").x).toBe(byId(layout, "c").x);
+    expect(byId(layout, "downstream").x).toBeGreaterThan(byId(layout, "c").x);
+    expect(
+      layout.edges.filter((candidate) => candidate.route === "cycle"),
+    ).toHaveLength(3);
+    expect(
+      layout.edges.every((candidate) => !candidate.path.includes("NaN")),
+    ).toBe(true);
+    expectEdgesNotToCrossCards(layout);
+  });
+
+  it("keeps disconnected components and isolated agents exactly once", () => {
+    const layout = layoutSystemGraph(
+      graph(["isolated", "a", "b", "x", "y"], [edge("a", "b"), edge("x", "y")]),
+    );
+
+    expect(layout.nodes.map((candidate) => candidate.id).sort()).toEqual([
+      "a",
+      "b",
+      "isolated",
+      "x",
+      "y",
+    ]);
+    expect(
+      new Set(layout.nodes.map((candidate) => candidate.componentId)).size,
+    ).toBe(3);
+    expectNodesNotToOverlap(layout);
+  });
+
+  it("groups dual-mode records into one connector with stable mode semantics", () => {
+    const layout = layoutSystemGraph(
+      graph(
+        ["caller", "target"],
+        [
+          edge("caller", "target", "async"),
+          edge("caller", "target", "blocking"),
+          edge("caller", "target", "async"),
+        ],
+      ),
+    );
+
+    expect(layout.edges).toHaveLength(1);
+    expect(layout.edges[0]).toMatchObject({
+      from: "caller",
+      to: "target",
+      modes: ["blocking", "async"],
+      label: "blocking + async",
+      route: "forward",
+    });
+  });
+
+  it("stagger ports, lands arrows at card borders, and keeps label boxes off cards", () => {
+    const layout = layoutSystemGraph(
+      graph(
+        ["source", "one", "two", "three"],
+        [
+          edge("source", "one"),
+          edge("source", "two", "async"),
+          edge("source", "three"),
+        ],
+      ),
+    );
+    const sourcePorts = layout.edges.map((candidate) => candidate.points[0]!.y);
+    expect(new Set(sourcePorts).size).toBe(sourcePorts.length);
+
+    for (const routed of layout.edges) {
+      const target = byId(layout, routed.to);
+      const end = routed.points.at(-1)!;
+      expect(end.x).toBe(target.x - 1);
+      expect(end.y).toBeGreaterThanOrEqual(target.y);
+      expect(end.y).toBeLessThanOrEqual(target.y + target.height);
+      for (const placed of layout.nodes) {
+        expect(
+          rectanglesOverlap(routed.labelBounds, placed),
+          `${routed.label} overlaps ${placed.id}`,
+        ).toBe(false);
+      }
+    }
+  });
+
+  it("routes rank-skipping connectors outside intermediate cards", () => {
+    const layout = layoutSystemGraph(
+      graph(
+        ["a", "b", "c", "side"],
+        [edge("a", "b"), edge("b", "c"), edge("a", "c"), edge("side", "c")],
+      ),
+    );
+
+    expect(byId(layout, "c").x).toBeGreaterThan(byId(layout, "b").x);
+    expectEdgesNotToCrossCards(layout);
+  });
+
+  it("returns fixed card geometry and bounds containing every routed primitive", () => {
+    const layout = layoutSystemGraph(
+      graph(
+        ["a", "b", "c"],
+        [edge("a", "b"), edge("b", "a", "async"), edge("b", "c")],
+      ),
+    );
+    expectNodesNotToOverlap(layout);
+    expectEdgesNotToCrossCards(layout);
+
+    for (const placed of layout.nodes) {
+      expect(placed.width).toBe(SYSTEM_GRAPH_NODE_WIDTH);
+      expect(placed.height).toBe(SYSTEM_GRAPH_NODE_HEIGHT);
+      expect(placed.x).toBeGreaterThanOrEqual(0);
+      expect(placed.y).toBeGreaterThanOrEqual(0);
+      expect(placed.x + placed.width).toBeLessThanOrEqual(layout.bounds.width);
+      expect(placed.y + placed.height).toBeLessThanOrEqual(
+        layout.bounds.height,
+      );
+    }
+    for (const routed of layout.edges) {
+      for (const point of routed.points) {
+        expect(point.x).toBeGreaterThanOrEqual(0);
+        expect(point.y).toBeGreaterThanOrEqual(0);
+        expect(point.x).toBeLessThanOrEqual(layout.bounds.width);
+        expect(point.y).toBeLessThanOrEqual(layout.bounds.height);
+      }
+      expect(routed.labelBounds.x).toBeGreaterThanOrEqual(0);
+      expect(routed.labelBounds.y).toBeGreaterThanOrEqual(0);
+      expect(
+        routed.labelBounds.x + routed.labelBounds.width,
+      ).toBeLessThanOrEqual(layout.bounds.width);
+      expect(
+        routed.labelBounds.y + routed.labelBounds.height,
+      ).toBeLessThanOrEqual(layout.bounds.height);
+    }
+  });
+
+  it("is deeply deterministic when node and edge input order changes", () => {
+    const edges = [
+      edge("a", "b"),
+      edge("a", "c", "async"),
+      edge("c", "a"),
+      edge("d", "e"),
+    ];
+    const forward = layoutSystemGraph(
+      graph(["a", "b", "c", "d", "e", "z"], edges),
+    );
+    const reversed = layoutSystemGraph(
+      graph(["z", "e", "d", "c", "b", "a"], [...edges].reverse()),
+    );
+
+    expect(reversed).toEqual(forward);
+  });
+
+  it("fails closed for malformed endpoint geometry instead of hanging", () => {
+    expect(() =>
+      layoutSystemGraph(graph(["known"], [edge("known", "missing")])),
+    ).toThrow("Invalid system graph layout input");
+  });
+});

--- a/packages/harness/web/src/lib/system-graph-layout.ts
+++ b/packages/harness/web/src/lib/system-graph-layout.ts
@@ -1,0 +1,790 @@
+import type {
+  AgentInvocationMode,
+  SystemGraph,
+  SystemGraphNode,
+} from "@shared/system-graph";
+
+import {
+  groupSystemGraphEdges,
+  type VisibleSystemGraphEdge,
+} from "./system-graph";
+
+export const SYSTEM_GRAPH_NODE_WIDTH = 184;
+export const SYSTEM_GRAPH_NODE_HEIGHT = 64;
+export const SYSTEM_GRAPH_RANK_GAP = 48;
+export const SYSTEM_GRAPH_SLOT_GAP = 12;
+
+const COMPONENT_GAP = 64;
+const LAYOUT_PADDING = 32;
+const PORT_LIMIT = 24;
+const PORT_STEP = 8;
+const LABEL_HEIGHT = 16;
+
+export interface SystemGraphPoint {
+  x: number;
+  y: number;
+}
+
+export interface SystemGraphLayoutNode {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  componentId: string;
+}
+
+export interface SystemGraphLabelBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SystemGraphLayoutEdge {
+  from: string;
+  to: string;
+  modes: AgentInvocationMode[];
+  path: string;
+  points: SystemGraphPoint[];
+  label: string;
+  labelX: number;
+  labelY: number;
+  labelBounds: SystemGraphLabelBounds;
+  route: "forward" | "cycle";
+}
+
+export interface SystemGraphLayout {
+  nodes: SystemGraphLayoutNode[];
+  edges: SystemGraphLayoutEdge[];
+  bounds: { width: number; height: number };
+}
+
+export interface SystemGraphStrongComponent {
+  id: string;
+  nodeIds: string[];
+  rank: number;
+}
+
+export interface SystemGraphWeakComponent {
+  id: string;
+  nodeIds: string[];
+  stronglyConnected: SystemGraphStrongComponent[];
+  connected: boolean;
+}
+
+export interface SystemGraphTopology {
+  components: SystemGraphWeakComponent[];
+}
+
+interface WorkGuard {
+  step(): void;
+}
+
+interface ComponentBox {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+}
+
+interface EdgeSeed {
+  edge: VisibleSystemGraphEdge;
+  route: "forward" | "cycle";
+  componentId: string;
+  sourceOffset: number;
+  targetOffset: number;
+  cycleLane: number;
+  forwardLane: number;
+}
+
+interface RoutedEdge extends EdgeSeed {
+  points: SystemGraphPoint[];
+  label: string;
+  labelX: number;
+  labelY: number;
+  labelBounds: SystemGraphLabelBounds;
+}
+
+const compareIds = (left: string, right: string): number =>
+  left === right ? 0 : left < right ? -1 : 1;
+
+const round = (value: number): number => Math.round(value * 100) / 100;
+
+function makeGuard(nodeCount: number, edgeCount: number): WorkGuard {
+  const limit = Math.max(128, (nodeCount + edgeCount + 1) * 96);
+  let work = 0;
+  return {
+    step(): void {
+      work += 1;
+      if (work > limit) {
+        throw new Error("System graph layout exceeded its finite work budget");
+      }
+    },
+  };
+}
+
+function validateGraph(graph: SystemGraph): void {
+  const ids = new Set<string>();
+  for (const node of graph.nodes) {
+    if (!node.id || ids.has(node.id)) {
+      throw new Error("Invalid system graph layout input");
+    }
+    ids.add(node.id);
+  }
+  if (graph.edges.some((edge) => !ids.has(edge.from) || !ids.has(edge.to))) {
+    throw new Error("Invalid system graph layout input");
+  }
+}
+
+function sortedAdjacency(
+  nodeIds: readonly string[],
+  edges: readonly VisibleSystemGraphEdge[],
+): {
+  directed: Map<string, string[]>;
+  undirected: Map<string, string[]>;
+} {
+  const directedSets = new Map(nodeIds.map((id) => [id, new Set<string>()]));
+  const undirectedSets = new Map(nodeIds.map((id) => [id, new Set<string>()]));
+  for (const edge of edges) {
+    directedSets.get(edge.from)!.add(edge.to);
+    undirectedSets.get(edge.from)!.add(edge.to);
+    undirectedSets.get(edge.to)!.add(edge.from);
+  }
+  const toSorted = (sets: Map<string, Set<string>>): Map<string, string[]> =>
+    new Map(
+      [...sets.entries()].map(([id, values]) => [
+        id,
+        [...values].sort(compareIds),
+      ]),
+    );
+  return {
+    directed: toSorted(directedSets),
+    undirected: toSorted(undirectedSets),
+  };
+}
+
+function findWeakComponents(
+  nodeIds: readonly string[],
+  undirected: ReadonlyMap<string, readonly string[]>,
+  guard: WorkGuard,
+): string[][] {
+  const visited = new Set<string>();
+  const components: string[][] = [];
+  for (const start of nodeIds) {
+    guard.step();
+    if (visited.has(start)) continue;
+    const members: string[] = [];
+    const queue = [start];
+    visited.add(start);
+    while (queue.length > 0) {
+      guard.step();
+      const id = queue.shift()!;
+      members.push(id);
+      for (const neighbor of undirected.get(id) ?? []) {
+        guard.step();
+        if (visited.has(neighbor)) continue;
+        visited.add(neighbor);
+        queue.push(neighbor);
+      }
+    }
+    members.sort(compareIds);
+    components.push(members);
+  }
+  return components;
+}
+
+function findStrongComponents(
+  members: readonly string[],
+  directed: ReadonlyMap<string, readonly string[]>,
+  guard: WorkGuard,
+): string[][] {
+  const memberSet = new Set(members);
+  const indexById = new Map<string, number>();
+  const lowById = new Map<string, number>();
+  const stack: string[] = [];
+  const onStack = new Set<string>();
+  const result: string[][] = [];
+  let nextIndex = 0;
+
+  const visit = (id: string): void => {
+    guard.step();
+    indexById.set(id, nextIndex);
+    lowById.set(id, nextIndex);
+    nextIndex += 1;
+    stack.push(id);
+    onStack.add(id);
+
+    for (const target of directed.get(id) ?? []) {
+      guard.step();
+      if (!memberSet.has(target)) continue;
+      if (!indexById.has(target)) {
+        visit(target);
+        lowById.set(id, Math.min(lowById.get(id)!, lowById.get(target)!));
+      } else if (onStack.has(target)) {
+        lowById.set(id, Math.min(lowById.get(id)!, indexById.get(target)!));
+      }
+    }
+
+    if (lowById.get(id) !== indexById.get(id)) return;
+    const component: string[] = [];
+    while (stack.length > 0) {
+      guard.step();
+      const popped = stack.pop()!;
+      onStack.delete(popped);
+      component.push(popped);
+      if (popped === id) break;
+    }
+    component.sort(compareIds);
+    result.push(component);
+  };
+
+  for (const id of members) {
+    if (!indexById.has(id)) visit(id);
+  }
+  return result.sort((left, right) => compareIds(left[0]!, right[0]!));
+}
+
+function rankStrongComponents(
+  strong: readonly string[][],
+  edges: readonly VisibleSystemGraphEdge[],
+  guard: WorkGuard,
+): SystemGraphStrongComponent[] {
+  const strongIds = strong.map((members) => `scc:${members[0]}`);
+  const strongByNode = new Map<string, string>();
+  strong.forEach((members, index) => {
+    for (const id of members) strongByNode.set(id, strongIds[index]!);
+  });
+  const outgoing = new Map(strongIds.map((id) => [id, new Set<string>()]));
+  const indegree = new Map(strongIds.map((id) => [id, 0]));
+  for (const edge of edges) {
+    guard.step();
+    const from = strongByNode.get(edge.from);
+    const to = strongByNode.get(edge.to);
+    if (!from || !to || from === to || outgoing.get(from)!.has(to)) continue;
+    outgoing.get(from)!.add(to);
+    indegree.set(to, indegree.get(to)! + 1);
+  }
+  const rank = new Map(strongIds.map((id) => [id, 0]));
+  const ready = strongIds
+    .filter((id) => indegree.get(id) === 0)
+    .sort(compareIds);
+  let visited = 0;
+  while (ready.length > 0) {
+    guard.step();
+    const id = ready.shift()!;
+    visited += 1;
+    for (const target of [...outgoing.get(id)!].sort(compareIds)) {
+      guard.step();
+      rank.set(target, Math.max(rank.get(target)!, rank.get(id)! + 1));
+      indegree.set(target, indegree.get(target)! - 1);
+      if (indegree.get(target) === 0) {
+        ready.push(target);
+        ready.sort(compareIds);
+      }
+    }
+  }
+  if (visited !== strong.length) {
+    throw new Error("System graph SCC condensation was not acyclic");
+  }
+  return strong
+    .map((nodeIds, index) => ({
+      id: strongIds[index]!,
+      nodeIds: [...nodeIds],
+      rank: rank.get(strongIds[index]!)!,
+    }))
+    .sort(
+      (left, right) => left.rank - right.rank || compareIds(left.id, right.id),
+    );
+}
+
+export function analyzeSystemGraph(graph: SystemGraph): SystemGraphTopology {
+  validateGraph(graph);
+  const edges = groupSystemGraphEdges(graph.edges);
+  const nodeIds = graph.nodes.map((node) => node.id).sort(compareIds);
+  const guard = makeGuard(nodeIds.length, edges.length);
+  const { directed, undirected } = sortedAdjacency(nodeIds, edges);
+  const weak = findWeakComponents(nodeIds, undirected, guard);
+  const components = weak.map((members): SystemGraphWeakComponent => {
+    const memberSet = new Set(members);
+    const componentEdges = edges.filter(
+      (edge) => memberSet.has(edge.from) && memberSet.has(edge.to),
+    );
+    const stronglyConnected = rankStrongComponents(
+      findStrongComponents(members, directed, guard),
+      componentEdges,
+      guard,
+    );
+    return {
+      id: `component:${members[0]}`,
+      nodeIds: [...members],
+      stronglyConnected,
+      connected: componentEdges.length > 0,
+    };
+  });
+  components.sort(
+    (left, right) =>
+      Number(right.connected) - Number(left.connected) ||
+      compareIds(left.id, right.id),
+  );
+  return { components };
+}
+
+function placeNodes(topology: SystemGraphTopology): {
+  nodes: SystemGraphLayoutNode[];
+  componentBoxes: Map<string, ComponentBox>;
+  componentByNode: Map<string, string>;
+  strongByNode: Map<string, string>;
+} {
+  const nodes: SystemGraphLayoutNode[] = [];
+  const componentBoxes = new Map<string, ComponentBox>();
+  const componentByNode = new Map<string, string>();
+  const strongByNode = new Map<string, string>();
+  let yCursor = 0;
+
+  for (const component of topology.components) {
+    const byRank = new Map<number, string[]>();
+    for (const strong of component.stronglyConnected) {
+      const rankNodes = byRank.get(strong.rank) ?? [];
+      rankNodes.push(...strong.nodeIds);
+      rankNodes.sort(compareIds);
+      byRank.set(strong.rank, rankNodes);
+      for (const id of strong.nodeIds) {
+        strongByNode.set(id, strong.id);
+        componentByNode.set(id, component.id);
+      }
+    }
+    const ranks = [...byRank.keys()].sort((left, right) => left - right);
+    const rankHeight = (rank: number): number => {
+      const count = byRank.get(rank)!.length;
+      return (
+        count * SYSTEM_GRAPH_NODE_HEIGHT +
+        Math.max(0, count - 1) * SYSTEM_GRAPH_SLOT_GAP
+      );
+    };
+    const componentHeight = Math.max(
+      SYSTEM_GRAPH_NODE_HEIGHT,
+      ...ranks.map(rankHeight),
+    );
+    for (const rank of ranks) {
+      const rankNodes = byRank.get(rank)!;
+      const startY = yCursor + (componentHeight - rankHeight(rank)) / 2;
+      rankNodes.forEach((id, row) => {
+        nodes.push({
+          id,
+          x: rank * (SYSTEM_GRAPH_NODE_WIDTH + SYSTEM_GRAPH_RANK_GAP),
+          y: startY + row * (SYSTEM_GRAPH_NODE_HEIGHT + SYSTEM_GRAPH_SLOT_GAP),
+          width: SYSTEM_GRAPH_NODE_WIDTH,
+          height: SYSTEM_GRAPH_NODE_HEIGHT,
+          componentId: component.id,
+        });
+      });
+    }
+    const componentNodes = nodes.filter(
+      (candidate) => candidate.componentId === component.id,
+    );
+    componentBoxes.set(component.id, {
+      minX: Math.min(...componentNodes.map((candidate) => candidate.x)),
+      minY: Math.min(...componentNodes.map((candidate) => candidate.y)),
+      maxX: Math.max(
+        ...componentNodes.map((candidate) => candidate.x + candidate.width),
+      ),
+      maxY: Math.max(
+        ...componentNodes.map((candidate) => candidate.y + candidate.height),
+      ),
+    });
+    yCursor += componentHeight + COMPONENT_GAP;
+  }
+  nodes.sort((left, right) => compareIds(left.id, right.id));
+  return { nodes, componentBoxes, componentByNode, strongByNode };
+}
+
+function spreadPortOffsets(
+  seeds: EdgeSeed[],
+  nodeById: ReadonlyMap<string, SystemGraphLayoutNode>,
+  end: "source" | "target",
+): void {
+  const groups = new Map<string, EdgeSeed[]>();
+  for (const seed of seeds) {
+    const nodeId = end === "source" ? seed.edge.from : seed.edge.to;
+    const side = end === "source" || seed.route === "cycle" ? "right" : "left";
+    const key = `${nodeId}:${side}`;
+    groups.set(key, [...(groups.get(key) ?? []), seed]);
+  }
+  for (const group of groups.values()) {
+    group.sort((left, right) => {
+      const leftOther = nodeById.get(
+        end === "source" ? left.edge.to : left.edge.from,
+      )!;
+      const rightOther = nodeById.get(
+        end === "source" ? right.edge.to : right.edge.from,
+      )!;
+      return (
+        leftOther.y - rightOther.y ||
+        leftOther.x - rightOther.x ||
+        compareIds(left.edge.from, right.edge.from) ||
+        compareIds(left.edge.to, right.edge.to)
+      );
+    });
+    const step =
+      group.length <= 1
+        ? 0
+        : Math.min(PORT_STEP, (PORT_LIMIT * 2) / (group.length - 1));
+    group.forEach((seed, index) => {
+      const offset = round((index - (group.length - 1) / 2) * step);
+      if (end === "source") seed.sourceOffset = offset;
+      else seed.targetOffset = offset;
+    });
+  }
+}
+
+function labelForModes(modes: readonly AgentInvocationMode[]): string {
+  return modes.length === 2 ? "blocking + async" : modes[0]!;
+}
+
+function labelWidth(label: string): number {
+  return Math.max(40, label.length * 6.5 + 8);
+}
+
+function overlaps(
+  left: SystemGraphLabelBounds,
+  right: SystemGraphLabelBounds,
+  margin = 0,
+): boolean {
+  return !(
+    left.x + left.width + margin <= right.x ||
+    right.x + right.width + margin <= left.x ||
+    left.y + left.height + margin <= right.y ||
+    right.y + right.height + margin <= left.y
+  );
+}
+
+function chooseLabelBounds(
+  routed: Omit<RoutedEdge, "labelX" | "labelY" | "labelBounds">,
+  nodeById: ReadonlyMap<string, SystemGraphLayoutNode>,
+  allNodes: readonly SystemGraphLayoutNode[],
+  existing: readonly SystemGraphLabelBounds[],
+  componentBox: ComponentBox,
+): SystemGraphLabelBounds {
+  const source = nodeById.get(routed.edge.from)!;
+  const target = nodeById.get(routed.edge.to)!;
+  const width = labelWidth(routed.label);
+  const start = routed.points[0]!;
+  const end = routed.points.at(-1)!;
+  const middleX = (start.x + end.x) / 2;
+  const top = Math.min(source.y, target.y);
+  const bottom = Math.max(source.y + source.height, target.y + target.height);
+  const corridorX = routed.points[1]?.x ?? middleX;
+  const targetLabelX =
+    routed.route === "cycle"
+      ? target.x + target.width / 2
+      : target.x - width / 2 - 8;
+  const candidates: SystemGraphPoint[] = [
+    { x: targetLabelX, y: target.y - LABEL_HEIGHT / 2 - 4 },
+    { x: targetLabelX, y: target.y + target.height + LABEL_HEIGHT / 2 + 4 },
+    { x: corridorX, y: top - LABEL_HEIGHT / 2 - 4 },
+    { x: corridorX, y: bottom + LABEL_HEIGHT / 2 + 4 },
+    { x: middleX, y: top - LABEL_HEIGHT / 2 - 4 },
+    { x: middleX, y: bottom + LABEL_HEIGHT / 2 + 4 },
+  ];
+  const nodeBounds = allNodes.map(
+    (node): SystemGraphLabelBounds => ({
+      x: node.x,
+      y: node.y,
+      width: node.width,
+      height: node.height,
+    }),
+  );
+  const available = candidates
+    .map(
+      (center): SystemGraphLabelBounds => ({
+        x: center.x - width / 2,
+        y: center.y - LABEL_HEIGHT / 2,
+        width,
+        height: LABEL_HEIGHT,
+      }),
+    )
+    .find(
+      (candidate) =>
+        !nodeBounds.some((node) => overlaps(candidate, node, 2)) &&
+        !existing.some((label) => overlaps(candidate, label, 2)),
+    );
+  if (available) return available;
+
+  const centerX = (componentBox.minX + componentBox.maxX - width) / 2;
+  const fallbackSlots = (allNodes.length + existing.length + 1) * 6;
+  for (let slot = 0; slot < fallbackSlots; slot += 1) {
+    for (const y of [
+      componentBox.minY - LABEL_HEIGHT - 8 - slot * (LABEL_HEIGHT + 4),
+      componentBox.maxY + 8 + slot * (LABEL_HEIGHT + 4),
+    ]) {
+      const candidate = { x: centerX, y, width, height: LABEL_HEIGHT };
+      if (
+        !nodeBounds.some((node) => overlaps(candidate, node, 2)) &&
+        !existing.some((label) => overlaps(candidate, label, 2))
+      ) {
+        return candidate;
+      }
+    }
+  }
+  throw new Error("System graph labels exceeded their finite placement budget");
+}
+
+function routeEdges(
+  graph: SystemGraph,
+  nodes: SystemGraphLayoutNode[],
+  componentBoxes: ReadonlyMap<string, ComponentBox>,
+  componentByNode: ReadonlyMap<string, string>,
+  strongByNode: ReadonlyMap<string, string>,
+): RoutedEdge[] {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const seeds: EdgeSeed[] = groupSystemGraphEdges(graph.edges).map((edge) => {
+    const componentId = componentByNode.get(edge.from)!;
+    return {
+      edge,
+      route:
+        strongByNode.get(edge.from) === strongByNode.get(edge.to)
+          ? "cycle"
+          : "forward",
+      componentId,
+      sourceOffset: 0,
+      targetOffset: 0,
+      cycleLane: 0,
+      forwardLane: 0,
+    };
+  });
+  spreadPortOffsets(seeds, nodeById, "source");
+  spreadPortOffsets(seeds, nodeById, "target");
+  const cycleGroups = new Map<string, EdgeSeed[]>();
+  for (const seed of seeds.filter((candidate) => candidate.route === "cycle")) {
+    const key = strongByNode.get(seed.edge.from)!;
+    cycleGroups.set(key, [...(cycleGroups.get(key) ?? []), seed]);
+  }
+  for (const group of cycleGroups.values()) {
+    group
+      .sort(
+        (left, right) =>
+          compareIds(left.edge.from, right.edge.from) ||
+          compareIds(left.edge.to, right.edge.to),
+      )
+      .forEach((seed, index) => {
+        seed.cycleLane = index;
+      });
+  }
+
+  const longForwardGroups = new Map<string, EdgeSeed[]>();
+  for (const seed of seeds.filter((candidate) => {
+    if (candidate.route !== "forward") return false;
+    const source = nodeById.get(candidate.edge.from)!;
+    const target = nodeById.get(candidate.edge.to)!;
+    return (
+      target.x - source.x > SYSTEM_GRAPH_NODE_WIDTH + SYSTEM_GRAPH_RANK_GAP
+    );
+  })) {
+    longForwardGroups.set(seed.componentId, [
+      ...(longForwardGroups.get(seed.componentId) ?? []),
+      seed,
+    ]);
+  }
+  for (const group of longForwardGroups.values()) {
+    group
+      .sort(
+        (left, right) =>
+          compareIds(left.edge.from, right.edge.from) ||
+          compareIds(left.edge.to, right.edge.to),
+      )
+      .forEach((seed, index) => {
+        seed.forwardLane = index;
+      });
+  }
+
+  const labels: SystemGraphLabelBounds[] = [];
+  return seeds.map((seed): RoutedEdge => {
+    const source = nodeById.get(seed.edge.from)!;
+    const target = nodeById.get(seed.edge.to)!;
+    const start = {
+      x: source.x + source.width,
+      y: source.y + source.height / 2 + seed.sourceOffset,
+    };
+    let points: SystemGraphPoint[];
+    if (seed.route === "forward") {
+      const end = {
+        x: target.x - 1,
+        y: target.y + target.height / 2 + seed.targetOffset,
+      };
+      const skipsRank =
+        target.x - source.x > SYSTEM_GRAPH_NODE_WIDTH + SYSTEM_GRAPH_RANK_GAP;
+      if (skipsRank) {
+        // Crossing an occupied intermediate rank would draw through a card.
+        // Reserve a quiet corridor just above this weak component instead;
+        // modulo keeps even dense graphs inside the inter-component gutter.
+        const lane = seed.forwardLane % 5;
+        const sourceGutterX = source.x + source.width + 8 + lane * 4;
+        const targetGutterX = target.x - 8 - lane * 4;
+        const corridorY =
+          componentBoxes.get(seed.componentId)!.minY - 12 - lane * 4;
+        points = [
+          start,
+          { x: sourceGutterX, y: start.y },
+          { x: sourceGutterX, y: corridorY },
+          { x: targetGutterX, y: corridorY },
+          { x: targetGutterX, y: end.y },
+          end,
+        ];
+      } else {
+        const elbowX = round(start.x + (target.x - start.x) * 0.32);
+        points = [
+          start,
+          { x: elbowX, y: start.y },
+          { x: elbowX, y: end.y },
+          end,
+        ];
+      }
+    } else {
+      const endY =
+        source.id === target.id && seed.targetOffset === seed.sourceOffset
+          ? target.y + target.height / 2 - 12
+          : target.y + target.height / 2 + seed.targetOffset;
+      const end = { x: target.x + target.width + 1, y: endY };
+      const gutterX =
+        Math.max(source.x + source.width, target.x + target.width) +
+        8 +
+        (seed.cycleLane % 10) * 4;
+      if (source.id === target.id) {
+        const loopY = target.y - 12 - Math.floor(seed.cycleLane / 10) * 8;
+        points = [
+          start,
+          { x: gutterX, y: start.y },
+          { x: gutterX, y: loopY },
+          { x: target.x + target.width + 4, y: loopY },
+          { x: target.x + target.width + 4, y: end.y },
+          end,
+        ];
+      } else {
+        points = [
+          start,
+          { x: gutterX, y: start.y },
+          { x: gutterX, y: end.y },
+          end,
+        ];
+      }
+    }
+    points = points.map((point) => ({ x: round(point.x), y: round(point.y) }));
+    const label = labelForModes(seed.edge.modes);
+    const partial = { ...seed, points, label };
+    const labelBounds = chooseLabelBounds(
+      partial,
+      nodeById,
+      nodes,
+      labels,
+      componentBoxes.get(seed.componentId)!,
+    );
+    labels.push(labelBounds);
+    return {
+      ...partial,
+      labelBounds,
+      labelX: round(labelBounds.x + labelBounds.width / 2),
+      labelY: round(labelBounds.y + labelBounds.height - 3),
+    };
+  });
+}
+
+function pathFromPoints(points: readonly SystemGraphPoint[]): string {
+  if (points.length === 0) return "";
+  const parts = [`M ${round(points[0]!.x)} ${round(points[0]!.y)}`];
+  for (let index = 1; index < points.length; index += 1) {
+    const previous = points[index - 1]!;
+    const point = points[index]!;
+    if (point.y === previous.y) parts.push(`H ${round(point.x)}`);
+    else if (point.x === previous.x) parts.push(`V ${round(point.y)}`);
+    else parts.push(`L ${round(point.x)} ${round(point.y)}`);
+  }
+  return parts.join(" ");
+}
+
+function shiftLayout(
+  nodes: SystemGraphLayoutNode[],
+  edges: RoutedEdge[],
+): SystemGraphLayout {
+  const xs: number[] = [];
+  const ys: number[] = [];
+  for (const node of nodes) {
+    xs.push(node.x, node.x + node.width);
+    ys.push(node.y, node.y + node.height);
+  }
+  for (const edge of edges) {
+    for (const point of edge.points) {
+      xs.push(point.x);
+      ys.push(point.y);
+    }
+    xs.push(edge.labelBounds.x, edge.labelBounds.x + edge.labelBounds.width);
+    ys.push(edge.labelBounds.y, edge.labelBounds.y + edge.labelBounds.height);
+  }
+  if (xs.length === 0 || ys.length === 0) {
+    return { nodes: [], edges: [], bounds: { width: 0, height: 0 } };
+  }
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+  const maxX = Math.max(...xs);
+  const maxY = Math.max(...ys);
+  const dx = LAYOUT_PADDING - minX;
+  const dy = LAYOUT_PADDING - minY;
+  const shiftedNodes = nodes.map((node) => ({
+    ...node,
+    x: round(node.x + dx),
+    y: round(node.y + dy),
+  }));
+  const shiftedEdges = edges.map((edge): SystemGraphLayoutEdge => {
+    const points = edge.points.map((point) => ({
+      x: round(point.x + dx),
+      y: round(point.y + dy),
+    }));
+    const labelBounds = {
+      ...edge.labelBounds,
+      x: round(edge.labelBounds.x + dx),
+      y: round(edge.labelBounds.y + dy),
+    };
+    return {
+      from: edge.edge.from,
+      to: edge.edge.to,
+      modes: [...edge.edge.modes],
+      path: pathFromPoints(points),
+      points,
+      label: edge.label,
+      labelX: round(edge.labelX + dx),
+      labelY: round(edge.labelY + dy),
+      labelBounds,
+      route: edge.route,
+    };
+  });
+  return {
+    nodes: shiftedNodes,
+    edges: shiftedEdges,
+    bounds: {
+      width: round(maxX - minX + LAYOUT_PADDING * 2),
+      height: round(maxY - minY + LAYOUT_PADDING * 2),
+    },
+  };
+}
+
+export function layoutSystemGraph(graph: SystemGraph): SystemGraphLayout {
+  const topology = analyzeSystemGraph(graph);
+  if (graph.nodes.length === 0) {
+    return { nodes: [], edges: [], bounds: { width: 0, height: 0 } };
+  }
+  const placed = placeNodes(topology);
+  const edges = routeEdges(
+    graph,
+    placed.nodes,
+    placed.componentBoxes,
+    placed.componentByNode,
+    placed.strongByNode,
+  );
+  return shiftLayout(placed.nodes, edges);
+}
+
+export function systemGraphNodeById(
+  graph: SystemGraph,
+): ReadonlyMap<string, SystemGraphNode> {
+  return new Map(graph.nodes.map((node) => [node.id, node]));
+}

--- a/packages/harness/web/src/lib/system-graph-navigation.test.ts
+++ b/packages/harness/web/src/lib/system-graph-navigation.test.ts
@@ -1,9 +1,16 @@
+import { mkdtemp, mkdir, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
 import { describe, expect, it } from "vitest";
 import type {
   SystemGraphNode,
   WorkspaceScopeSummary,
 } from "@shared/system-graph";
+import { workspaceRelativeLocalKey } from "@shared/system-graph";
 import type { WorkflowInfo } from "@shared/types";
+
+import { HarnessRegistryInventoryProvider } from "../../../src/core/system-graph-inventory";
 
 import { mapSystemGraphNavigation } from "./system-graph-navigation";
 
@@ -29,6 +36,28 @@ const scopes: WorkspaceScopeSummary[] = [
   { workspaceKey: "workspace-root", cwd: "/repo" },
   { workspaceKey: "workspace-nested", cwd: "/repo/nested" },
 ];
+
+describe("workspaceRelativeLocalKey", () => {
+  it("handles scope roots, outside paths, Windows paths, and UNC paths", () => {
+    expect(workspaceRelativeLocalKey("/repo/agent", "/repo/agent")).toBe(
+      "local:agent",
+    );
+    expect(workspaceRelativeLocalKey("/", "/")).toBe("local:root");
+    expect(workspaceRelativeLocalKey("/repo", "/other/agent")).toBeNull();
+    expect(
+      workspaceRelativeLocalKey("C:\\Repo", "c:\\repo\\Tools\\Reporting"),
+    ).toBe("local:Tools/Reporting");
+    expect(
+      workspaceRelativeLocalKey("C:\\Repo", "D:\\Repo\\Reporting"),
+    ).toBeNull();
+    expect(
+      workspaceRelativeLocalKey(
+        "\\\\Server\\Share\\Repo",
+        "\\\\server\\share\\repo\\Reporting",
+      ),
+    ).toBe("local:Reporting");
+  });
+});
 
 describe("mapSystemGraphNavigation", () => {
   it("maps authoritative definition slugs and workspace-relative local keys", () => {
@@ -88,5 +117,41 @@ describe("mapSystemGraphNavigation", () => {
     );
 
     expect(navigation.get("local:exact")).toBe(exact);
+  });
+
+  it("uses the same local identity as server inventory for a symlinked project", async () => {
+    const root = await mkdtemp(path.join(tmpdir(), "system-graph-navigation-"));
+    try {
+      const source = path.join(root, "packages", "reporting");
+      const linked = path.join(root, "reporting");
+      await mkdir(source, { recursive: true });
+      await symlink(
+        source,
+        linked,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+      const local = workflow("Reporting", linked, null);
+      const workspaceKey = "workspace-symlink";
+      const workspaceScopes = [{ workspaceKey, cwd: root }];
+      const inventory = new HarnessRegistryInventoryProvider({
+        listWorkflows: () => [local],
+        listWorkspaceScopes: () => workspaceScopes,
+      });
+
+      const result = await inventory.listAgents({ workspaceKey, root });
+      expect(result.agents).toHaveLength(1);
+      const agentKey = result.agents[0]!.agentKey;
+      const navigation = mapSystemGraphNavigation(
+        [graphNode(agentKey)],
+        workspaceKey,
+        [local],
+        workspaceScopes,
+      );
+
+      expect(agentKey).toBe("local:reporting");
+      expect(navigation.get(agentKey)).toBe(local);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/harness/web/src/lib/system-graph-navigation.test.ts
+++ b/packages/harness/web/src/lib/system-graph-navigation.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type {
+  SystemGraphNode,
+  WorkspaceScopeSummary,
+} from "@shared/system-graph";
+import type { WorkflowInfo } from "@shared/types";
+
+import { mapSystemGraphNavigation } from "./system-graph-navigation";
+
+const workflow = (
+  name: string,
+  path: string,
+  definitionSlug: string | null,
+): WorkflowInfo => ({
+  name,
+  path,
+  definitionId: definitionSlug ? 1 : null,
+  definitionSlug,
+  source: "scan",
+});
+
+const graphNode = (agentKey: string, label = agentKey): SystemGraphNode => ({
+  id: `agent:${agentKey}`,
+  agentKey,
+  label,
+});
+
+const scopes: WorkspaceScopeSummary[] = [
+  { workspaceKey: "workspace-root", cwd: "/repo" },
+  { workspaceKey: "workspace-nested", cwd: "/repo/nested" },
+];
+
+describe("mapSystemGraphNavigation", () => {
+  it("maps authoritative definition slugs and workspace-relative local keys", () => {
+    const deployed = workflow("Research", "/repo/research", "research-agent");
+    const local = workflow("Reporting", "/repo/tools/reporting", null);
+    const navigation = mapSystemGraphNavigation(
+      [graphNode("research-agent"), graphNode("local:tools/reporting")],
+      "workspace-root",
+      [deployed, local],
+      scopes,
+    );
+
+    expect(navigation.get("research-agent")).toBe(deployed);
+    expect(navigation.get("local:tools/reporting")).toBe(local);
+  });
+
+  it("does not resolve by a display label or across a nested workspace boundary", () => {
+    const matchingLabel = workflow("Growth", "/repo/growth", null);
+    const nested = workflow("Nested", "/repo/nested/agent", "nested-agent");
+    const navigation = mapSystemGraphNavigation(
+      [graphNode("manifest-name", "Growth"), graphNode("nested-agent")],
+      "workspace-root",
+      [matchingLabel, nested],
+      scopes,
+    );
+
+    expect(navigation.has("manifest-name")).toBe(false);
+    expect(navigation.has("nested-agent")).toBe(false);
+  });
+
+  it("leaves duplicate slugs inert while retaining unambiguous local identities", () => {
+    const first = workflow("First", "/repo/first", "shared");
+    const second = workflow("Second", "/repo/second", "shared");
+    const navigation = mapSystemGraphNavigation(
+      [
+        graphNode("shared"),
+        graphNode("local:first"),
+        graphNode("local:second"),
+      ],
+      "workspace-root",
+      [first, second],
+      scopes,
+    );
+
+    expect(navigation.has("shared")).toBe(false);
+    expect(navigation.get("local:first")).toBe(first);
+    expect(navigation.get("local:second")).toBe(second);
+  });
+
+  it("does not make one workflow ambiguous when two exact identities coincide", () => {
+    const exact = workflow("Exact", "/repo/exact", "local:exact");
+    const navigation = mapSystemGraphNavigation(
+      [graphNode("local:exact")],
+      "workspace-root",
+      [exact],
+      scopes,
+    );
+
+    expect(navigation.get("local:exact")).toBe(exact);
+  });
+});

--- a/packages/harness/web/src/lib/system-graph-navigation.ts
+++ b/packages/harness/web/src/lib/system-graph-navigation.ts
@@ -1,40 +1,14 @@
-import type {
-  AgentKey,
-  SystemGraphNode,
-  WorkspaceKey,
-  WorkspaceScopeSummary,
+import {
+  workspaceRelativeLocalKey,
+  type AgentKey,
+  type SystemGraphNode,
+  type WorkspaceKey,
+  type WorkspaceScopeSummary,
 } from "@shared/system-graph";
 import type { WorkflowInfo } from "@shared/types";
 
-function isWindowsPath(path: string): boolean {
-  return /^[A-Za-z]:[\\/]/.test(path);
-}
-
-function canonicalSegments(path: string): string[] {
-  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
-  return normalized.split("/").filter(Boolean);
-}
-
-function sameSegment(left: string, right: string, windows: boolean): boolean {
-  return windows ? left.toLowerCase() === right.toLowerCase() : left === right;
-}
-
-function relativeWithin(root: string, candidate: string): string[] | null {
-  const windows = isWindowsPath(root);
-  if (windows !== isWindowsPath(candidate)) return null;
-  const rootSegments = canonicalSegments(root);
-  const candidateSegments = canonicalSegments(candidate);
-  if (
-    rootSegments.length > candidateSegments.length ||
-    rootSegments.some(
-      (segment, index) =>
-        !sameSegment(segment, candidateSegments[index]!, windows),
-    )
-  ) {
-    return null;
-  }
-  return candidateSegments.slice(rootSegments.length);
-}
+const pathDepth = (value: string): number =>
+  value.split(/[\\/]/).filter(Boolean).length;
 
 function ownerScope(
   workflowPath: string,
@@ -42,24 +16,15 @@ function ownerScope(
 ): WorkspaceScopeSummary | null {
   return (
     scopes
-      .filter((scope) => relativeWithin(scope.cwd, workflowPath) !== null)
+      .filter(
+        (scope) => workspaceRelativeLocalKey(scope.cwd, workflowPath) !== null,
+      )
       .sort(
         (left, right) =>
-          canonicalSegments(right.cwd).length -
-            canonicalSegments(left.cwd).length ||
+          pathDepth(right.cwd) - pathDepth(left.cwd) ||
           left.workspaceKey.localeCompare(right.workspaceKey),
       )[0] ?? null
   );
-}
-
-function localAgentKey(root: string, workflowPath: string): AgentKey | null {
-  const relative = relativeWithin(root, workflowPath);
-  if (relative === null) return null;
-  const local =
-    relative.length > 0
-      ? relative.join("/")
-      : canonicalSegments(workflowPath).at(-1);
-  return local ? `local:${local}` : null;
 }
 
 /**
@@ -87,7 +52,7 @@ export function mapSystemGraphNavigation(
     if (ownerScope(workflow.path, scopes)?.workspaceKey !== workspaceKey)
       continue;
     register(workflow.definitionSlug?.trim() || null, workflow);
-    register(localAgentKey(selected.cwd, workflow.path), workflow);
+    register(workspaceRelativeLocalKey(selected.cwd, workflow.path), workflow);
   }
   return new Map(
     [...candidates.entries()]

--- a/packages/harness/web/src/lib/system-graph-navigation.ts
+++ b/packages/harness/web/src/lib/system-graph-navigation.ts
@@ -1,0 +1,97 @@
+import type {
+  AgentKey,
+  SystemGraphNode,
+  WorkspaceKey,
+  WorkspaceScopeSummary,
+} from "@shared/system-graph";
+import type { WorkflowInfo } from "@shared/types";
+
+function isWindowsPath(path: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(path);
+}
+
+function canonicalSegments(path: string): string[] {
+  const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  return normalized.split("/").filter(Boolean);
+}
+
+function sameSegment(left: string, right: string, windows: boolean): boolean {
+  return windows ? left.toLowerCase() === right.toLowerCase() : left === right;
+}
+
+function relativeWithin(root: string, candidate: string): string[] | null {
+  const windows = isWindowsPath(root);
+  if (windows !== isWindowsPath(candidate)) return null;
+  const rootSegments = canonicalSegments(root);
+  const candidateSegments = canonicalSegments(candidate);
+  if (
+    rootSegments.length > candidateSegments.length ||
+    rootSegments.some(
+      (segment, index) =>
+        !sameSegment(segment, candidateSegments[index]!, windows),
+    )
+  ) {
+    return null;
+  }
+  return candidateSegments.slice(rootSegments.length);
+}
+
+function ownerScope(
+  workflowPath: string,
+  scopes: readonly WorkspaceScopeSummary[],
+): WorkspaceScopeSummary | null {
+  return (
+    scopes
+      .filter((scope) => relativeWithin(scope.cwd, workflowPath) !== null)
+      .sort(
+        (left, right) =>
+          canonicalSegments(right.cwd).length -
+            canonicalSegments(left.cwd).length ||
+          left.workspaceKey.localeCompare(right.workspaceKey),
+      )[0] ?? null
+  );
+}
+
+function localAgentKey(root: string, workflowPath: string): AgentKey | null {
+  const relative = relativeWithin(root, workflowPath);
+  if (relative === null) return null;
+  const local =
+    relative.length > 0
+      ? relative.join("/")
+      : canonicalSegments(workflowPath).at(-1);
+  return local ? `local:${local}` : null;
+}
+
+/**
+ * Navigation is deliberately narrower than graph projection. The public graph
+ * omits source paths, so Studio may open a card only when its public AgentKey
+ * matches registry evidence already in memory. Display labels never resolve.
+ */
+export function mapSystemGraphNavigation(
+  nodes: readonly SystemGraphNode[],
+  workspaceKey: WorkspaceKey,
+  workflows: readonly WorkflowInfo[],
+  scopes: readonly WorkspaceScopeSummary[],
+): ReadonlyMap<AgentKey, WorkflowInfo> {
+  const selected = scopes.find((scope) => scope.workspaceKey === workspaceKey);
+  if (!selected) return new Map();
+  const graphKeys = new Set(nodes.map((node) => node.agentKey));
+  const candidates = new Map<AgentKey, Set<WorkflowInfo>>();
+  const register = (key: AgentKey | null, workflow: WorkflowInfo): void => {
+    if (!key || !graphKeys.has(key)) return;
+    const matches = candidates.get(key) ?? new Set<WorkflowInfo>();
+    matches.add(workflow);
+    candidates.set(key, matches);
+  };
+  for (const workflow of workflows) {
+    if (ownerScope(workflow.path, scopes)?.workspaceKey !== workspaceKey)
+      continue;
+    register(workflow.definitionSlug?.trim() || null, workflow);
+    register(localAgentKey(selected.cwd, workflow.path), workflow);
+  }
+  return new Map(
+    [...candidates.entries()]
+      .filter(([, matches]) => matches.size === 1)
+      .map(([key, matches]) => [key, [...matches][0]!] as const),
+  );
+}

--- a/packages/harness/web/src/lib/system-graph-viewport.test.ts
+++ b/packages/harness/web/src/lib/system-graph-viewport.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import {
   SYSTEM_GRAPH_FLOOR_ZOOM,
+  SYSTEM_GRAPH_KEYBOARD_PAN_STEP,
   SYSTEM_GRAPH_MAX_ZOOM,
   createSystemGraphViewportStore,
   fitSystemGraphView,
+  panSystemGraphViewWithKeyboard,
   resetSystemGraphView,
+  revealSystemGraphRect,
+  systemGraphViewIntersectsViewport,
   zoomSystemGraphAtPointer,
 } from "./system-graph-viewport";
 
@@ -70,25 +74,87 @@ describe("system graph view math", () => {
     expect(after.y + graphPoint.y * after.zoom).toBeCloseTo(pointer.y, 8);
   });
 
+  it("rejects a restored view whose graph no longer intersects the viewport", () => {
+    const graph = { width: 900, height: 480 };
+    const viewport = { width: 600, height: 400 };
+
+    expect(
+      systemGraphViewIntersectsViewport(
+        { zoom: 1, x: 0, y: 0 },
+        graph,
+        viewport,
+      ),
+    ).toBe(true);
+    expect(
+      systemGraphViewIntersectsViewport(
+        { zoom: 1, x: 2_000, y: 2_000 },
+        graph,
+        viewport,
+      ),
+    ).toBe(false);
+    expect(
+      systemGraphViewIntersectsViewport(
+        { zoom: 1, x: 749, y: 0 },
+        graph,
+        viewport,
+      ),
+    ).toBe(true);
+    expect(
+      systemGraphViewIntersectsViewport(
+        { zoom: 1, x: 749, y: 0 },
+        graph,
+        viewport,
+        [{ x: 32, y: 32, width: 184, height: 64 }],
+      ),
+    ).toBe(false);
+  });
+
+  it("pans by keyboard in the requested direction", () => {
+    const view = { zoom: 1, x: 12, y: -8 };
+
+    expect(panSystemGraphViewWithKeyboard(view, "ArrowLeft")).toEqual({
+      ...view,
+      x: view.x - SYSTEM_GRAPH_KEYBOARD_PAN_STEP,
+    });
+    expect(panSystemGraphViewWithKeyboard(view, "ArrowDown")).toEqual({
+      ...view,
+      y: view.y + SYSTEM_GRAPH_KEYBOARD_PAN_STEP,
+    });
+  });
+
+  it("moves an offscreen focused card fully inside the viewport", () => {
+    const graph = { width: 1_000, height: 600 };
+    const viewport = { width: 500, height: 300 };
+    const node = { x: 32, y: 32, width: 184, height: 64 };
+    const hidden = { zoom: 1, x: -900, y: 0 };
+
+    const revealed = revealSystemGraphRect(hidden, graph, viewport, node);
+    const left =
+      viewport.width / 2 +
+      revealed.x +
+      (node.x - graph.width / 2) * revealed.zoom;
+    const top =
+      viewport.height / 2 +
+      revealed.y +
+      (node.y - graph.height / 2) * revealed.zoom;
+
+    expect(left).toBeGreaterThanOrEqual(16);
+    expect(left + node.width * revealed.zoom).toBeLessThanOrEqual(
+      viewport.width - 16,
+    );
+    expect(top).toBeGreaterThanOrEqual(16);
+    expect(top + node.height * revealed.zoom).toBeLessThanOrEqual(
+      viewport.height - 16,
+    );
+  });
+
   it("keeps in-memory views isolated per workspace", () => {
     const store = createSystemGraphViewportStore();
-    store.set("workspace-a", {
-      view: { zoom: 1.5, x: 20, y: -10 },
-      autoFitted: true,
-    });
-    store.set("workspace-b", {
-      view: { zoom: 0.5, x: -30, y: 40 },
-      autoFitted: true,
-    });
+    store.set("workspace-a", { zoom: 1.5, x: 20, y: -10 });
+    store.set("workspace-b", { zoom: 0.5, x: -30, y: 40 });
 
-    expect(store.get("workspace-a")).toEqual({
-      view: { zoom: 1.5, x: 20, y: -10 },
-      autoFitted: true,
-    });
-    expect(store.get("workspace-b")).toEqual({
-      view: { zoom: 0.5, x: -30, y: 40 },
-      autoFitted: true,
-    });
+    expect(store.get("workspace-a")).toEqual({ zoom: 1.5, x: 20, y: -10 });
+    expect(store.get("workspace-b")).toEqual({ zoom: 0.5, x: -30, y: 40 });
     expect(store.get("workspace-c")).toBeUndefined();
   });
 });

--- a/packages/harness/web/src/lib/system-graph-viewport.test.ts
+++ b/packages/harness/web/src/lib/system-graph-viewport.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  SYSTEM_GRAPH_FLOOR_ZOOM,
+  SYSTEM_GRAPH_MAX_ZOOM,
+  createSystemGraphViewportStore,
+  fitSystemGraphView,
+  resetSystemGraphView,
+  zoomSystemGraphAtPointer,
+} from "./system-graph-viewport";
+
+describe("fitSystemGraphView", () => {
+  it("contains a graph with preferred air in roomy, narrow, and short viewports", () => {
+    for (const viewport of [
+      { width: 1200, height: 800 },
+      { width: 480, height: 800 },
+      { width: 1200, height: 280 },
+    ]) {
+      const graph = { width: 900, height: 480 };
+      const fit = fitSystemGraphView(graph, viewport, 16);
+      const insetX = Math.min(3.5 * 16, viewport.width * 0.2);
+      const insetY = Math.min(3.5 * 16, viewport.height * 0.2);
+      expect(graph.width * fit.zoom).toBeLessThanOrEqual(
+        viewport.width - insetX * 2 + 1,
+      );
+      expect(graph.height * fit.zoom).toBeLessThanOrEqual(
+        viewport.height - insetY * 2 + 1,
+      );
+      expect(fit.x).toBe(0);
+      expect(fit.y).toBe(0);
+    }
+  });
+
+  it("uses the 10% hard floor only when a very large graph cannot fit above it", () => {
+    const fit = fitSystemGraphView(
+      { width: 20_000, height: 10_000 },
+      { width: 600, height: 400 },
+      16,
+    );
+    expect(fit.zoom).toBe(SYSTEM_GRAPH_FLOOR_ZOOM);
+    expect(fit.minZoom).toBe(SYSTEM_GRAPH_FLOOR_ZOOM);
+  });
+
+  it("caps a tiny graph at the 300% maximum", () => {
+    expect(
+      fitSystemGraphView(
+        { width: 20, height: 20 },
+        { width: 1200, height: 800 },
+        16,
+      ).zoom,
+    ).toBe(SYSTEM_GRAPH_MAX_ZOOM);
+  });
+});
+
+describe("system graph view math", () => {
+  it("resets to 100% with zero pan", () => {
+    expect(resetSystemGraphView()).toEqual({ zoom: 1, x: 0, y: 0 });
+  });
+
+  it("keeps the graph point beneath the pointer fixed while zooming", () => {
+    const before = { zoom: 0.75, x: 28, y: -16 };
+    const pointer = { x: 160, y: -90 };
+    const graphPoint = {
+      x: (pointer.x - before.x) / before.zoom,
+      y: (pointer.y - before.y) / before.zoom,
+    };
+    const after = zoomSystemGraphAtPointer(before, 1.5, pointer);
+
+    expect(after.x + graphPoint.x * after.zoom).toBeCloseTo(pointer.x, 8);
+    expect(after.y + graphPoint.y * after.zoom).toBeCloseTo(pointer.y, 8);
+  });
+
+  it("keeps in-memory views isolated per workspace", () => {
+    const store = createSystemGraphViewportStore();
+    store.set("workspace-a", {
+      view: { zoom: 1.5, x: 20, y: -10 },
+      autoFitted: true,
+    });
+    store.set("workspace-b", {
+      view: { zoom: 0.5, x: -30, y: 40 },
+      autoFitted: true,
+    });
+
+    expect(store.get("workspace-a")).toEqual({
+      view: { zoom: 1.5, x: 20, y: -10 },
+      autoFitted: true,
+    });
+    expect(store.get("workspace-b")).toEqual({
+      view: { zoom: 0.5, x: -30, y: 40 },
+      autoFitted: true,
+    });
+    expect(store.get("workspace-c")).toBeUndefined();
+  });
+});

--- a/packages/harness/web/src/lib/system-graph-viewport.ts
+++ b/packages/harness/web/src/lib/system-graph-viewport.ts
@@ -5,9 +5,11 @@ export const SYSTEM_GRAPH_FLOOR_ZOOM = 0.1;
 export const SYSTEM_GRAPH_MAX_ZOOM = 3;
 export const SYSTEM_GRAPH_ZOOM_STEP = 0.25;
 export const SYSTEM_GRAPH_WHEEL_RATE = 0.0015;
+export const SYSTEM_GRAPH_KEYBOARD_PAN_STEP = 48;
 
 const FIT_EDGE_REM = 3.5;
 const FIT_EDGE_AXIS_CAP = 0.2;
+const FOCUS_REVEAL_INSET = 16;
 
 export interface SystemGraphSize {
   width: number;
@@ -20,18 +22,18 @@ export interface SystemGraphView {
   y: number;
 }
 
+export interface SystemGraphRect extends SystemGraphSize {
+  x: number;
+  y: number;
+}
+
 export interface SystemGraphFit extends SystemGraphView {
   minZoom: number;
 }
 
-export interface SavedSystemGraphView {
-  view: SystemGraphView;
-  autoFitted: boolean;
-}
-
 export interface SystemGraphViewportStore {
-  get(workspaceKey: WorkspaceKey): SavedSystemGraphView | undefined;
-  set(workspaceKey: WorkspaceKey, saved: SavedSystemGraphView): void;
+  get(workspaceKey: WorkspaceKey): SystemGraphView | undefined;
+  set(workspaceKey: WorkspaceKey, view: SystemGraphView): void;
 }
 
 const roundZoom = (zoom: number): number => Math.round(zoom * 100) / 100;
@@ -88,6 +90,106 @@ export function resetSystemGraphView(): SystemGraphView {
   return { zoom: 1, x: 0, y: 0 };
 }
 
+export function systemGraphViewIntersectsViewport(
+  view: SystemGraphView,
+  graph: SystemGraphSize,
+  viewport: SystemGraphSize,
+  visibleRects: readonly SystemGraphRect[] = [
+    { x: 0, y: 0, width: graph.width, height: graph.height },
+  ],
+): boolean {
+  if (
+    !Number.isFinite(view.zoom) ||
+    !Number.isFinite(view.x) ||
+    !Number.isFinite(view.y) ||
+    view.zoom <= 0 ||
+    graph.width <= 0 ||
+    graph.height <= 0 ||
+    viewport.width <= 0 ||
+    viewport.height <= 0
+  ) {
+    return false;
+  }
+  return visibleRects.some((rect) => {
+    const left =
+      viewport.width / 2 + view.x + (rect.x - graph.width / 2) * view.zoom;
+    const top =
+      viewport.height / 2 + view.y + (rect.y - graph.height / 2) * view.zoom;
+    return (
+      left < viewport.width &&
+      left + rect.width * view.zoom > 0 &&
+      top < viewport.height &&
+      top + rect.height * view.zoom > 0
+    );
+  });
+}
+
+export type SystemGraphArrowKey =
+  | "ArrowLeft"
+  | "ArrowRight"
+  | "ArrowUp"
+  | "ArrowDown";
+
+export function panSystemGraphViewWithKeyboard(
+  view: SystemGraphView,
+  key: SystemGraphArrowKey,
+): SystemGraphView {
+  switch (key) {
+    case "ArrowLeft":
+      return { ...view, x: view.x - SYSTEM_GRAPH_KEYBOARD_PAN_STEP };
+    case "ArrowRight":
+      return { ...view, x: view.x + SYSTEM_GRAPH_KEYBOARD_PAN_STEP };
+    case "ArrowUp":
+      return { ...view, y: view.y - SYSTEM_GRAPH_KEYBOARD_PAN_STEP };
+    case "ArrowDown":
+      return { ...view, y: view.y + SYSTEM_GRAPH_KEYBOARD_PAN_STEP };
+  }
+}
+
+function revealAxisOffset(
+  start: number,
+  end: number,
+  viewportStart: number,
+  viewportEnd: number,
+): number {
+  if (end - start > viewportEnd - viewportStart) {
+    return (viewportStart + viewportEnd - start - end) / 2;
+  }
+  if (start < viewportStart) return viewportStart - start;
+  if (end > viewportEnd) return viewportEnd - end;
+  return 0;
+}
+
+export function revealSystemGraphRect(
+  view: SystemGraphView,
+  graph: SystemGraphSize,
+  viewport: SystemGraphSize,
+  rect: SystemGraphRect,
+): SystemGraphView {
+  if (
+    graph.width <= 0 ||
+    graph.height <= 0 ||
+    viewport.width <= 0 ||
+    viewport.height <= 0 ||
+    view.zoom <= 0
+  ) {
+    return { ...view };
+  }
+  const insetX = Math.min(FOCUS_REVEAL_INSET, viewport.width / 2);
+  const insetY = Math.min(FOCUS_REVEAL_INSET, viewport.height / 2);
+  const left =
+    viewport.width / 2 + view.x + (rect.x - graph.width / 2) * view.zoom;
+  const top =
+    viewport.height / 2 + view.y + (rect.y - graph.height / 2) * view.zoom;
+  const right = left + rect.width * view.zoom;
+  const bottom = top + rect.height * view.zoom;
+  return {
+    ...view,
+    x: view.x + revealAxisOffset(left, right, insetX, viewport.width - insetX),
+    y: view.y + revealAxisOffset(top, bottom, insetY, viewport.height - insetY),
+  };
+}
+
 export function zoomSystemGraphAtPointer(
   view: SystemGraphView,
   nextZoom: number,
@@ -122,19 +224,14 @@ export function wheelSystemGraphView(
 }
 
 export function createSystemGraphViewportStore(): SystemGraphViewportStore {
-  const saved = new Map<WorkspaceKey, SavedSystemGraphView>();
+  const saved = new Map<WorkspaceKey, SystemGraphView>();
   return {
     get(workspaceKey) {
       const value = saved.get(workspaceKey);
-      return value
-        ? { view: { ...value.view }, autoFitted: value.autoFitted }
-        : undefined;
+      return value ? { ...value } : undefined;
     },
     set(workspaceKey, value) {
-      saved.set(workspaceKey, {
-        view: { ...value.view },
-        autoFitted: value.autoFitted,
-      });
+      saved.set(workspaceKey, { ...value });
     },
   };
 }

--- a/packages/harness/web/src/lib/system-graph-viewport.ts
+++ b/packages/harness/web/src/lib/system-graph-viewport.ts
@@ -1,0 +1,140 @@
+import type { WorkspaceKey } from "@shared/system-graph";
+
+export const SYSTEM_GRAPH_DEFAULT_MIN_ZOOM = 0.25;
+export const SYSTEM_GRAPH_FLOOR_ZOOM = 0.1;
+export const SYSTEM_GRAPH_MAX_ZOOM = 3;
+export const SYSTEM_GRAPH_ZOOM_STEP = 0.25;
+export const SYSTEM_GRAPH_WHEEL_RATE = 0.0015;
+
+const FIT_EDGE_REM = 3.5;
+const FIT_EDGE_AXIS_CAP = 0.2;
+
+export interface SystemGraphSize {
+  width: number;
+  height: number;
+}
+
+export interface SystemGraphView {
+  zoom: number;
+  x: number;
+  y: number;
+}
+
+export interface SystemGraphFit extends SystemGraphView {
+  minZoom: number;
+}
+
+export interface SavedSystemGraphView {
+  view: SystemGraphView;
+  autoFitted: boolean;
+}
+
+export interface SystemGraphViewportStore {
+  get(workspaceKey: WorkspaceKey): SavedSystemGraphView | undefined;
+  set(workspaceKey: WorkspaceKey, saved: SavedSystemGraphView): void;
+}
+
+const roundZoom = (zoom: number): number => Math.round(zoom * 100) / 100;
+
+export function clampSystemGraphZoom(
+  zoom: number,
+  minZoom = SYSTEM_GRAPH_DEFAULT_MIN_ZOOM,
+): number {
+  return Math.min(
+    SYSTEM_GRAPH_MAX_ZOOM,
+    Math.max(Math.max(SYSTEM_GRAPH_FLOOR_ZOOM, minZoom), roundZoom(zoom)),
+  );
+}
+
+export function fitSystemGraphView(
+  graph: SystemGraphSize,
+  viewport: SystemGraphSize,
+  rootFontSize: number,
+): SystemGraphFit {
+  if (
+    graph.width <= 0 ||
+    graph.height <= 0 ||
+    viewport.width <= 0 ||
+    viewport.height <= 0
+  ) {
+    return {
+      zoom: 1,
+      x: 0,
+      y: 0,
+      minZoom: SYSTEM_GRAPH_DEFAULT_MIN_ZOOM,
+    };
+  }
+  const preferred = FIT_EDGE_REM * rootFontSize;
+  const insetX = Math.min(preferred, viewport.width * FIT_EDGE_AXIS_CAP);
+  const insetY = Math.min(preferred, viewport.height * FIT_EDGE_AXIS_CAP);
+  const fitted = Math.min(
+    (viewport.width - insetX * 2) / graph.width,
+    (viewport.height - insetY * 2) / graph.height,
+    SYSTEM_GRAPH_MAX_ZOOM,
+  );
+  const zoom = Math.max(
+    SYSTEM_GRAPH_FLOOR_ZOOM,
+    Math.min(SYSTEM_GRAPH_MAX_ZOOM, Math.floor(fitted * 100) / 100),
+  );
+  return {
+    zoom,
+    x: 0,
+    y: 0,
+    minZoom: Math.min(SYSTEM_GRAPH_DEFAULT_MIN_ZOOM, zoom),
+  };
+}
+
+export function resetSystemGraphView(): SystemGraphView {
+  return { zoom: 1, x: 0, y: 0 };
+}
+
+export function zoomSystemGraphAtPointer(
+  view: SystemGraphView,
+  nextZoom: number,
+  pointer: SystemGraphPoint,
+): SystemGraphView {
+  if (view.zoom <= 0 || nextZoom === view.zoom)
+    return { ...view, zoom: nextZoom };
+  const ratio = nextZoom / view.zoom;
+  return {
+    zoom: nextZoom,
+    x: pointer.x - ratio * (pointer.x - view.x),
+    y: pointer.y - ratio * (pointer.y - view.y),
+  };
+}
+
+export interface SystemGraphPoint {
+  x: number;
+  y: number;
+}
+
+export function wheelSystemGraphView(
+  view: SystemGraphView,
+  deltaY: number,
+  pointer: SystemGraphPoint,
+  minZoom: number,
+): SystemGraphView {
+  const zoom = clampSystemGraphZoom(
+    view.zoom * Math.exp(-deltaY * SYSTEM_GRAPH_WHEEL_RATE),
+    minZoom,
+  );
+  return zoomSystemGraphAtPointer(view, zoom, pointer);
+}
+
+export function createSystemGraphViewportStore(): SystemGraphViewportStore {
+  const saved = new Map<WorkspaceKey, SavedSystemGraphView>();
+  return {
+    get(workspaceKey) {
+      const value = saved.get(workspaceKey);
+      return value
+        ? { view: { ...value.view }, autoFitted: value.autoFitted }
+        : undefined;
+    },
+    set(workspaceKey, value) {
+      saved.set(workspaceKey, {
+        view: { ...value.view },
+        autoFitted: value.autoFitted,
+      });
+    },
+  };
+}

--- a/packages/harness/web/src/lib/system-graph.test.ts
+++ b/packages/harness/web/src/lib/system-graph.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { SystemGraph } from "@shared/system-graph";
 
-import {
-  groupSystemGraphEdges,
-  orderSystemGraphNodes,
-  parseSystemGraph,
-} from "./system-graph";
+import { groupSystemGraphEdges, parseSystemGraph } from "./system-graph";
 
 const valid: SystemGraph = {
   kind: "system",
@@ -113,31 +109,6 @@ describe("groupSystemGraphEdges", () => {
         to: "agent:growth",
         modes: ["blocking", "async"],
       },
-    ]);
-  });
-});
-
-describe("orderSystemGraphNodes", () => {
-  it("places a direct caller above its target regardless of response order", () => {
-    expect(
-      orderSystemGraphNodes(parseSystemGraph(valid)).map(
-        (node) => node.agentKey,
-      ),
-    ).toEqual(["research", "growth"]);
-  });
-
-  it("does not double-count a pair that has both invocation modes", () => {
-    const graph = parseSystemGraph({
-      ...valid,
-      edges: [
-        { ...valid.edges[0], mode: "blocking" },
-        { ...valid.edges[0], mode: "async" },
-      ],
-    });
-
-    expect(orderSystemGraphNodes(graph).map((node) => node.agentKey)).toEqual([
-      "research",
-      "growth",
     ]);
   });
 });

--- a/packages/harness/web/src/lib/system-graph.ts
+++ b/packages/harness/web/src/lib/system-graph.ts
@@ -92,6 +92,9 @@ const MODE_ORDER: Record<SystemGraphEdge["mode"], number> = {
   async: 1,
 };
 
+const compareIds = (left: string, right: string): number =>
+  left === right ? 0 : left < right ? -1 : 1;
+
 /** Public graph data retains one record per mode. The V0 Canvas draws one
  * connector per endpoint pair so dual-mode relationships never overlap. */
 export function groupSystemGraphEdges(
@@ -114,7 +117,7 @@ export function groupSystemGraphEdges(
   return [...grouped.values()]
     .sort(
       (left, right) =>
-        left.from.localeCompare(right.from) || left.to.localeCompare(right.to),
+        compareIds(left.from, right.from) || compareIds(left.to, right.to),
     )
     .map(({ from, to, modes }) => ({
       from,
@@ -182,47 +185,4 @@ export function parseSystemGraph(value: unknown): SystemGraph {
     edges: typedEdges,
     warnings: typedWarnings,
   };
-}
-
-/** Stable Kahn order: direct callers render above the agents they invoke. */
-export function orderSystemGraphNodes(graph: SystemGraph): SystemGraphNode[] {
-  const byId = new Map(graph.nodes.map((node) => [node.id, node]));
-  const indegree = new Map(graph.nodes.map((node) => [node.id, 0]));
-  const outgoing = new Map<string, string[]>();
-  const topologyPairs = new Set<string>();
-  for (const edge of graph.edges) {
-    const pair = `${edge.from}\0${edge.to}`;
-    if (topologyPairs.has(pair)) continue;
-    topologyPairs.add(pair);
-    indegree.set(edge.to, (indegree.get(edge.to) ?? 0) + 1);
-    outgoing.set(edge.from, [...(outgoing.get(edge.from) ?? []), edge.to]);
-  }
-  const compareIds = (left: string, right: string): number =>
-    left.localeCompare(right);
-  const ready = graph.nodes
-    .filter((node) => indegree.get(node.id) === 0)
-    .map((node) => node.id)
-    .sort(compareIds);
-  const ordered: SystemGraphNode[] = [];
-  const visited = new Set<string>();
-
-  while (ready.length > 0) {
-    const id = ready.shift()!;
-    if (visited.has(id)) continue;
-    visited.add(id);
-    ordered.push(byId.get(id)!);
-    for (const target of [...(outgoing.get(id) ?? [])].sort(compareIds)) {
-      const next = (indegree.get(target) ?? 1) - 1;
-      indegree.set(target, next);
-      if (next === 0) {
-        ready.push(target);
-        ready.sort(compareIds);
-      }
-    }
-  }
-
-  // Cycles have no zero-indegree entry. Preserve the contract's stable order
-  // for those remaining nodes instead of dropping them from the view.
-  ordered.push(...graph.nodes.filter((node) => !visited.has(node.id)));
-  return ordered;
 }

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -4131,6 +4131,11 @@ button.rail-footer-card:hover {
   user-select: none;
 }
 
+.system-graph-viewport:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
+
 .system-graph-subject {
   position: absolute;
   top: 50%;

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -4059,80 +4059,103 @@ button.rail-footer-card:hover {
   min-width: 0;
 }
 
-/* V0 workspace system graph: the same opaque raised-node / dotted-flow
-   language as the design system's flow widgets, projected into the existing
-   right Canvas pane without introducing a second token vocabulary. */
-.system-graph-canvas {
-  flex: 1;
-  min-height: 0;
+/* V0 workspace dependency graph -----------------------------------------
+   A folder is a full-main destination, while the agent workbench remains
+   mounted behind CSS. The field and cards use the design repository's flow
+   geometry and existing Studio tokens; V0 intentionally has no legend,
+   metrics, status treatments, inspector, or grouping chrome. */
+.workspace-graph-view {
+  grid-column: 1 / -1;
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--surface-raised);
+}
+
+.workspace-graph-bar {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  flex: 0 0 auto;
+  height: var(--pane-header-h);
+  padding: 0 var(--pane-pad-x);
+  color: var(--text-dim);
+  border-bottom: 1px solid var(--ui-line);
+  background: var(--surface-raised);
+}
+
+.workspace-graph-title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text);
+  font-size: var(--type-label);
+  font-weight: 590;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.workspace-graph-body,
+.system-graph-canvas,
+.system-graph-viewport {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.workspace-graph-body {
+  display: flex;
+  flex-direction: column;
+}
+
+.system-graph-canvas {
+  display: flex;
+  flex-direction: column;
+  background: var(--surface-base);
+}
+
+.system-graph-viewport {
+  touch-action: none;
+  cursor: grab;
   background-color: var(--surface-base);
   background-image: radial-gradient(var(--flow-grid-dot) 1px, transparent 1px);
+  background-position: 0 0;
   background-size: 16px 16px;
 }
 
-.system-graph-heading {
-  flex: 0 0 auto;
-  height: var(--pane-header-h);
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--sp3);
-  padding: 0 var(--pane-pad-x);
-  border-bottom: 1px solid var(--ui-line);
-  background: var(--surface-raised);
-  color: var(--text);
-  font-size: var(--type-label);
-  font-weight: 600;
+.system-graph-viewport.is-panning {
+  cursor: grabbing;
+  user-select: none;
 }
 
-.system-graph-heading span:last-child {
-  color: var(--text-faint);
-  font-size: var(--type-meta);
-  font-weight: 400;
+.system-graph-subject {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform-origin: center;
+  will-change: transform;
 }
 
-.system-graph-scroll {
-  flex: 1;
-  min-height: 0;
-  overflow: auto;
-}
-
-.system-graph-svg {
-  display: block;
-  width: 100%;
-  min-width: 320px;
-  min-height: 100%;
-}
-
-.system-graph-node rect {
-  fill: var(--surface-raised);
-  stroke: var(--ui-line-strong);
-}
-
-.system-graph-node circle {
-  fill: var(--text-dim);
-}
-
-.system-graph-node-label {
-  fill: var(--text);
-  font-family: var(--font);
-  font-size: var(--type-ui);
-  font-weight: 600;
-}
-
-.system-graph-node-meta,
-.system-graph-edge-label {
-  fill: var(--text-faint);
-  font-family: var(--font);
-  font-size: var(--type-micro);
+.system-graph-edges {
+  position: absolute;
+  inset: 0;
+  overflow: visible;
+  pointer-events: none;
 }
 
 .system-graph-edge {
   fill: none;
   stroke: var(--text-faint);
+  stroke-linecap: round;
+  stroke-linejoin: round;
   stroke-width: 1.5;
+  vector-effect: non-scaling-stroke;
+}
+
+.system-graph-edge.is-async {
   stroke-dasharray: 5 5;
 }
 
@@ -4140,18 +4163,132 @@ button.rail-footer-card:hover {
   fill: var(--text-faint);
 }
 
-.system-graph-warning {
-  flex: 0 0 auto;
-  margin: 0;
-  padding: var(--sp2) var(--pane-pad-x);
-  border-top: 1px solid var(--ui-line);
+.system-graph-edge-label {
+  fill: var(--text-faint);
+  stroke: var(--surface-base);
+  stroke-width: 4px;
+  paint-order: stroke fill;
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  pointer-events: none;
+}
+
+.system-graph-node {
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  gap: var(--sp1);
+  box-sizing: border-box;
+  padding: var(--sp2) var(--sp3);
+  overflow: hidden;
+  appearance: none;
+  color: var(--text);
   background: var(--surface-raised);
+  border: 1px dashed var(--ui-line-strong);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-xs);
+  font: inherit;
+  text-align: left;
+}
+
+button.system-graph-node.is-navigable {
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    border-color var(--transition-fast),
+    box-shadow var(--transition-fast);
+}
+
+button.system-graph-node.is-navigable:hover {
+  background: var(--surface-hover);
+  border-color: var(--text-faint);
+}
+
+button.system-graph-node.is-navigable:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  button.system-graph-node.is-navigable {
+    transition: none;
+  }
+}
+
+.system-graph-node-label,
+.system-graph-node-meta {
+  width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.system-graph-node-label {
+  font-size: var(--type-label);
+  font-weight: 590;
+}
+
+.system-graph-node-meta {
   color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+}
+
+.system-graph-subject[data-semantic-zoom="far"] .system-graph-node-meta,
+.system-graph-subject[data-semantic-zoom="far"] .system-graph-edge-label {
+  display: none;
+}
+
+.system-graph-controls {
+  position: absolute;
+  right: var(--sp3);
+  bottom: var(--sp3);
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  gap: var(--sp1);
+  padding: var(--sp1);
+  border: 1px solid var(--ui-line-strong);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-xs);
+}
+
+.system-graph-controls .theme-toggle:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.system-graph-controls .system-graph-zoom-reset {
+  width: auto;
+  min-width: calc(var(--control-h-xs) + var(--sp3));
+  padding: 0 var(--sp2);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  font-variant-numeric: tabular-nums;
+}
+
+.system-graph-warning {
+  position: absolute;
+  top: var(--sp3);
+  right: var(--sp3);
+  z-index: 2;
+  margin: 0;
+  padding: var(--sp2) var(--sp3);
+  color: var(--text-faint);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-xs);
+  font-family: var(--font-mono);
   font-size: var(--type-meta);
 }
 
 .system-graph-state {
   flex: 1;
+  min-height: 0;
 }
 
 .workflow-actions-header {
@@ -8644,7 +8781,10 @@ button.rail-footer-card:hover {
    stretch cards to the full monitor. */
 .app.is-browsing > .center-pane,
 .app.is-browsing > .right-pane,
-.app.is-browsing > .pane-resize-handle {
+.app.is-browsing > .pane-resize-handle,
+.app.is-workspace-graph > .center-pane,
+.app.is-workspace-graph > .right-pane,
+.app.is-workspace-graph > .pane-resize-handle {
   display: none;
 }
 


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The V0 Agent Studio workspace dependency graph was still a right-sidebar Canvas projection backed by a single vertical Kahn lane. That surface rewrote right-pane state, constrained the graph to half the workbench, and could not render fan-in, fan-out, cycles, rank-skipping relationships, or disconnected agents reliably.

## Summary and scope

- Promote folder selection to a full-main workspace graph destination spanning everything to the right of the Workspaces rail.
- Keep the center workbench, terminal, right pane, selected right tab, Canvas document, collapse/width/expanded preferences, and active session mounted and inert underneath the graph; selecting an agent restores the existing view through the normal focus path.
- Move cached graph loading, retry, empty, and static-warning ownership into a dedicated `WorkspaceGraphView`; the endpoint, public `SystemGraph`, source detector, server store, and browser-cache contract remain unchanged.
- Add deterministic weak-component and Tarjan SCC analysis, longest-path ranks, fixed `184 x 64` card geometry, stable component tiling, bounded fan ports, collision-aware labels, card-avoiding rank-skip routes, outer cycle corridors, natural bounds, and a finite fail-closed layout budget.
- Render absolute HTML agent cards above one SVG edge plane using the existing Studio/design-system tokens. Blocking connectors are solid, async connectors are dashed, and dual-mode pairs remain one solid `blocking + async` connector.
- Add exact, ambiguity-safe `AgentKey -> WorkflowInfo` navigation without display-label guessing.
- Add pointer-captured pan, pointer-anchored wheel zoom, 25% controls, reset, fit, double-click fit, 10%-300% safety bounds, semantic zoom below 55%, resize-safe floors, and per-workspace in-memory view restoration.
- Cover desktop light/dark and mobile layouts with chain, fan-in, fan-out, cycle, combined-mode, and isolated-node mock topology.
- Add a minor Changeset for `@sapiom/harness`.

### Key refinements from code review

- Reject a restored viewport snapshot when no agent card intersects the current pane, then recover with the first-entry auto-fit instead of reopening a blank graph.
- Derive workspace-relative `local:` AgentKeys through one browser/server-safe contract, with coverage for symlinks, equal roots, outside paths, Windows drives, and UNC paths.
- Make the graph viewport keyboard-focusable with arrow-key panning, a visible design-token focus ring, and automatic reveal when tab focus reaches an offscreen card.

V0 intentionally omits the legend, resource nodes, groups, operational status/failure UI, metrics, costs, filters, inspector, and lifecycle freshness. Watcher-driven invalidation remains SAP-2904, and the final Polsia-scale dogfood journey remains SAP-2906.

## Related work

Related issue or discussion: [SAP-2905](https://linear.app/sapiom/issue/SAP-2905/render-non-linear-workspace-topologies-reliably)

Stacked on #715 (SAP-2903), which is stacked on #713 (SAP-2902) and #712 (SAP-2901). This PR intentionally targets `yashnadge/sap-2903-detect-blocking-and-asynchronous-direct-agent-calls` so the complete V0 graph stack remains testable before merge.

## Validation

```text
pnpm --filter @sapiom/harness exec vitest run --exclude src/core/workspace-watcher.test.ts — 150 files, 2,192 tests passed
pnpm --filter @sapiom/harness exec vitest run src/core/workspace-watcher.test.ts -t '^(?!.*distinguishes an unreadable project).*$' — 16 passed, 1 intentionally excluded
pnpm --filter @sapiom/harness test:perf — 5 passed; 200-file source scan hot p95 154.6 ms
pnpm --filter @sapiom/harness typecheck — passed
pnpm --filter @sapiom/harness lint — 0 errors; 1 pre-existing warning in src/server/rest.test.ts
pnpm --filter @sapiom/harness... build — all 8 packages and the production Harness SPA passed
pnpm --filter @sapiom/harness test:ui — 337 passed (3.4m)
pnpm --filter @sapiom/harness test:ui --grep 'workspace graph|full-main cached|workspace projection' — 7 passed
pnpm --filter @sapiom/harness-desktop typecheck — passed
pnpm --filter @sapiom/harness-desktop test — 18 files, 152 tests passed
pnpm --filter @sapiom/harness-desktop dist — Linux AppImage and deb packaging passed
packages/harness-desktop/scripts/smoke.sh — 13 packaged-app checks passed; 1 Windows-only check skipped
pnpm terminology:check — passed (436 files)
pnpm provider-copy:check — passed (74 files)
pnpm exec prettier --check <new graph files> — passed
pnpm changeset status — passed; Harness minor and expected transitive bumps recognized
git diff --check b0d41a0...HEAD — passed
```

The unmodified unreadable-directory watcher assertion is intentionally excluded here because this cloud filesystem still permits the owner to read a `chmod 000` fixture. It fails identically on the #715 base and is unrelated to this graph change; the other 16 watcher tests pass.

Manual visual review passed against design repo `sapiom/design-eng@4bb7cd90` at desktop light, desktop dark, and the 375 x 812 mobile breakpoint. The dotted field remains fixed, cards stay at their design geometry, labels and connectors avoid cards, controls remain unobstructed, and mobile has no page overflow.

### Tests and documentation

Added pure topology/layout tests for chains, fan-in/out, cycles and downstream SCCs, disconnected agents, deterministic permutations, port staggering, route/card collision, label/card collision, mode grouping, malformed input, and complete natural bounds. Added viewport tests for fit insets, safety floors, reset, pointer anchoring, and per-workspace isolation; navigation tests cover nested scopes, exact local/definition identities, ambiguity, and label non-resolution.

Browser coverage now proves the corrected full-main destination, mounted-but-hidden agent surfaces, session/right-tab restoration, folder disclosure independence, cached/degraded/error retry behavior, no-session access, mode/card anatomy, all viewport controls, view restoration, dark theme, mobile containment, no right-sheet scrim, and card navigation. The expanded Linear issue contains the complete design contract, architecture, acceptance criteria, and V0 exclusions; no separate user documentation is needed for this incremental Studio feature.

## Compatibility and release impact

- Breaking or externally visible changes: Workspace folders now open their graph as a full-main Studio destination instead of replacing the right sidebar Canvas. The public `SystemGraph`, endpoint, cache, and per-agent Canvas behavior are unchanged.
- Changeset: Added a minor Changeset for `@sapiom/harness`; Changesets reports the expected dependent package bumps.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

OpenAI Codex helped research the design reference, expand SAP-2905, implement the destination/layout/renderer/viewport/navigation changes, add tests, and review the final diff. The result was verified with the unit, performance, typecheck, lint, production build, full browser, desktop packaging/runtime smoke, terminology, provider-copy, formatting, design-token, and changeset checks listed above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

