### PR TITLE
feat(harness): keep workspace graphs fresh

### DIFF
--- a/.changeset/workspace-graph-freshness.md
+++ b/.changeset/workspace-graph-freshness.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": minor
+---
+
+Keep Agent Studio workspace dependency graphs current with revisioned lifecycle snapshots, session-independent filesystem watching, per-agent relationship caching, and last-good stale or degraded presentation during refresh failures.

--- a/packages/harness/src/core/system-graph-inventory.test.ts
+++ b/packages/harness/src/core/system-graph-inventory.test.ts
@@ -91,6 +91,13 @@ describe("HarnessRegistryInventoryProvider", () => {
           [path.join(linkedRoot, "agent", "nested-agent", "index.ts")],
         ),
       ).toEqual([canonicalNestedRoot]);
+      expect(
+        dirtyGraphSourceRoots(
+          linkedRoot,
+          [agentRoot, nestedRoot],
+          [path.join(linkedRoot, "unregistered", "index.ts")],
+        ),
+      ).toEqual([]);
     } finally {
       await fs.rm(tempRoot, { recursive: true, force: true });
     }

--- a/packages/harness/src/core/system-graph-inventory.test.ts
+++ b/packages/harness/src/core/system-graph-inventory.test.ts
@@ -1,7 +1,12 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 import type { WorkflowInfo } from "../shared/types.js";
 import {
+  dirtyGraphSourceRoots,
+  graphSourceRootsWithinScope,
   HarnessRegistryInventoryProvider,
   type WorkspaceScope,
 } from "./system-graph-inventory.js";
@@ -53,6 +58,44 @@ function provider(
 }
 
 describe("HarnessRegistryInventoryProvider", () => {
+  it("matches canonical workflow roots beneath a symlinked workspace", async () => {
+    if (process.platform === "win32") return;
+    const tempRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "system-graph-symlink-"),
+    );
+    try {
+      const workspaceRoot = path.join(tempRoot, "real-workspace");
+      const agentRoot = path.join(workspaceRoot, "agent");
+      const nestedRoot = path.join(agentRoot, "nested-agent");
+      const outsideRoot = path.join(tempRoot, "outside", "agent");
+      const linkedRoot = path.join(tempRoot, "linked-workspace");
+      await Promise.all([
+        fs.mkdir(nestedRoot, { recursive: true }),
+        fs.mkdir(outsideRoot, { recursive: true }),
+      ]);
+      await fs.symlink(workspaceRoot, linkedRoot, "dir");
+
+      const canonicalAgentRoot = await fs.realpath(agentRoot);
+      const canonicalNestedRoot = await fs.realpath(nestedRoot);
+      expect(
+        graphSourceRootsWithinScope(linkedRoot, [
+          agentRoot,
+          nestedRoot,
+          outsideRoot,
+        ]),
+      ).toEqual([canonicalAgentRoot, canonicalNestedRoot]);
+      expect(
+        dirtyGraphSourceRoots(
+          linkedRoot,
+          [agentRoot, nestedRoot, outsideRoot],
+          [path.join(linkedRoot, "agent", "nested-agent", "index.ts")],
+        ),
+      ).toEqual([canonicalNestedRoot]);
+    } finally {
+      await fs.rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("returns every registry-known agent regardless of deployment, source, or relationships", async () => {
     const inspectManifestName = vi.fn(async (sourceRoot: string) => {
       if (sourceRoot.endsWith("/growth")) {

--- a/packages/harness/src/core/system-graph-inventory.ts
+++ b/packages/harness/src/core/system-graph-inventory.ts
@@ -129,6 +129,23 @@ export function canonicalGraphPath(input: string): string {
   try {
     return realpathSync.native(resolved);
   } catch {
+    // Watchers can report a path after an atomic rename or deletion, so the
+    // leaf itself may no longer exist. Resolve the nearest existing ancestor
+    // and append the missing tail; otherwise a symlinked workspace would stop
+    // matching exactly when targeted invalidation matters most.
+    const missingSegments: string[] = [];
+    let ancestor = resolved;
+    let parent = api.dirname(ancestor);
+    while (parent !== ancestor) {
+      missingSegments.unshift(api.basename(ancestor));
+      ancestor = parent;
+      try {
+        return api.join(realpathSync.native(ancestor), ...missingSegments);
+      } catch {
+        // Keep walking toward an existing ancestor.
+      }
+      parent = api.dirname(ancestor);
+    }
     return resolved;
   }
 }
@@ -143,6 +160,56 @@ export function isWithinGraphPath(root: string, candidate: string): boolean {
       !relative.startsWith(`..${api.sep}`) &&
       !api.isAbsolute(relative))
   );
+}
+
+/** Canonical registered roots contained by a workspace, safe for symlinked scopes. */
+export function graphSourceRootsWithinScope(
+  scopeRoot: string,
+  sourceRoots: readonly string[],
+): string[] {
+  const canonicalScopeRoot = canonicalGraphPath(scopeRoot);
+  return [
+    ...new Set(
+      sourceRoots
+        .map(canonicalGraphPath)
+        .filter((sourceRoot) =>
+          isWithinGraphPath(canonicalScopeRoot, sourceRoot),
+        ),
+    ),
+  ].sort();
+}
+
+/**
+ * Attribute exact source edits to the deepest registered project roots.
+ * A null path list is the polling/ambiguous-event fallback and dirties every
+ * caller in the scope.
+ */
+export function dirtyGraphSourceRoots(
+  scopeRoot: string,
+  sourceRoots: readonly string[],
+  sourcePaths: readonly string[] | null,
+): string[] {
+  const roots = graphSourceRootsWithinScope(scopeRoot, sourceRoots);
+  if (sourcePaths === null) return roots;
+
+  const dirty = new Set<string>();
+  for (const sourcePath of sourcePaths) {
+    const canonicalSourcePath = canonicalGraphPath(sourcePath);
+    const matches = roots.filter((sourceRoot) =>
+      isWithinGraphPath(sourceRoot, canonicalSourcePath),
+    );
+    for (const match of matches) {
+      if (
+        !matches.some(
+          (candidate) =>
+            candidate !== match && isWithinGraphPath(match, candidate),
+        )
+      ) {
+        dirty.add(match);
+      }
+    }
+  }
+  return [...dirty].sort();
 }
 
 function graphPathIdentity(input: string): string {

--- a/packages/harness/src/core/system-graph-relationships.test.ts
+++ b/packages/harness/src/core/system-graph-relationships.test.ts
@@ -1,10 +1,14 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { AgentInventoryItem } from "./system-graph-inventory.js";
-import { SourceAgentRelationshipProvider } from "./system-graph-relationships.js";
+import {
+  CachedAgentRelationshipProvider,
+  SourceAgentRelationshipProvider,
+  type AgentRelationshipProvider,
+} from "./system-graph-relationships.js";
 
 const temporaryRoots: string[] = [];
 
@@ -78,5 +82,94 @@ ctx.sapiom.agents.launch({ definition: dynamicTarget });
     const second = await provider.listRelationships(caller);
 
     expect(second).toEqual(first);
+  });
+});
+
+describe("CachedAgentRelationshipProvider", () => {
+  it("coalesces and reuses unchanged caller extraction", async () => {
+    const caller = await callerWithSource("export const value = 1;\n");
+    const inner: AgentRelationshipProvider = {
+      listRelationships: vi.fn(async () => ({
+        relationships: [],
+        warnings: [],
+      })),
+    };
+    const fingerprint = vi.fn(async () => "fingerprint-one");
+    const provider = new CachedAgentRelationshipProvider(inner, fingerprint);
+
+    const first = provider.listRelationships(caller);
+    await expect(provider.listRelationships(caller)).resolves.toEqual(
+      await first,
+    );
+    await provider.listRelationships(caller);
+
+    expect(inner.listRelationships).toHaveBeenCalledTimes(1);
+    expect(fingerprint).toHaveBeenCalledTimes(3);
+  });
+
+  it("rescans only after the caller fingerprint changes", async () => {
+    const caller = await callerWithSource("export const value = 1;\n");
+    const inner: AgentRelationshipProvider = {
+      listRelationships: vi.fn(async () => ({
+        relationships: [],
+        warnings: [],
+      })),
+    };
+    const fingerprint = vi
+      .fn()
+      .mockResolvedValueOnce("one")
+      .mockResolvedValueOnce("two");
+    const provider = new CachedAgentRelationshipProvider(inner, fingerprint);
+
+    await provider.listRelationships(caller);
+    await provider.listRelationships(caller);
+
+    expect(inner.listRelationships).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retain a failed caller result", async () => {
+    const caller = await callerWithSource("export const value = 1;\n");
+    const inner: AgentRelationshipProvider = {
+      listRelationships: vi
+        .fn()
+        .mockRejectedValueOnce(new Error("not installed"))
+        .mockResolvedValueOnce({ relationships: [], warnings: [] }),
+    };
+    const provider = new CachedAgentRelationshipProvider(
+      inner,
+      async () => "same",
+    );
+
+    await expect(provider.listRelationships(caller)).rejects.toThrow(
+      "not installed",
+    );
+    await expect(provider.listRelationships(caller)).resolves.toEqual({
+      relationships: [],
+      warnings: [],
+    });
+    expect(inner.listRelationships).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts removed callers while preserving retained callers", async () => {
+    const first = await callerWithSource("export const first = 1;\n");
+    const second = await callerWithSource("export const second = 1;\n");
+    const inner: AgentRelationshipProvider = {
+      listRelationships: vi.fn(async () => ({
+        relationships: [],
+        warnings: [],
+      })),
+    };
+    const provider = new CachedAgentRelationshipProvider(
+      inner,
+      async () => "same",
+    );
+    await provider.listRelationships(first);
+    await provider.listRelationships(second);
+
+    provider.retainCallers([second]);
+    await provider.listRelationships(first);
+    await provider.listRelationships(second);
+
+    expect(inner.listRelationships).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/harness/src/core/system-graph-relationships.ts
+++ b/packages/harness/src/core/system-graph-relationships.ts
@@ -1,9 +1,12 @@
+import * as path from "node:path";
+
 import {
   detectAgentInvocations,
   type AgentInvocationDetectionWarning,
   type AgentInvocationMode,
   type SourceEvidence,
 } from "./canvas-interconnections.js";
+import { fingerprintWorkflowSources } from "./canvas-cache.js";
 import type { AgentInventoryItem } from "./system-graph-inventory.js";
 
 export interface AgentRelationshipCandidate {
@@ -26,6 +29,77 @@ export interface AgentRelationshipProvider {
   listRelationships(
     caller: AgentInventoryItem,
   ): Promise<AgentRelationshipProviderResult>;
+  /** Optional lifecycle hook for providers that retain per-caller state. */
+  retainCallers?(callers: readonly AgentInventoryItem[]): void;
+}
+
+interface CachedRelationshipEntry {
+  fingerprint: string;
+  result: Promise<AgentRelationshipProviderResult>;
+}
+
+/**
+ * Successful per-caller relationship extraction behind the same cheap source
+ * fingerprint used by Canvas. Projection can therefore rebuild against a new
+ * inventory without re-walking unchanged caller trees.
+ */
+export class CachedAgentRelationshipProvider
+  implements AgentRelationshipProvider
+{
+  private readonly entries = new Map<string, CachedRelationshipEntry>();
+
+  constructor(
+    private readonly inner: AgentRelationshipProvider = new SourceAgentRelationshipProvider(),
+    private readonly fingerprint: (
+      sourceRoot: string,
+    ) => Promise<string> = fingerprintWorkflowSources,
+  ) {}
+
+  async listRelationships(
+    caller: AgentInventoryItem,
+  ): Promise<AgentRelationshipProviderResult> {
+    const key = path.resolve(caller.sourceRoot);
+    let fingerprint: string;
+    try {
+      fingerprint = await this.fingerprint(key);
+    } catch (error) {
+      this.entries.delete(key);
+      throw error;
+    }
+
+    const hit = this.entries.get(key);
+    if (hit?.fingerprint === fingerprint) return hit.result;
+
+    let result: Promise<AgentRelationshipProviderResult>;
+    try {
+      result = Promise.resolve(this.inner.listRelationships(caller));
+    } catch (error) {
+      result = Promise.reject(error);
+    }
+    const entry = { fingerprint, result };
+    this.entries.set(key, entry);
+    void result.catch(() => {
+      if (this.entries.get(key) === entry) this.entries.delete(key);
+    });
+    return result;
+  }
+
+  invalidateSource(sourceRoot: string): void {
+    this.entries.delete(path.resolve(sourceRoot));
+  }
+
+  retainCallers(callers: readonly AgentInventoryItem[]): void {
+    const retained = new Set(
+      callers.map((caller) => path.resolve(caller.sourceRoot)),
+    );
+    for (const sourceRoot of this.entries.keys()) {
+      if (!retained.has(sourceRoot)) this.entries.delete(sourceRoot);
+    }
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
 }
 
 function evidenceOrder(left: SourceEvidence, right: SourceEvidence): number {

--- a/packages/harness/src/core/system-graph-store.test.ts
+++ b/packages/harness/src/core/system-graph-store.test.ts
@@ -1,134 +1,274 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { SystemGraph } from "../shared/system-graph.js";
 import type {
-  SystemGraphBuilder,
+  SystemGraph,
+  SystemGraphSnapshot,
+} from "../shared/system-graph.js";
+import type {
   SystemGraphBuildResult,
+  SystemGraphBuilder,
   WorkspaceScope,
 } from "./system-graph.js";
-import {
-  SystemGraphStore,
-  type StoredSystemGraph,
-} from "./system-graph-store.js";
+import { SystemGraphStore } from "./system-graph-store.js";
 
 const scope: WorkspaceScope = {
   workspaceKey: "workspace-one",
   root: "/private/one",
 };
-const graph: SystemGraph = {
-  kind: "system",
-  scope: { kind: "working-tree", workspaceKey: scope.workspaceKey },
-  nodes: [],
-  edges: [],
-  warnings: [],
-};
 
-function buildResult(cacheable = true): SystemGraphBuildResult {
-  return { cacheable, graph };
+function graphFor(label: string): SystemGraph {
+  return {
+    kind: "system",
+    scope: { kind: "working-tree", workspaceKey: scope.workspaceKey },
+    nodes: [{ id: `agent:${label}`, agentKey: label, label }],
+    edges: [],
+    warnings: [],
+  };
 }
 
-function storedResult(degraded = false): StoredSystemGraph {
-  return { graph, degraded };
+function buildResult(
+  label: string,
+  cacheable = true,
+): SystemGraphBuildResult {
+  return { cacheable, graph: graphFor(label) };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: Error) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 describe("SystemGraphStore", () => {
-  it("coalesces concurrent and sequential reads for an unchanged workspace", async () => {
-    let resolveBuild!: (value: SystemGraphBuildResult) => void;
-    const pending = new Promise<SystemGraphBuildResult>((resolve) => {
-      resolveBuild = resolve;
-    });
-    const builder: SystemGraphBuilder = { build: vi.fn(() => pending) };
+  it("coalesces cold reads and retains an unchanged ready snapshot", async () => {
+    const pending = deferred<SystemGraphBuildResult>();
+    const builder: SystemGraphBuilder = {
+      build: vi.fn(() => pending.promise),
+    };
     const store = new SystemGraphStore(builder);
 
     const first = store.get(scope);
-    const concurrent = store.get(scope);
-    expect(first).toBe(concurrent);
-    resolveBuild(buildResult());
-    await expect(first).resolves.toEqual(storedResult());
-    await expect(store.get(scope)).resolves.toEqual(storedResult());
+    expect(store.get(scope)).toBe(first);
+    pending.resolve(buildResult("first"));
+
+    const ready = await first;
+    expect(ready).toMatchObject({ state: "ready", graph: graphFor("first") });
+    await expect(store.get(scope)).resolves.toBe(ready);
     expect(builder.build).toHaveBeenCalledTimes(1);
   });
 
-  it("evicts failed builds so the next open retries", async () => {
-    const builder: SystemGraphBuilder = {
-      build: vi
-        .fn()
-        .mockRejectedValueOnce(new Error("scan failed"))
-        .mockResolvedValueOnce(buildResult()),
-    };
-    const store = new SystemGraphStore(builder);
-
-    await expect(store.get(scope)).rejects.toThrow("scan failed");
-    await expect(store.get(scope)).resolves.toEqual(storedResult());
-    expect(builder.build).toHaveBeenCalledTimes(2);
-  });
-
-  it("supports explicit invalidation without coupling it to UI opens", async () => {
-    const builder: SystemGraphBuilder = {
-      build: vi.fn(async () => buildResult()),
-    };
-    const store = new SystemGraphStore(builder);
-    await store.get(scope);
-    store.invalidate(scope.workspaceKey);
-    await store.get(scope);
-    expect(builder.build).toHaveBeenCalledTimes(2);
-  });
-
-  it("coalesces a degraded graph and allows one later re-enrichment", async () => {
+  it("keeps the last-good graph visible while a refresh runs", async () => {
+    const refresh = deferred<SystemGraphBuildResult>();
     const build = vi
       .fn()
-      .mockResolvedValueOnce(buildResult(false))
-      .mockResolvedValueOnce(buildResult());
-    const store = new SystemGraphStore({ build });
+      .mockResolvedValueOnce(buildResult("first"))
+      .mockReturnValueOnce(refresh.promise);
+    const changes: SystemGraphSnapshot[] = [];
+    const store = new SystemGraphStore(
+      { build },
+      { onChange: (snapshot) => changes.push(snapshot) },
+    );
+    await store.get(scope);
 
-    const first = store.get(scope);
-    const concurrent = store.get(scope);
-    expect(first).toBe(concurrent);
-    await expect(first).resolves.toEqual(storedResult(true));
-    await expect(store.get(scope)).resolves.toEqual(storedResult());
-    expect(build).toHaveBeenCalledTimes(2);
+    const stale = store.requestRefresh(scope);
+    expect(stale).toMatchObject({ state: "stale", graph: graphFor("first") });
+    await expect(store.get(scope)).resolves.toBe(stale);
+
+    refresh.resolve(buildResult("second"));
+    await vi.waitFor(() => {
+      expect(store.peek(scope.workspaceKey)).toMatchObject({
+        state: "ready",
+        graph: graphFor("second"),
+      });
+    });
+    expect(changes.map((change) => change.state)).toContain("stale");
   });
 
-  it("retains the second degraded graph until explicit invalidation", async () => {
-    const build = vi.fn(async () => buildResult(false));
-    const store = new SystemGraphStore({ build });
-
-    await expect(store.get(scope)).resolves.toEqual(storedResult(true));
-    const second = store.get(scope);
-    await expect(second).resolves.toEqual(storedResult(true));
-    expect(store.get(scope)).toBe(second);
-    expect(build).toHaveBeenCalledTimes(2);
-
-    store.invalidate(scope.workspaceKey);
-    await expect(store.get(scope)).resolves.toEqual(storedResult(true));
-    expect(build).toHaveBeenCalledTimes(3);
-  });
-
-  it("does not let an invalidated in-flight build consume the retry", async () => {
-    let resolveFirst!: (value: SystemGraphBuildResult) => void;
-    let resolveSecond!: (value: SystemGraphBuildResult) => void;
-    const firstBuild = new Promise<SystemGraphBuildResult>((resolve) => {
-      resolveFirst = resolve;
-    });
-    const secondBuild = new Promise<SystemGraphBuildResult>((resolve) => {
-      resolveSecond = resolve;
-    });
+  it("discards an older refresh and commits the newest edit", async () => {
+    const oldRefresh = deferred<SystemGraphBuildResult>();
+    const newestRefresh = deferred<SystemGraphBuildResult>();
     const build = vi
       .fn()
-      .mockReturnValueOnce(firstBuild)
-      .mockReturnValueOnce(secondBuild)
-      .mockResolvedValueOnce(buildResult());
+      .mockResolvedValueOnce(buildResult("initial"))
+      .mockReturnValueOnce(oldRefresh.promise)
+      .mockReturnValueOnce(newestRefresh.promise);
+    const store = new SystemGraphStore({ build });
+    await store.get(scope);
+
+    store.requestRefresh(scope);
+    store.requestRefresh(scope);
+    oldRefresh.resolve(buildResult("obsolete"));
+    await vi.waitFor(() => expect(build).toHaveBeenCalledTimes(3));
+    expect(store.peek(scope.workspaceKey)?.graph).toEqual(graphFor("initial"));
+
+    newestRefresh.resolve(buildResult("newest"));
+    await vi.waitFor(() => {
+      expect(store.peek(scope.workspaceKey)).toMatchObject({
+        state: "ready",
+        graph: graphFor("newest"),
+      });
+    });
+  });
+
+  it("preserves last-good data after a hard refresh failure", async () => {
+    const failed = deferred<SystemGraphBuildResult>();
+    const build = vi
+      .fn()
+      .mockResolvedValueOnce(buildResult("initial"))
+      .mockReturnValueOnce(failed.promise)
+      .mockResolvedValueOnce(buildResult("recovered"));
+    const store = new SystemGraphStore({ build });
+    await store.get(scope);
+
+    const refreshing = store.requestRefresh(scope);
+    failed.reject(new Error("scan failed"));
+
+    await vi.waitFor(() => {
+      expect(store.peek(scope.workspaceKey)).toMatchObject({
+        state: "stale",
+        graph: graphFor("initial"),
+      });
+      expect(store.peek(scope.workspaceKey)!.revision).toBeGreaterThan(
+        refreshing.revision,
+      );
+    });
+
+    await store.get(scope);
+    await vi.waitFor(() => {
+      expect(store.peek(scope.workspaceKey)).toMatchObject({
+        state: "ready",
+        graph: graphFor("recovered"),
+      });
+    });
+  });
+
+  it("publishes the current partial graph instead of retaining failed edges", async () => {
+    const build = vi
+      .fn()
+      .mockResolvedValueOnce(buildResult("initial"))
+      .mockResolvedValueOnce(buildResult("partial", false));
+    const store = new SystemGraphStore({ build });
+    await store.get(scope);
+
+    store.requestRefresh(scope);
+
+    await vi.waitFor(() => {
+      expect(store.peek(scope.workspaceKey)).toMatchObject({
+        state: "degraded",
+        graph: graphFor("partial"),
+      });
+    });
+  });
+
+  it("keeps last-good data stale after a failed inventory refresh", async () => {
+    const pending = deferred<SystemGraphBuildResult>();
+    const build = vi
+      .fn()
+      .mockResolvedValueOnce(buildResult("initial"))
+      .mockReturnValueOnce(pending.promise);
+    const store = new SystemGraphStore({ build });
+    await store.get(scope);
+
+    store.requestRefresh(scope);
+    const stale = store.reportRefreshFailure(scope);
+    expect(stale).toMatchObject({
+      state: "stale",
+      graph: graphFor("initial"),
+    });
+
+    pending.resolve(buildResult("obsolete"));
+    await vi.waitFor(() => expect(build).toHaveBeenCalledTimes(2));
+    expect(store.peek(scope.workspaceKey)).toBe(stale);
+  });
+
+  it("returns an honest cold degraded snapshot when no graph can be built", async () => {
+    const store = new SystemGraphStore({
+      build: vi.fn().mockRejectedValue(new Error("unavailable")),
+    });
+
+    await expect(store.get(scope)).resolves.toMatchObject({
+      state: "degraded",
+      graph: null,
+    });
+  });
+
+  it("allows one later-open retry for a partial projection", async () => {
+    const retry = deferred<SystemGraphBuildResult>();
+    const build = vi
+      .fn()
+      .mockResolvedValueOnce(buildResult("partial", false))
+      .mockReturnValueOnce(retry.promise);
     const store = new SystemGraphStore({ build });
 
-    const stale = store.get(scope);
-    store.invalidate(scope.workspaceKey);
-    const current = store.get(scope);
-    resolveFirst(buildResult(false));
-    await stale;
-    resolveSecond(buildResult(false));
-    await current;
+    const degraded = await store.get(scope);
+    expect(degraded.state).toBe("degraded");
+    const retrying = store.get(scope);
+    expect(store.peek(scope.workspaceKey)).toMatchObject({
+      state: "degraded",
+      graph: graphFor("partial"),
+    });
+    await store.get(scope);
+    expect(build).toHaveBeenCalledTimes(2);
 
-    await expect(store.get(scope)).resolves.toEqual(storedResult());
-    expect(build).toHaveBeenCalledTimes(3);
+    retry.resolve(buildResult("recovered"));
+    await expect(retrying).resolves.toMatchObject({
+      state: "degraded",
+      graph: graphFor("partial"),
+    });
+    await vi.waitFor(() => {
+      expect(store.peek(scope.workspaceKey)?.state).toBe("ready");
+    });
+  });
+
+  it("does not publish or retain an in-flight build after scope retirement", async () => {
+    const pending = deferred<SystemGraphBuildResult>();
+    const onChange = vi.fn();
+    const store = new SystemGraphStore(
+      { build: vi.fn(() => pending.promise) },
+      { onChange },
+    );
+    const initial = store.get(scope);
+    store.retire(scope.workspaceKey);
+    pending.resolve(buildResult("retired"));
+    await initial;
+
+    expect(store.peek(scope.workspaceKey)).toBeNull();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("retires only projections outside the retained workspace set", async () => {
+    const secondScope = {
+      workspaceKey: "workspace-two",
+      root: "/private/two",
+    };
+    const store = new SystemGraphStore({
+      build: vi.fn().mockResolvedValue(buildResult("ready")),
+    });
+    await Promise.all([store.get(scope), store.get(secondScope)]);
+
+    store.retain(new Set([scope.workspaceKey]));
+
+    expect(store.peek(scope.workspaceKey)).not.toBeNull();
+    expect(store.peek(secondScope.workspaceKey)).toBeNull();
+  });
+
+  it("keeps revisions monotonic when a retired workspace returns", async () => {
+    const store = new SystemGraphStore({
+      build: vi.fn().mockResolvedValue(buildResult("ready")),
+    });
+    const first = await store.get(scope);
+    store.retire(scope.workspaceKey);
+
+    const returned = await store.get(scope);
+
+    expect(returned.revision).toBeGreaterThan(first.revision);
   });
 });

--- a/packages/harness/src/core/system-graph-store.test.ts
+++ b/packages/harness/src/core/system-graph-store.test.ts
@@ -189,6 +189,23 @@ describe("SystemGraphStore", () => {
     expect(store.peek(scope.workspaceKey)).toBe(stale);
   });
 
+  it("does not publish a new revision for repeated inventory failures", async () => {
+    const onChange = vi.fn();
+    const store = new SystemGraphStore(
+      { build: vi.fn().mockResolvedValue(buildResult("initial")) },
+      { onChange },
+    );
+    await store.get(scope);
+    onChange.mockClear();
+
+    const firstFailure = store.reportRefreshFailure(scope);
+    const repeatedFailure = store.reportRefreshFailure(scope);
+
+    expect(repeatedFailure).toBe(firstFailure);
+    expect(firstFailure.state).toBe("stale");
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
   it("returns an honest cold degraded snapshot when no graph can be built", async () => {
     const store = new SystemGraphStore({
       build: vi.fn().mockRejectedValue(new Error("unavailable")),

--- a/packages/harness/src/core/system-graph-store.test.ts
+++ b/packages/harness/src/core/system-graph-store.test.ts
@@ -206,6 +206,22 @@ describe("SystemGraphStore", () => {
     expect(onChange).toHaveBeenCalledTimes(1);
   });
 
+  it("allows an explicit refresh after automatic recovery was exhausted", async () => {
+    const build = vi
+      .fn()
+      .mockResolvedValueOnce(buildResult("initial"))
+      .mockResolvedValueOnce(buildResult("recovered"));
+    const store = new SystemGraphStore({ build });
+    await store.get(scope);
+    store.reportRefreshFailure(scope);
+
+    await expect(store.refresh(scope)).resolves.toMatchObject({
+      state: "ready",
+      graph: graphFor("recovered"),
+    });
+    expect(build).toHaveBeenCalledTimes(2);
+  });
+
   it("returns an honest cold degraded snapshot when no graph can be built", async () => {
     const store = new SystemGraphStore({
       build: vi.fn().mockRejectedValue(new Error("unavailable")),

--- a/packages/harness/src/core/system-graph-store.ts
+++ b/packages/harness/src/core/system-graph-store.ts
@@ -87,7 +87,7 @@ export class SystemGraphStore {
     const visibleGraph = entry.lastGood ?? entry.snapshot.graph;
     return visibleGraph === null
       ? this.transition(entry, "degraded", null)
-      : this.transition(entry, "stale", visibleGraph, true);
+      : this.transition(entry, "stale", visibleGraph);
   }
 
   /** Retires projections for workspace scopes Studio no longer exposes. */

--- a/packages/harness/src/core/system-graph-store.ts
+++ b/packages/harness/src/core/system-graph-store.ts
@@ -1,59 +1,291 @@
-import type { SystemGraph, WorkspaceKey } from "../shared/system-graph.js";
+import type {
+  SystemGraph,
+  SystemGraphLifecycleState,
+  SystemGraphSnapshot,
+  WorkspaceKey,
+} from "../shared/system-graph.js";
 import type { SystemGraphBuilder, WorkspaceScope } from "./system-graph.js";
 
-export interface StoredSystemGraph {
-  graph: SystemGraph;
-  degraded: boolean;
+export interface SystemGraphStoreOptions {
+  /** Called only for an accepted lifecycle transition. */
+  onChange?: (snapshot: SystemGraphSnapshot) => void;
 }
 
-/** Read-through cache. Promises coalesce concurrent opens. A degraded first
- * read gets one later re-enrichment; its second result is retained so a
- * permanent inspection failure cannot charge every workspace open. */
+interface SystemGraphEntry {
+  scope: WorkspaceScope;
+  snapshot: SystemGraphSnapshot;
+  lastGood: SystemGraph | null;
+  activeBuild: Promise<SystemGraphSnapshot> | null;
+  generation: number;
+  refreshPending: boolean;
+  automaticRetryUsed: boolean;
+  retired: boolean;
+}
+
+/**
+ * Process-lifetime, workspace-scoped projection store.
+ *
+ * Cold reads coalesce behind one build. Later refreshes keep the last usable
+ * graph visible as stale, serialize rebuilds, and reject an older generation's
+ * result when another edit arrives while it is in flight.
+ */
 export class SystemGraphStore {
-  private readonly entries = new Map<
-    WorkspaceKey,
-    Promise<StoredSystemGraph>
-  >();
-  private readonly degradedRetries = new Set<WorkspaceKey>();
+  private readonly entries = new Map<WorkspaceKey, SystemGraphEntry>();
+  private readonly revisionFloors = new Map<WorkspaceKey, number>();
 
-  constructor(private readonly builder: SystemGraphBuilder) {}
+  constructor(
+    private readonly builder: SystemGraphBuilder,
+    private readonly options: SystemGraphStoreOptions = {},
+  ) {}
 
-  get(scope: WorkspaceScope): Promise<StoredSystemGraph> {
-    const existing = this.entries.get(scope.workspaceKey);
-    if (existing) return existing;
-
-    let building: Promise<StoredSystemGraph>;
-    try {
-      building = this.builder.build(scope).then(({ cacheable, graph }) => {
-        if (this.entries.get(scope.workspaceKey) === building) {
-          if (cacheable) {
-            this.degradedRetries.delete(scope.workspaceKey);
-          } else if (!this.degradedRetries.has(scope.workspaceKey)) {
-            this.degradedRetries.add(scope.workspaceKey);
-            this.entries.delete(scope.workspaceKey);
-          }
-        }
-        return { graph, degraded: !cacheable };
-      });
-    } catch (err) {
-      building = Promise.reject(err);
+  get(scope: WorkspaceScope): Promise<SystemGraphSnapshot> {
+    const entry = this.ensureEntry(scope);
+    if (entry.activeBuild) {
+      return entry.snapshot.graph === null
+        ? entry.activeBuild
+        : Promise.resolve(entry.snapshot);
     }
-    this.entries.set(scope.workspaceKey, building);
-    void building.catch(() => {
-      if (this.entries.get(scope.workspaceKey) === building) {
-        this.entries.delete(scope.workspaceKey);
-      }
-    });
-    return building;
+    if (entry.snapshot.state === "building" && entry.snapshot.graph === null) {
+      return this.startBuild(entry);
+    }
+
+    // Non-ready projections are deliberately not healthy cache hits. One
+    // later open awaits a recovery build, while a permanent failure cannot
+    // charge every collapse/expand forever.
+    if (
+      (entry.snapshot.state === "degraded" ||
+        entry.snapshot.state === "stale") &&
+      !entry.automaticRetryUsed
+    ) {
+      entry.automaticRetryUsed = true;
+      this.queueRefresh(entry, entry.snapshot.state === "degraded");
+    }
+    return Promise.resolve(entry.snapshot);
   }
 
-  invalidate(workspaceKey: WorkspaceKey): void {
+  /** Marks a workspace dirty and starts (or queues) a background refresh. */
+  requestRefresh(scope: WorkspaceScope): SystemGraphSnapshot {
+    const entry = this.ensureEntry(scope);
+    entry.automaticRetryUsed = false;
+    this.queueRefresh(entry);
+    return entry.snapshot;
+  }
+
+  peek(workspaceKey: WorkspaceKey): SystemGraphSnapshot | null {
+    return this.entries.get(workspaceKey)?.snapshot ?? null;
+  }
+
+  /** Records a refresh prerequisite failure while preserving visible data. */
+  reportRefreshFailure(scope: WorkspaceScope): SystemGraphSnapshot {
+    const entry = this.ensureEntry(scope);
+    entry.generation += 1;
+    entry.refreshPending = false;
+    // Registry recovery must happen before projection. Do not let a later
+    // graph read rebuild from the stale inventory and relabel it ready; the
+    // watcher retries the failed inventory callback instead.
+    entry.automaticRetryUsed = true;
+    const visibleGraph = entry.lastGood ?? entry.snapshot.graph;
+    return visibleGraph === null
+      ? this.transition(entry, "degraded", null)
+      : this.transition(entry, "stale", visibleGraph, true);
+  }
+
+  /** Retires projections for workspace scopes Studio no longer exposes. */
+  retain(workspaceKeys: ReadonlySet<WorkspaceKey>): void {
+    for (const workspaceKey of [...this.entries.keys()]) {
+      if (!workspaceKeys.has(workspaceKey)) this.retire(workspaceKey);
+    }
+  }
+
+  /** Stops retaining a scope that Studio no longer exposes. */
+  retire(workspaceKey: WorkspaceKey): void {
+    const entry = this.entries.get(workspaceKey);
+    if (!entry) return;
+    entry.retired = true;
+    entry.generation += 1;
+    this.revisionFloors.set(workspaceKey, entry.snapshot.revision);
     this.entries.delete(workspaceKey);
-    this.degradedRetries.delete(workspaceKey);
+    this.retainBuilderWorkspaces();
+  }
+
+  /** Backward-compatible alias for callers that explicitly drop a snapshot. */
+  invalidate(workspaceKey: WorkspaceKey): void {
+    this.retire(workspaceKey);
   }
 
   clear(): void {
-    this.entries.clear();
-    this.degradedRetries.clear();
+    for (const workspaceKey of [...this.entries.keys()]) {
+      this.retire(workspaceKey);
+    }
+    this.revisionFloors.clear();
+  }
+
+  private ensureEntry(scope: WorkspaceScope): SystemGraphEntry {
+    const existing = this.entries.get(scope.workspaceKey);
+    if (existing) {
+      existing.scope = scope;
+      return existing;
+    }
+    const entry: SystemGraphEntry = {
+      scope,
+      snapshot: {
+        workspaceKey: scope.workspaceKey,
+        revision: this.revisionFloors.get(scope.workspaceKey) ?? 0,
+        state: "building",
+        graph: null,
+      },
+      lastGood: null,
+      activeBuild: null,
+      generation: 0,
+      refreshPending: false,
+      automaticRetryUsed: false,
+      retired: false,
+    };
+    this.entries.set(scope.workspaceKey, entry);
+    return entry;
+  }
+
+  private queueRefresh(
+    entry: SystemGraphEntry,
+    preserveLifecycle = false,
+  ): Promise<SystemGraphSnapshot> | null {
+    if (entry.retired) return null;
+    entry.generation += 1;
+    entry.refreshPending = true;
+    const visibleGraph = entry.lastGood ?? entry.snapshot.graph;
+    if (!preserveLifecycle) {
+      this.transition(
+        entry,
+        visibleGraph === null ? "building" : "stale",
+        visibleGraph,
+      );
+    }
+    if (entry.activeBuild) return entry.activeBuild;
+    entry.refreshPending = false;
+    return this.startBuild(entry);
+  }
+
+  private startBuild(entry: SystemGraphEntry): Promise<SystemGraphSnapshot> {
+    if (entry.activeBuild) return entry.activeBuild;
+    const generation = entry.generation;
+    entry.refreshPending = false;
+    const visibleGraph = entry.lastGood ?? entry.snapshot.graph;
+    if (entry.snapshot.state !== "degraded") {
+      this.transition(
+        entry,
+        visibleGraph === null ? "building" : "stale",
+        visibleGraph,
+      );
+    }
+
+    let build: Promise<Awaited<ReturnType<SystemGraphBuilder["build"]>>>;
+    try {
+      build = Promise.resolve(this.builder.build(entry.scope));
+    } catch (error) {
+      build = Promise.reject(error);
+    }
+
+    const active = build.then(
+      (result) => this.finishBuild(entry, generation, result),
+      () => this.finishFailure(entry, generation),
+    );
+    entry.activeBuild = active;
+    return active;
+  }
+
+  private finishBuild(
+    entry: SystemGraphEntry,
+    generation: number,
+    result: Awaited<ReturnType<SystemGraphBuilder["build"]>>,
+  ): SystemGraphSnapshot | Promise<SystemGraphSnapshot> {
+    if (!this.canCommit(entry, generation)) {
+      return this.continueAfterSupersededBuild(entry);
+    }
+    entry.activeBuild = null;
+    if (result.cacheable) {
+      entry.lastGood = result.graph;
+      entry.automaticRetryUsed = false;
+      return this.transition(entry, "ready", result.graph);
+    }
+    return this.transition(entry, "degraded", result.graph);
+  }
+
+  private finishFailure(
+    entry: SystemGraphEntry,
+    generation: number,
+  ): SystemGraphSnapshot | Promise<SystemGraphSnapshot> {
+    if (!this.canCommit(entry, generation)) {
+      return this.continueAfterSupersededBuild(entry);
+    }
+    entry.activeBuild = null;
+    const visibleGraph = entry.lastGood ?? entry.snapshot.graph;
+    return visibleGraph === null
+      ? this.transition(entry, "degraded", null)
+      : this.transition(entry, "stale", visibleGraph, true);
+  }
+
+  private canCommit(entry: SystemGraphEntry, generation: number): boolean {
+    return (
+      !entry.retired &&
+      this.entries.get(entry.scope.workspaceKey) === entry &&
+      entry.generation === generation
+    );
+  }
+
+  private continueAfterSupersededBuild(
+    entry: SystemGraphEntry,
+  ): SystemGraphSnapshot | Promise<SystemGraphSnapshot> {
+    entry.activeBuild = null;
+    if (
+      entry.retired ||
+      this.entries.get(entry.scope.workspaceKey) !== entry
+    ) {
+      this.retainBuilderWorkspaces();
+      return entry.snapshot;
+    }
+    if (entry.refreshPending) {
+      entry.refreshPending = false;
+      return this.startBuild(entry);
+    }
+    return entry.snapshot;
+  }
+
+  private retainBuilderWorkspaces(): void {
+    try {
+      this.builder.retainWorkspaces?.(new Set(this.entries.keys()));
+    } catch {
+      // Cache pruning cannot make graph reads or scope retirement fail.
+    }
+  }
+
+  private transition(
+    entry: SystemGraphEntry,
+    state: SystemGraphLifecycleState,
+    graph: SystemGraph | null,
+    forceRevision = false,
+  ): SystemGraphSnapshot {
+    if (
+      !forceRevision &&
+      entry.snapshot.state === state &&
+      entry.snapshot.graph === graph
+    ) {
+      return entry.snapshot;
+    }
+    entry.snapshot = {
+      workspaceKey: entry.scope.workspaceKey,
+      revision: entry.snapshot.revision + 1,
+      state,
+      graph,
+    };
+    this.revisionFloors.set(
+      entry.scope.workspaceKey,
+      entry.snapshot.revision,
+    );
+    try {
+      this.options.onChange?.(entry.snapshot);
+    } catch {
+      // Observers (the event bus) cannot make graph refreshes fail.
+    }
+    return entry.snapshot;
   }
 }

--- a/packages/harness/src/core/system-graph-store.ts
+++ b/packages/harness/src/core/system-graph-store.ts
@@ -71,6 +71,13 @@ export class SystemGraphStore {
     return entry.snapshot;
   }
 
+  /** Explicit user recovery: start a fresh projection and await its result. */
+  refresh(scope: WorkspaceScope): Promise<SystemGraphSnapshot> {
+    const entry = this.ensureEntry(scope);
+    entry.automaticRetryUsed = false;
+    return this.queueRefresh(entry) ?? Promise.resolve(entry.snapshot);
+  }
+
   peek(workspaceKey: WorkspaceKey): SystemGraphSnapshot | null {
     return this.entries.get(workspaceKey)?.snapshot ?? null;
   }

--- a/packages/harness/src/core/system-graph-watcher.test.ts
+++ b/packages/harness/src/core/system-graph-watcher.test.ts
@@ -1,0 +1,116 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { WorkspaceScope } from "./system-graph.js";
+import { SystemGraphWatcherManager } from "./system-graph-watcher.js";
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+let root: string;
+let scope: WorkspaceScope;
+let manager: SystemGraphWatcherManager;
+let onSourceChange: ReturnType<typeof vi.fn>;
+let onInventoryChange: ReturnType<typeof vi.fn>;
+
+async function scaffoldAgent(name: string): Promise<string> {
+  const agentRoot = path.join(root, name);
+  await fs.mkdir(agentRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(agentRoot, "sapiom.json"),
+    JSON.stringify({ name }),
+  );
+  await fs.writeFile(path.join(agentRoot, "index.ts"), "export {};\n");
+  return agentRoot;
+}
+
+describe("SystemGraphWatcherManager", () => {
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "system-graph-watch-"));
+    scope = { workspaceKey: "workspace-test", root };
+    onSourceChange = vi.fn();
+    onInventoryChange = vi.fn();
+    manager = new SystemGraphWatcherManager({
+      onSourceChange,
+      onInventoryChange,
+    });
+  });
+
+  afterEach(async () => {
+    manager.stopAll();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("refreshes source relationships without reporting inventory churn", async () => {
+    const agentRoot = await scaffoldAgent("research");
+    manager.start(scope);
+    await sleep(100);
+    onInventoryChange.mockClear();
+
+    await fs.writeFile(
+      path.join(agentRoot, "index.ts"),
+      'ctx.sapiom.agents.run({ definition: "growth" });\n',
+    );
+    await sleep(1_100);
+
+    expect(onSourceChange).toHaveBeenCalled();
+    expect(onSourceChange.mock.calls.at(-1)?.[0]).toEqual(scope);
+    expect(onInventoryChange).not.toHaveBeenCalled();
+  });
+
+  it("reports agent inventory additions and removals", async () => {
+    manager.start(scope);
+    await sleep(100);
+    const agentRoot = await scaffoldAgent("growth");
+    await sleep(1_100);
+    expect(onInventoryChange).toHaveBeenCalledWith(scope);
+
+    onInventoryChange.mockClear();
+    await fs.rm(agentRoot, { recursive: true, force: true });
+    await sleep(1_100);
+    expect(onInventoryChange).toHaveBeenCalledWith(scope);
+  });
+
+  it("retries a failed inventory refresh without another filesystem edit", async () => {
+    onInventoryChange
+      .mockRejectedValueOnce(new Error("registry unavailable"))
+      .mockResolvedValue(undefined);
+    manager.start(scope);
+    await scaffoldAgent("growth");
+
+    await vi.waitFor(() => expect(onInventoryChange).toHaveBeenCalledTimes(2), {
+      timeout: 4_000,
+      interval: 100,
+    });
+  });
+
+  it("ignores non-source and generated-tree churn", async () => {
+    manager.start(scope);
+    await fs.writeFile(path.join(root, "README.md"), "notes\n");
+    await fs.mkdir(path.join(root, "node_modules", "pkg"), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(root, "node_modules", "pkg", "index.ts"),
+      "export {};\n",
+    );
+    await sleep(1_100);
+
+    expect(onSourceChange).not.toHaveBeenCalled();
+    expect(onInventoryChange).not.toHaveBeenCalled();
+  });
+
+  it("does not re-baseline an existing workspace on repeated opens", () => {
+    manager.start(scope);
+    manager.start(scope);
+    expect(manager.size).toBe(1);
+  });
+
+  it("retires watchers for scopes no longer exposed by Studio", () => {
+    manager.start(scope);
+    manager.retain(new Set());
+    expect(manager.size).toBe(0);
+  });
+});

--- a/packages/harness/src/core/system-graph-watcher.test.ts
+++ b/packages/harness/src/core/system-graph-watcher.test.ts
@@ -4,7 +4,11 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { WorkspaceScope } from "./system-graph.js";
-import { SystemGraphWatcherManager } from "./system-graph-watcher.js";
+import {
+  SystemGraphWatcherManager,
+  type SystemGraphWatchFactory,
+  type SystemGraphWatchHandle,
+} from "./system-graph-watcher.js";
 
 const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
@@ -59,6 +63,7 @@ describe("SystemGraphWatcherManager", () => {
 
   it("refreshes source relationships without reporting inventory churn", async () => {
     const agentRoot = await scaffoldAgent("research");
+    await scaffoldAgent("growth");
     manager.start(scope);
     await sleep(100);
     onInventoryChange.mockClear();
@@ -74,7 +79,68 @@ describe("SystemGraphWatcherManager", () => {
 
     expect(onSourceChange).toHaveBeenCalled();
     expect(onSourceChange.mock.calls.at(-1)?.[0]).toEqual(scope);
+    expect(onSourceChange.mock.calls.at(-1)?.[1]).toEqual([agentRoot]);
     expect(onInventoryChange).not.toHaveBeenCalled();
+  });
+
+  it("routes native paths, ignores generated churn, and recovers via polling", async () => {
+    let watchListener!: Parameters<SystemGraphWatchFactory>[1];
+    let errorListener!: (error: Error) => void;
+    const close = vi.fn();
+    const watchFactory: SystemGraphWatchFactory = (_watchRoot, listener) => {
+      watchListener = listener;
+      const handle: SystemGraphWatchHandle = {
+        close,
+        on: (_event, onError) => {
+          errorListener = onError;
+          return handle;
+        },
+      };
+      return handle;
+    };
+    manager = new SystemGraphWatcherManager(
+      {
+        listSourceRoots: () => [...sourceRoots],
+        onSourceChange,
+        onInventoryChange,
+      },
+      {
+        watchFactory,
+        sourceDebounceMs: 10,
+        inventoryDebounceMs: 10,
+        pollIntervalMs: 25,
+      },
+    );
+    const agentRoot = await scaffoldAgent("research");
+    manager.start(scope);
+
+    watchListener("change", "research/index.ts");
+    await vi.waitFor(() => expect(onSourceChange).toHaveBeenCalled(), {
+      timeout: 2_000,
+      interval: 20,
+    });
+    expect(onSourceChange.mock.calls.at(-1)?.[1]).toEqual([
+      path.join(agentRoot, "index.ts"),
+    ]);
+
+    onSourceChange.mockClear();
+    watchListener("change", "node_modules/pkg/index.ts");
+    await sleep(50);
+    expect(onSourceChange).not.toHaveBeenCalled();
+
+    errorListener(new Error("recursive watch unavailable"));
+    expect(close).toHaveBeenCalledTimes(1);
+    await sleep(100);
+    onSourceChange.mockClear();
+    await fs.writeFile(
+      path.join(agentRoot, "index.ts"),
+      "export const recovered = true;\n",
+    );
+    await vi.waitFor(() => expect(onSourceChange).toHaveBeenCalled(), {
+      timeout: 2_000,
+      interval: 20,
+    });
+    expect(onSourceChange.mock.calls.at(-1)?.[1]).toEqual([agentRoot]);
   });
 
   it("reports agent inventory additions and removals", async () => {

--- a/packages/harness/src/core/system-graph-watcher.test.ts
+++ b/packages/harness/src/core/system-graph-watcher.test.ts
@@ -14,6 +14,7 @@ let scope: WorkspaceScope;
 let manager: SystemGraphWatcherManager;
 let onSourceChange: ReturnType<typeof vi.fn>;
 let onInventoryChange: ReturnType<typeof vi.fn>;
+let sourceRoots: Set<string>;
 
 async function scaffoldAgent(name: string): Promise<string> {
   const agentRoot = path.join(root, name);
@@ -23,6 +24,7 @@ async function scaffoldAgent(name: string): Promise<string> {
     JSON.stringify({ name }),
   );
   await fs.writeFile(path.join(agentRoot, "index.ts"), "export {};\n");
+  sourceRoots.add(agentRoot);
   return agentRoot;
 }
 
@@ -32,10 +34,22 @@ describe("SystemGraphWatcherManager", () => {
     scope = { workspaceKey: "workspace-test", root };
     onSourceChange = vi.fn();
     onInventoryChange = vi.fn();
-    manager = new SystemGraphWatcherManager({
-      onSourceChange,
-      onInventoryChange,
-    });
+    sourceRoots = new Set();
+    manager = new SystemGraphWatcherManager(
+      {
+        listSourceRoots: () => [...sourceRoots],
+        onSourceChange,
+        onInventoryChange,
+      },
+      {
+        forcePolling: true,
+        sourceDebounceMs: 10,
+        inventoryDebounceMs: 10,
+        inventoryRetryBaseMs: 20,
+        maxInventoryRetries: 2,
+        pollIntervalMs: 25,
+      },
+    );
   });
 
   afterEach(async () => {
@@ -53,7 +67,10 @@ describe("SystemGraphWatcherManager", () => {
       path.join(agentRoot, "index.ts"),
       'ctx.sapiom.agents.run({ definition: "growth" });\n',
     );
-    await sleep(1_100);
+    await vi.waitFor(() => expect(onSourceChange).toHaveBeenCalled(), {
+      timeout: 2_000,
+      interval: 20,
+    });
 
     expect(onSourceChange).toHaveBeenCalled();
     expect(onSourceChange.mock.calls.at(-1)?.[0]).toEqual(scope);
@@ -64,13 +81,18 @@ describe("SystemGraphWatcherManager", () => {
     manager.start(scope);
     await sleep(100);
     const agentRoot = await scaffoldAgent("growth");
-    await sleep(1_100);
-    expect(onInventoryChange).toHaveBeenCalledWith(scope);
+    await vi.waitFor(
+      () => expect(onInventoryChange).toHaveBeenCalledWith(scope),
+      { timeout: 2_000, interval: 20 },
+    );
 
     onInventoryChange.mockClear();
+    sourceRoots.delete(agentRoot);
     await fs.rm(agentRoot, { recursive: true, force: true });
-    await sleep(1_100);
-    expect(onInventoryChange).toHaveBeenCalledWith(scope);
+    await vi.waitFor(
+      () => expect(onInventoryChange).toHaveBeenCalledWith(scope),
+      { timeout: 2_000, interval: 20 },
+    );
   });
 
   it("retries a failed inventory refresh without another filesystem edit", async () => {
@@ -81,8 +103,52 @@ describe("SystemGraphWatcherManager", () => {
     await scaffoldAgent("growth");
 
     await vi.waitFor(() => expect(onInventoryChange).toHaveBeenCalledTimes(2), {
-      timeout: 4_000,
-      interval: 100,
+      timeout: 2_000,
+      interval: 20,
+    });
+  });
+
+  it("bounds inventory retries until a later filesystem change", async () => {
+    onInventoryChange.mockRejectedValue(new Error("registry unavailable"));
+    manager.start(scope);
+    await scaffoldAgent("growth");
+
+    await vi.waitFor(() => expect(onInventoryChange).toHaveBeenCalledTimes(3), {
+      timeout: 2_000,
+      interval: 20,
+    });
+    await sleep(200);
+    expect(onInventoryChange).toHaveBeenCalledTimes(3);
+
+    await scaffoldAgent("reporting");
+    await vi.waitFor(
+      () => expect(onInventoryChange.mock.calls.length).toBeGreaterThan(3),
+      { timeout: 2_000, interval: 20 },
+    );
+  });
+
+  it("polls every registered source file past Canvas's project-sized cap", async () => {
+    const agentRoot = await scaffoldAgent("large");
+    await Promise.all(
+      Array.from({ length: 425 }, (_, index) =>
+        fs.writeFile(
+          path.join(agentRoot, `step-${index.toString().padStart(3, "0")}.ts`),
+          `export const step${index} = ${index};\n`,
+        ),
+      ),
+    );
+    manager.start(scope);
+    await sleep(200);
+    onSourceChange.mockClear();
+
+    await fs.writeFile(
+      path.join(agentRoot, "step-424.ts"),
+      "export const step424 = 424_424;\n",
+    );
+
+    await vi.waitFor(() => expect(onSourceChange).toHaveBeenCalled(), {
+      timeout: 2_000,
+      interval: 20,
     });
   });
 
@@ -96,7 +162,12 @@ describe("SystemGraphWatcherManager", () => {
       path.join(root, "node_modules", "pkg", "index.ts"),
       "export {};\n",
     );
-    await sleep(1_100);
+    await fs.mkdir(path.join(root, "unregistered"), { recursive: true });
+    await fs.writeFile(
+      path.join(root, "unregistered", "index.ts"),
+      "export const ignored = true;\n",
+    );
+    await sleep(300);
 
     expect(onSourceChange).not.toHaveBeenCalled();
     expect(onInventoryChange).not.toHaveBeenCalled();

--- a/packages/harness/src/core/system-graph-watcher.ts
+++ b/packages/harness/src/core/system-graph-watcher.ts
@@ -58,13 +58,13 @@ function confinedSourcePath(root: string, relativePath: string): string | null {
  */
 export async function snapshotWorkflowSourceRootsAsync(
   sourceRoots: readonly string[],
-): Promise<string> {
+): Promise<ReadonlyMap<string, string>> {
   const roots = [
     ...new Set(sourceRoots.map((root) => path.resolve(root))),
   ].sort();
-  const parts = roots.map((root) => `root\0${root}`);
+  const snapshots = new Map<string, string>();
 
-  const walk = async (dir: string): Promise<void> => {
+  const walk = async (dir: string, parts: string[]): Promise<void> => {
     let entries: fs.Dirent[];
     try {
       entries = await fsp.readdir(dir, { withFileTypes: true });
@@ -77,7 +77,7 @@ export async function snapshotWorkflowSourceRootsAsync(
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         if (isAgentProjectScanIgnoredDir(entry.name)) continue;
-        await walk(full);
+        await walk(full, parts);
         continue;
       }
       if (!entry.isFile() || !SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
@@ -92,8 +92,42 @@ export async function snapshotWorkflowSourceRootsAsync(
     }
   };
 
-  for (const root of roots) await walk(root);
-  return parts.sort().join("|");
+  for (const root of roots) {
+    const parts = [`root\0${root}`];
+    await walk(root, parts);
+    snapshots.set(root, parts.sort().join("|"));
+  }
+  return snapshots;
+}
+
+function isNestedSourceRoot(parent: string, candidate: string): boolean {
+  const relative = path.relative(parent, candidate);
+  return (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function changedSourceRoots(
+  previous: ReadonlyMap<string, string>,
+  current: ReadonlyMap<string, string>,
+): string[] {
+  const changed = [...new Set([...previous.keys(), ...current.keys()])].filter(
+    (root) => previous.get(root) !== current.get(root),
+  );
+  // Nested registered projects appear in their parent's recursive snapshot.
+  // Attribute the edit only to the deepest changed caller(s).
+  return changed
+    .filter(
+      (root) =>
+        !changed.some(
+          (candidate) =>
+            candidate !== root && isNestedSourceRoot(root, candidate),
+        ),
+    )
+    .sort();
 }
 
 export interface SystemGraphWatcherCallbacks {
@@ -107,6 +141,16 @@ export interface SystemGraphWatcherCallbacks {
   onInventoryChange: (scope: WorkspaceScope) => void | Promise<void>;
 }
 
+export interface SystemGraphWatchHandle {
+  close(): void;
+  on(event: "error", listener: (error: Error) => void): SystemGraphWatchHandle;
+}
+
+export type SystemGraphWatchFactory = (
+  root: string,
+  listener: (event: "rename" | "change", filename: string | null) => void,
+) => SystemGraphWatchHandle;
+
 export interface SystemGraphWatcherOptions {
   sourceDebounceMs?: number;
   inventoryDebounceMs?: number;
@@ -115,10 +159,12 @@ export interface SystemGraphWatcherOptions {
   pollIntervalMs?: number;
   /** Deterministic test seam for the supported polling fallback. */
   forcePolling?: boolean;
+  /** Deterministic test seam for native event routing and watcher errors. */
+  watchFactory?: SystemGraphWatchFactory;
 }
 
 class WorkspaceSystemGraphWatcher {
-  private watcher: fs.FSWatcher | null = null;
+  private watcher: SystemGraphWatchHandle | null = null;
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private sourceTimer: ReturnType<typeof setTimeout> | null = null;
   private inventoryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -126,7 +172,7 @@ class WorkspaceSystemGraphWatcher {
   private closed = false;
   private sourcePaths = new Set<string>();
   private ambiguousSourceChange = false;
-  private lastSourceSnapshot: string | null = null;
+  private lastSourceSnapshots: ReadonlyMap<string, string> | null = null;
   private lastInventorySnapshot: string;
   private failedInventorySnapshot: string | null = null;
   private inventoryGeneration = 0;
@@ -280,27 +326,35 @@ class WorkspaceSystemGraphWatcher {
       return;
     }
     try {
-      this.watcher = fs.watch(
-        this.scope.root,
-        { recursive: true },
-        (_event, rawFilename) => {
-          if (rawFilename === null) {
-            this.scheduleSourceChange(null);
-            this.scheduleInventoryCheck();
-            return;
-          }
-          const relativePath = normalizeWatchPath(rawFilename);
-          if (ignoredRelativePath(relativePath)) return;
-          if (sourceRelativePath(relativePath)) {
-            this.scheduleSourceChange(
-              confinedSourcePath(this.scope.root, relativePath),
-            );
-          }
-          // Event kind is unreliable across editors/platforms. The marker
-          // fingerprint decides whether inventory really changed.
+      const listener = (
+        _event: "rename" | "change",
+        rawFilename: string | null,
+      ): void => {
+        if (rawFilename === null) {
+          this.scheduleSourceChange(null);
           this.scheduleInventoryCheck();
-        },
-      );
+          return;
+        }
+        const relativePath = normalizeWatchPath(rawFilename);
+        if (ignoredRelativePath(relativePath)) return;
+        if (sourceRelativePath(relativePath)) {
+          this.scheduleSourceChange(
+            confinedSourcePath(this.scope.root, relativePath),
+          );
+        }
+        // Event kind is unreliable across editors/platforms. The marker
+        // fingerprint decides whether inventory really changed.
+        this.scheduleInventoryCheck();
+      };
+      this.watcher = this.options.watchFactory
+        ? this.options.watchFactory(this.scope.root, listener)
+        : fs.watch(
+            this.scope.root,
+            { recursive: true },
+            (_event, rawFilename) => {
+              listener(_event, rawFilename);
+            },
+          );
       this.watcher.on("error", () => this.fallBackToPolling());
     } catch {
       this.fallBackToPolling();
@@ -325,15 +379,23 @@ class WorkspaceSystemGraphWatcher {
         snapshotWorkflowSourceRootsAsync(sourceRoots),
         snapshotWorkspaceWorkflowsAsync(this.scope.root),
       ])
-        .then(([sourceSnapshot, inventorySnapshot]) => {
+        .then(([sourceSnapshots, inventorySnapshot]) => {
           if (this.closed) return;
+          const changedRoots = this.lastSourceSnapshots
+            ? changedSourceRoots(this.lastSourceSnapshots, sourceSnapshots)
+            : [];
+          const ambiguousInitialChange =
+            this.lastSourceSnapshots === null && refreshAfterInitialSnapshot;
           const sourceChanged =
-            (this.lastSourceSnapshot !== null &&
-              sourceSnapshot !== this.lastSourceSnapshot) ||
-            (this.lastSourceSnapshot === null && refreshAfterInitialSnapshot);
-          this.lastSourceSnapshot = sourceSnapshot;
+            ambiguousInitialChange || changedRoots.length > 0;
+          this.lastSourceSnapshots = sourceSnapshots;
           refreshAfterInitialSnapshot = false;
-          if (sourceChanged) this.scheduleSourceChange(null);
+          if (ambiguousInitialChange) this.scheduleSourceChange(null);
+          else {
+            for (const sourceRoot of changedRoots) {
+              this.scheduleSourceChange(sourceRoot);
+            }
+          }
 
           if (inventorySnapshot !== this.lastInventorySnapshot) {
             this.dispatchInventoryChange(inventorySnapshot);

--- a/packages/harness/src/core/system-graph-watcher.ts
+++ b/packages/harness/src/core/system-graph-watcher.ts
@@ -1,12 +1,10 @@
 import * as fs from "node:fs";
+import * as fsp from "node:fs/promises";
 import * as path from "node:path";
 
 import type { WorkspaceKey } from "../shared/system-graph.js";
 import { isAgentProjectScanIgnoredDir } from "./agent-project-discovery.js";
-import {
-  normalizeWatchPath,
-  snapshotWorkflowSources,
-} from "./canvas-watcher.js";
+import { normalizeWatchPath } from "./canvas-watcher.js";
 import type { WorkspaceScope } from "./system-graph.js";
 import {
   snapshotWorkspaceWorkflows,
@@ -15,9 +13,11 @@ import {
 
 const SOURCE_DEBOUNCE_MS = 150;
 const INVENTORY_DEBOUNCE_MS = 250;
-const INVENTORY_RETRY_MS = 500;
-const POLL_INTERVAL_MS = 500;
+const INVENTORY_RETRY_BASE_MS = 500;
+const MAX_INVENTORY_RETRIES = 3;
+const POLL_INTERVAL_MS = 2_000;
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx"]);
+const UNREADABLE_SOURCE_FINGERPRINT = "<unreadable>";
 
 function ignoredRelativePath(relativePath: string): boolean {
   return relativePath
@@ -46,7 +46,59 @@ function confinedSourcePath(root: string, relativePath: string): string | null {
   return absolute;
 }
 
+/**
+ * Async source fingerprint for the registered agent roots in one workspace.
+ *
+ * The graph watcher deliberately does not reuse Canvas's synchronous,
+ * 400-file project snapshot here: a workspace can contain many agent projects,
+ * and polling it on the server event loop would both stutter Studio and miss
+ * edits after that project-sized ceiling. Async directory reads yield between
+ * entries, while scoping the walk to registry roots keeps the unbounded file
+ * count honest without traversing unrelated workspace trees.
+ */
+export async function snapshotWorkflowSourceRootsAsync(
+  sourceRoots: readonly string[],
+): Promise<string> {
+  const roots = [
+    ...new Set(sourceRoots.map((root) => path.resolve(root))),
+  ].sort();
+  const parts = roots.map((root) => `root\0${root}`);
+
+  const walk = async (dir: string): Promise<void> => {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      parts.push(`${dir}\0${UNREADABLE_SOURCE_FINGERPRINT}`);
+      return;
+    }
+
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (isAgentProjectScanIgnoredDir(entry.name)) continue;
+        await walk(full);
+        continue;
+      }
+      if (!entry.isFile() || !SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+        continue;
+      }
+      try {
+        const stat = await fsp.stat(full);
+        parts.push(`${full}:${stat.mtimeMs}:${stat.size}`);
+      } catch {
+        parts.push(`${full}:gone`);
+      }
+    }
+  };
+
+  for (const root of roots) await walk(root);
+  return parts.sort().join("|");
+}
+
 export interface SystemGraphWatcherCallbacks {
+  /** Current registry roots inside this scope; read lazily on every poll. */
+  listSourceRoots: (scope: WorkspaceScope) => readonly string[];
   onSourceChange: (
     scope: WorkspaceScope,
     /** Null when the platform can only report a workspace-level change. */
@@ -55,24 +107,37 @@ export interface SystemGraphWatcherCallbacks {
   onInventoryChange: (scope: WorkspaceScope) => void | Promise<void>;
 }
 
+export interface SystemGraphWatcherOptions {
+  sourceDebounceMs?: number;
+  inventoryDebounceMs?: number;
+  inventoryRetryBaseMs?: number;
+  maxInventoryRetries?: number;
+  pollIntervalMs?: number;
+  /** Deterministic test seam for the supported polling fallback. */
+  forcePolling?: boolean;
+}
+
 class WorkspaceSystemGraphWatcher {
   private watcher: fs.FSWatcher | null = null;
   private pollTimer: ReturnType<typeof setInterval> | null = null;
   private sourceTimer: ReturnType<typeof setTimeout> | null = null;
   private inventoryTimer: ReturnType<typeof setTimeout> | null = null;
+  private inventoryRetryTimer: ReturnType<typeof setTimeout> | null = null;
   private closed = false;
   private sourcePaths = new Set<string>();
   private ambiguousSourceChange = false;
-  private lastSourceSnapshot: string;
+  private lastSourceSnapshot: string | null = null;
   private lastInventorySnapshot: string;
+  private failedInventorySnapshot: string | null = null;
+  private inventoryGeneration = 0;
   private pollInFlight = false;
   private callbackQueue: Promise<void> = Promise.resolve();
 
   constructor(
     readonly scope: WorkspaceScope,
     private readonly callbacks: SystemGraphWatcherCallbacks,
+    private readonly options: SystemGraphWatcherOptions,
   ) {
-    this.lastSourceSnapshot = snapshotWorkflowSources(scope.root);
     this.lastInventorySnapshot = snapshotWorkspaceWorkflows(scope.root);
     this.arm();
   }
@@ -110,37 +175,110 @@ class WorkspaceSystemGraphWatcher {
       this.sourcePaths.clear();
       this.ambiguousSourceChange = false;
       this.enqueue(() => this.callbacks.onSourceChange(this.scope, paths));
-    }, SOURCE_DEBOUNCE_MS);
+    }, this.options.sourceDebounceMs ?? SOURCE_DEBOUNCE_MS);
   }
 
-  private dispatchInventoryChange(snapshot: string): void {
-    const previousSnapshot = this.lastInventorySnapshot;
+  private dispatchInventoryChange(
+    snapshot: string,
+    retryNumber = 0,
+    retryGeneration?: number,
+  ): void {
+    const generation = retryGeneration ?? this.inventoryGeneration + 1;
+    if (
+      retryGeneration !== undefined &&
+      retryGeneration !== this.inventoryGeneration
+    ) {
+      return;
+    }
+    if (retryGeneration === undefined) {
+      this.inventoryGeneration = generation;
+      if (this.inventoryRetryTimer) clearTimeout(this.inventoryRetryTimer);
+      this.inventoryRetryTimer = null;
+    }
     this.lastInventorySnapshot = snapshot;
+    this.failedInventorySnapshot = null;
     this.enqueue(
-      () => this.callbacks.onInventoryChange(this.scope),
       () => {
-        if (this.closed || this.lastInventorySnapshot !== snapshot) return;
-        // A failed registry scan did not consume the structural change. Restore
-        // the old baseline and retry even when no second filesystem event lands.
-        this.lastInventorySnapshot = previousSnapshot;
-        this.scheduleInventoryCheck(INVENTORY_RETRY_MS);
+        if (generation !== this.inventoryGeneration) return;
+        return this.callbacks.onInventoryChange(this.scope);
+      },
+      () => {
+        if (
+          this.closed ||
+          generation !== this.inventoryGeneration ||
+          this.lastInventorySnapshot !== snapshot
+        ) {
+          return;
+        }
+        if (
+          retryNumber >=
+          (this.options.maxInventoryRetries ?? MAX_INVENTORY_RETRIES)
+        ) {
+          // Consume the observed fingerprint after bounded recovery. This
+          // leaves the server snapshot stale without turning polling into a
+          // permanent registry-scan/event-bus loop. A later real source or
+          // inventory change clears this sentinel and starts a fresh series.
+          this.failedInventorySnapshot = snapshot;
+          return;
+        }
+        this.scheduleInventoryRetry(snapshot, retryNumber + 1, generation);
       },
     );
   }
 
-  private scheduleInventoryCheck(delay = INVENTORY_DEBOUNCE_MS): void {
+  private scheduleInventoryRetry(
+    snapshot: string,
+    retryNumber: number,
+    generation: number,
+  ): void {
+    if (this.closed || generation !== this.inventoryGeneration) return;
+    if (this.inventoryRetryTimer) clearTimeout(this.inventoryRetryTimer);
+    const delay =
+      (this.options.inventoryRetryBaseMs ?? INVENTORY_RETRY_BASE_MS) *
+      2 ** (retryNumber - 1);
+    this.inventoryRetryTimer = setTimeout(() => {
+      this.inventoryRetryTimer = null;
+      if (this.closed || generation !== this.inventoryGeneration) return;
+      void snapshotWorkspaceWorkflowsAsync(this.scope.root)
+        .then((currentSnapshot) => {
+          if (this.closed || generation !== this.inventoryGeneration) return;
+          if (currentSnapshot !== snapshot) {
+            this.dispatchInventoryChange(currentSnapshot);
+            return;
+          }
+          this.dispatchInventoryChange(snapshot, retryNumber, generation);
+        })
+        .catch(() => {
+          if (this.closed || generation !== this.inventoryGeneration) return;
+          this.dispatchInventoryChange(snapshot, retryNumber, generation);
+        });
+    }, delay);
+  }
+
+  private scheduleInventoryCheck(
+    delay = this.options.inventoryDebounceMs ?? INVENTORY_DEBOUNCE_MS,
+  ): void {
     if (this.closed) return;
     if (this.inventoryTimer) clearTimeout(this.inventoryTimer);
     this.inventoryTimer = setTimeout(() => {
       this.inventoryTimer = null;
       const snapshot = snapshotWorkspaceWorkflows(this.scope.root);
-      if (snapshot === this.lastInventorySnapshot) return;
+      if (
+        snapshot === this.lastInventorySnapshot &&
+        snapshot !== this.failedInventorySnapshot
+      ) {
+        return;
+      }
       this.dispatchInventoryChange(snapshot);
     }, delay);
   }
 
   private arm(): void {
     if (this.closed) return;
+    if (this.options.forcePolling) {
+      this.fallBackToPolling();
+      return;
+    }
     try {
       this.watcher = fs.watch(
         this.scope.root,
@@ -171,24 +309,42 @@ class WorkspaceSystemGraphWatcher {
 
   private fallBackToPolling(): void {
     if (this.closed || this.pollTimer) return;
+    let refreshAfterInitialSnapshot = this.watcher !== null;
     this.watcher?.close();
     this.watcher = null;
-    this.lastSourceSnapshot = snapshotWorkflowSources(this.scope.root);
-    this.lastInventorySnapshot = snapshotWorkspaceWorkflows(this.scope.root);
-    this.pollTimer = setInterval(() => {
-      if (this.pollInFlight) return;
+    const poll = (): void => {
+      if (this.closed || this.pollInFlight) return;
       this.pollInFlight = true;
-      const sourceSnapshot = snapshotWorkflowSources(this.scope.root);
-      if (sourceSnapshot !== this.lastSourceSnapshot) {
-        this.lastSourceSnapshot = sourceSnapshot;
-        this.scheduleSourceChange(null);
+      let sourceRoots: readonly string[] = [];
+      try {
+        sourceRoots = this.callbacks.listSourceRoots(this.scope);
+      } catch {
+        // Registry reads are hints too. Inventory polling still proceeds.
       }
-      snapshotWorkspaceWorkflowsAsync(this.scope.root)
-        .then((inventorySnapshot) => {
-          if (this.closed || inventorySnapshot === this.lastInventorySnapshot) {
-            return;
+      void Promise.all([
+        snapshotWorkflowSourceRootsAsync(sourceRoots),
+        snapshotWorkspaceWorkflowsAsync(this.scope.root),
+      ])
+        .then(([sourceSnapshot, inventorySnapshot]) => {
+          if (this.closed) return;
+          const sourceChanged =
+            (this.lastSourceSnapshot !== null &&
+              sourceSnapshot !== this.lastSourceSnapshot) ||
+            (this.lastSourceSnapshot === null && refreshAfterInitialSnapshot);
+          this.lastSourceSnapshot = sourceSnapshot;
+          refreshAfterInitialSnapshot = false;
+          if (sourceChanged) this.scheduleSourceChange(null);
+
+          if (inventorySnapshot !== this.lastInventorySnapshot) {
+            this.dispatchInventoryChange(inventorySnapshot);
+          } else if (
+            sourceChanged &&
+            inventorySnapshot === this.failedInventorySnapshot
+          ) {
+            // Polling has no raw filesystem event. A source-fingerprint change
+            // is its proof that a real edit occurred after bounded give-up.
+            this.dispatchInventoryChange(inventorySnapshot);
           }
-          this.dispatchInventoryChange(inventorySnapshot);
         })
         .catch(() => {
           // The next poll retries an unreadable workspace.
@@ -196,13 +352,19 @@ class WorkspaceSystemGraphWatcher {
         .finally(() => {
           this.pollInFlight = false;
         });
-    }, POLL_INTERVAL_MS);
+    };
+    poll();
+    this.pollTimer = setInterval(
+      poll,
+      this.options.pollIntervalMs ?? POLL_INTERVAL_MS,
+    );
   }
 
   close(): void {
     this.closed = true;
     if (this.sourceTimer) clearTimeout(this.sourceTimer);
     if (this.inventoryTimer) clearTimeout(this.inventoryTimer);
+    if (this.inventoryRetryTimer) clearTimeout(this.inventoryRetryTimer);
     if (this.pollTimer) clearInterval(this.pollTimer);
     this.watcher?.close();
     this.watcher = null;
@@ -216,7 +378,10 @@ export class SystemGraphWatcherManager {
     WorkspaceSystemGraphWatcher
   >();
 
-  constructor(private readonly callbacks: SystemGraphWatcherCallbacks) {}
+  constructor(
+    private readonly callbacks: SystemGraphWatcherCallbacks,
+    private readonly options: SystemGraphWatcherOptions = {},
+  ) {}
 
   start(scope: WorkspaceScope): void {
     const existing = this.watchers.get(scope.workspaceKey);
@@ -224,7 +389,7 @@ export class SystemGraphWatcherManager {
     this.stop(scope.workspaceKey);
     this.watchers.set(
       scope.workspaceKey,
-      new WorkspaceSystemGraphWatcher(scope, this.callbacks),
+      new WorkspaceSystemGraphWatcher(scope, this.callbacks, this.options),
     );
   }
 

--- a/packages/harness/src/core/system-graph-watcher.ts
+++ b/packages/harness/src/core/system-graph-watcher.ts
@@ -1,0 +1,251 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { WorkspaceKey } from "../shared/system-graph.js";
+import { isAgentProjectScanIgnoredDir } from "./agent-project-discovery.js";
+import {
+  normalizeWatchPath,
+  snapshotWorkflowSources,
+} from "./canvas-watcher.js";
+import type { WorkspaceScope } from "./system-graph.js";
+import {
+  snapshotWorkspaceWorkflows,
+  snapshotWorkspaceWorkflowsAsync,
+} from "./workspace-watcher.js";
+
+const SOURCE_DEBOUNCE_MS = 150;
+const INVENTORY_DEBOUNCE_MS = 250;
+const INVENTORY_RETRY_MS = 500;
+const POLL_INTERVAL_MS = 500;
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx"]);
+
+function ignoredRelativePath(relativePath: string): boolean {
+  return relativePath
+    .split("/")
+    .filter(Boolean)
+    .some((segment) => isAgentProjectScanIgnoredDir(segment));
+}
+
+function sourceRelativePath(relativePath: string): boolean {
+  return (
+    !ignoredRelativePath(relativePath) &&
+    SOURCE_EXTENSIONS.has(path.extname(relativePath))
+  );
+}
+
+function confinedSourcePath(root: string, relativePath: string): string | null {
+  const absolute = path.resolve(root, relativePath);
+  const relative = path.relative(root, absolute);
+  if (
+    relative === ".." ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    return null;
+  }
+  return absolute;
+}
+
+export interface SystemGraphWatcherCallbacks {
+  onSourceChange: (
+    scope: WorkspaceScope,
+    /** Null when the platform can only report a workspace-level change. */
+    sourcePaths: readonly string[] | null,
+  ) => void | Promise<void>;
+  onInventoryChange: (scope: WorkspaceScope) => void | Promise<void>;
+}
+
+class WorkspaceSystemGraphWatcher {
+  private watcher: fs.FSWatcher | null = null;
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+  private sourceTimer: ReturnType<typeof setTimeout> | null = null;
+  private inventoryTimer: ReturnType<typeof setTimeout> | null = null;
+  private closed = false;
+  private sourcePaths = new Set<string>();
+  private ambiguousSourceChange = false;
+  private lastSourceSnapshot: string;
+  private lastInventorySnapshot: string;
+  private pollInFlight = false;
+  private callbackQueue: Promise<void> = Promise.resolve();
+
+  constructor(
+    readonly scope: WorkspaceScope,
+    private readonly callbacks: SystemGraphWatcherCallbacks,
+  ) {
+    this.lastSourceSnapshot = snapshotWorkflowSources(scope.root);
+    this.lastInventorySnapshot = snapshotWorkspaceWorkflows(scope.root);
+    this.arm();
+  }
+
+  private enqueue(
+    callback: () => void | Promise<void>,
+    onFailure?: () => void,
+  ): void {
+    this.callbackQueue = this.callbackQueue.then(async () => {
+      if (this.closed) return;
+      try {
+        await callback();
+      } catch {
+        // Watch callbacks are refresh hints. A failed scan/build must not tear
+        // down the watcher or affect the rest of Studio.
+        try {
+          onFailure?.();
+        } catch {
+          // Failure recovery is best-effort too.
+        }
+      }
+    });
+  }
+
+  private scheduleSourceChange(sourcePath: string | null): void {
+    if (this.closed) return;
+    if (sourcePath === null) this.ambiguousSourceChange = true;
+    else this.sourcePaths.add(sourcePath);
+    if (this.sourceTimer) clearTimeout(this.sourceTimer);
+    this.sourceTimer = setTimeout(() => {
+      this.sourceTimer = null;
+      const paths = this.ambiguousSourceChange
+        ? null
+        : [...this.sourcePaths].sort();
+      this.sourcePaths.clear();
+      this.ambiguousSourceChange = false;
+      this.enqueue(() => this.callbacks.onSourceChange(this.scope, paths));
+    }, SOURCE_DEBOUNCE_MS);
+  }
+
+  private dispatchInventoryChange(snapshot: string): void {
+    const previousSnapshot = this.lastInventorySnapshot;
+    this.lastInventorySnapshot = snapshot;
+    this.enqueue(
+      () => this.callbacks.onInventoryChange(this.scope),
+      () => {
+        if (this.closed || this.lastInventorySnapshot !== snapshot) return;
+        // A failed registry scan did not consume the structural change. Restore
+        // the old baseline and retry even when no second filesystem event lands.
+        this.lastInventorySnapshot = previousSnapshot;
+        this.scheduleInventoryCheck(INVENTORY_RETRY_MS);
+      },
+    );
+  }
+
+  private scheduleInventoryCheck(delay = INVENTORY_DEBOUNCE_MS): void {
+    if (this.closed) return;
+    if (this.inventoryTimer) clearTimeout(this.inventoryTimer);
+    this.inventoryTimer = setTimeout(() => {
+      this.inventoryTimer = null;
+      const snapshot = snapshotWorkspaceWorkflows(this.scope.root);
+      if (snapshot === this.lastInventorySnapshot) return;
+      this.dispatchInventoryChange(snapshot);
+    }, delay);
+  }
+
+  private arm(): void {
+    if (this.closed) return;
+    try {
+      this.watcher = fs.watch(
+        this.scope.root,
+        { recursive: true },
+        (_event, rawFilename) => {
+          if (rawFilename === null) {
+            this.scheduleSourceChange(null);
+            this.scheduleInventoryCheck();
+            return;
+          }
+          const relativePath = normalizeWatchPath(rawFilename);
+          if (ignoredRelativePath(relativePath)) return;
+          if (sourceRelativePath(relativePath)) {
+            this.scheduleSourceChange(
+              confinedSourcePath(this.scope.root, relativePath),
+            );
+          }
+          // Event kind is unreliable across editors/platforms. The marker
+          // fingerprint decides whether inventory really changed.
+          this.scheduleInventoryCheck();
+        },
+      );
+      this.watcher.on("error", () => this.fallBackToPolling());
+    } catch {
+      this.fallBackToPolling();
+    }
+  }
+
+  private fallBackToPolling(): void {
+    if (this.closed || this.pollTimer) return;
+    this.watcher?.close();
+    this.watcher = null;
+    this.lastSourceSnapshot = snapshotWorkflowSources(this.scope.root);
+    this.lastInventorySnapshot = snapshotWorkspaceWorkflows(this.scope.root);
+    this.pollTimer = setInterval(() => {
+      if (this.pollInFlight) return;
+      this.pollInFlight = true;
+      const sourceSnapshot = snapshotWorkflowSources(this.scope.root);
+      if (sourceSnapshot !== this.lastSourceSnapshot) {
+        this.lastSourceSnapshot = sourceSnapshot;
+        this.scheduleSourceChange(null);
+      }
+      snapshotWorkspaceWorkflowsAsync(this.scope.root)
+        .then((inventorySnapshot) => {
+          if (this.closed || inventorySnapshot === this.lastInventorySnapshot) {
+            return;
+          }
+          this.dispatchInventoryChange(inventorySnapshot);
+        })
+        .catch(() => {
+          // The next poll retries an unreadable workspace.
+        })
+        .finally(() => {
+          this.pollInFlight = false;
+        });
+    }, POLL_INTERVAL_MS);
+  }
+
+  close(): void {
+    this.closed = true;
+    if (this.sourceTimer) clearTimeout(this.sourceTimer);
+    if (this.inventoryTimer) clearTimeout(this.inventoryTimer);
+    if (this.pollTimer) clearInterval(this.pollTimer);
+    this.watcher?.close();
+    this.watcher = null;
+  }
+}
+
+/** One watcher per requested workspace, independent of harness sessions. */
+export class SystemGraphWatcherManager {
+  private readonly watchers = new Map<
+    WorkspaceKey,
+    WorkspaceSystemGraphWatcher
+  >();
+
+  constructor(private readonly callbacks: SystemGraphWatcherCallbacks) {}
+
+  start(scope: WorkspaceScope): void {
+    const existing = this.watchers.get(scope.workspaceKey);
+    if (existing?.scope.root === scope.root) return;
+    this.stop(scope.workspaceKey);
+    this.watchers.set(
+      scope.workspaceKey,
+      new WorkspaceSystemGraphWatcher(scope, this.callbacks),
+    );
+  }
+
+  retain(workspaceKeys: ReadonlySet<WorkspaceKey>): void {
+    for (const workspaceKey of [...this.watchers.keys()]) {
+      if (!workspaceKeys.has(workspaceKey)) this.stop(workspaceKey);
+    }
+  }
+
+  stop(workspaceKey: WorkspaceKey): void {
+    this.watchers.get(workspaceKey)?.close();
+    this.watchers.delete(workspaceKey);
+  }
+
+  stopAll(): void {
+    for (const workspaceKey of [...this.watchers.keys()]) {
+      this.stop(workspaceKey);
+    }
+  }
+
+  get size(): number {
+    return this.watchers.size;
+  }
+}

--- a/packages/harness/src/core/system-graph.test.ts
+++ b/packages/harness/src/core/system-graph.test.ts
@@ -422,16 +422,15 @@ describe("StaticSystemGraphBuilder", () => {
         warnings: [],
       })),
     };
-    const graph = await buildGraph(
-      new StaticSystemGraphBuilder(
-        inventory,
-        relationshipProvider(async () => {
-          throw new Error("boom at /private/research");
-        }),
-      ),
-      scope,
-    );
+    const built = await new StaticSystemGraphBuilder(
+      inventory,
+      relationshipProvider(async () => {
+        throw new Error("boom at /private/research");
+      }),
+    ).build(scope);
+    const graph = built.graph;
 
+    expect(built.cacheable).toBe(false);
     expect(graph.warnings).toEqual([
       {
         code: "projection-failed",
@@ -556,5 +555,53 @@ describe("StaticSystemGraphBuilder", () => {
       warnings: [],
     });
     expect(built.graph).not.toHaveProperty("cacheable");
+  });
+
+  it("retains caller caches across active workspaces and prunes retired ones", async () => {
+    const secondScope: WorkspaceScope = {
+      workspaceKey: "workspace-second",
+      root: "/private/second",
+    };
+    const inventory: AgentInventoryProvider = {
+      listAgents: vi.fn(async (activeScope) => {
+        const second = activeScope.workspaceKey === secondScope.workspaceKey;
+        const agentKey = second ? "second" : "first";
+        return {
+          agents: [
+            {
+              agentKey,
+              definitionId: null,
+              definitionSlug: agentKey,
+              label: agentKey,
+              resolutionAliases: [agentKey],
+              sourceRoot: activeScope.root,
+            },
+          ],
+          cacheable: true,
+          warnings: [],
+        };
+      }),
+    };
+    const retainCallers = vi.fn();
+    const relationships: AgentRelationshipProvider = {
+      listRelationships: vi.fn(async () => EMPTY_RELATIONSHIPS),
+      retainCallers,
+    };
+    const builder = new StaticSystemGraphBuilder(inventory, relationships);
+
+    await builder.build(scope);
+    await builder.build(secondScope);
+    expect(
+      retainCallers.mock.calls.at(-1)?.[0].map(
+        (caller: { agentKey: string }) => caller.agentKey,
+      ),
+    ).toEqual(["first", "second"]);
+
+    builder.retainWorkspaces(new Set([secondScope.workspaceKey]));
+    expect(
+      retainCallers.mock.calls.at(-1)?.[0].map(
+        (caller: { agentKey: string }) => caller.agentKey,
+      ),
+    ).toEqual(["second"]);
   });
 });

--- a/packages/harness/src/core/system-graph.ts
+++ b/packages/harness/src/core/system-graph.ts
@@ -18,6 +18,7 @@ import {
   workspaceRelativeLocalKey,
 } from "./system-graph-inventory.js";
 import {
+  CachedAgentRelationshipProvider,
   SourceAgentRelationshipProvider,
   type AgentRelationshipProvider,
   type AgentRelationshipProviderResult,
@@ -31,7 +32,10 @@ export type {
   AgentInventoryWarning,
   WorkspaceScope,
 } from "./system-graph-inventory.js";
-export { SourceAgentRelationshipProvider } from "./system-graph-relationships.js";
+export {
+  CachedAgentRelationshipProvider,
+  SourceAgentRelationshipProvider,
+} from "./system-graph-relationships.js";
 export type {
   AgentRelationshipCandidate,
   AgentRelationshipProvider,
@@ -49,6 +53,8 @@ export interface WorkspaceScopeCatalog extends WorkspaceScopeResolver {
 
 export interface SystemGraphBuilder {
   build(scope: WorkspaceScope): Promise<SystemGraphBuildResult>;
+  /** Optional lifecycle hook for builders with workspace-scoped caches. */
+  retainWorkspaces?(workspaceKeys: ReadonlySet<WorkspaceKey>): void;
 }
 
 export interface SystemGraphBuildResult {
@@ -252,15 +258,24 @@ function normalizeInventory(
 }
 
 export class StaticSystemGraphBuilder implements SystemGraphBuilder {
+  private readonly callersByWorkspace = new Map<
+    WorkspaceKey,
+    readonly AgentInventoryItem[]
+  >();
+
   constructor(
     private readonly inventory: AgentInventoryProvider,
-    private readonly relationships: AgentRelationshipProvider = new SourceAgentRelationshipProvider(),
+    private readonly relationships: AgentRelationshipProvider = new CachedAgentRelationshipProvider(
+      new SourceAgentRelationshipProvider(),
+    ),
   ) {}
 
   async build(scope: WorkspaceScope): Promise<SystemGraphBuildResult> {
     const inventory = await this.inventory.listAgents(scope);
     const normalized = normalizeInventory(scope, inventory.agents);
     const agents = normalized.agents;
+    this.callersByWorkspace.set(scope.workspaceKey, agents);
+    this.retainRelationshipCallers();
     const nodes = agents.map((agent) => ({
       id: `agent:${agent.agentKey}`,
       agentKey: agent.agentKey,
@@ -289,6 +304,7 @@ export class StaticSystemGraphBuilder implements SystemGraphBuilder {
       ...normalized.warnings,
     ];
     const seenEdges = new Set<string>();
+    let relationshipsComplete = true;
 
     // Source walks are independent. Run them together so first-open latency is
     // bounded by the slowest agent tree rather than the sum of every tree.
@@ -315,6 +331,7 @@ export class StaticSystemGraphBuilder implements SystemGraphBuilder {
 
     for (const { caller, result, failed } of scans) {
       if (failed) {
+        relationshipsComplete = false;
         warnings.push({
           code: "projection-failed",
           agentKey: caller.agentKey,
@@ -392,7 +409,7 @@ export class StaticSystemGraphBuilder implements SystemGraphBuilder {
     ].sort(warningOrder);
 
     return {
-      cacheable: inventory.cacheable,
+      cacheable: inventory.cacheable && relationshipsComplete,
       graph: {
         kind: "system",
         scope: { kind: "working-tree", workspaceKey: scope.workspaceKey },
@@ -401,5 +418,24 @@ export class StaticSystemGraphBuilder implements SystemGraphBuilder {
         warnings: uniqueWarnings,
       },
     };
+  }
+
+  retainWorkspaces(workspaceKeys: ReadonlySet<WorkspaceKey>): void {
+    for (const workspaceKey of this.callersByWorkspace.keys()) {
+      if (!workspaceKeys.has(workspaceKey)) {
+        this.callersByWorkspace.delete(workspaceKey);
+      }
+    }
+    this.retainRelationshipCallers();
+  }
+
+  private retainRelationshipCallers(): void {
+    try {
+      this.relationships.retainCallers?.(
+        [...this.callersByWorkspace.values()].flat(),
+      );
+    } catch {
+      // Cache pruning is an optimization and cannot make projection fail.
+    }
   }
 }

--- a/packages/harness/src/server/events-ws.test.ts
+++ b/packages/harness/src/server/events-ws.test.ts
@@ -42,6 +42,33 @@ describe("createEventsWebSocketHandler", () => {
     expect(sent).toEqual([JSON.stringify({ type: "canvas.reload", harnessSessionId: "sess-1" })]);
   });
 
+  it("forwards path-free workspace graph revisions", () => {
+    const bus = new EventBus();
+    const handler = createEventsWebSocketHandler(bus, BOOT_TOKEN);
+    const { ws, sent } = createFakeWs();
+
+    handler(
+      ws,
+      {} as IncomingMessage,
+      new URLSearchParams({ token: BOOT_TOKEN }),
+    );
+    bus.publish({
+      type: "system-graph.changed",
+      workspaceKey: "workspace-test",
+      revision: 4,
+      state: "stale",
+    });
+
+    expect(sent).toEqual([
+      JSON.stringify({
+        type: "system-graph.changed",
+        workspaceKey: "workspace-test",
+        revision: 4,
+        state: "stale",
+      }),
+    ]);
+  });
+
   it("unsubscribes from the bus once the socket closes", () => {
     const bus = new EventBus();
     const handler = createEventsWebSocketHandler(bus, BOOT_TOKEN);

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -106,6 +106,8 @@ import {
 } from "../core/system-graph.js";
 import {
   canonicalGraphPath,
+  dirtyGraphSourceRoots,
+  graphSourceRootsWithinScope,
   isWithinGraphPath,
 } from "../core/system-graph-inventory.js";
 import { SystemGraphStore } from "../core/system-graph-store.js";
@@ -1107,39 +1109,28 @@ export const startServer = async (
     return found;
   };
 
+  const workflowRootsForGraphScope = (scope: WorkspaceScope): string[] =>
+    graphSourceRootsWithinScope(
+      scope.root,
+      workflowsCache.map((workflow) => workflow.path),
+    );
+
   const systemGraphWatcher = new SystemGraphWatcherManager({
+    listSourceRoots: workflowRootsForGraphScope,
     onSourceChange: (scope, sourcePaths) => {
-      const workflowRoots = workflowsCache
-        .map((workflow) => canonicalGraphPath(workflow.path))
-        .filter((workflowRoot) => isWithinGraphPath(scope.root, workflowRoot));
-      const dirtyRoots = new Set<string>();
-      if (sourcePaths === null) {
-        for (const workflowRoot of workflowRoots) dirtyRoots.add(workflowRoot);
-      } else {
-        for (const sourcePath of sourcePaths) {
-          const canonicalSourcePath = canonicalGraphPath(sourcePath);
-          const matches = workflowRoots.filter((workflowRoot) =>
-            isWithinGraphPath(workflowRoot, canonicalSourcePath),
-          );
-          // Manually connected projects can be nested. Attribute a changed
-          // file to the most-specific registered caller rather than charging
-          // every registered ancestor for the same extraction.
-          for (const match of matches) {
-            if (
-              !matches.some(
-                (candidate) =>
-                  candidate !== match && isWithinGraphPath(match, candidate),
-              )
-            ) {
-              dirtyRoots.add(match);
-            }
-          }
-        }
-      }
+      const canonicalScope = {
+        workspaceKey: scope.workspaceKey,
+        root: canonicalGraphPath(scope.root),
+      };
+      const dirtyRoots = dirtyGraphSourceRoots(
+        canonicalScope.root,
+        workflowsCache.map((workflow) => workflow.path),
+        sourcePaths,
+      );
       for (const workflowRoot of dirtyRoots) {
         systemGraphRelationships.invalidateSource(workflowRoot);
       }
-      systemGraphStore.requestRefresh(scope);
+      systemGraphStore.requestRefresh(canonicalScope);
     },
     onInventoryChange: async (scope) => {
       try {

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -97,11 +97,19 @@ import { ensureCanvasTemplate } from "../core/canvas-template.js";
 import { renderCanvasForSession } from "../core/canvas-render.js";
 import { invalidateExtractionCache } from "../core/canvas-cache.js";
 import {
+  CachedAgentRelationshipProvider,
   HarnessRegistryInventoryProvider,
   LocalWorkspaceScopeCatalog,
+  SourceAgentRelationshipProvider,
   StaticSystemGraphBuilder,
+  type WorkspaceScope,
 } from "../core/system-graph.js";
+import {
+  canonicalGraphPath,
+  isWithinGraphPath,
+} from "../core/system-graph-inventory.js";
 import { SystemGraphStore } from "../core/system-graph-store.js";
+import { SystemGraphWatcherManager } from "../core/system-graph-watcher.js";
 import { sweepNdjson } from "../core/collector/store-retention.js";
 import {
   createDefinitionSlugResolver,
@@ -743,6 +751,9 @@ export const startServer = async (
     ...(await loadSettings(statePaths.settings)).recentDirs,
     ...sessionManager.list().map((session) => session.cwd),
   ]);
+  const systemGraphRelationships = new CachedAgentRelationshipProvider(
+    new SourceAgentRelationshipProvider(),
+  );
   const systemGraphStore = new SystemGraphStore(
     new StaticSystemGraphBuilder(
       new HarnessRegistryInventoryProvider({
@@ -750,8 +761,38 @@ export const startServer = async (
         listWorkspaceScopes: () => workspaceScopeCatalog.list(),
         inspectManifestName,
       }),
+      systemGraphRelationships,
     ),
+    {
+      onChange: ({ workspaceKey, revision, state }) => {
+        bus.publish({
+          type: "system-graph.changed",
+          workspaceKey,
+          revision,
+          state,
+        });
+      },
+    },
   );
+  const activeSystemGraphScopes = new Map<string, WorkspaceScope>();
+
+  const refreshSystemGraphScopesForRoot = (changedRoot: string): void => {
+    const canonicalChangedRoot = canonicalGraphPath(changedRoot);
+    for (const scope of activeSystemGraphScopes.values()) {
+      if (!systemGraphStore.peek(scope.workspaceKey)) continue;
+      const scopeRoot = canonicalGraphPath(scope.root);
+      if (
+        !isWithinGraphPath(scopeRoot, canonicalChangedRoot) &&
+        !isWithinGraphPath(canonicalChangedRoot, scopeRoot)
+      ) {
+        continue;
+      }
+      systemGraphStore.requestRefresh({
+        workspaceKey: scope.workspaceKey,
+        root: scopeRoot,
+      });
+    }
+  };
 
   const sessionSweepTimer = setInterval(
     () => sessionManager.sweepDeadSessions(),
@@ -869,6 +910,10 @@ export const startServer = async (
     await workflowRegistry.scan(session.cwd);
     const after = await workflowRegistry.list();
     workflowsCache = after;
+    const inventoryChanged = !workflowListsEqual(before, after);
+    if (inventoryChanged) {
+      await refreshSystemGraphScopesForRoot(session.cwd);
+    }
 
     // A removed project must not leave a live session permanently bound to a
     // path that the registry can no longer resolve. Clear only stale bindings;
@@ -912,7 +957,7 @@ export const startServer = async (
       }
     }
 
-    if (workflowListsEqual(before, after)) return;
+    if (!inventoryChanged) return;
     await Promise.all(sessionManager.list().map((s) => writeSessionContext(s)));
     bus.publish({ type: "workflows.changed" });
   };
@@ -1045,8 +1090,11 @@ export const startServer = async (
   const scanWorkflowsAndBroadcast = async (
     root: string,
   ): Promise<WorkflowInfo[]> => {
+    const before = workflowsCache;
     const found = await workflowRegistry.scan(root);
-    workflowsCache = await workflowRegistry.list();
+    const after = await workflowRegistry.list();
+    workflowsCache = after;
+    if (workflowListsEqual(before, after)) return found;
     // Rewrite every open session's context file before broadcasting — a
     // listener reacting to workflows.changed (the SPA, or an agent that
     // happens to re-read the file right then) must never see the
@@ -1054,8 +1102,69 @@ export const startServer = async (
     await Promise.all(
       sessionManager.list().map((session) => writeSessionContext(session)),
     );
+    await refreshSystemGraphScopesForRoot(root);
     bus.publish({ type: "workflows.changed" });
     return found;
+  };
+
+  const systemGraphWatcher = new SystemGraphWatcherManager({
+    onSourceChange: (scope, sourcePaths) => {
+      const workflowRoots = workflowsCache
+        .map((workflow) => canonicalGraphPath(workflow.path))
+        .filter((workflowRoot) => isWithinGraphPath(scope.root, workflowRoot));
+      const dirtyRoots = new Set<string>();
+      if (sourcePaths === null) {
+        for (const workflowRoot of workflowRoots) dirtyRoots.add(workflowRoot);
+      } else {
+        for (const sourcePath of sourcePaths) {
+          const canonicalSourcePath = canonicalGraphPath(sourcePath);
+          const matches = workflowRoots.filter((workflowRoot) =>
+            isWithinGraphPath(workflowRoot, canonicalSourcePath),
+          );
+          // Manually connected projects can be nested. Attribute a changed
+          // file to the most-specific registered caller rather than charging
+          // every registered ancestor for the same extraction.
+          for (const match of matches) {
+            if (
+              !matches.some(
+                (candidate) =>
+                  candidate !== match && isWithinGraphPath(match, candidate),
+              )
+            ) {
+              dirtyRoots.add(match);
+            }
+          }
+        }
+      }
+      for (const workflowRoot of dirtyRoots) {
+        systemGraphRelationships.invalidateSource(workflowRoot);
+      }
+      systemGraphStore.requestRefresh(scope);
+    },
+    onInventoryChange: async (scope) => {
+      try {
+        await scanWorkflowsAndBroadcast(scope.root);
+      } catch (err) {
+        if (systemGraphStore.peek(scope.workspaceKey)) {
+          systemGraphStore.reportRefreshFailure(scope);
+        }
+        console.error("[harness] workspace graph inventory refresh failed");
+        throw err;
+      }
+    },
+  });
+
+  const listWorkspaceScopesAndRetain = async () => {
+    const scopes = await workspaceScopeCatalog.list();
+    const retained = new Set(scopes.map((scope) => scope.workspaceKey));
+    systemGraphWatcher.retain(retained);
+    systemGraphStore.retain(retained);
+    for (const workspaceKey of activeSystemGraphScopes.keys()) {
+      if (!retained.has(workspaceKey)) {
+        activeSystemGraphScopes.delete(workspaceKey);
+      }
+    }
+    return scopes;
   };
 
   /** Enrich only the bound workflow before a Canvas render. Canvas extraction
@@ -1255,7 +1364,7 @@ export const startServer = async (
           }
         : null,
       listWorkflows: () => workflowRegistry.list().then(enrichWorkflows),
-      listWorkspaceScopes: () => workspaceScopeCatalog.list(),
+      listWorkspaceScopes: listWorkspaceScopesAndRetain,
       listMacros: () => DEFAULT_MACROS,
       findWorkflow: (workflowPath) =>
         workflowsCache.find((w) => w.path === workflowPath) ?? null,
@@ -1305,6 +1414,10 @@ export const startServer = async (
     createSystemGraphRouter({
       scopeResolver: workspaceScopeCatalog,
       store: systemGraphStore,
+      onScopeAccess: (scope) => {
+        activeSystemGraphScopes.set(scope.workspaceKey, scope);
+        systemGraphWatcher.start(scope);
+      },
     }),
   );
   app.use(
@@ -1327,8 +1440,17 @@ export const startServer = async (
   // as WorkflowRegistryLike so this wrapper needs no unsafe cast.
   const enrichedWorkflowRegistry: WorkflowRegistryLike = {
     list: () => workflowRegistry.list().then(enrichWorkflows),
-    scan: (root: string) => workflowRegistry.scan(root),
-    connectPath: (inputPath: string) => workflowRegistry.connectPath(inputPath),
+    scan: scanWorkflowsAndBroadcast,
+    connectPath: async (inputPath: string) => {
+      const workflow = await workflowRegistry.connectPath(inputPath);
+      workflowsCache = await workflowRegistry.list();
+      await Promise.all(
+        sessionManager.list().map((session) => writeSessionContext(session)),
+      );
+      await refreshSystemGraphScopesForRoot(workflow.path);
+      bus.publish({ type: "workflows.changed" });
+      return workflow;
+    },
   };
   app.use(
     createRunsRouter({
@@ -1696,6 +1818,10 @@ export const startServer = async (
       clearInterval(ndjsonRetentionTimer);
       canvasWatcher.stopAll();
       workspaceWatcher.stopAll();
+      systemGraphWatcher.stopAll();
+      activeSystemGraphScopes.clear();
+      systemGraphRelationships.clear();
+      systemGraphStore.clear();
       installWatcher.stopAll();
       for (const tailer of codexTailers.values()) tailer.stop();
       codexTailers.clear();

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -29,6 +29,7 @@ import type {
   WorkflowInfo,
 } from "../shared/types.js";
 import { JSON_BODY_LIMIT_BYTES } from "../shared/types.js";
+import type { SystemGraphSnapshot } from "../shared/system-graph.js";
 import { unhandledRequestErrorHandler } from "./error-handler.js";
 import { resolveStatePaths } from "../core/paths.js";
 import {
@@ -778,9 +779,13 @@ export const startServer = async (
   );
   const activeSystemGraphScopes = new Map<string, WorkspaceScope>();
 
-  const refreshSystemGraphScopesForRoot = (changedRoot: string): void => {
+  const refreshSystemGraphScopesForRoot = (
+    changedRoot: string,
+    excludedWorkspaceKey?: string,
+  ): void => {
     const canonicalChangedRoot = canonicalGraphPath(changedRoot);
     for (const scope of activeSystemGraphScopes.values()) {
+      if (scope.workspaceKey === excludedWorkspaceKey) continue;
       if (!systemGraphStore.peek(scope.workspaceKey)) continue;
       const scopeRoot = canonicalGraphPath(scope.root);
       if (
@@ -1091,6 +1096,7 @@ export const startServer = async (
   // it with unrelated workflows some earlier scan already found elsewhere.
   const scanWorkflowsAndBroadcast = async (
     root: string,
+    options: { refreshGraphs?: () => Promise<void> } = {},
   ): Promise<WorkflowInfo[]> => {
     const before = workflowsCache;
     const found = await workflowRegistry.scan(root);
@@ -1104,9 +1110,32 @@ export const startServer = async (
     await Promise.all(
       sessionManager.list().map((session) => writeSessionContext(session)),
     );
-    await refreshSystemGraphScopesForRoot(root);
+    if (options.refreshGraphs) await options.refreshGraphs();
+    else await refreshSystemGraphScopesForRoot(root);
     bus.publish({ type: "workflows.changed" });
     return found;
+  };
+
+  const refreshSystemGraphInventory = async (
+    scope: WorkspaceScope,
+  ) => {
+    const canonicalScope = {
+      workspaceKey: scope.workspaceKey,
+      root: canonicalGraphPath(scope.root),
+    };
+    let refreshPromise: Promise<SystemGraphSnapshot> | null = null;
+    const refreshGraph = (): Promise<void> => {
+      refreshSystemGraphScopesForRoot(
+        canonicalScope.root,
+        canonicalScope.workspaceKey,
+      );
+      refreshPromise = systemGraphStore.refresh(canonicalScope);
+      return refreshPromise.then(() => undefined);
+    };
+    await scanWorkflowsAndBroadcast(canonicalScope.root, {
+      refreshGraphs: refreshGraph,
+    });
+    return await (refreshPromise ?? systemGraphStore.refresh(canonicalScope));
   };
 
   const workflowRootsForGraphScope = (scope: WorkspaceScope): string[] =>
@@ -1127,6 +1156,7 @@ export const startServer = async (
         workflowsCache.map((workflow) => workflow.path),
         sourcePaths,
       );
+      if (dirtyRoots.length === 0) return;
       for (const workflowRoot of dirtyRoots) {
         systemGraphRelationships.invalidateSource(workflowRoot);
       }
@@ -1134,11 +1164,9 @@ export const startServer = async (
     },
     onInventoryChange: async (scope) => {
       try {
-        await scanWorkflowsAndBroadcast(scope.root);
+        await refreshSystemGraphInventory(scope);
       } catch (err) {
-        if (systemGraphStore.peek(scope.workspaceKey)) {
-          systemGraphStore.reportRefreshFailure(scope);
-        }
+        systemGraphStore.reportRefreshFailure(scope);
         console.error("[harness] workspace graph inventory refresh failed");
         throw err;
       }
@@ -1408,6 +1436,14 @@ export const startServer = async (
       onScopeAccess: (scope) => {
         activeSystemGraphScopes.set(scope.workspaceKey, scope);
         systemGraphWatcher.start(scope);
+      },
+      onScopeRefresh: async (scope) => {
+        try {
+          return await refreshSystemGraphInventory(scope);
+        } catch {
+          console.error("[harness] workspace graph manual refresh failed");
+          return systemGraphStore.reportRefreshFailure(scope);
+        }
       },
     }),
   );

--- a/packages/harness/src/server/system-graph-freshness.test.ts
+++ b/packages/harness/src/server/system-graph-freshness.test.ts
@@ -1,0 +1,229 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket } from "ws";
+
+import type { AppState, BusMessage, WorkflowInfo } from "../shared/types.js";
+import type { SystemGraphSnapshot } from "../shared/system-graph.js";
+import { startServer, type HarnessServer } from "./index.js";
+
+async function scaffoldAgent(
+  workspaceRoot: string,
+  name: string,
+  source = "export {};\n",
+): Promise<string> {
+  const agentRoot = path.join(workspaceRoot, name);
+  await fs.mkdir(agentRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(agentRoot, "sapiom.json"),
+    JSON.stringify({ name, definitionId: null }),
+  );
+  await fs.writeFile(path.join(agentRoot, "index.ts"), source);
+  return agentRoot;
+}
+
+describe("workspace graph freshness wiring", () => {
+  let tempRoot: string;
+  let stateRoot: string;
+  let workspaceRoot: string;
+  let server: HarnessServer | undefined;
+  let socket: WebSocket | undefined;
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "system-graph-freshness-"),
+    );
+    stateRoot = path.join(tempRoot, "state");
+    workspaceRoot = path.join(tempRoot, "workspace");
+    await fs.mkdir(stateRoot, { recursive: true });
+    await fs.mkdir(workspaceRoot, { recursive: true });
+    await fs.writeFile(
+      path.join(stateRoot, "settings.json"),
+      JSON.stringify({ recentDirs: [workspaceRoot] }),
+    );
+  });
+
+  afterEach(async () => {
+    socket?.close();
+    await server?.close();
+    server = undefined;
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it(
+    "refreshes source relationships and agent inventory without a session",
+    { retry: 1, timeout: 30_000 },
+    async () => {
+      const researchRoot = await scaffoldAgent(workspaceRoot, "research");
+      await scaffoldAgent(workspaceRoot, "growth");
+      server = await startServer({
+        port: 0,
+        bootToken: "test-token",
+        telemetryOptIn: false,
+        adapters: {},
+        stateRoot,
+        launchDir: workspaceRoot,
+        autoCreateSession: false,
+      });
+      const baseUrl = `http://127.0.0.1:${server.port}`;
+      const headers = { "X-Harness-Token": "test-token" };
+
+      await vi.waitFor(
+        async () => {
+          const response = await fetch(`${baseUrl}/api/workflows`, { headers });
+          const workflows = (await response.json()) as WorkflowInfo[];
+          expect(
+            workflows.map((workflow) => workflow.definitionSlug).sort(),
+          ).toEqual(["growth", "research"]);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+
+      const stateResponse = await fetch(`${baseUrl}/api/state`, { headers });
+      const state = (await stateResponse.json()) as AppState;
+      const workspaceKey = state.workspaceScopes?.find(
+        (scope) => scope.cwd === workspaceRoot,
+      )?.workspaceKey;
+      expect(workspaceKey).toBeTruthy();
+      const graphUrl = `${baseUrl}/api/workspaces/${workspaceKey}/system-graph`;
+
+      const graphEvents: Array<
+        Extract<BusMessage, { type: "system-graph.changed" }>
+      > = [];
+      socket = new WebSocket(
+        `ws://127.0.0.1:${server.port}/ws/events?token=test-token`,
+      );
+      await new Promise<void>((resolve, reject) => {
+        socket!.once("open", resolve);
+        socket!.once("error", reject);
+      });
+      socket.on("message", (raw) => {
+        const message = JSON.parse(raw.toString()) as BusMessage;
+        if (message.type === "system-graph.changed") graphEvents.push(message);
+      });
+
+      const readGraph = async (): Promise<SystemGraphSnapshot> => {
+        const response = await fetch(graphUrl, { headers });
+        expect(response.status).toBe(200);
+        const raw = await response.text();
+        expect(raw).not.toContain(workspaceRoot);
+        return JSON.parse(raw) as SystemGraphSnapshot;
+      };
+      const initial = await readGraph();
+      expect(initial).toMatchObject({ state: "ready" });
+      expect(initial.graph?.edges).toEqual([]);
+      graphEvents.length = 0;
+
+      await fs.writeFile(
+        path.join(researchRoot, "index.ts"),
+        'ctx.sapiom.agents.run({ definition: "growth" });\n',
+      );
+      let sourceRefresh!: SystemGraphSnapshot;
+      await vi.waitFor(
+        async () => {
+          sourceRefresh = await readGraph();
+          expect(sourceRefresh.revision).toBeGreaterThan(initial.revision);
+          expect(sourceRefresh.state).toBe("ready");
+          expect(sourceRefresh.graph?.edges).toEqual([
+            expect.objectContaining({
+              from: "agent:research",
+              to: "agent:growth",
+              mode: "blocking",
+            }),
+          ]);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+      expect(graphEvents.some((event) => event.state === "stale")).toBe(true);
+      expect(graphEvents.some((event) => event.state === "ready")).toBe(true);
+
+      await fs.writeFile(path.join(researchRoot, "index.ts"), "export {};\n");
+      let sourceRemoved!: SystemGraphSnapshot;
+      await vi.waitFor(
+        async () => {
+          sourceRemoved = await readGraph();
+          expect(sourceRemoved.revision).toBeGreaterThan(
+            sourceRefresh.revision,
+          );
+          expect(sourceRemoved.graph?.edges).toEqual([]);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+
+      const reportingRoot = await scaffoldAgent(workspaceRoot, "reporting");
+      let added!: SystemGraphSnapshot;
+      await vi.waitFor(
+        async () => {
+          added = await readGraph();
+          expect(added.revision).toBeGreaterThan(sourceRemoved.revision);
+          expect(
+            added.graph?.nodes.some((node) => node.agentKey === "reporting"),
+          ).toBe(true);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+
+      const insightsRoot = path.join(workspaceRoot, "insights");
+      await fs.rename(reportingRoot, insightsRoot);
+      await fs.writeFile(
+        path.join(insightsRoot, "sapiom.json"),
+        JSON.stringify({ name: "insights", definitionId: null }),
+      );
+      await fs.writeFile(
+        path.join(insightsRoot, "index.ts"),
+        'ctx.sapiom.agents.run({ definition: "growth" });\n',
+      );
+      let renamed!: SystemGraphSnapshot;
+      await vi.waitFor(
+        async () => {
+          renamed = await readGraph();
+          expect(renamed.revision).toBeGreaterThan(added.revision);
+          expect(
+            renamed.graph?.nodes.some((node) => node.agentKey === "reporting"),
+          ).toBe(false);
+          expect(
+            renamed.graph?.edges.some(
+              (edge) =>
+                edge.from === "agent:insights" && edge.to === "agent:growth",
+            ),
+          ).toBe(true);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+
+      await fs.writeFile(
+        path.join(insightsRoot, "sapiom.json"),
+        JSON.stringify({ name: "insights-v2", definitionId: null }),
+      );
+      let renamedSlug!: SystemGraphSnapshot;
+      await vi.waitFor(
+        async () => {
+          renamedSlug = await readGraph();
+          expect(renamedSlug.revision).toBeGreaterThan(renamed.revision);
+          expect(
+            renamedSlug.graph?.edges.some(
+              (edge) =>
+                edge.from === "agent:insights-v2" && edge.to === "agent:growth",
+            ),
+          ).toBe(true);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+
+      await fs.rm(insightsRoot, { recursive: true, force: true });
+      await vi.waitFor(
+        async () => {
+          const removed = await readGraph();
+          expect(removed.revision).toBeGreaterThan(renamedSlug.revision);
+          expect(
+            removed.graph?.nodes.some(
+              (node) => node.agentKey === "insights-v2",
+            ),
+          ).toBe(false);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+    },
+  );
+});

--- a/packages/harness/src/server/system-graph-freshness.test.ts
+++ b/packages/harness/src/server/system-graph-freshness.test.ts
@@ -224,6 +224,17 @@ describe("workspace graph freshness wiring", () => {
         },
         { timeout: 8_000, interval: 150 },
       );
+
+      const beforeManualRetry = await readGraph();
+      const manualRetryResponse = await fetch(`${graphUrl}/refresh`, {
+        method: "POST",
+        headers,
+      });
+      expect(manualRetryResponse.status).toBe(200);
+      const manualRetry =
+        (await manualRetryResponse.json()) as SystemGraphSnapshot;
+      expect(manualRetry).toMatchObject({ state: "ready" });
+      expect(manualRetry.revision).toBeGreaterThan(beforeManualRetry.revision);
     },
   );
 });

--- a/packages/harness/src/server/system-graph.test.ts
+++ b/packages/harness/src/server/system-graph.test.ts
@@ -121,6 +121,29 @@ describe("createSystemGraphRouter", () => {
     expect(builder.build).toHaveBeenCalledTimes(2);
   });
 
+  it("rebuilds the projection through the protected explicit refresh route", async () => {
+    const { baseUrl, builder } = start();
+    const route = `${baseUrl}/api/workspaces/${workspaceKey}/system-graph`;
+    const headers = { "X-Harness-Token": "test-token" };
+    await fetch(route, { headers });
+
+    expect((await fetch(`${route}/refresh`, { method: "POST" })).status).toBe(
+      401,
+    );
+    const refreshed = await fetch(`${route}/refresh`, {
+      method: "POST",
+      headers,
+    });
+
+    expect(refreshed.status).toBe(200);
+    expect((await refreshed.json()) as SystemGraphSnapshot).toMatchObject({
+      workspaceKey,
+      state: "ready",
+      graph,
+    });
+    expect(builder.build).toHaveBeenCalledTimes(2);
+  });
+
   it("rejects an unknown opaque workspace key without scanning", async () => {
     const { baseUrl, builder } = start();
     const response = await fetch(

--- a/packages/harness/src/server/system-graph.test.ts
+++ b/packages/harness/src/server/system-graph.test.ts
@@ -10,6 +10,7 @@ import type {
 import {
   SYSTEM_GRAPH_CACHE_HEADER,
   type SystemGraph,
+  type SystemGraphSnapshot,
 } from "../shared/system-graph.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { createSystemGraphRouter } from "./system-graph.js";
@@ -43,7 +44,7 @@ describe("createSystemGraphRouter", () => {
     server = undefined;
   });
 
-  function start(cacheable = true) {
+  function start(cacheable = true, onScopeAccess = vi.fn()) {
     const scopeResolver: WorkspaceScopeResolver = {
       resolve: vi.fn(async (key: string) =>
         key === workspaceKey
@@ -61,6 +62,7 @@ describe("createSystemGraphRouter", () => {
       createSystemGraphRouter({
         scopeResolver,
         store: new SystemGraphStore(builder),
+        onScopeAccess,
       }),
     );
     server = app.listen(0);
@@ -69,11 +71,12 @@ describe("createSystemGraphRouter", () => {
       baseUrl: `http://127.0.0.1:${address.port}`,
       scopeResolver,
       builder,
+      onScopeAccess,
     };
   }
 
   it("is boot-token protected and returns the cached public graph", async () => {
-    const { baseUrl, builder } = start();
+    const { baseUrl, builder, onScopeAccess } = start();
     const route = `${baseUrl}/api/workspaces/${workspaceKey}/system-graph`;
 
     expect((await fetch(route)).status).toBe(401);
@@ -86,9 +89,15 @@ describe("createSystemGraphRouter", () => {
 
     expect(first.status).toBe(200);
     expect(first.headers.get(SYSTEM_GRAPH_CACHE_HEADER)).toBe("complete");
-    expect(await first.json()).toEqual(graph);
+    expect((await first.json()) as SystemGraphSnapshot).toEqual({
+      workspaceKey,
+      revision: 1,
+      state: "ready",
+      graph,
+    });
     expect(second.status).toBe(200);
     expect(builder.build).toHaveBeenCalledTimes(1);
+    expect(onScopeAccess).toHaveBeenCalledTimes(2);
   });
 
   it("reports degradation and bounds re-enrichment to one later request", async () => {
@@ -104,7 +113,11 @@ describe("createSystemGraphRouter", () => {
     expect(first.headers.get(SYSTEM_GRAPH_CACHE_HEADER)).toBe("degraded");
     expect(second.headers.get(SYSTEM_GRAPH_CACHE_HEADER)).toBe("degraded");
     expect(third.headers.get(SYSTEM_GRAPH_CACHE_HEADER)).toBe("degraded");
-    expect(await third.json()).toEqual(graph);
+    expect((await third.json()) as SystemGraphSnapshot).toMatchObject({
+      workspaceKey,
+      state: "degraded",
+      graph,
+    });
     expect(builder.build).toHaveBeenCalledTimes(2);
   });
 

--- a/packages/harness/src/server/system-graph.ts
+++ b/packages/harness/src/server/system-graph.ts
@@ -1,4 +1,9 @@
-import { Router } from "express";
+import {
+  Router,
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
 
 import type {
   WorkspaceScope,
@@ -8,12 +13,17 @@ import type { SystemGraphStore } from "../core/system-graph-store.js";
 import {
   SYSTEM_GRAPH_CACHE_HEADER,
   type SystemGraphCacheStatus,
+  type SystemGraphSnapshot,
 } from "../shared/system-graph.js";
 
 export interface SystemGraphRouterOptions {
   scopeResolver: WorkspaceScopeResolver;
   store: SystemGraphStore;
   onScopeAccess?: (scope: WorkspaceScope) => void | Promise<void>;
+  /** Re-run registry prerequisites before an explicit user retry. */
+  onScopeRefresh?: (
+    scope: WorkspaceScope,
+  ) => SystemGraphSnapshot | Promise<SystemGraphSnapshot>;
 }
 
 /** Mounted beneath the boot-token-protected `/api` boundary. */
@@ -21,33 +31,46 @@ export function createSystemGraphRouter(
   options: SystemGraphRouterOptions,
 ): Router {
   const router = Router();
+  const route = "/workspaces/:workspaceKey/system-graph";
 
-  router.get(
-    "/workspaces/:workspaceKey/system-graph",
-    async (req, res, next) => {
-      try {
-        const scope = await options.scopeResolver.resolve(
-          req.params.workspaceKey,
-        );
-        if (!scope) {
-          res.status(404).json({ error: "Workspace not found" });
-          return;
-        }
-        try {
-          await options.onScopeAccess?.(scope);
-        } catch {
-          // Watcher setup is best-effort. A graph read must remain available
-          // even when automatic freshness cannot be armed.
-        }
-        const snapshot = await options.store.get(scope);
-        const cacheStatus: SystemGraphCacheStatus =
-          snapshot.state === "ready" ? "complete" : "degraded";
-        res.set(SYSTEM_GRAPH_CACHE_HEADER, cacheStatus).json(snapshot);
-      } catch (err) {
-        next(err);
+  const serve = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+    refresh: boolean,
+  ): Promise<void> => {
+    try {
+      const scope = await options.scopeResolver.resolve(
+        req.params.workspaceKey,
+      );
+      if (!scope) {
+        res.status(404).json({ error: "Workspace not found" });
+        return;
       }
-    },
-  );
+      try {
+        await options.onScopeAccess?.(scope);
+      } catch {
+        // Watcher setup is best-effort. A graph read must remain available
+        // even when automatic freshness cannot be armed.
+      }
+      const snapshot = refresh
+        ? await (options.onScopeRefresh?.(scope) ??
+            options.store.refresh(scope))
+        : await options.store.get(scope);
+      const cacheStatus: SystemGraphCacheStatus =
+        snapshot.state === "ready" ? "complete" : "degraded";
+      res.set(SYSTEM_GRAPH_CACHE_HEADER, cacheStatus).json(snapshot);
+    } catch (err) {
+      next(err);
+    }
+  };
+
+  router.get(route, (req, res, next) => {
+    void serve(req, res, next, false);
+  });
+  router.post(`${route}/refresh`, (req, res, next) => {
+    void serve(req, res, next, true);
+  });
 
   return router;
 }

--- a/packages/harness/src/server/system-graph.ts
+++ b/packages/harness/src/server/system-graph.ts
@@ -1,6 +1,9 @@
 import { Router } from "express";
 
-import type { WorkspaceScopeResolver } from "../core/system-graph.js";
+import type {
+  WorkspaceScope,
+  WorkspaceScopeResolver,
+} from "../core/system-graph.js";
 import type { SystemGraphStore } from "../core/system-graph-store.js";
 import {
   SYSTEM_GRAPH_CACHE_HEADER,
@@ -10,6 +13,7 @@ import {
 export interface SystemGraphRouterOptions {
   scopeResolver: WorkspaceScopeResolver;
   store: SystemGraphStore;
+  onScopeAccess?: (scope: WorkspaceScope) => void | Promise<void>;
 }
 
 /** Mounted beneath the boot-token-protected `/api` boundary. */
@@ -29,11 +33,16 @@ export function createSystemGraphRouter(
           res.status(404).json({ error: "Workspace not found" });
           return;
         }
-        const result = await options.store.get(scope);
-        const cacheStatus: SystemGraphCacheStatus = result.degraded
-          ? "degraded"
-          : "complete";
-        res.set(SYSTEM_GRAPH_CACHE_HEADER, cacheStatus).json(result.graph);
+        try {
+          await options.onScopeAccess?.(scope);
+        } catch {
+          // Watcher setup is best-effort. A graph read must remain available
+          // even when automatic freshness cannot be armed.
+        }
+        const snapshot = await options.store.get(scope);
+        const cacheStatus: SystemGraphCacheStatus =
+          snapshot.state === "ready" ? "complete" : "degraded";
+        res.set(SYSTEM_GRAPH_CACHE_HEADER, cacheStatus).json(snapshot);
       } catch (err) {
         next(err);
       }

--- a/packages/harness/src/shared/system-graph.ts
+++ b/packages/harness/src/shared/system-graph.ts
@@ -54,3 +54,18 @@ export interface SystemGraph {
   edges: SystemGraphEdge[];
   warnings: GraphWarning[];
 }
+export type SystemGraphLifecycleState =
+  | "building"
+  | "ready"
+  | "stale"
+  | "degraded";
+
+/** Path-free lifecycle envelope for one workspace projection. */
+export interface SystemGraphSnapshot {
+  workspaceKey: WorkspaceKey;
+  /** Monotonic within one server process and workspace. */
+  revision: number;
+  state: SystemGraphLifecycleState;
+  /** Null only before a usable projection exists. */
+  graph: SystemGraph | null;
+}

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -6,6 +6,11 @@
  * integration boundary.
  */
 
+import type {
+  SystemGraphLifecycleState,
+  WorkspaceKey,
+} from "./system-graph.js";
+
 // ---------------------------------------------------------------------------
 // Constants & well-known paths
 // ---------------------------------------------------------------------------
@@ -530,6 +535,12 @@ export type BusMessage =
       target: "prod" | "local";
     }
   | { type: "workflows.changed" }
+  | {
+      type: "system-graph.changed";
+      workspaceKey: WorkspaceKey;
+      revision: number;
+      state: SystemGraphLifecycleState;
+    }
   /**
    * Full snapshot of one background task, re-broadcast on every change
    * (spawn, each new status line, completion/failure). Tasks are rare and

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -669,6 +669,124 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     await expect.poll(requestCount).toBe(2);
   });
 
+  test("workspace graph revisions invalidate closed views and preserve stale data", async ({
+    page,
+  }) => {
+    const requestCount = () =>
+      page.evaluate(
+        () =>
+          ((window as unknown as {
+            __HARNESS_TEST__?: { systemGraphRequests?: string[] };
+          }).__HARNESS_TEST__?.systemGraphRequests ?? []).length,
+      );
+    await page.getByTestId("workspace-select-acme-app").click();
+    await expect(page.getByTestId("system-graph-canvas")).toBeVisible();
+    await expect.poll(requestCount).toBe(1);
+
+    const workspaceKey = await page.evaluate(
+      () =>
+        (window as unknown as {
+          __HARNESS_TEST__?: { systemGraphRequests?: string[] };
+        }).__HARNESS_TEST__?.systemGraphRequests?.[0] ?? "",
+    );
+    await page
+      .getByTestId("workflow-leasing")
+      .locator(".workflow-item-trigger")
+      .click();
+
+    // The graph destination is closed, but the global event subscriber still
+    // invalidates its process-lifetime browser promise.
+    await page.evaluate((key) => {
+      const win = window as unknown as {
+        __MOCK_SYSTEM_GRAPH_REVISION__?: number;
+        __MOCK_SYSTEM_GRAPH_STATE__?: string;
+        __HARNESS_TEST__?: { publish?: (message: unknown) => void };
+      };
+      win.__MOCK_SYSTEM_GRAPH_REVISION__ = 3;
+      win.__MOCK_SYSTEM_GRAPH_STATE__ = "ready";
+      win.__HARNESS_TEST__?.publish?.({
+        type: "system-graph.changed",
+        workspaceKey: key,
+        revision: 2,
+        state: "stale",
+      });
+    }, workspaceKey);
+
+    await page.getByTestId("workspace-select-acme-app").click();
+    await expect(page.getByTestId("system-graph-canvas")).toBeVisible();
+    await expect(page.getByTestId("system-graph-refreshing")).toBeVisible();
+    await expect.poll(requestCount).toBe(2);
+    await expect(page.getByTestId("system-graph-refreshing")).toHaveCount(0);
+
+    // A hard refresh failure keeps last-known data visible and labels it stale.
+    await page.evaluate((key) => {
+      const win = window as unknown as {
+        __MOCK_SYSTEM_GRAPH_REVISION__?: number;
+        __MOCK_SYSTEM_GRAPH_STATE__?: string;
+        __HARNESS_TEST__?: { publish?: (message: unknown) => void };
+      };
+      win.__MOCK_SYSTEM_GRAPH_REVISION__ = 4;
+      win.__MOCK_SYSTEM_GRAPH_STATE__ = "stale";
+      win.__HARNESS_TEST__?.publish?.({
+        type: "system-graph.changed",
+        workspaceKey: key,
+        revision: 4,
+        state: "stale",
+      });
+    }, workspaceKey);
+    await expect(page.getByTestId("system-graph-stale")).toBeVisible();
+    await expect(page.getByTestId("system-graph-canvas")).toBeVisible();
+    await expect.poll(requestCount).toBe(3);
+
+    // A partial refresh keeps valid topology interactive and labels it degraded.
+    await page.evaluate((key) => {
+      const win = window as unknown as {
+        __MOCK_SYSTEM_GRAPH_REVISION__?: number;
+        __MOCK_SYSTEM_GRAPH_STATE__?: string;
+        __HARNESS_TEST__?: { publish?: (message: unknown) => void };
+      };
+      win.__MOCK_SYSTEM_GRAPH_REVISION__ = 5;
+      win.__MOCK_SYSTEM_GRAPH_STATE__ = "degraded";
+      win.__HARNESS_TEST__?.publish?.({
+        type: "system-graph.changed",
+        workspaceKey: key,
+        revision: 5,
+        state: "degraded",
+      });
+    }, workspaceKey);
+    await expect(page.getByTestId("system-graph-degraded")).toBeVisible();
+    await expect(page.getByTestId("system-graph-canvas")).toBeVisible();
+    await expect.poll(requestCount).toBe(4);
+
+    await page.evaluate(() => {
+      const win = window as unknown as {
+        __MOCK_SYSTEM_GRAPH_REVISION__?: number;
+        __MOCK_SYSTEM_GRAPH_STATE__?: string;
+      };
+      win.__MOCK_SYSTEM_GRAPH_REVISION__ = 6;
+      win.__MOCK_SYSTEM_GRAPH_STATE__ = "ready";
+    });
+    await page.getByRole("button", { name: "Retry" }).click();
+    await expect(page.getByTestId("system-graph-degraded")).toHaveCount(0);
+    await expect(page.getByTestId("system-graph-canvas")).toBeVisible();
+    await expect.poll(requestCount).toBe(5);
+
+    // An unrelated workspace announcement cannot invalidate this view.
+    await page.evaluate(() => {
+      const win = window as unknown as {
+        __HARNESS_TEST__?: { publish?: (message: unknown) => void };
+      };
+      win.__HARNESS_TEST__?.publish?.({
+        type: "system-graph.changed",
+        workspaceKey: "workspace-unrelated",
+        revision: 99,
+        state: "stale",
+      });
+    });
+    await page.waitForTimeout(250);
+    expect(await requestCount()).toBe(5);
+  });
+
   test("switching sessions makes the canvas follow the new session's content", async ({ page }) => {
     // Zone 3 keys off the active session. sess-boot ships a bundled doc (board);
     // the second leasing session ships none — so the canvas pane OPENS for the

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -1602,6 +1602,7 @@ export const App = (): JSX.Element => {
               api={harness.api}
               workflows={state.workflows}
               workspaceScopes={workspaceScopes}
+              lastMessage={harness.lastMessage}
               onOpenAgent={handleFocusAgent}
               onExpandRail={
                 railCollapsed ? () => setRailCollapsed(false) : undefined

--- a/packages/harness/web/src/components/WorkspaceGraphView.tsx
+++ b/packages/harness/web/src/components/WorkspaceGraphView.tsx
@@ -221,8 +221,16 @@ export function WorkspaceGraphView({
             className="system-graph-state"
             testId="system-graph-error"
             icon="TriangleAlert"
-            title="Couldn't build this workspace graph"
-            body="Studio couldn't produce a usable local projection. Retry after the workspace is readable."
+            title={
+              error
+                ? "Couldn't load this workspace graph"
+                : "Couldn't build this workspace graph"
+            }
+            body={
+              error
+                ? "Studio couldn't load the latest local graph. Check that Studio is still running, then retry."
+                : "Studio couldn't produce a usable local projection. Retry after the workspace is readable."
+            }
             cta={
               <button type="button" className="btn-primary" onClick={retry}>
                 Retry

--- a/packages/harness/web/src/components/WorkspaceGraphView.tsx
+++ b/packages/harness/web/src/components/WorkspaceGraphView.tsx
@@ -2,26 +2,20 @@ import { useEffect, useMemo, useState } from "react";
 import type { JSX } from "react";
 import type {
   AgentKey,
-  SystemGraph,
+  SystemGraphLifecycleState,
+  SystemGraphSnapshot,
   WorkspaceKey,
   WorkspaceScopeSummary,
 } from "@shared/system-graph";
-import type { WorkflowInfo } from "@shared/types";
+import type { BusMessage, WorkflowInfo } from "@shared/types";
 
 import type { HarnessApi } from "../lib/api";
-import { createSystemGraphLoader } from "../lib/system-graph-loader";
+import { systemGraphLoader } from "../lib/system-graph-loader";
 import { mapSystemGraphNavigation } from "../lib/system-graph-navigation";
 import { trackingAttrs } from "../lib/analytics/tracking-attrs";
 import { EmptyState } from "./EmptyState";
 import { Icon } from "./Icon";
 import { SystemGraphCanvas } from "./SystemGraphCanvas";
-
-/**
- * V0 mirrors the server's process-lifetime snapshot in the browser tab, with
- * one later-open retry for a degraded projection. SAP-2904 owns source-driven
- * invalidation and user-visible freshness states.
- */
-const loadSystemGraph = createSystemGraphLoader();
 
 interface WorkspaceGraphViewProps {
   workspaceKey: WorkspaceKey;
@@ -29,6 +23,7 @@ interface WorkspaceGraphViewProps {
   api: HarnessApi;
   workflows: readonly WorkflowInfo[];
   workspaceScopes: readonly WorkspaceScopeSummary[];
+  lastMessage: BusMessage | null;
   onOpenAgent: (path: string) => void;
   onExpandRail?: () => void;
 }
@@ -39,29 +34,90 @@ export function WorkspaceGraphView({
   api,
   workflows,
   workspaceScopes,
+  lastMessage,
   onOpenAgent,
   onExpandRail,
 }: WorkspaceGraphViewProps): JSX.Element {
-  const [graph, setGraph] = useState<SystemGraph | null>(null);
+  const [snapshot, setSnapshot] = useState<SystemGraphSnapshot | null>(() =>
+    systemGraphLoader.peek(workspaceKey),
+  );
+  const [announcement, setAnnouncement] = useState<{
+    revision: number;
+    state: SystemGraphLifecycleState;
+  } | null>(null);
   const [error, setError] = useState(false);
-  const [attempt, setAttempt] = useState(0);
+  const [refreshSeq, setRefreshSeq] = useState(0);
 
   useEffect(() => {
     let active = true;
-    setGraph(null);
     setError(false);
-    void loadSystemGraph(api, workspaceKey).then(
+    void systemGraphLoader.load(api, workspaceKey).then(
       (next) => {
-        if (active) setGraph(next);
+        if (!active) return;
+        setSnapshot((current) =>
+          current && current.revision > next.revision ? current : next,
+        );
+        setAnnouncement((current) =>
+          current && current.revision > next.revision ? current : null,
+        );
       },
       () => {
-        if (active) setError(true);
+        if (!active) return;
+        setAnnouncement(null);
+        setError(true);
       },
     );
     return () => {
       active = false;
     };
-  }, [api, workspaceKey, attempt]);
+  }, [api, workspaceKey, refreshSeq]);
+
+  useEffect(() => {
+    if (
+      lastMessage?.type !== "system-graph.changed" ||
+      lastMessage.workspaceKey !== workspaceKey
+    ) {
+      return;
+    }
+    const knownRevision = Math.max(
+      snapshot?.revision ?? -1,
+      announcement?.revision ?? -1,
+    );
+    if (lastMessage.revision <= knownRevision) return;
+    // The global event subscriber already invalidates the shared cache while
+    // this destination is closed. Repeating it here keeps the view correct in
+    // isolation and is a no-op for an already-observed revision.
+    systemGraphLoader.invalidate(workspaceKey, lastMessage.revision);
+    setAnnouncement({
+      revision: lastMessage.revision,
+      state: lastMessage.state,
+    });
+    setError(false);
+    setRefreshSeq((value) => value + 1);
+  }, [announcement?.revision, lastMessage, snapshot?.revision, workspaceKey]);
+
+  const graph = snapshot?.graph ?? null;
+  const announcementIsNewer =
+    announcement !== null && announcement.revision > (snapshot?.revision ?? -1);
+  let lifecycle: SystemGraphLifecycleState = snapshot?.state ?? "building";
+  if (announcementIsNewer) {
+    lifecycle =
+      announcement.state === "degraded"
+        ? "degraded"
+        : graph
+          ? "stale"
+          : "building";
+  }
+  if (error) lifecycle = snapshot?.graph ? "stale" : "degraded";
+  const refreshing =
+    announcementIsNewer && announcement?.state !== "degraded" && !error;
+
+  const retry = (): void => {
+    systemGraphLoader.invalidate(workspaceKey);
+    setAnnouncement(null);
+    setError(false);
+    setRefreshSeq((value) => value + 1);
+  };
 
   const navigation = useMemo(
     () =>
@@ -102,22 +158,73 @@ export function WorkspaceGraphView({
         >
           {workspaceName}
         </span>
+        {refreshing && graph && (
+          <span
+            className="status-tag workspace-graph-lifecycle"
+            data-testid="system-graph-refreshing"
+            data-state="refreshing"
+            role="status"
+          >
+            <span className="canvas-task-spinner" aria-hidden="true" />
+            Refreshing graph
+          </span>
+        )}
+        {lifecycle === "stale" && graph && !refreshing && (
+          <span
+            className="workspace-graph-lifecycle"
+            data-testid="system-graph-stale"
+            data-state="stale"
+            role="status"
+          >
+            <span className="status-tag">
+              <Icon name="TriangleAlert" size={13} />
+              Graph may be out of date
+            </span>
+            {error && (
+              <button
+                type="button"
+                className="status-tag status-tag-action"
+                onClick={retry}
+              >
+                <Icon name="RefreshCw" size={13} />
+                Retry
+              </button>
+            )}
+          </span>
+        )}
+        {lifecycle === "degraded" && graph && (
+          <span
+            className="workspace-graph-lifecycle"
+            data-testid="system-graph-degraded"
+            data-state="degraded"
+            role="status"
+          >
+            <span className="status-tag">
+              <Icon name="TriangleAlert" size={13} />
+              Graph may be incomplete
+            </span>
+            <button
+              type="button"
+              className="status-tag status-tag-action"
+              onClick={retry}
+            >
+              <Icon name="RefreshCw" size={13} />
+              Retry
+            </button>
+          </span>
+        )}
       </header>
 
       <div className="workspace-graph-body">
-        {error ? (
+        {!graph && lifecycle === "degraded" ? (
           <EmptyState
             className="system-graph-state"
             testId="system-graph-error"
             icon="TriangleAlert"
-            title="Couldn't load this workspace graph"
-            body="The local projection failed. Retry the filesystem scan."
+            title="Couldn't build this workspace graph"
+            body="Studio couldn't produce a usable local projection. Retry after the workspace is readable."
             cta={
-              <button
-                type="button"
-                className="btn-primary"
-                onClick={() => setAttempt((value) => value + 1)}
-              >
+              <button type="button" className="btn-primary" onClick={retry}>
                 Retry
               </button>
             }
@@ -130,6 +237,19 @@ export function WorkspaceGraphView({
             <span className="canvas-task-spinner" aria-hidden="true" />
             <p className="canvas-empty-hint">Loading workspace graph…</p>
           </div>
+        ) : graph.nodes.length === 0 && lifecycle === "degraded" ? (
+          <EmptyState
+            className="system-graph-state"
+            testId="system-graph-incomplete"
+            icon="TriangleAlert"
+            title="Workspace graph is incomplete"
+            body="Studio couldn't inspect enough of this workspace to show a reliable graph."
+            cta={
+              <button type="button" className="btn-primary" onClick={retry}>
+                Retry
+              </button>
+            }
+          />
         ) : graph.nodes.length === 0 ? (
           <EmptyState
             className="system-graph-state"

--- a/packages/harness/web/src/components/WorkspaceGraphView.tsx
+++ b/packages/harness/web/src/components/WorkspaceGraphView.tsx
@@ -180,16 +180,14 @@ export function WorkspaceGraphView({
               <Icon name="TriangleAlert" size={13} />
               Graph may be out of date
             </span>
-            {error && (
-              <button
-                type="button"
-                className="status-tag status-tag-action"
-                onClick={retry}
-              >
-                <Icon name="RefreshCw" size={13} />
-                Retry
-              </button>
-            )}
+            <button
+              type="button"
+              className="status-tag status-tag-action"
+              onClick={retry}
+            >
+              <Icon name="RefreshCw" size={13} />
+              Retry
+            </button>
           </span>
         )}
         {lifecycle === "degraded" && graph && (

--- a/packages/harness/web/src/lib/api.test.ts
+++ b/packages/harness/web/src/lib/api.test.ts
@@ -63,6 +63,47 @@ describe("RealApi.getSystemGraph", () => {
       }),
     );
   });
+
+  it("sends explicit graph retries through the refresh route", async () => {
+    if (isMockMode()) return;
+    vi.stubGlobal("window", {
+      __HARNESS__: { token: "test-token" },
+      location: { search: "" },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            workspaceKey: "workspace-test",
+            revision: 8,
+            state: "ready",
+            graph: {
+              kind: "system",
+              scope: {
+                kind: "working-tree",
+                workspaceKey: "workspace-test",
+              },
+              nodes: [],
+              edges: [],
+              warnings: [],
+            },
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    await createApi().getSystemGraph("workspace-test", { refresh: true });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/workspaces/workspace-test/system-graph/refresh",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ "X-Harness-Token": "test-token" }),
+      }),
+    );
+  });
 });
 
 describe("progressiveLeasingRun", () => {

--- a/packages/harness/web/src/lib/api.test.ts
+++ b/packages/harness/web/src/lib/api.test.ts
@@ -1,7 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { SYSTEM_GRAPH_CACHE_HEADER } from "@shared/system-graph";
-
 import {
   createApi,
   isMockMode,
@@ -17,7 +15,7 @@ describe("RealApi.getSystemGraph", () => {
     vi.unstubAllGlobals();
   });
 
-  it("returns transport degradation metadata outside the graph JSON", async () => {
+  it("parses the revisioned graph lifecycle envelope", async () => {
     if (isMockMode()) return;
     const graph = {
       kind: "system",
@@ -33,18 +31,30 @@ describe("RealApi.getSystemGraph", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
-        new Response(JSON.stringify(graph), {
-          status: 200,
-          headers: {
-            "Content-Type": "application/json",
-            [SYSTEM_GRAPH_CACHE_HEADER]: "degraded",
+        new Response(
+          JSON.stringify({
+            workspaceKey: "workspace-test",
+            revision: 7,
+            state: "degraded",
+            graph,
+          }),
+          {
+            status: 200,
+            headers: {
+              "Content-Type": "application/json",
+            },
           },
-        }),
+        ),
       ),
     );
 
     await expect(createApi().getSystemGraph("workspace-test")).resolves.toEqual(
-      { graph, degraded: true },
+      {
+        workspaceKey: "workspace-test",
+        revision: 7,
+        state: "degraded",
+        graph,
+      },
     );
     expect(fetch).toHaveBeenCalledWith(
       "/api/workspaces/workspace-test/system-graph",

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -270,7 +270,10 @@ export interface HarnessApi {
   authStatus(): Promise<AuthStatusResponse>;
   getState(): Promise<AppState>;
   /** Revisioned local dependency projection for one server-issued workspace key. */
-  getSystemGraph(workspaceKey: WorkspaceKey): Promise<SystemGraphSnapshot>;
+  getSystemGraph(
+    workspaceKey: WorkspaceKey,
+    options?: { refresh?: boolean },
+  ): Promise<SystemGraphSnapshot>;
   createSession(req: CreateSessionRequest): Promise<HarnessSession>;
   attachFile(id: string, req: AttachFileRequest): Promise<AttachFileResponse>;
   listSessions(): Promise<HarnessSession[]>;
@@ -421,9 +424,13 @@ class RealApi implements HarnessApi {
 
   async getSystemGraph(
     workspaceKey: WorkspaceKey,
+    options: { refresh?: boolean } = {},
   ): Promise<SystemGraphSnapshot> {
+    const route =
+      `/api/workspaces/${encodeURIComponent(workspaceKey)}/system-graph`;
     const response = await this.response(
-      `/api/workspaces/${encodeURIComponent(workspaceKey)}/system-graph`,
+      options.refresh ? `${route}/refresh` : route,
+      options.refresh ? { method: "POST" } : undefined,
     );
     const snapshot = parseSystemGraphSnapshot(
       (await response.json()) as unknown,
@@ -1060,6 +1067,7 @@ class MockApi implements HarnessApi {
 
   async getSystemGraph(
     workspaceKey: WorkspaceKey,
+    _options: { refresh?: boolean } = {},
   ): Promise<SystemGraphSnapshot> {
     await delay(180);
     if (!this.workspaceScopes().some((scope) => scope.workspaceKey === workspaceKey)) {

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -31,9 +31,8 @@ import type {
   WorkflowInfo,
 } from "@shared/types";
 import {
-  SYSTEM_GRAPH_CACHE_HEADER,
-  type SystemGraphCacheStatus,
   type SystemGraph,
+  type SystemGraphSnapshot,
   type WorkspaceKey,
   type WorkspaceScopeSummary,
 } from "@shared/system-graph";
@@ -41,8 +40,7 @@ import {
 import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
 
 import { getTheme } from "./theme";
-import { parseSystemGraph } from "./system-graph";
-import type { SystemGraphLoadResult } from "./system-graph-loader";
+import { parseSystemGraphSnapshot } from "./system-graph";
 
 import {
   MOCK_ACCOUNT_PLAN,
@@ -271,8 +269,8 @@ export interface HarnessApi {
    */
   authStatus(): Promise<AuthStatusResponse>;
   getState(): Promise<AppState>;
-  /** Static local dependency projection for one server-issued workspace key. */
-  getSystemGraph(workspaceKey: WorkspaceKey): Promise<SystemGraphLoadResult>;
+  /** Revisioned local dependency projection for one server-issued workspace key. */
+  getSystemGraph(workspaceKey: WorkspaceKey): Promise<SystemGraphSnapshot>;
   createSession(req: CreateSessionRequest): Promise<HarnessSession>;
   attachFile(id: string, req: AttachFileRequest): Promise<AttachFileResponse>;
   listSessions(): Promise<HarnessSession[]>;
@@ -423,18 +421,17 @@ class RealApi implements HarnessApi {
 
   async getSystemGraph(
     workspaceKey: WorkspaceKey,
-  ): Promise<SystemGraphLoadResult> {
+  ): Promise<SystemGraphSnapshot> {
     const response = await this.response(
       `/api/workspaces/${encodeURIComponent(workspaceKey)}/system-graph`,
     );
-    const graph = parseSystemGraph((await response.json()) as unknown);
-    if (graph.scope.workspaceKey !== workspaceKey) {
+    const snapshot = parseSystemGraphSnapshot(
+      (await response.json()) as unknown,
+    );
+    if (snapshot.workspaceKey !== workspaceKey) {
       throw new Error("Invalid system graph response");
     }
-    const cacheStatus = response.headers.get(
-      SYSTEM_GRAPH_CACHE_HEADER,
-    ) as SystemGraphCacheStatus | null;
-    return { graph, degraded: cacheStatus === "degraded" };
+    return snapshot;
   }
 
   createSession(req: CreateSessionRequest): Promise<HarnessSession> {
@@ -1063,17 +1060,20 @@ class MockApi implements HarnessApi {
 
   async getSystemGraph(
     workspaceKey: WorkspaceKey,
-  ): Promise<SystemGraphLoadResult> {
+  ): Promise<SystemGraphSnapshot> {
     await delay(180);
     if (!this.workspaceScopes().some((scope) => scope.workspaceKey === workspaceKey)) {
       throw new ApiError(404, "Workspace not found", "Workspace not found");
     }
-    let degraded = false;
+    let state: SystemGraphSnapshot["state"] = "ready";
+    let revision = 1;
     if (typeof window !== "undefined") {
       const win = window as unknown as {
         __HARNESS_TEST__?: Record<string, unknown>;
         __MOCK_SYSTEM_GRAPH_FAIL_ONCE__?: boolean;
         __MOCK_SYSTEM_GRAPH_DEGRADED_REMAINING__?: number;
+        __MOCK_SYSTEM_GRAPH_STATE__?: SystemGraphSnapshot["state"];
+        __MOCK_SYSTEM_GRAPH_REVISION__?: number;
       };
       const previous =
         (win.__HARNESS_TEST__?.systemGraphRequests as WorkspaceKey[] | undefined) ??
@@ -1092,10 +1092,12 @@ class MockApi implements HarnessApi {
       }
       const degradedRemaining =
         win.__MOCK_SYSTEM_GRAPH_DEGRADED_REMAINING__ ?? 0;
-      degraded = degradedRemaining > 0;
-      if (degraded) {
+      if (degradedRemaining > 0) {
+        state = "degraded";
         win.__MOCK_SYSTEM_GRAPH_DEGRADED_REMAINING__ = degradedRemaining - 1;
       }
+      state = win.__MOCK_SYSTEM_GRAPH_STATE__ ?? state;
+      revision = win.__MOCK_SYSTEM_GRAPH_REVISION__ ?? revision;
     }
     const graph: SystemGraph = {
       kind: "system",
@@ -1158,7 +1160,7 @@ class MockApi implements HarnessApi {
       ],
       warnings: [],
     };
-    return { graph, degraded };
+    return { workspaceKey, revision, state, graph };
   }
 
   async createSession(req: CreateSessionRequest): Promise<HarnessSession> {

--- a/packages/harness/web/src/lib/system-graph-loader.test.ts
+++ b/packages/harness/web/src/lib/system-graph-loader.test.ts
@@ -217,11 +217,9 @@ describe("createSystemGraphLoader", () => {
 
     const retiredRequest = loader.load(source, workspaceKey);
     loader.retain(new Set());
+    await expect(loader.load(source, workspaceKey)).resolves.toBe(ready);
     late.resolve(snapshot(1));
     await retiredRequest;
-    expect(loader.peek(workspaceKey)).toBeNull();
-
-    await expect(loader.load(source, workspaceKey)).resolves.toBe(ready);
     expect(loader.peek(workspaceKey)).toBe(ready);
     expect(getSystemGraph).toHaveBeenCalledTimes(2);
   });

--- a/packages/harness/web/src/lib/system-graph-loader.test.ts
+++ b/packages/harness/web/src/lib/system-graph-loader.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
-import type { SystemGraph, WorkspaceKey } from "@shared/system-graph";
+import type {
+  SystemGraph,
+  SystemGraphLifecycleState,
+  SystemGraphSnapshot,
+  WorkspaceKey,
+} from "@shared/system-graph";
 
 import {
   createSystemGraphLoader,
@@ -16,44 +21,208 @@ const graph: SystemGraph = {
   warnings: [],
 };
 
+const snapshot = (
+  revision: number,
+  state: SystemGraphLifecycleState = "ready",
+): SystemGraphSnapshot => ({ workspaceKey, revision, state, graph });
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
 describe("createSystemGraphLoader", () => {
-  it("coalesces requests and retains a complete graph", async () => {
-    const getSystemGraph = vi.fn(async () => ({ graph, degraded: false }));
-    const load = createSystemGraphLoader();
+  it("coalesces requests and retains a ready snapshot", async () => {
+    const ready = snapshot(1);
+    const getSystemGraph = vi.fn(async () => ready);
+    const loader = createSystemGraphLoader();
     const source: SystemGraphSource = { getSystemGraph };
 
-    const first = load(source, workspaceKey);
-    expect(load(source, workspaceKey)).toBe(first);
-    await expect(first).resolves.toBe(graph);
-    expect(load(source, workspaceKey)).toBe(first);
+    const first = loader.load(source, workspaceKey);
+    expect(loader.load(source, workspaceKey)).toBe(first);
+    await expect(first).resolves.toBe(ready);
+    expect(loader.load(source, workspaceKey)).toBe(first);
     expect(getSystemGraph).toHaveBeenCalledTimes(1);
   });
 
-  it("allows one later-open retry and retains a second degraded graph", async () => {
-    const getSystemGraph = vi.fn(async () => ({ graph, degraded: true }));
-    const load = createSystemGraphLoader();
+  it("allows one later-open retry and retains a second degraded snapshot", async () => {
+    const degraded = snapshot(1, "degraded");
+    const getSystemGraph = vi.fn(async () => degraded);
+    const loader = createSystemGraphLoader();
     const source: SystemGraphSource = { getSystemGraph };
 
-    const first = load(source, workspaceKey);
-    expect(load(source, workspaceKey)).toBe(first);
-    await expect(first).resolves.toBe(graph);
+    const first = loader.load(source, workspaceKey);
+    expect(loader.load(source, workspaceKey)).toBe(first);
+    await expect(first).resolves.toBe(degraded);
 
-    const second = load(source, workspaceKey);
-    await expect(second).resolves.toBe(graph);
-    expect(load(source, workspaceKey)).toBe(second);
+    const second = loader.load(source, workspaceKey);
+    await expect(second).resolves.toBe(degraded);
+    expect(loader.load(source, workspaceKey)).toBe(second);
+    expect(getSystemGraph).toHaveBeenCalledTimes(2);
+  });
+
+  it("allows one later-open retry for a stale last-known snapshot", async () => {
+    const stale = snapshot(2, "stale");
+    const ready = snapshot(3);
+    const getSystemGraph = vi
+      .fn()
+      .mockResolvedValueOnce(stale)
+      .mockResolvedValueOnce(ready);
+    const loader = createSystemGraphLoader();
+    const source: SystemGraphSource = { getSystemGraph };
+
+    await expect(loader.load(source, workspaceKey)).resolves.toBe(stale);
+    await expect(loader.load(source, workspaceKey)).resolves.toBe(ready);
+
+    expect(loader.peek(workspaceKey)).toBe(ready);
+    expect(getSystemGraph).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retain an initial building response forever", async () => {
+    const building: SystemGraphSnapshot = {
+      workspaceKey,
+      revision: 0,
+      state: "building",
+      graph: null,
+    };
+    const ready = snapshot(1);
+    const getSystemGraph = vi
+      .fn()
+      .mockResolvedValueOnce(building)
+      .mockResolvedValueOnce(ready);
+    const loader = createSystemGraphLoader();
+    const source: SystemGraphSource = { getSystemGraph };
+
+    await expect(loader.load(source, workspaceKey)).resolves.toBe(building);
+    await expect(loader.load(source, workspaceKey)).resolves.toBe(ready);
+
     expect(getSystemGraph).toHaveBeenCalledTimes(2);
   });
 
   it("retries a rejected request without consuming the degraded retry", async () => {
+    const ready = snapshot(1);
     const getSystemGraph = vi
       .fn()
       .mockRejectedValueOnce(new Error("scan failed"))
-      .mockResolvedValueOnce({ graph, degraded: false });
-    const load = createSystemGraphLoader();
+      .mockResolvedValueOnce(ready);
+    const loader = createSystemGraphLoader();
     const source: SystemGraphSource = { getSystemGraph };
 
-    await expect(load(source, workspaceKey)).rejects.toThrow("scan failed");
-    await expect(load(source, workspaceKey)).resolves.toBe(graph);
+    await expect(loader.load(source, workspaceKey)).rejects.toThrow(
+      "scan failed",
+    );
+    await expect(loader.load(source, workspaceKey)).resolves.toBe(ready);
+    expect(getSystemGraph).toHaveBeenCalledTimes(2);
+  });
+
+  it("forces a network request for an explicit retry at the same revision", async () => {
+    const degraded = snapshot(1, "degraded");
+    const ready = snapshot(1);
+    const getSystemGraph = vi
+      .fn()
+      .mockResolvedValueOnce(degraded)
+      .mockResolvedValueOnce(ready);
+    const loader = createSystemGraphLoader();
+    const source: SystemGraphSource = { getSystemGraph };
+    await loader.load(source, workspaceKey);
+
+    expect(loader.invalidate(workspaceKey)).toBe(true);
+    await expect(loader.load(source, workspaceKey)).resolves.toBe(ready);
+
+    expect(loader.peek(workspaceKey)).toBe(ready);
+    expect(getSystemGraph).toHaveBeenCalledTimes(2);
+  });
+
+  it("never lets an older in-flight response overwrite a newer revision", async () => {
+    const oldRequest = deferred<SystemGraphSnapshot>();
+    const newRequest = deferred<SystemGraphSnapshot>();
+    const getSystemGraph = vi
+      .fn()
+      .mockReturnValueOnce(oldRequest.promise)
+      .mockReturnValueOnce(newRequest.promise);
+    const loader = createSystemGraphLoader();
+    const source: SystemGraphSource = { getSystemGraph };
+
+    const first = loader.load(source, workspaceKey);
+    expect(loader.invalidate(workspaceKey, 2)).toBe(true);
+    const second = loader.load(source, workspaceKey);
+    oldRequest.resolve(snapshot(1));
+    newRequest.resolve(snapshot(2));
+
+    await expect(first).resolves.toEqual(snapshot(2));
+    await expect(second).resolves.toEqual(snapshot(2));
+    expect(loader.peek(workspaceKey)).toEqual(snapshot(2));
+    expect(getSystemGraph).toHaveBeenCalledTimes(2);
+  });
+
+  it("accepts an in-flight response that already matches a new announcement", async () => {
+    const pending = deferred<SystemGraphSnapshot>();
+    const getSystemGraph = vi.fn(() => pending.promise);
+    const loader = createSystemGraphLoader();
+    const source: SystemGraphSource = { getSystemGraph };
+
+    const first = loader.load(source, workspaceKey);
+    expect(loader.invalidate(workspaceKey, 2)).toBe(true);
+    pending.resolve(snapshot(2));
+
+    await expect(first).resolves.toEqual(snapshot(2));
+    await expect(loader.load(source, workspaceKey)).resolves.toEqual(
+      snapshot(2),
+    );
+    expect(getSystemGraph).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores old announcements and invalidates only their workspace", async () => {
+    const otherKey = "workspace-other";
+    let otherRevision = 3;
+    const getSystemGraph = vi.fn(async (key: WorkspaceKey) => ({
+      ...snapshot(key === otherKey ? otherRevision : 3),
+      workspaceKey: key,
+      graph: {
+        ...graph,
+        scope: { kind: "working-tree" as const, workspaceKey: key },
+      },
+    }));
+    const loader = createSystemGraphLoader();
+    const source: SystemGraphSource = { getSystemGraph };
+    await Promise.all([
+      loader.load(source, workspaceKey),
+      loader.load(source, otherKey),
+    ]);
+
+    expect(loader.invalidate(workspaceKey, 3)).toBe(false);
+    expect(loader.invalidate(otherKey, 4)).toBe(true);
+    otherRevision = 4;
+    await loader.load(source, workspaceKey);
+    await loader.load(source, otherKey);
+
+    expect(getSystemGraph).toHaveBeenCalledTimes(3);
+  });
+
+  it("retires removed workspace snapshots and rejects their late responses", async () => {
+    const late = deferred<SystemGraphSnapshot>();
+    const ready = snapshot(2);
+    const getSystemGraph = vi
+      .fn()
+      .mockReturnValueOnce(late.promise)
+      .mockResolvedValueOnce(ready);
+    const loader = createSystemGraphLoader();
+    const source: SystemGraphSource = { getSystemGraph };
+
+    const retiredRequest = loader.load(source, workspaceKey);
+    loader.retain(new Set());
+    late.resolve(snapshot(1));
+    await retiredRequest;
+    expect(loader.peek(workspaceKey)).toBeNull();
+
+    await expect(loader.load(source, workspaceKey)).resolves.toBe(ready);
+    expect(loader.peek(workspaceKey)).toBe(ready);
     expect(getSystemGraph).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/harness/web/src/lib/system-graph-loader.test.ts
+++ b/packages/harness/web/src/lib/system-graph-loader.test.ts
@@ -137,6 +137,33 @@ describe("createSystemGraphLoader", () => {
 
     expect(loader.peek(workspaceKey)).toBe(ready);
     expect(getSystemGraph).toHaveBeenCalledTimes(2);
+    expect(getSystemGraph).toHaveBeenNthCalledWith(1, workspaceKey);
+    expect(getSystemGraph).toHaveBeenNthCalledWith(2, workspaceKey, {
+      refresh: true,
+    });
+  });
+
+  it("accepts an explicit retry response after its lifecycle announcements", async () => {
+    const pending = deferred<SystemGraphSnapshot>();
+    const getSystemGraph = vi
+      .fn()
+      .mockResolvedValueOnce(snapshot(1, "degraded"))
+      .mockReturnValueOnce(pending.promise);
+    const loader = createSystemGraphLoader();
+    const source: SystemGraphSource = { getSystemGraph };
+    await loader.load(source, workspaceKey);
+
+    loader.invalidate(workspaceKey);
+    const retry = loader.load(source, workspaceKey);
+    await vi.waitFor(() => expect(getSystemGraph).toHaveBeenCalledTimes(2));
+    loader.invalidate(workspaceKey, 2);
+    pending.resolve(snapshot(2));
+
+    await expect(retry).resolves.toEqual(snapshot(2));
+    await expect(loader.load(source, workspaceKey)).resolves.toEqual(
+      snapshot(2),
+    );
+    expect(getSystemGraph).toHaveBeenCalledTimes(2);
   });
 
   it("never lets an older in-flight response overwrite a newer revision", async () => {

--- a/packages/harness/web/src/lib/system-graph-loader.ts
+++ b/packages/harness/web/src/lib/system-graph-loader.ts
@@ -1,7 +1,10 @@
 import type { SystemGraphSnapshot, WorkspaceKey } from "@shared/system-graph";
 
 export interface SystemGraphSource {
-  getSystemGraph(workspaceKey: WorkspaceKey): Promise<SystemGraphSnapshot>;
+  getSystemGraph(
+    workspaceKey: WorkspaceKey,
+    options?: { refresh?: boolean },
+  ): Promise<SystemGraphSnapshot>;
 }
 
 export interface SystemGraphLoader {
@@ -80,10 +83,15 @@ export function createSystemGraphLoader(): SystemGraphLoader {
       return promise;
     }
     if (shouldRetry) retryConsumed.add(workspaceKey);
+    const explicitRefresh = forcedReloads.has(workspaceKey);
 
     let request!: Promise<SystemGraphSnapshot>;
     request = Promise.resolve()
-      .then(() => source.getSystemGraph(workspaceKey))
+      .then(() =>
+        explicitRefresh
+          ? source.getSystemGraph(workspaceKey, { refresh: true })
+          : source.getSystemGraph(workspaceKey),
+      )
       .then((snapshot) => {
         if (snapshot.workspaceKey !== workspaceKey) {
           throw new Error("Invalid system graph response");
@@ -97,7 +105,8 @@ export function createSystemGraphLoader(): SystemGraphLoader {
         if (
           snapshot.revision < newestAnnouncement ||
           (lifetime.generation !== generation &&
-            forcedReloads.has(workspaceKey))
+            forcedReloads.has(workspaceKey) &&
+            !explicitRefresh)
         ) {
           if (requests.get(workspaceKey)?.promise === request) {
             requests.delete(workspaceKey);

--- a/packages/harness/web/src/lib/system-graph-loader.ts
+++ b/packages/harness/web/src/lib/system-graph-loader.ts
@@ -1,42 +1,166 @@
-import type { SystemGraph, WorkspaceKey } from "@shared/system-graph";
-
-export interface SystemGraphLoadResult {
-  graph: SystemGraph;
-  degraded: boolean;
-}
+import type { SystemGraphSnapshot, WorkspaceKey } from "@shared/system-graph";
 
 export interface SystemGraphSource {
-  getSystemGraph(workspaceKey: WorkspaceKey): Promise<SystemGraphLoadResult>;
+  getSystemGraph(workspaceKey: WorkspaceKey): Promise<SystemGraphSnapshot>;
 }
 
-/** Process-lifetime browser cache with one later-open retry for degradation. */
-export function createSystemGraphLoader(): (
-  source: SystemGraphSource,
-  workspaceKey: WorkspaceKey,
-) => Promise<SystemGraph> {
-  const requests = new Map<WorkspaceKey, Promise<SystemGraph>>();
-  const degradedRetries = new Set<WorkspaceKey>();
+export interface SystemGraphLoader {
+  load(
+    source: SystemGraphSource,
+    workspaceKey: WorkspaceKey,
+  ): Promise<SystemGraphSnapshot>;
+  /** Invalidates only a newer announcement; omit revision for an explicit retry. */
+  invalidate(workspaceKey: WorkspaceKey, revision?: number): boolean;
+  /** Drops browser state for workspace scopes Studio no longer exposes. */
+  retain(workspaceKeys: ReadonlySet<WorkspaceKey>): void;
+  peek(workspaceKey: WorkspaceKey): SystemGraphSnapshot | null;
+}
 
-  return (source, workspaceKey) => {
+/**
+ * Process-lifetime browser cache keyed by the server's opaque workspace key.
+ * Revisions invalidate resolved and in-flight requests, and a generation guard
+ * makes an older HTTP response follow the newest request instead of poisoning
+ * the cache after a source edit.
+ */
+export function createSystemGraphLoader(): SystemGraphLoader {
+  const requests = new Map<
+    WorkspaceKey,
+    { generation: number; promise: Promise<SystemGraphSnapshot> }
+  >();
+  const snapshots = new Map<WorkspaceKey, SystemGraphSnapshot>();
+  const generations = new Map<WorkspaceKey, number>();
+  const announcedRevisions = new Map<WorkspaceKey, number>();
+  const forcedReloads = new Set<WorkspaceKey>();
+  const retryableSeen = new Set<WorkspaceKey>();
+  const retryConsumed = new Set<WorkspaceKey>();
+  const discardBeforeGeneration = new Map<WorkspaceKey, number>();
+
+  const generationFor = (workspaceKey: WorkspaceKey): number =>
+    generations.get(workspaceKey) ?? 0;
+
+  const load = (
+    source: SystemGraphSource,
+    workspaceKey: WorkspaceKey,
+  ): Promise<SystemGraphSnapshot> => {
+    const generation = generationFor(workspaceKey);
     const existing = requests.get(workspaceKey);
-    if (existing) return existing;
+    if (existing?.generation === generation) return existing.promise;
 
-    let request: Promise<SystemGraph>;
-    request = source.getSystemGraph(workspaceKey).then((result) => {
-      if (result.degraded && !degradedRetries.has(workspaceKey)) {
-        degradedRetries.add(workspaceKey);
-        if (requests.get(workspaceKey) === request) {
-          requests.delete(workspaceKey);
+    const cached = snapshots.get(workspaceKey);
+    const announcedRevision = announcedRevisions.get(workspaceKey) ?? -1;
+    const cachedIsRetryable = cached !== undefined && cached.state !== "ready";
+    const shouldRetry =
+      cachedIsRetryable &&
+      retryableSeen.has(workspaceKey) &&
+      !retryConsumed.has(workspaceKey);
+    if (
+      cached &&
+      cached.revision >= announcedRevision &&
+      !forcedReloads.has(workspaceKey) &&
+      !shouldRetry
+    ) {
+      const promise = Promise.resolve(cached);
+      requests.set(workspaceKey, { generation, promise });
+      return promise;
+    }
+    if (shouldRetry) retryConsumed.add(workspaceKey);
+
+    let request!: Promise<SystemGraphSnapshot>;
+    request = Promise.resolve()
+      .then(() => source.getSystemGraph(workspaceKey))
+      .then((snapshot) => {
+        if (snapshot.workspaceKey !== workspaceKey) {
+          throw new Error("Invalid system graph response");
         }
-      }
-      return result.graph;
-    });
-    requests.set(workspaceKey, request);
+        if (
+          generation < (discardBeforeGeneration.get(workspaceKey) ?? -1)
+        ) {
+          // The scope was retired while this request was in flight. Its caller
+          // may finish, but the response cannot repopulate browser state.
+          return snapshot;
+        }
+        const newestAnnouncement = announcedRevisions.get(workspaceKey) ?? -1;
+        if (
+          snapshot.revision < newestAnnouncement ||
+          (generationFor(workspaceKey) !== generation &&
+            forcedReloads.has(workspaceKey))
+        ) {
+          if (requests.get(workspaceKey)?.promise === request) {
+            requests.delete(workspaceKey);
+          }
+          return load(source, workspaceKey);
+        }
+
+        snapshots.set(workspaceKey, snapshot);
+        forcedReloads.delete(workspaceKey);
+        if (
+          snapshot.state !== "ready" &&
+          !retryableSeen.has(workspaceKey)
+        ) {
+          retryableSeen.add(workspaceKey);
+          // A later open gets one recovery attempt. Keep the snapshot itself
+          // so the current view can continue showing loading, partial, or
+          // last-good data.
+          if (requests.get(workspaceKey)?.promise === request) {
+            requests.delete(workspaceKey);
+          }
+        } else if (snapshot.state === "ready") {
+          retryableSeen.delete(workspaceKey);
+          retryConsumed.delete(workspaceKey);
+        }
+        return snapshot;
+      });
+    requests.set(workspaceKey, { generation, promise: request });
     void request.catch(() => {
-      if (requests.get(workspaceKey) === request) {
+      if (requests.get(workspaceKey)?.promise === request) {
         requests.delete(workspaceKey);
       }
     });
     return request;
   };
+
+  return {
+    load,
+    invalidate(workspaceKey, revision) {
+      const knownRevision = Math.max(
+        snapshots.get(workspaceKey)?.revision ?? -1,
+        announcedRevisions.get(workspaceKey) ?? -1,
+      );
+      if (revision !== undefined && revision <= knownRevision) return false;
+      if (revision !== undefined)
+        announcedRevisions.set(workspaceKey, revision);
+      else forcedReloads.add(workspaceKey);
+      generations.set(workspaceKey, generationFor(workspaceKey) + 1);
+      requests.delete(workspaceKey);
+      retryableSeen.delete(workspaceKey);
+      retryConsumed.delete(workspaceKey);
+      return true;
+    },
+    retain(workspaceKeys) {
+      const cachedKeys = new Set<WorkspaceKey>([
+        ...requests.keys(),
+        ...snapshots.keys(),
+        ...announcedRevisions.keys(),
+        ...forcedReloads,
+        ...retryableSeen,
+        ...retryConsumed,
+      ]);
+      for (const workspaceKey of cachedKeys) {
+        if (workspaceKeys.has(workspaceKey)) continue;
+        const generation = generationFor(workspaceKey) + 1;
+        generations.set(workspaceKey, generation);
+        discardBeforeGeneration.set(workspaceKey, generation);
+        requests.delete(workspaceKey);
+        snapshots.delete(workspaceKey);
+        announcedRevisions.delete(workspaceKey);
+        forcedReloads.delete(workspaceKey);
+        retryableSeen.delete(workspaceKey);
+        retryConsumed.delete(workspaceKey);
+      }
+    },
+    peek: (workspaceKey) => snapshots.get(workspaceKey) ?? null,
+  };
 }
+
+/** One cache for the browser tab, invalidated by the global event subscriber. */
+export const systemGraphLoader = createSystemGraphLoader();

--- a/packages/harness/web/src/lib/system-graph-loader.ts
+++ b/packages/harness/web/src/lib/system-graph-loader.ts
@@ -23,28 +23,44 @@ export interface SystemGraphLoader {
  * the cache after a source edit.
  */
 export function createSystemGraphLoader(): SystemGraphLoader {
+  interface WorkspaceLifetime {
+    generation: number;
+    retired: boolean;
+  }
+
   const requests = new Map<
     WorkspaceKey,
-    { generation: number; promise: Promise<SystemGraphSnapshot> }
+    {
+      lifetime: WorkspaceLifetime;
+      generation: number;
+      promise: Promise<SystemGraphSnapshot>;
+    }
   >();
   const snapshots = new Map<WorkspaceKey, SystemGraphSnapshot>();
-  const generations = new Map<WorkspaceKey, number>();
+  const lifetimes = new Map<WorkspaceKey, WorkspaceLifetime>();
   const announcedRevisions = new Map<WorkspaceKey, number>();
   const forcedReloads = new Set<WorkspaceKey>();
   const retryableSeen = new Set<WorkspaceKey>();
   const retryConsumed = new Set<WorkspaceKey>();
-  const discardBeforeGeneration = new Map<WorkspaceKey, number>();
 
-  const generationFor = (workspaceKey: WorkspaceKey): number =>
-    generations.get(workspaceKey) ?? 0;
+  const lifetimeFor = (workspaceKey: WorkspaceKey): WorkspaceLifetime => {
+    const existing = lifetimes.get(workspaceKey);
+    if (existing) return existing;
+    const lifetime = { generation: 0, retired: false };
+    lifetimes.set(workspaceKey, lifetime);
+    return lifetime;
+  };
 
   const load = (
     source: SystemGraphSource,
     workspaceKey: WorkspaceKey,
   ): Promise<SystemGraphSnapshot> => {
-    const generation = generationFor(workspaceKey);
+    const lifetime = lifetimeFor(workspaceKey);
+    const generation = lifetime.generation;
     const existing = requests.get(workspaceKey);
-    if (existing?.generation === generation) return existing.promise;
+    if (existing?.lifetime === lifetime && existing.generation === generation) {
+      return existing.promise;
+    }
 
     const cached = snapshots.get(workspaceKey);
     const announcedRevision = announcedRevisions.get(workspaceKey) ?? -1;
@@ -60,7 +76,7 @@ export function createSystemGraphLoader(): SystemGraphLoader {
       !shouldRetry
     ) {
       const promise = Promise.resolve(cached);
-      requests.set(workspaceKey, { generation, promise });
+      requests.set(workspaceKey, { lifetime, generation, promise });
       return promise;
     }
     if (shouldRetry) retryConsumed.add(workspaceKey);
@@ -72,9 +88,7 @@ export function createSystemGraphLoader(): SystemGraphLoader {
         if (snapshot.workspaceKey !== workspaceKey) {
           throw new Error("Invalid system graph response");
         }
-        if (
-          generation < (discardBeforeGeneration.get(workspaceKey) ?? -1)
-        ) {
+        if (lifetime.retired) {
           // The scope was retired while this request was in flight. Its caller
           // may finish, but the response cannot repopulate browser state.
           return snapshot;
@@ -82,7 +96,7 @@ export function createSystemGraphLoader(): SystemGraphLoader {
         const newestAnnouncement = announcedRevisions.get(workspaceKey) ?? -1;
         if (
           snapshot.revision < newestAnnouncement ||
-          (generationFor(workspaceKey) !== generation &&
+          (lifetime.generation !== generation &&
             forcedReloads.has(workspaceKey))
         ) {
           if (requests.get(workspaceKey)?.promise === request) {
@@ -110,7 +124,7 @@ export function createSystemGraphLoader(): SystemGraphLoader {
         }
         return snapshot;
       });
-    requests.set(workspaceKey, { generation, promise: request });
+    requests.set(workspaceKey, { lifetime, generation, promise: request });
     void request.catch(() => {
       if (requests.get(workspaceKey)?.promise === request) {
         requests.delete(workspaceKey);
@@ -130,7 +144,7 @@ export function createSystemGraphLoader(): SystemGraphLoader {
       if (revision !== undefined)
         announcedRevisions.set(workspaceKey, revision);
       else forcedReloads.add(workspaceKey);
-      generations.set(workspaceKey, generationFor(workspaceKey) + 1);
+      lifetimeFor(workspaceKey).generation += 1;
       requests.delete(workspaceKey);
       retryableSeen.delete(workspaceKey);
       retryConsumed.delete(workspaceKey);
@@ -140,6 +154,7 @@ export function createSystemGraphLoader(): SystemGraphLoader {
       const cachedKeys = new Set<WorkspaceKey>([
         ...requests.keys(),
         ...snapshots.keys(),
+        ...lifetimes.keys(),
         ...announcedRevisions.keys(),
         ...forcedReloads,
         ...retryableSeen,
@@ -147,9 +162,9 @@ export function createSystemGraphLoader(): SystemGraphLoader {
       ]);
       for (const workspaceKey of cachedKeys) {
         if (workspaceKeys.has(workspaceKey)) continue;
-        const generation = generationFor(workspaceKey) + 1;
-        generations.set(workspaceKey, generation);
-        discardBeforeGeneration.set(workspaceKey, generation);
+        const lifetime = lifetimes.get(workspaceKey);
+        if (lifetime) lifetime.retired = true;
+        lifetimes.delete(workspaceKey);
         requests.delete(workspaceKey);
         snapshots.delete(workspaceKey);
         announcedRevisions.delete(workspaceKey);

--- a/packages/harness/web/src/lib/system-graph.test.ts
+++ b/packages/harness/web/src/lib/system-graph.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { SystemGraph } from "@shared/system-graph";
 
-import { groupSystemGraphEdges, parseSystemGraph } from "./system-graph";
+import {
+  groupSystemGraphEdges,
+  parseSystemGraph,
+  parseSystemGraphSnapshot,
+} from "./system-graph";
 
 const valid: SystemGraph = {
   kind: "system",
@@ -90,6 +94,78 @@ describe("parseSystemGraph", () => {
       parseSystemGraph({
         ...valid,
         edges: [{ ...valid.edges[0], mode: "unknown" }],
+      }),
+    ).toThrow("Invalid system graph response");
+  });
+});
+
+describe("parseSystemGraphSnapshot", () => {
+  it("accepts every honest lifecycle shape", () => {
+    expect(
+      parseSystemGraphSnapshot({
+        workspaceKey: "workspace-test",
+        revision: 1,
+        state: "building",
+        graph: null,
+      }),
+    ).toEqual({
+      workspaceKey: "workspace-test",
+      revision: 1,
+      state: "building",
+      graph: null,
+    });
+    for (const state of ["ready", "stale", "degraded"] as const) {
+      expect(
+        parseSystemGraphSnapshot({
+          workspaceKey: "workspace-test",
+          revision: 2,
+          state,
+          graph: valid,
+        }).state,
+      ).toBe(state);
+    }
+    expect(
+      parseSystemGraphSnapshot({
+        workspaceKey: "workspace-test",
+        revision: 3,
+        state: "degraded",
+        graph: null,
+      }).graph,
+    ).toBeNull();
+  });
+
+  it("rejects cross-workspace, path-bearing, and impossible snapshots", () => {
+    expect(() =>
+      parseSystemGraphSnapshot({
+        workspaceKey: "workspace-other",
+        revision: 1,
+        state: "ready",
+        graph: valid,
+      }),
+    ).toThrow("Invalid system graph response");
+    expect(() =>
+      parseSystemGraphSnapshot({
+        workspaceKey: "workspace-test",
+        revision: 1,
+        state: "stale",
+        graph: null,
+      }),
+    ).toThrow("Invalid system graph response");
+    expect(() =>
+      parseSystemGraphSnapshot({
+        workspaceKey: "workspace-test",
+        revision: 1,
+        state: "ready",
+        graph: valid,
+        root: "/private/workspace",
+      }),
+    ).toThrow("Invalid system graph response");
+    expect(() =>
+      parseSystemGraphSnapshot({
+        workspaceKey: "workspace-test",
+        revision: 1,
+        state: "building",
+        graph: valid,
       }),
     ).toThrow("Invalid system graph response");
   });

--- a/packages/harness/web/src/lib/system-graph.ts
+++ b/packages/harness/web/src/lib/system-graph.ts
@@ -2,7 +2,9 @@ import type {
   GraphWarning,
   SystemGraph,
   SystemGraphEdge,
+  SystemGraphLifecycleState,
   SystemGraphNode,
+  SystemGraphSnapshot,
 } from "@shared/system-graph";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -184,5 +186,47 @@ export function parseSystemGraph(value: unknown): SystemGraph {
     nodes: typedNodes,
     edges: typedEdges,
     warnings: typedWarnings,
+  };
+}
+const LIFECYCLE_STATES = new Set<SystemGraphLifecycleState>([
+  "building",
+  "ready",
+  "stale",
+  "degraded",
+]);
+
+/** Treat the lifecycle envelope as untrusted and keep it path-free. */
+export function parseSystemGraphSnapshot(value: unknown): SystemGraphSnapshot {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, ["workspaceKey", "revision", "state", "graph"]) ||
+    typeof value.workspaceKey !== "string" ||
+    !Number.isSafeInteger(value.revision) ||
+    (value.revision as number) < 0 ||
+    typeof value.state !== "string" ||
+    !LIFECYCLE_STATES.has(value.state as SystemGraphLifecycleState) ||
+    (value.graph !== null && !isRecord(value.graph))
+  ) {
+    throw new Error("Invalid system graph response");
+  }
+
+  const state = value.state as SystemGraphLifecycleState;
+  const graph = value.graph === null ? null : parseSystemGraph(value.graph);
+  if (
+    (state === "building" && graph !== null) ||
+    (state === "ready" || state === "stale") &&
+    graph === null
+  ) {
+    throw new Error("Invalid system graph response");
+  }
+  if (graph && graph.scope.workspaceKey !== value.workspaceKey) {
+    throw new Error("Invalid system graph response");
+  }
+
+  return {
+    workspaceKey: value.workspaceKey,
+    revision: value.revision as number,
+    state,
+    graph,
   };
 }

--- a/packages/harness/web/src/lib/system-graph.ts
+++ b/packages/harness/web/src/lib/system-graph.ts
@@ -214,8 +214,7 @@ export function parseSystemGraphSnapshot(value: unknown): SystemGraphSnapshot {
   const graph = value.graph === null ? null : parseSystemGraph(value.graph);
   if (
     (state === "building" && graph !== null) ||
-    (state === "ready" || state === "stale") &&
-    graph === null
+    ((state === "ready" || state === "stale") && graph === null)
   ) {
     throw new Error("Invalid system graph response");
   }

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -39,6 +39,7 @@ import { isWithinDir } from "./paths";
 import { mergeHistory } from "./history-meta";
 import { createToastMessage, type ToastMessage, type ToastTone } from "./toast";
 import { subscribeEvents } from "./events";
+import { systemGraphLoader } from "./system-graph-loader";
 import { track as trackProduct } from "./analytics/events";
 import {
   agentProvenance,
@@ -320,6 +321,15 @@ export interface HarnessStateHook {
 /** Central store for the SPA shell: fetches AppState + settings once, then keeps sessions/workflows fresh via the event bus. */
 export function useHarnessState(): HarnessStateHook {
   const [state, setState] = useState<AppState | null>(null);
+
+  useEffect(() => {
+    if (!state) return;
+    systemGraphLoader.retain(
+      new Set(
+        (state.workspaceScopes ?? []).map((scope) => scope.workspaceKey),
+      ),
+    );
+  }, [state?.workspaceScopes]);
   const [settings, setSettings] = useState<HarnessSettings | null>(null);
   /**
    * Mirror of `settings` for the one reader that cannot wait for a re-render:
@@ -1041,6 +1051,10 @@ export function useHarnessState(): HarnessStateHook {
             });
           }
         });
+      } else if (message.type === "system-graph.changed") {
+        // Invalidate even while its workspace destination is closed. The next
+        // open must never resurrect a pre-edit process-lifetime promise.
+        systemGraphLoader.invalidate(message.workspaceKey, message.revision);
       } else if (message.type === "execution.started") {
         startRunPolling(
           message.harnessSessionId,

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -4096,6 +4096,22 @@ button.rail-footer-card:hover {
   white-space: nowrap;
 }
 
+.workspace-graph-lifecycle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp1);
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.workspace-graph-lifecycle[data-state="degraded"] > .status-tag {
+  color: var(--text-warning);
+}
+
+.workspace-graph-lifecycle[data-state="stale"] > .status-tag {
+  color: var(--text-warning);
+}
+
 .workspace-graph-body,
 .system-graph-canvas,
 .system-graph-viewport {


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The V0 workspace dependency graph was a process-lifetime snapshot. Source edits and agent inventory changes could leave it stale until Studio restarted, sessionless workspaces had no watcher, and neither the server nor browser could reject late refresh results or distinguish current, stale, and partial data.

## Summary and scope

- Add a path-free, revisioned `SystemGraphSnapshot` lifecycle and `system-graph.changed` event.
- Cache successful relationship extraction per caller fingerprint while reprojecting against the latest inventory and retaining caches across active workspaces.
- Replace the promise-only store with last-good snapshots, monotonic revisions, generation guards, dirty follow-up refreshes, bounded recovery, and scope retirement.
- Add one session-independent graph watcher per opened workspace, including async registry-scoped polling, canonical targeted source invalidation, and bounded exponential recovery for failed inventory scans.
- Invalidate the browser cache by workspace revision and prevent late promises or retired scopes from repopulating it.
- Route explicit Retry actions through a protected registry-rescan + awaited graph refresh, while coalescing the refresh's own lifecycle announcements.
- Keep SAP-2905's full-main graph mounted while showing building, refreshing, stale, degraded, cold-failed, and recovered states.

This remains the V0 static direct-dependency graph. Runtime dependencies, transitive inference, graph history, operational overlays, cloud extraction, and changes to the per-agent Canvas are intentionally out of scope.

## Related work

Related issue or discussion: [SAP-2904](https://linear.app/sapiom/issue/SAP-2904/keep-the-local-workspace-graph-fresh-and-honest)

Stacked on #720 (SAP-2905), which owns the full-main graph destination and renderer.

## Validation

```text
pnpm exec vitest run <10 SAP-2904 graph/store/watcher/server/browser files> — 82/82 passed
pnpm exec vitest run --config vitest.perf.config.ts — 5/5 passed
pnpm --filter @sapiom/harness lint — passed with 0 errors (one pre-existing unused-import warning in src/server/rest.test.ts)
pnpm --filter @sapiom/harness typecheck — passed
pnpm --filter @sapiom/harness build — passed
pnpm exec playwright test --config web/e2e/playwright.config.ts --grep "workspace graph" — 5/5 passed, including mobile
pnpm exec prettier --check <new SAP-2904 files> — passed
pnpm --filter @sapiom/harness test — 2,239/2,240 unit tests passed; the sole chmod-based unreadable-directory assertion also fails unchanged on the untouched SAP-2905 base because this sandbox can read chmod(000) directories
pnpm exec vitest run src/core/workspace-watcher.test.ts -t "distinguishes an unreadable project" (SAP-2905 base) — reproduced the same environment-only failure
```

The lint, typecheck, production build, focused formatting, unit/integration/performance tests, and browser tests cover the applicable gates.

### Tests and documentation

Added unit coverage for caller-cache reuse and pruning, store lifecycle/races/manual recovery, bounded watcher backoff, per-root async polling beyond 400 source files, native watcher path routing/error fallback, symlinked/deleted-path attribution, snapshot parsing, browser revision/retry races, and workspace cache retirement without lifetime-map leaks. Added a real-server sessionless test covering invocation add/remove, agent add/rename/slug-change/delete, protected manual refresh, path-free payloads, and lifecycle events, plus Playwright lifecycle/recovery coverage.

No standalone guide was changed: the behavior is local Studio lifecycle UI and is documented by public types/JSDoc and the included Changeset.

## Compatibility and release impact

- Breaking or externally visible changes: The boot-token-protected local Harness graph endpoint now returns a `SystemGraphSnapshot` envelope instead of a bare `SystemGraph`; the bundled browser client is updated in lockstep.
- Changeset: Added a minor Changeset for `@sapiom/harness`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex implemented and reviewed the lifecycle/store/watcher/browser changes. I validated the resulting behavior with focused race tests, a real Harness server and filesystem, browser E2E coverage, the package typecheck/build, performance tests, and a full unit-suite run; I also reviewed the final stacked diff for path leakage, cache isolation, failure semantics, and unrelated formatting churn.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
