### PR TITLE
feat(mcp,skills): sapiom_dev_app_publish + teach App Links in the preview skill (SAP-2922)

### DIFF
--- a/.changeset/mcp-app-publish-tool.md
+++ b/.changeset/mcp-app-publish-tool.md
@@ -7,17 +7,23 @@ sandbox resource as an **App Link**: a durable
 `https://apps.sapiom.ai/{org}/{slug}` URL that outlives any sandbox. Reads the
 same resource `sapiom_dev_sandbox_preview` does (source dir, `start`, `port`,
 optional `build`/`env`), collects the source as a text-only file map, and calls
-the backend publish API in order — `POST /v1/app-links` (upsert on slug) →
+the App Links REST API in order — `POST /v1/app-links` (upsert on slug) →
 `PUT /v1/app-links/{id}/bundle` → `POST /v1/app-links/{id}/publish` — with the
 cached `sapiom_authenticate` credential as `x-api-key`. Returns
 `{ summary, url, appLinkId, bundleSha256, manifest }`.
 
-- A non-UTF-8 file is rejected **by name**, locally, before any HTTP call, so a
-  binary in the source dir never costs a round trip or a half-published link.
+- Bundles are validated locally, before any HTTP call: a non-UTF-8 file is
+  rejected **by name**, and an over-cap bundle is measured exactly as the server
+  measures it. A bad bundle costs neither an upload nor a half-finished link.
+  Symlinks are skipped rather than followed, so a link out of the source tree
+  can never publish what it points at.
 - Backend wire codes map to actionable errors: `BUNDLE_BINARY_FILE` (names the
   file), `BUNDLE_TOO_LARGE` (quotes both sizes), `PUBLIC_CONFIRM_REQUIRED`,
-  `PUBLIC_SPEND_CAP_REQUIRED`, 401 (re-authenticate) and 403 (names the missing
-  `org.app_links.publish`). Every one says nothing was published.
+  `PUBLIC_SPEND_CAP_REQUIRED`, `APP_LINK_MANAGEMENT_PERMISSION_REQUIRED`, 401
+  (re-authenticate) and 403 (names the missing `org.app_links.publish`). Each
+  error is step-aware about what it left behind: only a failure on the first
+  call can say nothing was created — after that the link exists with no active
+  bundle, and the error says to publish the same slug again to finish it.
 - `sapiom_dev_sandbox_preview` now states in its description **and** on its
   result that the preview URL expires with the sandbox's `ttl`, and points at
   `sapiom_dev_app_publish` for a durable address — the agent reads that at the

--- a/.changeset/mcp-app-publish-tool.md
+++ b/.changeset/mcp-app-publish-tool.md
@@ -1,0 +1,24 @@
+---
+"@sapiom/mcp": minor
+---
+
+New tool `sapiom_dev_app_publish` — publishes the project's `sapiom.json`
+sandbox resource as an **App Link**: a durable
+`https://apps.sapiom.ai/{org}/{slug}` URL that outlives any sandbox. Reads the
+same resource `sapiom_dev_sandbox_preview` does (source dir, `start`, `port`,
+optional `build`/`env`), collects the source as a text-only file map, and calls
+the backend publish API in order — `POST /v1/app-links` (upsert on slug) →
+`PUT /v1/app-links/{id}/bundle` → `POST /v1/app-links/{id}/publish` — with the
+cached `sapiom_authenticate` credential as `x-api-key`. Returns
+`{ summary, url, appLinkId, bundleSha256, manifest }`.
+
+- A non-UTF-8 file is rejected **by name**, locally, before any HTTP call, so a
+  binary in the source dir never costs a round trip or a half-published link.
+- Backend wire codes map to actionable errors: `BUNDLE_BINARY_FILE` (names the
+  file), `BUNDLE_TOO_LARGE` (quotes both sizes), `PUBLIC_CONFIRM_REQUIRED`,
+  `PUBLIC_SPEND_CAP_REQUIRED`, 401 (re-authenticate) and 403 (names the missing
+  `org.app_links.publish`). Every one says nothing was published.
+- `sapiom_dev_sandbox_preview` now states in its description **and** on its
+  result that the preview URL expires with the sandbox's `ttl`, and points at
+  `sapiom_dev_app_publish` for a durable address — the agent reads that at the
+  moment it is about to hand the URL over.

--- a/.changeset/skill-teach-app-links.md
+++ b/.changeset/skill-teach-app-links.md
@@ -1,0 +1,14 @@
+---
+"@sapiom/agent-core": patch
+---
+
+`sapiom-sandbox-preview` skill now teaches App Links. It says plainly that a
+sandbox preview URL is temporary (it dies with the resource's `ttl`, along with
+any bookmark or Slack message it was pasted into), and adds a "Make it durable /
+share it" section that routes "share this", "send this to my team", "a permanent
+link", "keep it alive", "my link died" to `sapiom_dev_app_publish` — with the
+five facts an agent otherwise gets wrong: wake-on-demand cold start, org-scoped
+by default (public needs `confirmPublic` + `dailySpendCapUsd`, so ask first),
+republish-in-place on the same slug, text-only bundles, and the ~10 MiB cap. The
+frontmatter `description` picks up the durability triggers so the skill fires on
+a "link that won't die" ask.

--- a/packages/agent-core/skills/sapiom-sandbox-preview/SKILL.md
+++ b/packages/agent-core/skills/sapiom-sandbox-preview/SKILL.md
@@ -83,10 +83,11 @@ It reads the **same** `sapiom.json` sandbox resource (source dir, `start`, `port
   slug for v2.
 - **Text-only bundles.** UTF-8 files only — no images, fonts, or archives. A binary is
   rejected **by name** before anything is uploaded; drop it, or use inline SVG, a data URL,
-  or a CDN reference. `node_modules`, `.git`, dotfiles and `sapiom.json` are never uploaded,
-  so install dependencies at wake with the resource's `build` command.
-- **~10 MiB** per bundle over this path. Drop generated output (`dist`, build artifacts,
-  vendored assets) rather than shipping it.
+  or a CDN reference. `node_modules`, `.git`, dotfiles, symlinks and the project's own
+  `sapiom.json` are never uploaded, so install dependencies at wake with the resource's
+  `build` command.
+- **~10 MiB** per bundle over this path, checked locally before the upload. Drop generated
+  output (`dist`, build artifacts, vendored assets) rather than shipping it.
 - Pass `resource` only when the project defines more than one sandbox resource. `slug`
   (`[a-z0-9-]{1,63}`) is the app's identity; `name` is what the "Starting…" page shows.
 

--- a/packages/agent-core/skills/sapiom-sandbox-preview/SKILL.md
+++ b/packages/agent-core/skills/sapiom-sandbox-preview/SKILL.md
@@ -1,30 +1,37 @@
 ---
 name: sapiom-sandbox-preview
-description: Deploy a live preview of a web app from the current project to a
-  Sapiom sandbox. Use when the user wants to preview, host, or deploy a web
-  app, dev server, API, or static site to a live URL ("preview this app",
-  "give me a live link", "host this server"), or mentions sapiom.json sandbox
-  resources. Do NOT use for deploying Sapiom agents (that's
-  sapiom_dev_agents_deploy) or for one-off capability calls.
+description: Deploy a web app from the current project to a live Sapiom URL —
+  either a throwaway sandbox preview or a durable App Link. Use when the user
+  wants to preview, host, deploy, or share a web app, dashboard, dev server,
+  API, or static site ("preview this app", "give me a live link", "host this
+  server"), and especially when they want that link to last ("a permanent
+  link", "something I can share with my team", "keep it alive", "my link
+  died"), or mentions sapiom.json sandbox resources or App Links. Do NOT use
+  for deploying Sapiom agents (that's sapiom_dev_agents_deploy) or for one-off
+  capability calls.
 ---
 
-# Sandbox Previews
+# Sandbox Previews & App Links
 
-Deploy the web app in the current project directory to a Sapiom **sandbox** and get a
-**live public URL** — provisioned, uploaded, built, and started in one tool call. Driven
-by the sapiom-dev MCP (`npx -y @sapiom/mcp`; see the [Get Started guide](https://docs.sapiom.ai/)
-if it isn't connected).
+Two ways to put the web app in the current project on a live URL, both driven by the
+sapiom-dev MCP (`npx -y @sapiom/mcp`; see the [Get Started guide](https://docs.sapiom.ai/)
+if it isn't connected) and both reading the same `sapiom.json` resource:
 
-**This is not agent deployment.** Sapiom *agents* deploy with `sapiom_dev_agents_deploy`;
-sandbox previews host an ordinary app (Node server, static site, API) from your working
-directory.
+| You want                                      | Tool                         | The URL                                             |
+| --------------------------------------------- | ---------------------------- | --------------------------------------------------- |
+| To look at it now, iterate, throw it away     | `sapiom_dev_sandbox_preview` | **Temporary** — dies with the sandbox's `ttl`       |
+| A link that lasts, or that someone else opens | `sapiom_dev_app_publish`     | **Durable** — `https://apps.sapiom.ai/{org}/{slug}` |
+
+**This is not agent deployment.** Sapiom _agents_ deploy with `sapiom_dev_agents_deploy`;
+both tools here host an ordinary app (Node server, static site, API, dashboard) from your
+working directory.
 
 ## Prerequisite
 
 Run `sapiom_authenticate` once (browser login; caches a key in `~/.sapiom/credentials.json`).
-`sapiom_dev_sandbox_preview` returns a structured not-authenticated error otherwise;
-`configure` and `check` only touch local files and work signed-out. Check with
-`sapiom_status`.
+`sapiom_dev_sandbox_preview` and `sapiom_dev_app_publish` return a structured
+not-authenticated error otherwise; `configure` and `check` only touch local files and work
+signed-out. Check with `sapiom_status`.
 
 ## The lifecycle
 
@@ -32,16 +39,59 @@ Run `sapiom_authenticate` once (browser login; caches a key in `~/.sapiom/creden
    project's `sapiom.json`. Fill the typed arguments instead of hand-writing JSON — the
    config is validated and written under `resources.<name>` (`type: "sandbox"`). Returns
    the stored config.
-2. **`sapiom_dev_sandbox_check`** *(optional)* — statically validates the resources without
+2. **`sapiom_dev_sandbox_check`** _(optional)_ — statically validates the resources without
    deploying. Returns `{ ok, sandboxes, issues }`; fix any `issues` before previewing.
 3. **`sapiom_dev_sandbox_preview`** — reads `sapiom.json`, provisions the sandbox if
    needed, uploads the local code, builds, starts, and exposes a public URL. Returns
    `{ name, url, status, logs }`. Pass `name` only when the project defines more than one
    resource.
+4. **`sapiom_dev_app_publish`** — when the link needs to outlive the sandbox. See below.
 
 **A `failed` status is not an error** — it carries the build/start logs so you can fix the
 app or the config and run `sapiom_dev_sandbox_preview` again. `unverified` means the app
 started but didn't answer 2xx yet.
+
+**The preview URL is temporary.** It belongs to a sandbox that expires with the resource's
+`ttl` (default `1h`), and it goes away with it — along with any bookmark, Slack message, or
+doc anyone pasted it into. Say so when you hand it over, and reach for
+`sapiom_dev_app_publish` instead whenever the link is meant to survive.
+
+## Make it durable / share it
+
+Route to **`sapiom_dev_app_publish`** whenever the ask is about the link lasting or leaving
+your machine — "share this", "send this to my team", "a permanent link", "keep it alive",
+"can I bookmark this", "put this somewhere", "my link died", "the URL stopped working".
+
+```
+sapiom_dev_app_publish { slug: "dash", name: "Dash" }
+  → { url: "https://apps.sapiom.ai/{org}/dash", appLinkId, bundleSha256, manifest }
+```
+
+It reads the **same** `sapiom.json` sandbox resource (source dir, `start`, `port`, optional
+`build`/`env`), uploads the source as a stored bundle, and activates it. What to know:
+
+- **Wake on demand, not always-on.** Nothing runs until someone visits. The first visit
+  after a publish cold-starts the app — tens of seconds behind a "Starting…" page — then
+  it's fast until it idles out again. Tell the user that, so a slow first load doesn't read
+  as broken.
+- **Org-scoped by default.** Only logged-in members of the organization can open it.
+  `visibility: "public"` (anyone with the link) additionally needs `confirmPublic: true`
+  and a `dailySpendCapUsd` — the org pays for every wake, so **ask the user before setting
+  either**.
+- **Republish in place.** Publishing the same `slug` again replaces the app at the _same_
+  URL and returns a new `bundleSha256`. That is how you ship an update; never mint a second
+  slug for v2.
+- **Text-only bundles.** UTF-8 files only — no images, fonts, or archives. A binary is
+  rejected **by name** before anything is uploaded; drop it, or use inline SVG, a data URL,
+  or a CDN reference. `node_modules`, `.git`, dotfiles and `sapiom.json` are never uploaded,
+  so install dependencies at wake with the resource's `build` command.
+- **~10 MiB** per bundle over this path. Drop generated output (`dist`, build artifacts,
+  vendored assets) rather than shipping it.
+- Pass `resource` only when the project defines more than one sandbox resource. `slug`
+  (`[a-z0-9-]{1,63}`) is the app's identity; `name` is what the "Starting…" page shows.
+
+The canonical link is the identity — share `https://apps.sapiom.ai/{org}/{slug}`, never the
+sandbox address the browser lands on after a wake.
 
 ## The `sapiom.json` resource
 
@@ -60,15 +110,15 @@ started but didn't answer 2xx yet.
 }
 ```
 
-| Field | Required | Notes |
-|---|---|---|
-| `source` | yes | `{ "kind": "upload", "path"? }` (upload the local dir) or `{ "kind": "git", "slug", "path"? }` (server checks out a Sapiom repo) |
-| `start` | yes | The server command (e.g. `node server.js`) |
-| `port` | yes | 1–65535 — the port your app listens on |
-| `build` | no | Build command run before start (e.g. `npm run build`) |
-| `tier` | no | Sandbox size: `xs` \| `s` \| `m` \| `l` \| `xl` |
-| `ttl` | no | Sandbox lifetime, e.g. `"1h"`, `"24h"`, `"7d"` |
-| `env` | no | Environment variables (string map) |
+| Field    | Required | Notes                                                                                                                            |
+| -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `source` | yes      | `{ "kind": "upload", "path"? }` (upload the local dir) or `{ "kind": "git", "slug", "path"? }` (server checks out a Sapiom repo) |
+| `start`  | yes      | The server command (e.g. `node server.js`)                                                                                       |
+| `port`   | yes      | 1–65535 — the port your app listens on                                                                                           |
+| `build`  | no       | Build command run before start (e.g. `npm run build`)                                                                            |
+| `tier`   | no       | Sandbox size: `xs` \| `s` \| `m` \| `l` \| `xl`                                                                                  |
+| `ttl`    | no       | Sandbox lifetime, e.g. `"1h"`, `"24h"`, `"7d"` — **preview only**; an App Link's URL is not bounded by it                        |
+| `env`    | no       | Environment variables (string map)                                                                                               |
 
 Uploads skip `node_modules`, `.git`, and dotfiles — dependencies install in the sandbox at
 build time; never upload them.

--- a/packages/agent-core/src/__tests__/skill-sync.test.ts
+++ b/packages/agent-core/src/__tests__/skill-sync.test.ts
@@ -140,4 +140,30 @@ describe("sapiom-sandbox-preview skill sync", () => {
       readFileSync(canonicalPreview, "utf8"),
     );
   });
+
+  // Content guards (SAP-2922). Byte-identity cannot stop two identically wrong
+  // copies: the whole point of this skill is that a durability ask must land on
+  // sapiom_dev_app_publish and not on a preview URL that expires.
+  describe("teaches App Links", () => {
+    const content = readFileSync(canonicalPreview, "utf8");
+
+    it("routes durability asks to sapiom_dev_app_publish, from the frontmatter down", () => {
+      const frontmatter = content.split("---")[1] ?? "";
+      expect(frontmatter).toMatch(/permanent|durable/i);
+      expect(frontmatter).toMatch(/share/i);
+      expect(content).toContain("sapiom_dev_app_publish");
+      expect(content).toContain("https://apps.sapiom.ai/{org}/{slug}");
+    });
+
+    it("says plainly that the preview URL expires with the sandbox ttl", () => {
+      expect(content).toMatch(/preview URL is temporary/i);
+      expect(content).toMatch(/ttl/);
+    });
+
+    it("warns about the cold start and the public-visibility cost", () => {
+      expect(content).toMatch(/cold-start/i);
+      expect(content).toMatch(/confirmPublic/);
+      expect(content).toMatch(/dailySpendCapUsd/);
+    });
+  });
 });

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,8 +2,9 @@
 
 The **local developer** MCP server for Sapiom. It runs on your machine over
 stdio under the server name `sapiom-dev`. Today it gives a coding agent the
-tools to scaffold, test, deploy, and inspect Sapiom agents; the namespace leaves
-room for other developer tooling later.
+tools to scaffold, test, deploy, and inspect Sapiom agents, and to put a web app
+behind a live sandbox URL or a durable App Link; the namespace leaves room for
+other developer tooling later.
 
 > **Not the capability surface.** This is _not_ the remote "Sapiom" MCP (the
 > hosted connector with `sapiom_sandbox_*`, scrape, search, … capability tools).
@@ -94,9 +95,21 @@ filesystem, environment, and process effects in author code remain real.
 | `sapiom_dev_agents_schedule_inspect` | ✓                | Inspect one schedule (with fire history) or list an agent's schedules      |
 | `sapiom_dev_agents_schedule_cancel`  | ✓                | Cancel a schedule (stops all future fires)                                 |
 | `sapiom_dev_agents_cron_preview`     | ✓                | Validate a cron expression and preview its next occurrences                |
+| `sapiom_dev_sandbox_configure`       | —                | Write a validated `type: "sandbox"` preview resource into `sapiom.json`    |
+| `sapiom_dev_sandbox_check`           | —                | Validate the project's sandbox resources without deploying                 |
+| `sapiom_dev_sandbox_preview`         | ✓                | Deploy the app to a sandbox for a live URL that expires with its `ttl`     |
+| `sapiom_dev_app_publish`             | ✓                | Publish the same app to a durable App Link (`apps.sapiom.ai/{org}/{slug}`) |
 
 A typical loop: `scaffold` → write step code → `run_local` until green → `link`
 → `deploy` → `run` → `inspect`.
+
+For a web app rather than an agent: `sandbox_configure` → `sandbox_preview`
+while iterating (a throwaway URL that dies with the sandbox) → `app_publish`
+once the link needs to be permanent or shared. `app_publish` reads the same
+`sapiom.json` sandbox resource, uploads the source as a stored text-only bundle
+(≤ 10 MiB), and returns a durable `https://apps.sapiom.ai/{org}/{slug}` URL that
+wakes the app on demand — republishing the same slug updates it in place. See
+the `sapiom-sandbox-preview` skill for the routing rules.
 
 ## How capabilities fit in
 

--- a/packages/mcp/src/analytics.e2e.test.ts
+++ b/packages/mcp/src/analytics.e2e.test.ts
@@ -43,6 +43,7 @@ const ALL_TOOL_NAMES = [
   "sapiom_dev_agents_schedule_cancel",
   "sapiom_dev_agents_schedule_inspect",
   "sapiom_dev_agents_signal",
+  "sapiom_dev_app_publish",
   "sapiom_dev_sandbox_check",
   "sapiom_dev_sandbox_configure",
   "sapiom_dev_sandbox_preview",

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -8,6 +8,7 @@ import { register as registerAuthenticate } from "./tools/authenticate.js";
 import { register as registerStatus } from "./tools/status.js";
 import { register as registerAgents } from "./tools/agents.js";
 import { register as registerSandbox } from "./tools/sandbox.js";
+import { register as registerAppPublish } from "./tools/app-publish.js";
 import { register as registerFeedback } from "./tools/feedback.js";
 import { fetchInstructions } from "./instructions-fetch.js";
 
@@ -58,6 +59,7 @@ async function main(): Promise<void> {
   registerStatus(server, env);
   registerAgents(server, env);
   registerSandbox(server, env);
+  registerAppPublish(server, env);
   registerFeedback(server, env);
 
   // Connect via stdio transport

--- a/packages/mcp/src/tools/app-publish.test.ts
+++ b/packages/mcp/src/tools/app-publish.test.ts
@@ -3,11 +3,17 @@
  *
  * The backend is mocked at `fetch` (this is the only tool that speaks to the
  * App Links REST API directly), so the assertions that matter are the ones a
- * consumer depends on: the interfaces §3 call ORDER, the durability wording the
+ * consumer depends on: the three-call ORDER, the durability wording the
  * routing decision hangs on, the wire-code → actionable-error mapping, and that
  * a binary file is rejected by name with no HTTP call at all.
  */
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -139,13 +145,26 @@ function mockHappyBackend(): ReturnType<typeof vi.fn> {
   return fetchMock;
 }
 
-/** Every fetch fails with one wire error body. */
-function mockBackendError(body: unknown, status: number): void {
-  globalThis.fetch = vi
-    .fn()
-    .mockResolvedValue(
-      jsonRes(body, status),
-    ) as unknown as typeof globalThis.fetch;
+/**
+ * Play the happy responses up to `step`, then fail it. Fire-on-every-call
+ * mocking would land every case on call #1 and never exercise the
+ * link-already-created path that the error copy has to be honest about.
+ */
+const STEP_INDEX = { create: 0, bundle: 1, publish: 2 } as const;
+
+function mockBackendErrorAt(
+  step: keyof typeof STEP_INDEX,
+  body: unknown,
+  status: number,
+): ReturnType<typeof vi.fn> {
+  const happy = [jsonRes(APP_LINK, 201), jsonRes(BUNDLE), jsonRes(APP_LINK)];
+  const fetchMock = vi.fn();
+  for (const res of happy.slice(0, STEP_INDEX[step])) {
+    fetchMock.mockResolvedValueOnce(res);
+  }
+  fetchMock.mockResolvedValue(jsonRes(body, status));
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  return fetchMock;
 }
 
 describe("sapiom_dev_app_publish tool", () => {
@@ -209,7 +228,7 @@ describe("sapiom_dev_app_publish tool", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("calls upsert → bundle → publish in interfaces §3 order, authed with x-api-key", async () => {
+  it("calls upsert → bundle → publish in order, authed with x-api-key", async () => {
     const fetchMock = mockHappyBackend();
     const dir = project({ "index.html": "<h1>hi</h1>", "src/app.js": "1;" });
 
@@ -266,7 +285,7 @@ describe("sapiom_dev_app_publish tool", () => {
     );
   });
 
-  it("reports the sha the backend says is active, not the one we uploaded", async () => {
+  it("reports the sha the backend says is active, and flags it when that is not ours", async () => {
     globalThis.fetch = vi
       .fn()
       .mockResolvedValueOnce(jsonRes(APP_LINK, 201))
@@ -281,7 +300,83 @@ describe("sapiom_dev_app_publish tool", () => {
       name: "Dash",
     });
 
-    expect(parse(res).bundleSha256).toBe("raced99");
+    const payload = parse(res);
+    expect(payload.bundleSha256).toBe("raced99");
+    // `manifest` describes OUR upload, so a foreign live sha cannot be reported
+    // beside it as if it matched.
+    expect(payload.warning).toContain("abc123");
+    expect(payload.warning).toContain("raced99");
+    expect(payload.summary).toContain("see `warning`");
+  });
+
+  it("says nothing about a race when the active sha is the one we uploaded", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(APP_LINK, 201))
+      .mockResolvedValueOnce(jsonRes(BUNDLE))
+      .mockResolvedValueOnce(
+        jsonRes({ ...APP_LINK, bundleSha256: "abc123" }),
+      ) as unknown as typeof globalThis.fetch;
+
+    const res = await setup().handler({
+      dir: project(),
+      slug: "dash",
+      name: "Dash",
+    });
+
+    const payload = parse(res);
+    expect(payload.warning).toBeUndefined();
+    expect(payload.summary).toContain("1 files");
+  });
+
+  it("skips a symlink rather than publishing what it points at", async () => {
+    const fetchMock = mockHappyBackend();
+    const dir = project({ "index.html": "<h1>hi</h1>" });
+    // The hazard: a bundle can end up behind a public URL, so following a link
+    // out of the source tree would publish whatever is on the other end.
+    writeFileSync(path.join(dir, "..", "app-publish-secret.txt"), "SECRET");
+    symlinkSync(
+      path.join(dir, "..", "app-publish-secret.txt"),
+      path.join(dir, "leak.txt"),
+    );
+    symlinkSync(dir, path.join(dir, "loop"));
+
+    const res = await setup().handler({ dir, slug: "dash", name: "Dash" });
+
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).files).toEqual({
+      "index.html": "<h1>hi</h1>",
+    });
+    rmSync(path.join(dir, "..", "app-publish-secret.txt"), { force: true });
+  });
+
+  it("keeps a nested sapiom.json — only the project's own is config", async () => {
+    const fetchMock = mockHappyBackend();
+    const dir = project({
+      "index.html": "<h1>hi</h1>",
+      "fixtures/sapiom.json": '{"sample":true}',
+    });
+
+    await setup().handler({ dir, slug: "dash", name: "Dash" });
+
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).files).toEqual({
+      "index.html": "<h1>hi</h1>",
+      "fixtures/sapiom.json": '{"sample":true}',
+    });
+  });
+
+  it("refuses an over-cap bundle locally, before any HTTP call", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    const dir = project({ "big.txt": "x".repeat(10 * 1024 * 1024 + 1) });
+
+    const res = await setup().handler({ dir, slug: "dash", name: "Dash" });
+
+    expect(res.isError).toBe(true);
+    const { error } = parse(res);
+    expect(error.code).toBe("BUNDLE_TOO_LARGE");
+    expect(error.message).toContain("Nothing was created or published.");
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("returns the durable url, ids and manifest plus a one-line summary", async () => {
@@ -404,9 +499,10 @@ describe("sapiom_dev_app_publish tool", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  describe("wire error mapping (interfaces §3)", () => {
+  describe("wire error mapping", () => {
     const cases: Array<{
       label: string;
+      step: keyof typeof STEP_INDEX;
       body: Record<string, unknown>;
       status: number;
       code: string;
@@ -414,6 +510,7 @@ describe("sapiom_dev_app_publish tool", () => {
     }> = [
       {
         label: "BUNDLE_BINARY_FILE names the file",
+        step: "bundle",
         body: {
           code: "BUNDLE_BINARY_FILE",
           message: "nope",
@@ -425,6 +522,7 @@ describe("sapiom_dev_app_publish tool", () => {
       },
       {
         label: "BUNDLE_TOO_LARGE quotes both sizes",
+        step: "bundle",
         body: {
           code: "BUNDLE_TOO_LARGE",
           message: "too big",
@@ -437,6 +535,7 @@ describe("sapiom_dev_app_publish tool", () => {
       },
       {
         label: "PUBLIC_CONFIRM_REQUIRED asks for the acknowledgement",
+        step: "create",
         body: { code: "PUBLIC_CONFIRM_REQUIRED", message: "confirm" },
         status: 409,
         code: "PUBLIC_CONFIRM_REQUIRED",
@@ -444,6 +543,7 @@ describe("sapiom_dev_app_publish tool", () => {
       },
       {
         label: "PUBLIC_SPEND_CAP_REQUIRED asks for the cap",
+        step: "create",
         body: { code: "PUBLIC_SPEND_CAP_REQUIRED", message: "cap" },
         status: 400,
         code: "PUBLIC_SPEND_CAP_REQUIRED",
@@ -451,6 +551,7 @@ describe("sapiom_dev_app_publish tool", () => {
       },
       {
         label: "a management-permission 403 says to drop the management fields",
+        step: "create",
         body: {
           code: "APP_LINK_MANAGEMENT_PERMISSION_REQUIRED",
           message:
@@ -462,6 +563,7 @@ describe("sapiom_dev_app_publish tool", () => {
       },
       {
         label: "401 points at re-authentication",
+        step: "create",
         body: { message: "Unauthorized" },
         status: 401,
         code: "NOT_AUTHENTICATED",
@@ -469,6 +571,7 @@ describe("sapiom_dev_app_publish tool", () => {
       },
       {
         label: "403 names the missing permission",
+        step: "create",
         body: { message: "Missing required permission" },
         status: 403,
         code: "FORBIDDEN",
@@ -478,7 +581,7 @@ describe("sapiom_dev_app_publish tool", () => {
 
     for (const c of cases) {
       it(c.label, async () => {
-        mockBackendError(c.body, c.status);
+        mockBackendErrorAt(c.step, c.body, c.status);
         const res = await setup().handler({
           dir: project(),
           slug: "dash",
@@ -489,11 +592,19 @@ describe("sapiom_dev_app_publish tool", () => {
         const { error } = parse(res);
         expect(error.code).toBe(c.code);
         expect(`${error.message} ${error.hint ?? ""}`).toMatch(c.expect);
+        // The state the agent is left in, per step. Claiming "nothing was
+        // created" after the upsert already created the link is the one thing
+        // this copy must never do.
+        if (c.step === "create") {
+          expect(error.message).toContain("Nothing was created or published.");
+        } else {
+          expect(error.message).toContain('The "dash" app link EXISTS');
+        }
       });
     }
 
     it("403 hint names org.app_links.publish", async () => {
-      mockBackendError({ message: "no" }, 403);
+      mockBackendErrorAt("create", { message: "no" }, 403);
       const res = await setup().handler({
         dir: project(),
         slug: "dash",
@@ -503,13 +614,72 @@ describe("sapiom_dev_app_publish tool", () => {
     });
 
     it("falls back to HTTP_<status> for an unmapped failure", async () => {
-      mockBackendError({ message: "boom" }, 500);
+      mockBackendErrorAt("create", { message: "boom" }, 500);
       const res = await setup().handler({
         dir: project(),
         slug: "dash",
         name: "Dash",
       });
       expect(parse(res).error.code).toBe("HTTP_500");
+    });
+
+    it("a failure at activate still says the link exists and needs finishing", async () => {
+      const fetchMock = mockBackendErrorAt(
+        "publish",
+        { code: "NO_BUNDLE", message: "no bundle" },
+        409,
+      );
+      const res = await setup().handler({
+        dir: project(),
+        slug: "dash",
+        name: "Dash",
+      });
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      const { error } = parse(res);
+      expect(error.code).toBe("NO_BUNDLE");
+      expect(error.message).toContain('The "dash" app link EXISTS');
+      expect(error.message).toContain("publish the same slug again");
+      expect(error.message).not.toContain("Nothing was");
+      expect(error.step).toBe("POST /v1/app-links/{id}/publish");
+    });
+
+    it("an unreachable backend mid-flow does not claim nothing was created", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(jsonRes(APP_LINK, 201))
+        .mockRejectedValue(new Error("ECONNRESET"));
+      globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+      const res = await setup().handler({
+        dir: project(),
+        slug: "dash",
+        name: "Dash",
+      });
+
+      const { error } = parse(res);
+      expect(error.code).toBe("NETWORK");
+      expect(error.message).toContain('The "dash" app link EXISTS');
+    });
+
+    it("refuses a 2xx body that is not an app link instead of addressing /undefined/", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "",
+        text: () => Promise.resolve("<html>gateway</html>"),
+      });
+      globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+      const res = await setup().handler({
+        dir: project(),
+        slug: "dash",
+        name: "Dash",
+      });
+
+      expect(res.isError).toBe(true);
+      expect(parse(res).error.code).toBe("UNEXPECTED_RESPONSE");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 
     it("maps an unreachable backend to NETWORK", async () => {
@@ -526,6 +696,7 @@ describe("sapiom_dev_app_publish tool", () => {
       const { error } = parse(res);
       expect(error.code).toBe("NETWORK");
       expect(error.hint).toContain("ECONNREFUSED");
+      expect(error.message).toContain("Nothing was created or published.");
     });
   });
 

--- a/packages/mcp/src/tools/app-publish.test.ts
+++ b/packages/mcp/src/tools/app-publish.test.ts
@@ -350,6 +350,72 @@ describe("sapiom_dev_app_publish tool", () => {
     rmSync(path.join(dir, "..", "app-publish-secret.txt"), { force: true });
   });
 
+  it("accepts a symlinked source directory — the root is the path the user named", async () => {
+    const fetchMock = mockHappyBackend();
+    const dir = project(
+      { "index.html": "<h1>hi</h1>" },
+      { ...SANDBOX, source: { kind: "upload", path: "web" } },
+    );
+    // `web` is a symlink to the real source dir, as in a workspace layout.
+    mkdirSync(path.join(dir, "real-web"), { recursive: true });
+    writeFileSync(path.join(dir, "real-web", "index.html"), "<h1>linked</h1>");
+    symlinkSync(path.join(dir, "real-web"), path.join(dir, "web"));
+
+    const res = await setup().handler({ dir, slug: "dash", name: "Dash" });
+
+    expect(res.isError).toBeUndefined();
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).files).toEqual({
+      "index.html": "<h1>linked</h1>",
+    });
+  });
+
+  it("keeps web/sapiom.json when source.path is web — only <project>/sapiom.json is config", async () => {
+    const fetchMock = mockHappyBackend();
+    const dir = project(
+      {
+        "web/index.html": "<h1>hi</h1>",
+        // Under `source.path: "web"` the project config was never in the tree,
+        // so this file is app content and must survive.
+        "web/sapiom.json": '{"appConfig":true}',
+      },
+      { ...SANDBOX, source: { kind: "upload", path: "web" } },
+    );
+
+    await setup().handler({ dir, slug: "dash", name: "Dash" });
+
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).files).toEqual({
+      "index.html": "<h1>hi</h1>",
+      "sapiom.json": '{"appConfig":true}',
+    });
+  });
+
+  it("treats a publish body that is not a link as success, not UNEXPECTED_RESPONSE", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(APP_LINK, 201))
+      .mockResolvedValueOnce(jsonRes(BUNDLE))
+      // A 204 / bare ack: nothing downstream needs this body.
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 204,
+        statusText: "",
+        text: () => Promise.resolve(""),
+      }) as unknown as typeof globalThis.fetch;
+
+    const res = await setup().handler({
+      dir: project(),
+      slug: "dash",
+      name: "Dash",
+    });
+
+    expect(res.isError).toBeUndefined();
+    const payload = parse(res);
+    expect(payload.url).toBe(APP_LINK.url);
+    expect(payload.appLinkId).toBe(APP_LINK.id);
+    expect(payload.bundleSha256).toBe("abc123");
+    expect(payload.warning).toBeUndefined();
+  });
+
   it("keeps a nested sapiom.json — only the project's own is config", async () => {
     const fetchMock = mockHappyBackend();
     const dir = project({
@@ -678,7 +744,10 @@ describe("sapiom_dev_app_publish tool", () => {
       });
 
       expect(res.isError).toBe(true);
-      expect(parse(res).error.code).toBe("UNEXPECTED_RESPONSE");
+      const { error } = parse(res);
+      expect(error.code).toBe("UNEXPECTED_RESPONSE");
+      expect(error.step).toBe("POST /v1/app-links");
+      expect(error.message).toContain("Nothing was created or published.");
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/mcp/src/tools/app-publish.test.ts
+++ b/packages/mcp/src/tools/app-publish.test.ts
@@ -1,0 +1,552 @@
+/**
+ * `sapiom_dev_app_publish` — the tool's contract with the agent calling it.
+ *
+ * The backend is mocked at `fetch` (this is the only tool that speaks to the
+ * App Links REST API directly), so the assertions that matter are the ones a
+ * consumer depends on: the interfaces §3 call ORDER, the durability wording the
+ * routing decision hangs on, the wire-code → actionable-error mapping, and that
+ * a binary file is rejected by name with no HTTP call at all.
+ */
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { z } from "zod";
+
+import type { ResolvedEnvironment } from "../credentials.js";
+
+vi.mock("../credentials.js", () => ({ readCredentials: vi.fn() }));
+
+import { readCredentials } from "../credentials.js";
+import { register } from "./app-publish.js";
+
+type ToolHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}>;
+
+interface Registration {
+  name: string;
+  description: string;
+  schema: Record<string, z.ZodTypeAny>;
+  handler: ToolHandler;
+}
+
+function createMockServer(): {
+  server: McpServer;
+  registrations: Map<string, Registration>;
+} {
+  const registrations = new Map<string, Registration>();
+  const server = {
+    tool: vi.fn(
+      (
+        name: string,
+        description: string,
+        schema: Record<string, z.ZodTypeAny>,
+        handler: ToolHandler,
+      ) => {
+        registrations.set(name, { name, description, schema, handler });
+      },
+    ),
+  } as unknown as McpServer;
+  return { server, registrations };
+}
+
+const TOOL = "sapiom_dev_app_publish";
+
+const env: ResolvedEnvironment = {
+  name: "production",
+  appURL: "https://app.sapiom.ai",
+  apiURL: "https://api.sapiom.ai",
+  services: {},
+  credentials: null,
+};
+
+const SANDBOX = {
+  type: "sandbox",
+  source: { kind: "upload" },
+  build: "npm install",
+  start: "node server.js",
+  port: 3000,
+  env: { API_TOKEN: "t" },
+};
+
+const APP_LINK = {
+  id: "11111111-1111-4111-8111-111111111111",
+  slug: "dash",
+  name: "Dash",
+  visibility: "organization",
+  url: "https://apps.sapiom.ai/acme/dash",
+};
+
+const BUNDLE = {
+  bundleSha256: "abc123",
+  manifest: {
+    start: "node server.js",
+    port: 3000,
+    build: "npm install",
+    envKeys: ["API_TOKEN"],
+    fileCount: 1,
+    bytes: 42,
+  },
+};
+
+const parse = (res: { content: Array<{ text: string }> }) =>
+  JSON.parse(res.content[0].text);
+
+function setup(): Registration {
+  const { server, registrations } = createMockServer();
+  register(server, env);
+  return registrations.get(TOOL)!;
+}
+
+/** A project dir with one sandbox resource and `files` under the source root. */
+function tmpProject(
+  files: Record<string, string | Uint8Array> = { "index.html": "<h1>hi</h1>" },
+  sandbox: Record<string, unknown> = SANDBOX,
+): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "app-publish-"));
+  writeFileSync(
+    path.join(dir, "sapiom.json"),
+    JSON.stringify({ version: 1, resources: { web: sandbox } }),
+  );
+  for (const [rel, contents] of Object.entries(files)) {
+    const abs = path.join(dir, rel);
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, contents);
+  }
+  return dir;
+}
+
+/** JSON response for the next fetch call. */
+const jsonRes = (body: unknown, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  statusText: "",
+  text: () => Promise.resolve(JSON.stringify(body)),
+});
+
+/** The happy-path backend: upsert → bundle → publish. */
+function mockHappyBackend(): ReturnType<typeof vi.fn> {
+  const fetchMock = vi
+    .fn()
+    .mockResolvedValueOnce(jsonRes(APP_LINK, 201))
+    .mockResolvedValueOnce(jsonRes(BUNDLE))
+    .mockResolvedValueOnce(jsonRes(APP_LINK));
+  globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  return fetchMock;
+}
+
+/** Every fetch fails with one wire error body. */
+function mockBackendError(body: unknown, status: number): void {
+  globalThis.fetch = vi
+    .fn()
+    .mockResolvedValue(
+      jsonRes(body, status),
+    ) as unknown as typeof globalThis.fetch;
+}
+
+describe("sapiom_dev_app_publish tool", () => {
+  let originalFetch: typeof globalThis.fetch;
+  const dirs: string[] = [];
+
+  const project = (...args: Parameters<typeof tmpProject>): string => {
+    const dir = tmpProject(...args);
+    dirs.push(dir);
+    return dir;
+  };
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    vi.clearAllMocks();
+    vi.mocked(readCredentials).mockResolvedValue({
+      apiKey: "sk_test",
+      tenantId: "t-1",
+      organizationName: "Acme",
+      apiKeyId: "k-1",
+    } as never);
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+  });
+
+  it("registers under the documented name", () => {
+    expect(setup().name).toBe(TOOL);
+  });
+
+  it("routes durability asks to itself: the description names what a preview URL cannot do", () => {
+    const { description } = setup();
+    expect(description).toMatch(/durable/i);
+    expect(description).toMatch(/permanent/i);
+    expect(description).toMatch(/shareable/i);
+    expect(description).toMatch(/expires with the sandbox/i);
+    // Cold start, org-scoping, republish-in-place, text-only, and the REST cap:
+    // the five facts an agent gets wrong if the description omits them.
+    expect(description).toMatch(/cold-start/i);
+    expect(description).toMatch(/org-scoped by default/i);
+    expect(description).toMatch(/same slug again replaces the app in place/i);
+    expect(description).toMatch(/TEXT-ONLY/);
+    expect(description).toMatch(/10 MiB/);
+  });
+
+  it("is not authenticated without a cached credential, and makes no call", async () => {
+    vi.mocked(readCredentials).mockResolvedValue(null);
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+    const res = await setup().handler({
+      dir: project(),
+      slug: "dash",
+      name: "Dash",
+    });
+
+    expect(res.isError).toBe(true);
+    expect(parse(res).error.code).toBe("NOT_AUTHENTICATED");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("calls upsert → bundle → publish in interfaces §3 order, authed with x-api-key", async () => {
+    const fetchMock = mockHappyBackend();
+    const dir = project({ "index.html": "<h1>hi</h1>", "src/app.js": "1;" });
+
+    const res = await setup().handler({ dir, slug: "dash", name: "Dash" });
+
+    expect(res.isError).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    const [upsertUrl, upsertInit] = fetchMock.mock.calls[0];
+    expect(upsertUrl).toBe("https://api.sapiom.ai/v1/app-links");
+    expect(upsertInit.method).toBe("POST");
+    expect(upsertInit.headers["x-api-key"]).toBe("sk_test");
+    expect(JSON.parse(upsertInit.body)).toEqual({
+      slug: "dash",
+      name: "Dash",
+      // The resource's env travels with the app; `tier`/`ttl` deliberately do not.
+      env: { API_TOKEN: "t" },
+    });
+
+    const [bundleUrl, bundleInit] = fetchMock.mock.calls[1];
+    expect(bundleUrl).toBe(
+      `https://api.sapiom.ai/v1/app-links/${APP_LINK.id}/bundle`,
+    );
+    expect(bundleInit.method).toBe("PUT");
+    expect(JSON.parse(bundleInit.body)).toEqual({
+      files: { "index.html": "<h1>hi</h1>", "src/app.js": "1;" },
+      start: "node server.js",
+      port: 3000,
+      build: "npm install",
+    });
+
+    const [publishUrl, publishInit] = fetchMock.mock.calls[2];
+    expect(publishUrl).toBe(
+      `https://api.sapiom.ai/v1/app-links/${APP_LINK.id}/publish`,
+    );
+    expect(publishInit.method).toBe("POST");
+    // The activate route takes no body — it activates the bundle just stored.
+    expect(JSON.parse(publishInit.body)).toEqual({});
+  });
+
+  it("keeps a base path on a custom apiURL instead of dropping it", async () => {
+    const { server, registrations } = createMockServer();
+    register(server, { ...env, apiURL: "http://localhost:3000/api/" });
+    const fetchMock = mockHappyBackend();
+
+    await registrations.get(TOOL)!.handler({
+      dir: project(),
+      slug: "dash",
+      name: "Dash",
+    });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "http://localhost:3000/api/v1/app-links",
+    );
+  });
+
+  it("reports the sha the backend says is active, not the one we uploaded", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(APP_LINK, 201))
+      .mockResolvedValueOnce(jsonRes(BUNDLE))
+      .mockResolvedValueOnce(
+        jsonRes({ ...APP_LINK, bundleSha256: "raced99" }),
+      ) as unknown as typeof globalThis.fetch;
+
+    const res = await setup().handler({
+      dir: project(),
+      slug: "dash",
+      name: "Dash",
+    });
+
+    expect(parse(res).bundleSha256).toBe("raced99");
+  });
+
+  it("returns the durable url, ids and manifest plus a one-line summary", async () => {
+    mockHappyBackend();
+    const res = await setup().handler({
+      dir: project(),
+      slug: "dash",
+      name: "Dash",
+    });
+
+    const payload = parse(res);
+    expect(payload).toMatchObject({
+      url: "https://apps.sapiom.ai/acme/dash",
+      appLinkId: APP_LINK.id,
+      bundleSha256: "abc123",
+      manifest: BUNDLE.manifest,
+    });
+    expect(payload.summary).toContain("https://apps.sapiom.ai/acme/dash");
+    expect(payload.summary).toMatch(/durable/i);
+    expect(payload.summary.split("\n")).toHaveLength(1);
+  });
+
+  it("forwards the optional metadata a public app needs", async () => {
+    const fetchMock = mockHappyBackend();
+    await setup().handler({
+      dir: project(),
+      slug: "dash",
+      name: "Dash",
+      description: "The dash",
+      visibility: "public",
+      confirmPublic: true,
+      dailySpendCapUsd: "5.00",
+    });
+
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({
+      slug: "dash",
+      name: "Dash",
+      description: "The dash",
+      visibility: "public",
+      confirmPublic: true,
+      dailySpendCapUsd: "5.00",
+      env: { API_TOKEN: "t" },
+    });
+  });
+
+  it("never bundles sapiom.json — its env block is the app's own secrets", async () => {
+    const fetchMock = mockHappyBackend();
+    const dir = project({ "index.html": "<h1>hi</h1>" });
+
+    await setup().handler({ dir, slug: "dash", name: "Dash" });
+
+    const { files } = JSON.parse(fetchMock.mock.calls[1][1].body);
+    expect(files).toEqual({ "index.html": "<h1>hi</h1>" });
+  });
+
+  it("skips node_modules, .git and dotfiles, and reads a nested source path", async () => {
+    const fetchMock = mockHappyBackend();
+    const dir = project(
+      {
+        "web/index.html": "<h1>hi</h1>",
+        "web/node_modules/left-pad/index.js": "module.exports=1",
+        "web/.env": "SECRET=1",
+        "web/.git/config": "[core]",
+        "outside.txt": "not part of the app",
+      },
+      { ...SANDBOX, source: { kind: "upload", path: "web" } },
+    );
+
+    await setup().handler({ dir, slug: "dash", name: "Dash" });
+
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body).files).toEqual({
+      "index.html": "<h1>hi</h1>",
+    });
+  });
+
+  it("names a binary file and publishes nothing — before any HTTP call", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    const dir = project({
+      "index.html": "<h1>hi</h1>",
+      "logo.png": new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0xff, 0xfe, 0x00]),
+    });
+
+    const res = await setup().handler({ dir, slug: "dash", name: "Dash" });
+
+    expect(res.isError).toBe(true);
+    const { error } = parse(res);
+    expect(error.code).toBe("BUNDLE_BINARY_FILE");
+    expect(error.message).toContain("logo.png");
+    expect(error.hint).toContain("logo.png");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a missing sandbox resource without touching the network", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    const dir = mkdtempSync(path.join(tmpdir(), "app-publish-empty-"));
+    dirs.push(dir);
+    writeFileSync(
+      path.join(dir, "sapiom.json"),
+      JSON.stringify({ version: 1 }),
+    );
+
+    const res = await setup().handler({ dir, slug: "dash", name: "Dash" });
+
+    expect(res.isError).toBe(true);
+    expect(parse(res).error.code).toBe("NO_SANDBOX");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty source directory before uploading", async () => {
+    const fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    const dir = project({ ".hidden": "skipped" });
+
+    const res = await setup().handler({ dir, slug: "dash", name: "Dash" });
+
+    expect(res.isError).toBe(true);
+    expect(parse(res).error.code).toBe("BUNDLE_INVALID");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  describe("wire error mapping (interfaces §3)", () => {
+    const cases: Array<{
+      label: string;
+      body: Record<string, unknown>;
+      status: number;
+      code: string;
+      expect: RegExp;
+    }> = [
+      {
+        label: "BUNDLE_BINARY_FILE names the file",
+        body: {
+          code: "BUNDLE_BINARY_FILE",
+          message: "nope",
+          path: "assets/font.woff",
+        },
+        status: 400,
+        code: "BUNDLE_BINARY_FILE",
+        expect: /assets\/font\.woff/,
+      },
+      {
+        label: "BUNDLE_TOO_LARGE quotes both sizes",
+        body: {
+          code: "BUNDLE_TOO_LARGE",
+          message: "too big",
+          bytes: 20_000_000,
+          maxBytes: 10_485_760,
+        },
+        status: 400,
+        code: "BUNDLE_TOO_LARGE",
+        expect: /20000000 bytes exceeds the 10485760-byte limit/,
+      },
+      {
+        label: "PUBLIC_CONFIRM_REQUIRED asks for the acknowledgement",
+        body: { code: "PUBLIC_CONFIRM_REQUIRED", message: "confirm" },
+        status: 409,
+        code: "PUBLIC_CONFIRM_REQUIRED",
+        expect: /anyone with the link/i,
+      },
+      {
+        label: "PUBLIC_SPEND_CAP_REQUIRED asks for the cap",
+        body: { code: "PUBLIC_SPEND_CAP_REQUIRED", message: "cap" },
+        status: 400,
+        code: "PUBLIC_SPEND_CAP_REQUIRED",
+        expect: /daily spend cap/i,
+      },
+      {
+        label: "a management-permission 403 says to drop the management fields",
+        body: {
+          code: "APP_LINK_MANAGEMENT_PERMISSION_REQUIRED",
+          message:
+            "Changing visibility on an existing app link requires org.write.",
+        },
+        status: 403,
+        code: "APP_LINK_MANAGEMENT_PERMISSION_REQUIRED",
+        expect: /Republish without the management fields/,
+      },
+      {
+        label: "401 points at re-authentication",
+        body: { message: "Unauthorized" },
+        status: 401,
+        code: "NOT_AUTHENTICATED",
+        expect: /401/,
+      },
+      {
+        label: "403 names the missing permission",
+        body: { message: "Missing required permission" },
+        status: 403,
+        code: "FORBIDDEN",
+        expect: /403/,
+      },
+    ];
+
+    for (const c of cases) {
+      it(c.label, async () => {
+        mockBackendError(c.body, c.status);
+        const res = await setup().handler({
+          dir: project(),
+          slug: "dash",
+          name: "Dash",
+        });
+
+        expect(res.isError).toBe(true);
+        const { error } = parse(res);
+        expect(error.code).toBe(c.code);
+        expect(`${error.message} ${error.hint ?? ""}`).toMatch(c.expect);
+      });
+    }
+
+    it("403 hint names org.app_links.publish", async () => {
+      mockBackendError({ message: "no" }, 403);
+      const res = await setup().handler({
+        dir: project(),
+        slug: "dash",
+        name: "Dash",
+      });
+      expect(parse(res).error.hint).toContain("org.app_links.publish");
+    });
+
+    it("falls back to HTTP_<status> for an unmapped failure", async () => {
+      mockBackendError({ message: "boom" }, 500);
+      const res = await setup().handler({
+        dir: project(),
+        slug: "dash",
+        name: "Dash",
+      });
+      expect(parse(res).error.code).toBe("HTTP_500");
+    });
+
+    it("maps an unreachable backend to NETWORK", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockRejectedValue(
+          new Error("ECONNREFUSED"),
+        ) as unknown as typeof globalThis.fetch;
+      const res = await setup().handler({
+        dir: project(),
+        slug: "dash",
+        name: "Dash",
+      });
+      const { error } = parse(res);
+      expect(error.code).toBe("NETWORK");
+      expect(error.hint).toContain("ECONNREFUSED");
+    });
+  });
+
+  it("republishing the same slug keeps the URL and reports the new sha", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonRes(APP_LINK, 201))
+      .mockResolvedValueOnce(jsonRes({ ...BUNDLE, bundleSha256: "def456" }))
+      .mockResolvedValueOnce(
+        jsonRes(APP_LINK),
+      ) as unknown as typeof globalThis.fetch;
+
+    const res = await setup().handler({
+      dir: project({ "index.html": "<h1>changed</h1>" }),
+      slug: "dash",
+      name: "Dash",
+    });
+
+    expect(parse(res)).toMatchObject({
+      url: APP_LINK.url,
+      bundleSha256: "def456",
+    });
+  });
+});

--- a/packages/mcp/src/tools/app-publish.ts
+++ b/packages/mcp/src/tools/app-publish.ts
@@ -29,7 +29,13 @@
  * that has to fix its input should never have paid for an upload, or left a
  * half-finished link behind, to learn that.
  */
-import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
 import path from "node:path";
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -226,8 +232,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         });
         // The id addresses the next two calls, so a body that is not the link
         // we asked for (a proxy's HTML error page answering 200, say) has to
-        // stop here rather than become `/v1/app-links/undefined/bundle`.
-        const link = asAppLink(created);
+        // stop here.
+        const link = requireAppLink(created);
 
         const bundle = (await api(
           "bundle",
@@ -245,14 +251,17 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         // last uploaded to this link, which is normally the one the PUT above
         // just stored. Normally: another publisher can upload to the same slug
         // between our two calls, in which case the active bundle is theirs.
-        const published = asAppLink(
-          await api(
-            "publish",
-            "POST",
-            `/v1/app-links/${encodeURIComponent(link.id)}/publish`,
-            {},
-          ),
+        const activated = await api(
+          "publish",
+          "POST",
+          `/v1/app-links/${encodeURIComponent(link.id)}/publish`,
+          {},
         );
+        // Read through when it echoes the link, fall back to step 1 when it does
+        // not. Unlike step 1, nothing downstream NEEDS this body — a 204 or a
+        // bare `{ok:true}` is a publish that worked, and must not be reported as
+        // a failure that "may or may not have taken effect".
+        const published = asAppLink(activated) ?? link;
         // Report what the backend says is live, and say so when that is not
         // what we uploaded — `manifest` describes OUR bundle, so pairing a
         // foreign sha with it silently would misdescribe the running app.
@@ -301,27 +310,32 @@ function summarize(
   );
 }
 
-/**
- * Narrow a wire body to an app link, or fail loudly. A 200/201 whose body is
- * not JSON (`safeParse` hands back the raw string) or lacks an `id` cannot be
- * used to address the next call.
- */
-function asAppLink(data: unknown): AppLinkWire {
+/** A wire body that is usable as an app link, or `null`. */
+function asAppLink(data: unknown): AppLinkWire | null {
   const link = data as AppLinkWire | undefined;
-  if (
-    typeof link?.id !== "string" ||
-    link.id === "" ||
-    typeof link.url !== "string"
-  ) {
-    throw new PreviewOperationError({
-      code: "UNEXPECTED_RESPONSE",
-      message:
-        "The App Links API answered with a success status but not an app link. " +
-        "The publish may or may not have taken effect.",
-      hint: "Check the SAPIOM_ENVIRONMENT / api URL this MCP is pointed at, then retry.",
-    });
-  }
-  return link;
+  const usable =
+    typeof link?.id === "string" &&
+    link.id !== "" &&
+    typeof link.url === "string";
+  return usable ? (link as AppLinkWire) : null;
+}
+
+/**
+ * The step-1 body, which MUST be a link: its `id` addresses the next two calls,
+ * so a 201 that is not JSON (`safeParse` hands back the raw string) or has no
+ * `id` has to stop here rather than become `/v1/app-links/undefined/bundle`.
+ */
+function requireAppLink(data: unknown): AppLinkWire {
+  const link = asAppLink(data);
+  if (link) return link;
+  throw new PreviewOperationError({
+    code: "UNEXPECTED_RESPONSE",
+    message:
+      "The App Links API answered with a success status but not an app link. " +
+      "Nothing was created or published.",
+    step: STEP_ROUTE.create,
+    hint: "Check the SAPIOM_ENVIRONMENT / api URL this MCP is pointed at, then retry.",
+  });
 }
 
 // ─── Bundle collection ───────────────────────────────────────────────────────
@@ -333,17 +347,20 @@ function asAppLink(data: unknown): AppLinkWire {
  * Not `collectDirFiles` from `@sapiom/tools`: that reads with a lossy `utf8`
  * decode, which turns a binary into U+FFFD soup instead of an error — exactly
  * the corruption `BUNDLE_BINARY_FILE` exists to prevent. Skips (like it does)
- * `node_modules`, `.git`, and dotfiles/dot-dirs, plus the project's own
- * `sapiom.json` AT THE BUNDLE ROOT — that file is project config, not app
- * source, and its `env` block holds the app's own secrets, which a static
- * `start` command would serve to every visitor of a public link. A nested
- * `sapiom.json` deeper in the tree is ordinary app content and is kept.
+ * `node_modules`, `.git`, and dotfiles/dot-dirs, plus THE PROJECT'S OWN
+ * `sapiom.json` — matched by absolute path, not by name or depth, because it is
+ * only config at `<projectDir>/sapiom.json`. That file's `env` block holds the
+ * app's own secrets, which a static `start` command would serve to every visitor
+ * of a public link. Any other `sapiom.json` in the tree — a nested one, or
+ * `web/sapiom.json` under a `source.path` of `web` — is ordinary app content.
  *
- * Symlinks are skipped rather than followed. `collectDirFiles` follows them,
- * but its destination is a private sandbox; here the bundle can end up behind a
- * public URL, and a link out of the tree (`report.txt -> ../../secrets`) would
- * publish whatever it points at. A self-referential link would also recurse
- * forever.
+ * Symlinks INSIDE the tree are skipped rather than followed. `collectDirFiles`
+ * follows them, but its destination is a private sandbox; here the bundle can
+ * end up behind a public URL, and a link out of the tree
+ * (`report.txt -> ../../secrets`) would publish whatever it points at. A
+ * self-referential link would also recurse forever. The source root itself is
+ * resolved (`statSync`): it is the path the user explicitly pointed at, and a
+ * symlinked source directory is ordinary in a workspace.
  *
  * A `git`-source resource is read from the same local working tree: the bundle
  * store takes a file map, so there is nothing for a server-side checkout to do.
@@ -354,32 +371,35 @@ export function collectBundleFiles(
 ): Record<string, string> {
   const sub = cfg.source.path ?? ".";
   const root = path.resolve(projectDir, sub);
-  if (!existsSync(root) || !lstatSync(root).isDirectory()) {
+  // `statSync`, not `lstatSync`: the root is the path the user named, and a
+  // symlinked source directory must not be reported as a missing one.
+  if (!existsSync(root) || !statSync(root).isDirectory()) {
     throw new PreviewOperationError({
       code: "NO_SOURCE_DIR",
       message: `Source directory not found: ${root}`,
       hint: `Fix \`source.path\` on the "${cfg.name}" resource in ${CONFIG_FILE}.`,
     });
   }
+  const projectConfig = path.resolve(projectDir, CONFIG_FILE);
 
   const files: Record<string, string> = {};
-  const walk = (abs: string, depth: number): void => {
+  const walk = (abs: string): void => {
     for (const entry of readdirSync(abs).sort()) {
       if (ALWAYS_SKIP.has(entry) || entry.startsWith(".")) continue;
-      if (depth === 0 && entry === CONFIG_FILE) continue;
       const childAbs = path.join(abs, entry);
+      if (childAbs === projectConfig) continue;
       const stat = lstatSync(childAbs);
       if (stat.isSymbolicLink()) continue;
       const rel = path.relative(root, childAbs).split(path.sep).join("/");
       if (stat.isDirectory()) {
-        walk(childAbs, depth + 1);
+        walk(childAbs);
         continue;
       }
       if (!stat.isFile()) continue;
       files[rel] = decodeTextFile(childAbs, rel);
     }
   };
-  walk(root, 0);
+  walk(root);
 
   if (Object.keys(files).length === 0) {
     throw new PreviewOperationError({

--- a/packages/mcp/src/tools/app-publish.ts
+++ b/packages/mcp/src/tools/app-publish.ts
@@ -1,0 +1,530 @@
+/**
+ * `sapiom_dev_app_publish` — publish the project's sandbox resource as an
+ * **App Link**: a durable `https://apps.sapiom.ai/{org}/{slug}` URL that
+ * outlives any sandbox.
+ *
+ * The sibling of `sapiom_dev_sandbox_preview` (sandbox.ts): same `sapiom.json`
+ * `type: "sandbox"` resource, same source directory, same `start`/`port`/`build`
+ * — different destination. `preview` deploys into a live sandbox whose URL dies
+ * with the sandbox's `ttl`; this uploads the source as a stored bundle behind a
+ * permanent address and lets app-host wake it on the first visit. Nothing is
+ * provisioned here: no gateway call, no sandbox, no Blaxel. The wake happens
+ * later, on demand.
+ *
+ * The three REST calls are `plans/app-links/interfaces.md` §3, in order:
+ *   POST /v1/app-links            (upsert on slug)
+ *   PUT  /v1/app-links/{id}/bundle
+ *   POST /v1/app-links/{id}/publish
+ *
+ * Auth is the cached `sapiom_authenticate` credential as `x-api-key` — the
+ * user's own key, so the `org.app_links.publish` delegation gap that affects
+ * workflow per-run `sat_` tokens (SAP-2882) does not apply here.
+ *
+ * Bundles are UTF-8 TEXT ONLY: the sandbox file-map transport decodes
+ * everything as text, so a binary would arrive silently corrupted. This module
+ * rejects one by name locally, before any HTTP call, with the same
+ * `BUNDLE_BINARY_FILE` code the backend uses — an agent that has to fix its
+ * input should never have paid for an upload to learn that.
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  CONFIG_FILE,
+  getSandbox,
+  PreviewOperationError,
+  type SandboxConfig,
+} from "@sapiom/sandbox-preview";
+import { z } from "zod";
+
+import { readCredentials, type ResolvedEnvironment } from "../credentials.js";
+import { registerTool } from "../register-tool.js";
+
+type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+/** Same shape as the backend's `APP_LINK_SLUG_PATTERN` (app-links.types.ts). */
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,62}$/;
+
+/** Same shape as the backend's `USD_DECIMAL_PATTERN`. */
+const USD_PATTERN = /^\d{1,10}(\.\d{1,2})?$/;
+
+/** The REST bundle cap (`MAX_BUNDLE_BYTES`), quoted in the tool description. */
+const BUNDLE_CAP_MIB = 10;
+
+/**
+ * Never bundled. `node_modules` because dependencies install in the sandbox at
+ * wake via `build`; `sapiom.json` because it is project config rather than app
+ * source and its `env` block holds the app's own secrets — a static `start`
+ * command would serve them to every visitor of a public link.
+ */
+const ALWAYS_SKIP = new Set(["node_modules", ".git", CONFIG_FILE]);
+
+/** Fatal decoder — the point is to REJECT a non-UTF-8 file, never to replace its bytes. */
+const strictUtf8 = new TextDecoder("utf-8", { fatal: true });
+
+// ─── Wire shapes (interfaces §1, §3) ─────────────────────────────────────────
+
+interface AppLinkManifest {
+  start: string;
+  port: number;
+  build?: string;
+  envKeys: string[];
+  fileCount: number;
+  bytes: number;
+}
+
+interface AppLinkWire {
+  id: string;
+  slug: string;
+  name: string;
+  visibility: string;
+  url: string;
+  /** Null until a bundle is activated; set on the publish response. */
+  bundleSha256?: string | null;
+}
+
+interface UploadBundleWire {
+  bundleSha256: string;
+  manifest: AppLinkManifest;
+}
+
+// ─── Registration ────────────────────────────────────────────────────────────
+
+export function register(server: McpServer, env: ResolvedEnvironment): void {
+  registerTool(
+    server,
+    "sapiom_dev_app_publish",
+    "Publish this project's web app to a DURABLE Sapiom link: https://apps.sapiom.ai/{org}/{slug}. " +
+      "Use this — not sapiom_dev_sandbox_preview — whenever the user wants a link that is permanent, " +
+      "shareable, or safe to hand to a teammate: a sandbox preview URL expires with the sandbox's ttl, " +
+      'an App Link does not. Reads the same sapiom.json `type: "sandbox"` resource (source dir, start, ' +
+      "port, optional build/env), uploads the source as a stored bundle, and activates it. Nothing runs " +
+      "until someone visits: the first visit after a publish cold-starts the app (tens of seconds behind " +
+      'a "Starting…" page), so this is wake-on-demand hosting, not always-on. Org-scoped by default ' +
+      '(only logged-in members of your organization can open it); visibility "public" needs ' +
+      "confirmPublic: true and a dailySpendCapUsd because your org pays for every wake. Publishing the " +
+      "same slug again replaces the app in place at the SAME URL — that is how you ship an update. " +
+      `Bundles are TEXT-ONLY (UTF-8 files; no images, fonts, or archives) and capped at ${BUNDLE_CAP_MIB} MiB; ` +
+      "node_modules, .git, dotfiles and sapiom.json are never uploaded — install dependencies at wake via `build`. " +
+      "Returns { url, appLinkId, bundleSha256, manifest }.",
+    {
+      dir: z
+        .string()
+        .optional()
+        .describe(
+          "Project directory containing sapiom.json (defaults to the current working directory).",
+        ),
+      slug: z
+        .string()
+        .regex(
+          SLUG_PATTERN,
+          "slug must match [a-z0-9-]{1,63} and start with a letter or digit",
+        )
+        .describe(
+          "URL path segment, unique within your organization — the stable identity of the app. " +
+            "Republishing the same slug updates the same URL in place.",
+        ),
+      name: z
+        .string()
+        .min(1)
+        .max(255)
+        .describe(
+          'Human-readable app name, shown on the "Starting …" page while it wakes.',
+        ),
+      resource: z
+        .string()
+        .optional()
+        .describe(
+          "Which sapiom.json sandbox resource to publish, when the project defines more than one. " +
+            "Omit when there is exactly one.",
+        ),
+      description: z
+        .string()
+        .max(2000)
+        .optional()
+        .describe("Optional description of the app."),
+      visibility: z
+        .enum(["organization", "public"])
+        .optional()
+        .describe(
+          '"organization" (default: members only) or "public" (anyone with the link; requires ' +
+            "confirmPublic and dailySpendCapUsd).",
+        ),
+      confirmPublic: z
+        .boolean()
+        .optional()
+        .describe(
+          'Required with visibility "public": acknowledges that anyone with the link can wake the ' +
+            "app and your org pays for it. Ask the user before setting it.",
+        ),
+      dailySpendCapUsd: z
+        .string()
+        .regex(
+          USD_PATTERN,
+          'dailySpendCapUsd must be a decimal USD amount like "5.00"',
+        )
+        .optional()
+        .describe(
+          'Daily spend ceiling for a public app, as a decimal USD string (e.g. "5.00"). ' +
+            'Required with visibility "public".',
+        ),
+    },
+    async ({ dir, resource, ...input }) => {
+      const creds = await readCredentials(env.name);
+      if (!creds) return NOT_AUTHED;
+      try {
+        const projectDir = dir ?? process.cwd();
+        const cfg = getSandbox(projectDir, resource);
+        // Collected (and binary-checked) before the first HTTP call, so a bad
+        // file map costs no round trip and creates no half-published link.
+        const files = collectBundleFiles(projectDir, cfg);
+
+        const api = (method: string, route: string, body: unknown) =>
+          appLinksRequest(env.apiURL, creds.apiKey, method, route, body);
+
+        // interfaces §3 order: upsert → upload bundle → activate.
+        const link = (await api("POST", "/v1/app-links", {
+          slug: input.slug,
+          name: input.name,
+          ...(input.description === undefined
+            ? {}
+            : { description: input.description }),
+          ...(input.visibility === undefined
+            ? {}
+            : { visibility: input.visibility }),
+          ...(input.confirmPublic === undefined
+            ? {}
+            : { confirmPublic: input.confirmPublic }),
+          ...(input.dailySpendCapUsd === undefined
+            ? {}
+            : { dailySpendCapUsd: input.dailySpendCapUsd }),
+          // The sandbox resource's env travels with the app; stored encrypted,
+          // read back as key names only. Its `tier`/`ttl` deliberately do NOT:
+          // an App Link's sandbox lifetime is an implementation detail of the
+          // wake, and the whole point of publishing is to stop caring about it.
+          ...(cfg.env === undefined ? {} : { env: cfg.env }),
+        })) as AppLinkWire;
+
+        const bundle = (await api(
+          "PUT",
+          `/v1/app-links/${encodeURIComponent(link.id)}/bundle`,
+          {
+            files,
+            start: cfg.start,
+            port: cfg.port,
+            ...(cfg.build === undefined ? {} : { build: cfg.build }),
+          },
+        )) as UploadBundleWire;
+
+        // Activate. The route takes NO body — it activates whatever bundle was
+        // last uploaded to this link, which is the one the PUT above just
+        // stored. The response echoes the active `bundleSha256`, so a mismatch
+        // (another publisher raced us onto the same slug) is visible rather
+        // than silently reported as ours.
+        const published = (await api(
+          "POST",
+          `/v1/app-links/${encodeURIComponent(link.id)}/publish`,
+          {},
+        )) as AppLinkWire;
+        const activeSha = published.bundleSha256 ?? bundle.bundleSha256;
+
+        return ok({
+          summary: summarize(published, bundle),
+          url: published.url,
+          appLinkId: published.id,
+          bundleSha256: activeSha,
+          manifest: bundle.manifest,
+        });
+      } catch (err) {
+        return fail(err);
+      }
+    },
+  );
+}
+
+/** The one-line answer the agent can hand straight to the user. */
+function summarize(link: AppLinkWire, bundle: UploadBundleWire): string {
+  const audience =
+    link.visibility === "public"
+      ? "public — anyone with the link"
+      : "org members only";
+  return (
+    `Published "${link.name}" to ${link.url} (${audience}; ${bundle.manifest.fileCount} files). ` +
+    `The link is durable — republish the "${link.slug}" slug to update it in place. ` +
+    "The first visit after a publish cold-starts the app."
+  );
+}
+
+// ─── Bundle collection ───────────────────────────────────────────────────────
+
+/**
+ * Walk the resource's source directory into the `{ path: contents }` map the
+ * bundle endpoint takes.
+ *
+ * Not `collectDirFiles` from `@sapiom/tools`: that reads with a lossy `utf8`
+ * decode, which turns a binary into U+FFFD soup instead of an error — exactly
+ * the corruption `BUNDLE_BINARY_FILE` exists to prevent. Skips (like it does)
+ * `node_modules`, `.git`, and dotfiles/dot-dirs, plus `sapiom.json`.
+ *
+ * A `git`-source resource is read from the same local working tree: the bundle
+ * store takes a file map, so there is nothing for a server-side checkout to do.
+ */
+export function collectBundleFiles(
+  projectDir: string,
+  cfg: SandboxConfig,
+): Record<string, string> {
+  const sub = cfg.source.path ?? ".";
+  const root = path.resolve(projectDir, sub);
+  if (!existsSync(root) || !statSync(root).isDirectory()) {
+    throw new PreviewOperationError({
+      code: "NO_SOURCE_DIR",
+      message: `Source directory not found: ${root}`,
+      hint: `Fix \`source.path\` on the "${cfg.name}" resource in ${CONFIG_FILE}.`,
+    });
+  }
+
+  const files: Record<string, string> = {};
+  const walk = (abs: string): void => {
+    for (const entry of readdirSync(abs).sort()) {
+      if (ALWAYS_SKIP.has(entry) || entry.startsWith(".")) continue;
+      const childAbs = path.join(abs, entry);
+      const rel = path.relative(root, childAbs).split(path.sep).join("/");
+      if (statSync(childAbs).isDirectory()) {
+        walk(childAbs);
+        continue;
+      }
+      files[rel] = decodeTextFile(childAbs, rel);
+    }
+  };
+  walk(root);
+
+  if (Object.keys(files).length === 0) {
+    throw new PreviewOperationError({
+      code: "BUNDLE_INVALID",
+      message: `No files to publish under ${root}.`,
+      hint: "App Link bundles need at least one text file (node_modules, .git and dotfiles are skipped).",
+    });
+  }
+  return files;
+}
+
+/** Read one file as UTF-8, naming it in the error when it is not text. */
+function decodeTextFile(abs: string, rel: string): string {
+  const bytes = readFileSync(abs);
+  try {
+    return strictUtf8.decode(bytes);
+  } catch (cause) {
+    throw new PreviewOperationError({
+      code: "BUNDLE_BINARY_FILE",
+      message: `"${rel}" is not UTF-8 text, and App Link bundles are text-only. Nothing was published.`,
+      step: "collect",
+      hint:
+        `Remove ${rel} from the source directory (or replace it with a text asset — inline SVG, a data URL, ` +
+        `a CDN reference), then publish again. Cause: ${cause instanceof Error ? cause.message : String(cause)}.`,
+    });
+  }
+}
+
+// ─── REST transport ──────────────────────────────────────────────────────────
+
+/**
+ * One JSON call against the backend's App Links REST API, with the wire error
+ * codes of interfaces §3 turned into errors the agent can act on.
+ *
+ * A bare `GatewayClient` would not do: its mapping keeps only `HTTP_<status>`
+ * and drops the body's `code`, and `BUNDLE_BINARY_FILE` / `BUNDLE_TOO_LARGE`
+ * carry the detail (`path`, `bytes`) that makes the failure fixable.
+ */
+async function appLinksRequest(
+  apiURL: string,
+  apiKey: string,
+  method: string,
+  route: string,
+  body: unknown,
+): Promise<unknown> {
+  // Concatenated, not `new URL(route, base)`: a custom `apiURL` carrying a base
+  // path (a local proxy, a tunnel) would have it silently dropped by the latter.
+  const url = `${apiURL.replace(/\/+$/, "")}${route}`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method,
+      headers: { "x-api-key": apiKey, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (cause) {
+    throw new PreviewOperationError({
+      code: "NETWORK",
+      message: `Could not reach ${url}.`,
+      hint: cause instanceof Error ? cause.message : String(cause),
+    });
+  }
+
+  const text = await res.text();
+  const data = text ? safeParse(text) : undefined;
+  if (!res.ok) throw publishError(res.status, data, `${method} ${route}`);
+  return data;
+}
+
+interface ErrorBody {
+  code?: unknown;
+  message?: unknown;
+  /** `BUNDLE_BINARY_FILE`: the offending FILE path (interfaces §2). */
+  path?: unknown;
+  bytes?: unknown;
+  maxBytes?: unknown;
+}
+
+/**
+ * Map a failed publish call onto a structured tool error. Every branch says what
+ * to change and that nothing was published — the agent's next move should never
+ * be a blind retry of the identical call.
+ */
+function publishError(
+  status: number,
+  data: unknown,
+  where: string,
+): PreviewOperationError {
+  const bodyError = (data ?? {}) as ErrorBody;
+  const code = typeof bodyError.code === "string" ? bodyError.code : undefined;
+  const message = messageFrom(bodyError);
+
+  if (code === "BUNDLE_BINARY_FILE") {
+    const file = typeof bodyError.path === "string" ? bodyError.path : "a file";
+    return new PreviewOperationError({
+      code,
+      message: `Bundle rejected: "${file}" is not UTF-8 text. App Link bundles are text-only. Nothing was published.`,
+      step: where,
+      hint: `Remove ${file} (or replace it with a text asset — inline SVG, a data URL, a CDN reference) and publish again.`,
+    });
+  }
+  if (code === "BUNDLE_TOO_LARGE") {
+    const sizes =
+      typeof bodyError.bytes === "number" &&
+      typeof bodyError.maxBytes === "number"
+        ? `${bodyError.bytes} bytes exceeds the ${bodyError.maxBytes}-byte limit. `
+        : "";
+    return new PreviewOperationError({
+      code,
+      message: `Bundle rejected: ${sizes}Nothing was published.`,
+      step: where,
+      hint:
+        "Drop generated output (dist, build artifacts, lockfiles, vendored assets) from the source " +
+        "directory and install or build at wake via the resource's `build` command instead.",
+    });
+  }
+  if (code === "PUBLIC_CONFIRM_REQUIRED") {
+    return new PreviewOperationError({
+      code,
+      message:
+        'visibility "public" means anyone with the link can wake this app and your org pays. Nothing was published.',
+      step: where,
+      hint: "Ask the user, then retry with confirmPublic: true and a dailySpendCapUsd — or omit visibility to keep it org-scoped.",
+    });
+  }
+  if (code === "PUBLIC_SPEND_CAP_REQUIRED") {
+    return new PreviewOperationError({
+      code,
+      message:
+        "A public app must carry a daily spend cap. Nothing was published.",
+      step: where,
+      hint: 'Retry with dailySpendCapUsd (e.g. "5.00"), or omit visibility to keep the app org-scoped.',
+    });
+  }
+  if (status === 401) {
+    return new PreviewOperationError({
+      code: code ?? "NOT_AUTHENTICATED",
+      message:
+        `The cached credential was rejected (401). ${message ?? ""}`.trim(),
+      step: where,
+      hint: "Run sapiom_authenticate to sign in again.",
+    });
+  }
+  // A 403 has two distinct causes, and the fix differs: publish authority may
+  // create a link and republish its content, but not re-expose an existing one.
+  if (code === "APP_LINK_MANAGEMENT_PERMISSION_REQUIRED") {
+    return new PreviewOperationError({
+      code,
+      message: `${message ?? "Changing how an existing app link is exposed needs more than publish authority."} Nothing was published.`,
+      step: where,
+      hint:
+        "Republish without the management fields (visibility, dailySpendCapUsd) to update the app in " +
+        "place, or have someone with `org.write` change them once.",
+    });
+  }
+  if (status === 403) {
+    return new PreviewOperationError({
+      code: code ?? "FORBIDDEN",
+      message: `Publishing was refused (403). ${message ?? ""}`.trim(),
+      step: where,
+      hint:
+        "This credential is missing the `org.app_links.publish` permission (which `org.write` implies). " +
+        "Publish with a credential that holds it, or ask an org admin.",
+    });
+  }
+  return new PreviewOperationError({
+    code: code ?? `HTTP_${status}`,
+    message:
+      message ??
+      `Request failed (${status}). Nothing was published at ${where}.`,
+    step: where,
+  });
+}
+
+function safeParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function messageFrom(body: ErrorBody): string | undefined {
+  const m = body.message;
+  if (Array.isArray(m)) return m.join("; ");
+  if (typeof m === "string") return m;
+  return undefined;
+}
+
+// ─── Result envelope ─────────────────────────────────────────────────────────
+
+function ok(data: unknown): ToolResult {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+/**
+ * The structured `{"error": {code, message, hint?}}` envelope. The JSON matters
+ * beyond readability: `registerTool` parses `error.code` out of it to classify
+ * the `tool.call` analytics event.
+ */
+function fail(err: unknown): ToolResult {
+  const structured =
+    err instanceof PreviewOperationError
+      ? err.toStructured()
+      : {
+          code: "UNEXPECTED",
+          message: err instanceof Error ? err.message : String(err),
+        };
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ error: structured }, null, 2),
+      },
+    ],
+    isError: true,
+  };
+}
+
+const NOT_AUTHED = fail(
+  new PreviewOperationError({
+    code: "NOT_AUTHENTICATED",
+    message: "Not authenticated. Run sapiom_authenticate first.",
+  }),
+);

--- a/packages/mcp/src/tools/app-publish.ts
+++ b/packages/mcp/src/tools/app-publish.ts
@@ -7,26 +7,29 @@
  * `type: "sandbox"` resource, same source directory, same `start`/`port`/`build`
  * — different destination. `preview` deploys into a live sandbox whose URL dies
  * with the sandbox's `ttl`; this uploads the source as a stored bundle behind a
- * permanent address and lets app-host wake it on the first visit. Nothing is
- * provisioned here: no gateway call, no sandbox, no Blaxel. The wake happens
+ * permanent address, and the hosting layer wakes it on the first visit. Nothing
+ * is provisioned here: no gateway call, no sandbox, no Blaxel. The wake happens
  * later, on demand.
  *
- * The three REST calls are `plans/app-links/interfaces.md` §3, in order:
+ * Three calls against the App Links REST API, in order:
  *   POST /v1/app-links            (upsert on slug)
  *   PUT  /v1/app-links/{id}/bundle
  *   POST /v1/app-links/{id}/publish
  *
- * Auth is the cached `sapiom_authenticate` credential as `x-api-key` — the
- * user's own key, so the `org.app_links.publish` delegation gap that affects
- * workflow per-run `sat_` tokens (SAP-2882) does not apply here.
+ * Auth is the cached `sapiom_authenticate` credential as `x-api-key`.
  *
- * Bundles are UTF-8 TEXT ONLY: the sandbox file-map transport decodes
- * everything as text, so a binary would arrive silently corrupted. This module
- * rejects one by name locally, before any HTTP call, with the same
- * `BUNDLE_BINARY_FILE` code the backend uses — an agent that has to fix its
- * input should never have paid for an upload to learn that.
+ * The first call CREATES the link, so a failure in either of the last two
+ * leaves a real link with no active bundle. Error copy is step-aware for
+ * exactly that reason: only a step-1 failure may claim nothing was created.
+ *
+ * Bundles are UTF-8 TEXT ONLY and size-capped: the file-map transport decodes
+ * everything as text, so a binary would arrive silently corrupted. Both rules
+ * are enforced locally, before any HTTP call, with the same
+ * `BUNDLE_BINARY_FILE` / `BUNDLE_TOO_LARGE` codes the backend uses — an agent
+ * that has to fix its input should never have paid for an upload, or left a
+ * half-finished link behind, to learn that.
  */
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -54,19 +57,18 @@ const USD_PATTERN = /^\d{1,10}(\.\d{1,2})?$/;
 
 /** The REST bundle cap (`MAX_BUNDLE_BYTES`), quoted in the tool description. */
 const BUNDLE_CAP_MIB = 10;
+const BUNDLE_CAP_BYTES = BUNDLE_CAP_MIB * 1024 * 1024;
 
 /**
- * Never bundled. `node_modules` because dependencies install in the sandbox at
- * wake via `build`; `sapiom.json` because it is project config rather than app
- * source and its `env` block holds the app's own secrets — a static `start`
- * command would serve them to every visitor of a public link.
+ * Never bundled at any depth. `node_modules` because dependencies install in
+ * the sandbox at wake via `build`; `.git` because history is not app source.
  */
-const ALWAYS_SKIP = new Set(["node_modules", ".git", CONFIG_FILE]);
+const ALWAYS_SKIP = new Set(["node_modules", ".git"]);
 
 /** Fatal decoder — the point is to REJECT a non-UTF-8 file, never to replace its bytes. */
 const strictUtf8 = new TextDecoder("utf-8", { fatal: true });
 
-// ─── Wire shapes (interfaces §1, §3) ─────────────────────────────────────────
+// ─── Wire shapes ─────────────────────────────────────────────────────────────
 
 interface AppLinkManifest {
   start: string;
@@ -109,7 +111,8 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
       "confirmPublic: true and a dailySpendCapUsd because your org pays for every wake. Publishing the " +
       "same slug again replaces the app in place at the SAME URL — that is how you ship an update. " +
       `Bundles are TEXT-ONLY (UTF-8 files; no images, fonts, or archives) and capped at ${BUNDLE_CAP_MIB} MiB; ` +
-      "node_modules, .git, dotfiles and sapiom.json are never uploaded — install dependencies at wake via `build`. " +
+      "node_modules, .git, dotfiles, symlinks and the project's own sapiom.json are never uploaded — " +
+      "install dependencies at wake via `build`. Both limits are checked locally, so a bad bundle costs no upload. " +
       "Returns { url, appLinkId, bundleSha256, manifest }.",
     {
       dir: z
@@ -183,11 +186,24 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         // file map costs no round trip and creates no half-published link.
         const files = collectBundleFiles(projectDir, cfg);
 
-        const api = (method: string, route: string, body: unknown) =>
-          appLinksRequest(env.apiURL, creds.apiKey, method, route, body);
+        const api = (
+          step: PublishStep,
+          method: string,
+          route: string,
+          body: unknown,
+        ) =>
+          appLinksRequest(
+            env.apiURL,
+            creds.apiKey,
+            input.slug,
+            step,
+            method,
+            route,
+            body,
+          );
 
-        // interfaces §3 order: upsert → upload bundle → activate.
-        const link = (await api("POST", "/v1/app-links", {
+        // In order: upsert → upload bundle → activate.
+        const created = await api("create", "POST", "/v1/app-links", {
           slug: input.slug,
           name: input.name,
           ...(input.description === undefined
@@ -207,9 +223,14 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
           // an App Link's sandbox lifetime is an implementation detail of the
           // wake, and the whole point of publishing is to stop caring about it.
           ...(cfg.env === undefined ? {} : { env: cfg.env }),
-        })) as AppLinkWire;
+        });
+        // The id addresses the next two calls, so a body that is not the link
+        // we asked for (a proxy's HTML error page answering 200, say) has to
+        // stop here rather than become `/v1/app-links/undefined/bundle`.
+        const link = asAppLink(created);
 
         const bundle = (await api(
+          "bundle",
           "PUT",
           `/v1/app-links/${encodeURIComponent(link.id)}/bundle`,
           {
@@ -221,23 +242,37 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         )) as UploadBundleWire;
 
         // Activate. The route takes NO body — it activates whatever bundle was
-        // last uploaded to this link, which is the one the PUT above just
-        // stored. The response echoes the active `bundleSha256`, so a mismatch
-        // (another publisher raced us onto the same slug) is visible rather
-        // than silently reported as ours.
-        const published = (await api(
-          "POST",
-          `/v1/app-links/${encodeURIComponent(link.id)}/publish`,
-          {},
-        )) as AppLinkWire;
+        // last uploaded to this link, which is normally the one the PUT above
+        // just stored. Normally: another publisher can upload to the same slug
+        // between our two calls, in which case the active bundle is theirs.
+        const published = asAppLink(
+          await api(
+            "publish",
+            "POST",
+            `/v1/app-links/${encodeURIComponent(link.id)}/publish`,
+            {},
+          ),
+        );
+        // Report what the backend says is live, and say so when that is not
+        // what we uploaded — `manifest` describes OUR bundle, so pairing a
+        // foreign sha with it silently would misdescribe the running app.
         const activeSha = published.bundleSha256 ?? bundle.bundleSha256;
+        const raced = activeSha !== bundle.bundleSha256;
 
         return ok({
-          summary: summarize(published, bundle),
+          summary: summarize(published, bundle, raced),
           url: published.url,
           appLinkId: published.id,
           bundleSha256: activeSha,
           manifest: bundle.manifest,
+          ...(raced
+            ? {
+                warning:
+                  `The active bundle is ${activeSha}, not the ${bundle.bundleSha256} this call uploaded — ` +
+                  "something else published the same slug in between. `manifest` describes the uploaded " +
+                  "bundle, not the live one. Publish again if yours is the one that should be live.",
+              }
+            : {}),
         });
       } catch (err) {
         return fail(err);
@@ -247,16 +282,46 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
 }
 
 /** The one-line answer the agent can hand straight to the user. */
-function summarize(link: AppLinkWire, bundle: UploadBundleWire): string {
+function summarize(
+  link: AppLinkWire,
+  bundle: UploadBundleWire,
+  raced: boolean,
+): string {
   const audience =
     link.visibility === "public"
       ? "public — anyone with the link"
       : "org members only";
+  const files = raced
+    ? "a bundle published by something else — see `warning`"
+    : `${bundle.manifest.fileCount} files`;
   return (
-    `Published "${link.name}" to ${link.url} (${audience}; ${bundle.manifest.fileCount} files). ` +
+    `Published "${link.name}" to ${link.url} (${audience}; ${files}). ` +
     `The link is durable — republish the "${link.slug}" slug to update it in place. ` +
     "The first visit after a publish cold-starts the app."
   );
+}
+
+/**
+ * Narrow a wire body to an app link, or fail loudly. A 200/201 whose body is
+ * not JSON (`safeParse` hands back the raw string) or lacks an `id` cannot be
+ * used to address the next call.
+ */
+function asAppLink(data: unknown): AppLinkWire {
+  const link = data as AppLinkWire | undefined;
+  if (
+    typeof link?.id !== "string" ||
+    link.id === "" ||
+    typeof link.url !== "string"
+  ) {
+    throw new PreviewOperationError({
+      code: "UNEXPECTED_RESPONSE",
+      message:
+        "The App Links API answered with a success status but not an app link. " +
+        "The publish may or may not have taken effect.",
+      hint: "Check the SAPIOM_ENVIRONMENT / api URL this MCP is pointed at, then retry.",
+    });
+  }
+  return link;
 }
 
 // ─── Bundle collection ───────────────────────────────────────────────────────
@@ -268,7 +333,17 @@ function summarize(link: AppLinkWire, bundle: UploadBundleWire): string {
  * Not `collectDirFiles` from `@sapiom/tools`: that reads with a lossy `utf8`
  * decode, which turns a binary into U+FFFD soup instead of an error — exactly
  * the corruption `BUNDLE_BINARY_FILE` exists to prevent. Skips (like it does)
- * `node_modules`, `.git`, and dotfiles/dot-dirs, plus `sapiom.json`.
+ * `node_modules`, `.git`, and dotfiles/dot-dirs, plus the project's own
+ * `sapiom.json` AT THE BUNDLE ROOT — that file is project config, not app
+ * source, and its `env` block holds the app's own secrets, which a static
+ * `start` command would serve to every visitor of a public link. A nested
+ * `sapiom.json` deeper in the tree is ordinary app content and is kept.
+ *
+ * Symlinks are skipped rather than followed. `collectDirFiles` follows them,
+ * but its destination is a private sandbox; here the bundle can end up behind a
+ * public URL, and a link out of the tree (`report.txt -> ../../secrets`) would
+ * publish whatever it points at. A self-referential link would also recurse
+ * forever.
  *
  * A `git`-source resource is read from the same local working tree: the bundle
  * store takes a file map, so there is nothing for a server-side checkout to do.
@@ -279,7 +354,7 @@ export function collectBundleFiles(
 ): Record<string, string> {
   const sub = cfg.source.path ?? ".";
   const root = path.resolve(projectDir, sub);
-  if (!existsSync(root) || !statSync(root).isDirectory()) {
+  if (!existsSync(root) || !lstatSync(root).isDirectory()) {
     throw new PreviewOperationError({
       code: "NO_SOURCE_DIR",
       message: `Source directory not found: ${root}`,
@@ -288,28 +363,58 @@ export function collectBundleFiles(
   }
 
   const files: Record<string, string> = {};
-  const walk = (abs: string): void => {
+  const walk = (abs: string, depth: number): void => {
     for (const entry of readdirSync(abs).sort()) {
       if (ALWAYS_SKIP.has(entry) || entry.startsWith(".")) continue;
+      if (depth === 0 && entry === CONFIG_FILE) continue;
       const childAbs = path.join(abs, entry);
+      const stat = lstatSync(childAbs);
+      if (stat.isSymbolicLink()) continue;
       const rel = path.relative(root, childAbs).split(path.sep).join("/");
-      if (statSync(childAbs).isDirectory()) {
-        walk(childAbs);
+      if (stat.isDirectory()) {
+        walk(childAbs, depth + 1);
         continue;
       }
+      if (!stat.isFile()) continue;
       files[rel] = decodeTextFile(childAbs, rel);
     }
   };
-  walk(root);
+  walk(root, 0);
 
   if (Object.keys(files).length === 0) {
     throw new PreviewOperationError({
       code: "BUNDLE_INVALID",
       message: `No files to publish under ${root}.`,
-      hint: "App Link bundles need at least one text file (node_modules, .git and dotfiles are skipped).",
+      hint: "App Link bundles need at least one text file (node_modules, .git, dotfiles and symlinks are skipped).",
     });
   }
+  assertUnderCap(files);
   return files;
+}
+
+/**
+ * Refuse an over-cap bundle locally. Measured exactly as the backend does — the
+ * UTF-8 byte length of the canonical `{"files":{…}}` JSON with sorted keys — so
+ * this never disagrees with the server it is standing in for. Worth doing before
+ * the network: the alternative is uploading megabytes to be told no, having
+ * already created the link.
+ */
+function assertUnderCap(files: Record<string, string>): void {
+  const sorted = Object.fromEntries(
+    Object.entries(files).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0)),
+  );
+  const bytes = Buffer.byteLength(JSON.stringify({ files: sorted }), "utf8");
+  if (bytes <= BUNDLE_CAP_BYTES) return;
+  throw new PreviewOperationError({
+    code: "BUNDLE_TOO_LARGE",
+    message:
+      `The bundle is ${bytes} bytes, over the ${BUNDLE_CAP_BYTES}-byte (${BUNDLE_CAP_MIB} MiB) limit. ` +
+      "Nothing was created or published.",
+    step: "collect",
+    hint:
+      "Drop generated output (dist, build artifacts, lockfiles, vendored assets) from the source " +
+      "directory and install or build at wake via the resource's `build` command instead.",
+  });
 }
 
 /** Read one file as UTF-8, naming it in the error when it is not text. */
@@ -320,7 +425,7 @@ function decodeTextFile(abs: string, rel: string): string {
   } catch (cause) {
     throw new PreviewOperationError({
       code: "BUNDLE_BINARY_FILE",
-      message: `"${rel}" is not UTF-8 text, and App Link bundles are text-only. Nothing was published.`,
+      message: `"${rel}" is not UTF-8 text, and App Link bundles are text-only. Nothing was created or published.`,
       step: "collect",
       hint:
         `Remove ${rel} from the source directory (or replace it with a text asset — inline SVG, a data URL, ` +
@@ -332,8 +437,32 @@ function decodeTextFile(abs: string, rel: string): string {
 // ─── REST transport ──────────────────────────────────────────────────────────
 
 /**
+ * Which of the three calls is in flight. The distinction is not cosmetic: step
+ * `create` is the only one that can fail without leaving anything behind, so it
+ * is the only one whose error copy may say so.
+ */
+type PublishStep = "create" | "bundle" | "publish";
+
+const STEP_ROUTE: Record<PublishStep, string> = {
+  create: "POST /v1/app-links",
+  bundle: "PUT /v1/app-links/{id}/bundle",
+  publish: "POST /v1/app-links/{id}/publish",
+};
+
+/**
+ * What the agent must be told about the world after a failure at this step.
+ * After `create` succeeds the link exists, so "nothing was published" would be
+ * a lie — and an agent that believes it will not go clean up or finish the job.
+ */
+function aftermath(step: PublishStep, slug: string): string {
+  return step === "create"
+    ? "Nothing was created or published."
+    : `The "${slug}" app link EXISTS but has no new bundle active. Fix the above and publish the same slug again to finish it (or delete the link if you no longer want it).`;
+}
+
+/**
  * One JSON call against the backend's App Links REST API, with the wire error
- * codes of interfaces §3 turned into errors the agent can act on.
+ * codes turned into errors the agent can act on.
  *
  * A bare `GatewayClient` would not do: its mapping keeps only `HTTP_<status>`
  * and drops the body's `code`, and `BUNDLE_BINARY_FILE` / `BUNDLE_TOO_LARGE`
@@ -342,6 +471,8 @@ function decodeTextFile(abs: string, rel: string): string {
 async function appLinksRequest(
   apiURL: string,
   apiKey: string,
+  slug: string,
+  step: PublishStep,
   method: string,
   route: string,
   body: unknown,
@@ -359,21 +490,22 @@ async function appLinksRequest(
   } catch (cause) {
     throw new PreviewOperationError({
       code: "NETWORK",
-      message: `Could not reach ${url}.`,
+      message: `Could not reach ${url}. ${aftermath(step, slug)}`,
+      step: STEP_ROUTE[step],
       hint: cause instanceof Error ? cause.message : String(cause),
     });
   }
 
   const text = await res.text();
   const data = text ? safeParse(text) : undefined;
-  if (!res.ok) throw publishError(res.status, data, `${method} ${route}`);
+  if (!res.ok) throw publishError(res.status, data, step, slug);
   return data;
 }
 
 interface ErrorBody {
   code?: unknown;
   message?: unknown;
-  /** `BUNDLE_BINARY_FILE`: the offending FILE path (interfaces §2). */
+  /** `BUNDLE_BINARY_FILE`: the offending FILE path, not the request URL. */
   path?: unknown;
   bytes?: unknown;
   maxBytes?: unknown;
@@ -381,23 +513,26 @@ interface ErrorBody {
 
 /**
  * Map a failed publish call onto a structured tool error. Every branch says what
- * to change and that nothing was published — the agent's next move should never
- * be a blind retry of the identical call.
+ * to change and what state the app link is left in — the agent's next move
+ * should never be a blind retry of the identical call.
  */
 function publishError(
   status: number,
   data: unknown,
-  where: string,
+  step: PublishStep,
+  slug: string,
 ): PreviewOperationError {
   const bodyError = (data ?? {}) as ErrorBody;
   const code = typeof bodyError.code === "string" ? bodyError.code : undefined;
   const message = messageFrom(bodyError);
+  const where = STEP_ROUTE[step];
+  const left = aftermath(step, slug);
 
   if (code === "BUNDLE_BINARY_FILE") {
     const file = typeof bodyError.path === "string" ? bodyError.path : "a file";
     return new PreviewOperationError({
       code,
-      message: `Bundle rejected: "${file}" is not UTF-8 text. App Link bundles are text-only. Nothing was published.`,
+      message: `Bundle rejected: "${file}" is not UTF-8 text. App Link bundles are text-only. ${left}`,
       step: where,
       hint: `Remove ${file} (or replace it with a text asset — inline SVG, a data URL, a CDN reference) and publish again.`,
     });
@@ -410,7 +545,7 @@ function publishError(
         : "";
     return new PreviewOperationError({
       code,
-      message: `Bundle rejected: ${sizes}Nothing was published.`,
+      message: `Bundle rejected: ${sizes}${left}`,
       step: where,
       hint:
         "Drop generated output (dist, build artifacts, lockfiles, vendored assets) from the source " +
@@ -420,8 +555,7 @@ function publishError(
   if (code === "PUBLIC_CONFIRM_REQUIRED") {
     return new PreviewOperationError({
       code,
-      message:
-        'visibility "public" means anyone with the link can wake this app and your org pays. Nothing was published.',
+      message: `visibility "public" means anyone with the link can wake this app and your org pays. ${left}`,
       step: where,
       hint: "Ask the user, then retry with confirmPublic: true and a dailySpendCapUsd — or omit visibility to keep it org-scoped.",
     });
@@ -429,8 +563,7 @@ function publishError(
   if (code === "PUBLIC_SPEND_CAP_REQUIRED") {
     return new PreviewOperationError({
       code,
-      message:
-        "A public app must carry a daily spend cap. Nothing was published.",
+      message: `A public app must carry a daily spend cap. ${left}`,
       step: where,
       hint: 'Retry with dailySpendCapUsd (e.g. "5.00"), or omit visibility to keep the app org-scoped.',
     });
@@ -439,7 +572,9 @@ function publishError(
     return new PreviewOperationError({
       code: code ?? "NOT_AUTHENTICATED",
       message:
-        `The cached credential was rejected (401). ${message ?? ""}`.trim(),
+        `The cached credential was rejected (401). ${message ?? ""} ${left}`
+          .replace(/\s+/g, " ")
+          .trim(),
       step: where,
       hint: "Run sapiom_authenticate to sign in again.",
     });
@@ -449,7 +584,7 @@ function publishError(
   if (code === "APP_LINK_MANAGEMENT_PERMISSION_REQUIRED") {
     return new PreviewOperationError({
       code,
-      message: `${message ?? "Changing how an existing app link is exposed needs more than publish authority."} Nothing was published.`,
+      message: `${message ?? "Changing how an existing app link is exposed needs more than publish authority."} ${left}`,
       step: where,
       hint:
         "Republish without the management fields (visibility, dailySpendCapUsd) to update the app in " +
@@ -459,7 +594,9 @@ function publishError(
   if (status === 403) {
     return new PreviewOperationError({
       code: code ?? "FORBIDDEN",
-      message: `Publishing was refused (403). ${message ?? ""}`.trim(),
+      message: `Publishing was refused (403). ${message ?? ""} ${left}`
+        .replace(/\s+/g, " ")
+        .trim(),
       step: where,
       hint:
         "This credential is missing the `org.app_links.publish` permission (which `org.write` implies). " +
@@ -468,9 +605,7 @@ function publishError(
   }
   return new PreviewOperationError({
     code: code ?? `HTTP_${status}`,
-    message:
-      message ??
-      `Request failed (${status}). Nothing was published at ${where}.`,
+    message: `${message ?? `Request failed (${status}).`} ${left}`,
     step: where,
   });
 }

--- a/packages/mcp/src/tools/sandbox.ts
+++ b/packages/mcp/src/tools/sandbox.ts
@@ -7,7 +7,9 @@
  * - `sapiom_dev_sandbox_check` validates those resources without deploying.
  * - `sapiom_dev_sandbox_preview` reads the project's `sapiom.json` (`type: "sandbox"`),
  *   provisions the sandbox if needed, uploads the local code, and calls the
- *   server-side deploy op for a live URL.
+ *   server-side deploy op for a live URL — which lives and dies with the
+ *   sandbox's `ttl`. For a durable address, `sapiom_dev_app_publish`
+ *   (app-publish.ts) publishes the same resource as an App Link.
  *
  * Results are returned as JSON text so the calling agent can parse them.
  */
@@ -97,7 +99,9 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     "Deploy a web-app preview from the current project to a Sapiom sandbox and get a live URL. " +
       "Reads sapiom.json (a `type: \"sandbox\"` resource), provisions the sandbox if needed, uploads " +
       "the local code, builds, starts, and exposes a public URL. Returns { name, url, status, logs }. " +
-      "A `failed` status carries build/start logs (not an error) so you can fix and retry.",
+      "A `failed` status carries build/start logs (not an error) so you can fix and retry. " +
+      "The URL is TEMPORARY — it expires with the sandbox's `ttl`. For a link that is permanent, " +
+      "shareable, or meant for a teammate, use sapiom_dev_app_publish instead.",
     {
       dir: z.string().optional().describe("Project directory (defaults to the current working directory)."),
       name: z.string().optional().describe("Which sandbox to deploy, when the project defines more than one."),
@@ -107,7 +111,14 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
       if (!creds) return NOT_AUTHED;
       try {
         const result = await previewSandbox({ dir: dir ?? process.cwd(), name, apiKey: creds.apiKey });
-        return ok(result);
+        // Say it on the result, not only in the description: the agent reads this
+        // at the moment it is about to hand the URL to the user (SAP-2922).
+        return ok({
+          ...result,
+          note:
+            "This URL expires with the sandbox (its `ttl`) — sapiom_dev_app_publish gives the same app a " +
+            "durable address at https://apps.sapiom.ai/{org}/{slug}.",
+        });
       } catch (err) {
         return fail(err);
       }

--- a/plugins/sapiom/skills/sapiom-sandbox-preview/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-sandbox-preview/SKILL.md
@@ -83,10 +83,11 @@ It reads the **same** `sapiom.json` sandbox resource (source dir, `start`, `port
   slug for v2.
 - **Text-only bundles.** UTF-8 files only — no images, fonts, or archives. A binary is
   rejected **by name** before anything is uploaded; drop it, or use inline SVG, a data URL,
-  or a CDN reference. `node_modules`, `.git`, dotfiles and `sapiom.json` are never uploaded,
-  so install dependencies at wake with the resource's `build` command.
-- **~10 MiB** per bundle over this path. Drop generated output (`dist`, build artifacts,
-  vendored assets) rather than shipping it.
+  or a CDN reference. `node_modules`, `.git`, dotfiles, symlinks and the project's own
+  `sapiom.json` are never uploaded, so install dependencies at wake with the resource's
+  `build` command.
+- **~10 MiB** per bundle over this path, checked locally before the upload. Drop generated
+  output (`dist`, build artifacts, vendored assets) rather than shipping it.
 - Pass `resource` only when the project defines more than one sandbox resource. `slug`
   (`[a-z0-9-]{1,63}`) is the app's identity; `name` is what the "Starting…" page shows.
 

--- a/plugins/sapiom/skills/sapiom-sandbox-preview/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-sandbox-preview/SKILL.md
@@ -1,30 +1,37 @@
 ---
 name: sapiom-sandbox-preview
-description: Deploy a live preview of a web app from the current project to a
-  Sapiom sandbox. Use when the user wants to preview, host, or deploy a web
-  app, dev server, API, or static site to a live URL ("preview this app",
-  "give me a live link", "host this server"), or mentions sapiom.json sandbox
-  resources. Do NOT use for deploying Sapiom agents (that's
-  sapiom_dev_agents_deploy) or for one-off capability calls.
+description: Deploy a web app from the current project to a live Sapiom URL —
+  either a throwaway sandbox preview or a durable App Link. Use when the user
+  wants to preview, host, deploy, or share a web app, dashboard, dev server,
+  API, or static site ("preview this app", "give me a live link", "host this
+  server"), and especially when they want that link to last ("a permanent
+  link", "something I can share with my team", "keep it alive", "my link
+  died"), or mentions sapiom.json sandbox resources or App Links. Do NOT use
+  for deploying Sapiom agents (that's sapiom_dev_agents_deploy) or for one-off
+  capability calls.
 ---
 
-# Sandbox Previews
+# Sandbox Previews & App Links
 
-Deploy the web app in the current project directory to a Sapiom **sandbox** and get a
-**live public URL** — provisioned, uploaded, built, and started in one tool call. Driven
-by the sapiom-dev MCP (`npx -y @sapiom/mcp`; see the [Get Started guide](https://docs.sapiom.ai/)
-if it isn't connected).
+Two ways to put the web app in the current project on a live URL, both driven by the
+sapiom-dev MCP (`npx -y @sapiom/mcp`; see the [Get Started guide](https://docs.sapiom.ai/)
+if it isn't connected) and both reading the same `sapiom.json` resource:
 
-**This is not agent deployment.** Sapiom *agents* deploy with `sapiom_dev_agents_deploy`;
-sandbox previews host an ordinary app (Node server, static site, API) from your working
-directory.
+| You want                                      | Tool                         | The URL                                             |
+| --------------------------------------------- | ---------------------------- | --------------------------------------------------- |
+| To look at it now, iterate, throw it away     | `sapiom_dev_sandbox_preview` | **Temporary** — dies with the sandbox's `ttl`       |
+| A link that lasts, or that someone else opens | `sapiom_dev_app_publish`     | **Durable** — `https://apps.sapiom.ai/{org}/{slug}` |
+
+**This is not agent deployment.** Sapiom _agents_ deploy with `sapiom_dev_agents_deploy`;
+both tools here host an ordinary app (Node server, static site, API, dashboard) from your
+working directory.
 
 ## Prerequisite
 
 Run `sapiom_authenticate` once (browser login; caches a key in `~/.sapiom/credentials.json`).
-`sapiom_dev_sandbox_preview` returns a structured not-authenticated error otherwise;
-`configure` and `check` only touch local files and work signed-out. Check with
-`sapiom_status`.
+`sapiom_dev_sandbox_preview` and `sapiom_dev_app_publish` return a structured
+not-authenticated error otherwise; `configure` and `check` only touch local files and work
+signed-out. Check with `sapiom_status`.
 
 ## The lifecycle
 
@@ -32,16 +39,59 @@ Run `sapiom_authenticate` once (browser login; caches a key in `~/.sapiom/creden
    project's `sapiom.json`. Fill the typed arguments instead of hand-writing JSON — the
    config is validated and written under `resources.<name>` (`type: "sandbox"`). Returns
    the stored config.
-2. **`sapiom_dev_sandbox_check`** *(optional)* — statically validates the resources without
+2. **`sapiom_dev_sandbox_check`** _(optional)_ — statically validates the resources without
    deploying. Returns `{ ok, sandboxes, issues }`; fix any `issues` before previewing.
 3. **`sapiom_dev_sandbox_preview`** — reads `sapiom.json`, provisions the sandbox if
    needed, uploads the local code, builds, starts, and exposes a public URL. Returns
    `{ name, url, status, logs }`. Pass `name` only when the project defines more than one
    resource.
+4. **`sapiom_dev_app_publish`** — when the link needs to outlive the sandbox. See below.
 
 **A `failed` status is not an error** — it carries the build/start logs so you can fix the
 app or the config and run `sapiom_dev_sandbox_preview` again. `unverified` means the app
 started but didn't answer 2xx yet.
+
+**The preview URL is temporary.** It belongs to a sandbox that expires with the resource's
+`ttl` (default `1h`), and it goes away with it — along with any bookmark, Slack message, or
+doc anyone pasted it into. Say so when you hand it over, and reach for
+`sapiom_dev_app_publish` instead whenever the link is meant to survive.
+
+## Make it durable / share it
+
+Route to **`sapiom_dev_app_publish`** whenever the ask is about the link lasting or leaving
+your machine — "share this", "send this to my team", "a permanent link", "keep it alive",
+"can I bookmark this", "put this somewhere", "my link died", "the URL stopped working".
+
+```
+sapiom_dev_app_publish { slug: "dash", name: "Dash" }
+  → { url: "https://apps.sapiom.ai/{org}/dash", appLinkId, bundleSha256, manifest }
+```
+
+It reads the **same** `sapiom.json` sandbox resource (source dir, `start`, `port`, optional
+`build`/`env`), uploads the source as a stored bundle, and activates it. What to know:
+
+- **Wake on demand, not always-on.** Nothing runs until someone visits. The first visit
+  after a publish cold-starts the app — tens of seconds behind a "Starting…" page — then
+  it's fast until it idles out again. Tell the user that, so a slow first load doesn't read
+  as broken.
+- **Org-scoped by default.** Only logged-in members of the organization can open it.
+  `visibility: "public"` (anyone with the link) additionally needs `confirmPublic: true`
+  and a `dailySpendCapUsd` — the org pays for every wake, so **ask the user before setting
+  either**.
+- **Republish in place.** Publishing the same `slug` again replaces the app at the _same_
+  URL and returns a new `bundleSha256`. That is how you ship an update; never mint a second
+  slug for v2.
+- **Text-only bundles.** UTF-8 files only — no images, fonts, or archives. A binary is
+  rejected **by name** before anything is uploaded; drop it, or use inline SVG, a data URL,
+  or a CDN reference. `node_modules`, `.git`, dotfiles and `sapiom.json` are never uploaded,
+  so install dependencies at wake with the resource's `build` command.
+- **~10 MiB** per bundle over this path. Drop generated output (`dist`, build artifacts,
+  vendored assets) rather than shipping it.
+- Pass `resource` only when the project defines more than one sandbox resource. `slug`
+  (`[a-z0-9-]{1,63}`) is the app's identity; `name` is what the "Starting…" page shows.
+
+The canonical link is the identity — share `https://apps.sapiom.ai/{org}/{slug}`, never the
+sandbox address the browser lands on after a wake.
 
 ## The `sapiom.json` resource
 
@@ -60,15 +110,15 @@ started but didn't answer 2xx yet.
 }
 ```
 
-| Field | Required | Notes |
-|---|---|---|
-| `source` | yes | `{ "kind": "upload", "path"? }` (upload the local dir) or `{ "kind": "git", "slug", "path"? }` (server checks out a Sapiom repo) |
-| `start` | yes | The server command (e.g. `node server.js`) |
-| `port` | yes | 1–65535 — the port your app listens on |
-| `build` | no | Build command run before start (e.g. `npm run build`) |
-| `tier` | no | Sandbox size: `xs` \| `s` \| `m` \| `l` \| `xl` |
-| `ttl` | no | Sandbox lifetime, e.g. `"1h"`, `"24h"`, `"7d"` |
-| `env` | no | Environment variables (string map) |
+| Field    | Required | Notes                                                                                                                            |
+| -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `source` | yes      | `{ "kind": "upload", "path"? }` (upload the local dir) or `{ "kind": "git", "slug", "path"? }` (server checks out a Sapiom repo) |
+| `start`  | yes      | The server command (e.g. `node server.js`)                                                                                       |
+| `port`   | yes      | 1–65535 — the port your app listens on                                                                                           |
+| `build`  | no       | Build command run before start (e.g. `npm run build`)                                                                            |
+| `tier`   | no       | Sandbox size: `xs` \| `s` \| `m` \| `l` \| `xl`                                                                                  |
+| `ttl`    | no       | Sandbox lifetime, e.g. `"1h"`, `"24h"`, `"7d"` — **preview only**; an App Link's URL is not bounded by it                        |
+| `env`    | no       | Environment variables (string map)                                                                                               |
 
 Uploads skip `node_modules`, `.git`, and dotfiles — dependencies install in the sandbox at
 build time; never upload them.


### PR DESCRIPTION
Closes SAP-2922 — https://linear.app/sapiom/issue/SAP-2922

## Why

Studio's coding agent could only reach a sandbox preview URL, which dies with the sandbox's `ttl` — and nothing on that surface told it a durable alternative exists. Asked for "a link I can share with my team", it handed over a URL that would be dead by the time anyone clicked it. The backend App Links REST API has been live on prod and dev; this closes the gap between it and the surface the agent is actually taught to use.

## What

**`sapiom_dev_app_publish`** (`packages/mcp/src/tools/app-publish.ts`) — the sibling of `sapiom_dev_sandbox_preview`. Reads the **same** `sapiom.json` `type: "sandbox"` resource (source dir, `start`, `port`, optional `build`/`env`), collects the source as a text-only file map, and publishes it as an App Link via the backend in contract order:

1. `POST /v1/app-links` (upsert on slug)
2. `PUT /v1/app-links/{id}/bundle`
3. `POST /v1/app-links/{id}/publish`

Auth is the cached `sapiom_authenticate` credential as `x-api-key`. Returns `{ summary, url, appLinkId, bundleSha256, manifest }`. Nothing is provisioned here — no gateway call, no sandbox, no Blaxel; the wake happens later, on first visit, via app-host.

Notable choices:

- **Binary rejection is local.** A non-UTF-8 file is named and refused before the first HTTP call (strict `TextDecoder`, not the lossy `utf8` read `collectDirFiles` uses), so a binary in the source dir costs no round trip and creates no half-published link.
- **`sapiom.json` is never bundled** — it is project config, and its `env` block holds the app's own secrets, which a static `start` command would otherwise serve to every visitor of a public link. The resource's `env` travels separately, on the upsert; its `tier`/`ttl` deliberately do not.
- **`POST /publish` is sent with an empty body**, matching the controller (it activates whatever bundle was last uploaded). The response's `bundleSha256` is preferred over the uploaded one, so a racing publisher on the same slug is visible rather than reported as ours.
- **Wire codes → actionable errors**, each stating that nothing was published: `BUNDLE_BINARY_FILE` (names the file), `BUNDLE_TOO_LARGE` (quotes both sizes), `PUBLIC_CONFIRM_REQUIRED`, `PUBLIC_SPEND_CAP_REQUIRED`, `APP_LINK_MANAGEMENT_PERMISSION_REQUIRED` (drop the management fields — not a retry), 401, 403 (names `org.app_links.publish`), plus `NETWORK` and an `HTTP_<status>` fallback.

**Teaching, not just capability.** Both copies of the `sapiom-sandbox-preview` skill (byte-identical, guarded by the sync test) now say plainly that the preview URL expires with the `ttl`, and add a "Make it durable / share it" section routing "share this" / "send this to my team" / "a permanent link" / "keep it alive" / "my link died" to the new tool — carrying the five facts an agent otherwise gets wrong: wake-on-demand cold start, org-scoped by default (public needs `confirmPublic` + `dailySpendCapUsd`, so ask first), republish in place on the same slug, text-only bundles, ~10 MiB cap. The frontmatter `description` picks up the durability triggers.

Plus the nice-to-have: a successful `sapiom_dev_sandbox_preview` result now carries the hint on the **result**, not only in the tool description — the agent reads it at the moment it is about to hand the URL over.

## Tests

- `packages/mcp/src/tools/app-publish.test.ts` (24 tests, backend mocked at `fetch`): the three-call order and `x-api-key`, the durability wording the routing decision hangs on, every wire-code mapping, binary rejection with **no** HTTP call, missing/empty source dir, republish keeping the URL with a new sha, base-path preservation on a custom `apiURL`.
- `skill-sync.test.ts` gains content guards — byte-identity cannot stop two identically wrong copies.
- `analytics.e2e.test.ts` tool roster updated.

## Verification

```
pnpm --filter '@sapiom/mcp...' build   ✓
pnpm --filter @sapiom/mcp typecheck    ✓
pnpm --filter @sapiom/mcp lint         ✓  (agent-core lint ✓)
packages/mcp        vitest run         ✓  15 files, 127 tests
agent-core          skill-sync.test.ts ✓  15 tests
pnpm terminology:check                 ✓
pnpm provider-copy:check               ✓
```

Not verified here: a live publish against `api.sapiom.dev` (needs a funded org credential) — the acceptance criteria that need real HTTP are left for manual/dev-target checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014AysBPbfr9uLL7inXTr9Np
