### PR TITLE
fix(desktop): restore stable Studio pending graph beta

### DIFF
--- a/.changeset/stable-desktop-rollback.md
+++ b/.changeset/stable-desktop-rollback.md
@@ -1,0 +1,8 @@
+---
+"@sapiom/harness-desktop": patch
+---
+
+Restore the stable desktop channel to the Agent Studio experience from `0.3.5`
+by packaging `@sapiom/harness@0.8.9`. The Project dependency graph remains
+available only through the separately versioned beta build while it is
+validated.

--- a/packages/harness-desktop/scripts/copy-renderer.mjs
+++ b/packages/harness-desktop/scripts/copy-renderer.mjs
@@ -44,14 +44,41 @@ const DS_PACKAGE = "@sapiom/design-system";
  * ERR_PACKAGE_PATH_NOT_EXPORTED even when it IS installed — the same reason
  * vite.config.ts probes `${DS_PACKAGE}/package.json`.
  */
-function resolveDesignSystemDir() {
+async function resolveDesignSystemDir() {
   try {
-    return { dir: dirname(require.resolve(`${DS_PACKAGE}/package.json`)), seam: "private package" };
+    return {
+      dir: dirname(require.resolve(`${DS_PACKAGE}/package.json`)),
+      seam: "private package",
+    };
   } catch {
-    // The harness owns the committed fallback; resolve it through the package so
-    // this works from the workspace build regardless of cwd.
-    const harnessRoot = dirname(require.resolve("@sapiom/harness/package.json"));
-    return { dir: join(harnessRoot, "web", "src", "styles", "ds-neutral"), seam: "ds-neutral fallback" };
+    // The harness owns the committed fallback. Prefer resolving it through the
+    // installed package so workspace builds keep following the exact Harness
+    // source they package.
+    const harnessRoot = dirname(
+      require.resolve("@sapiom/harness/package.json"),
+    );
+    const packagedFallback = join(
+      harnessRoot,
+      "web",
+      "src",
+      "styles",
+      "ds-neutral",
+    );
+    try {
+      await stat(join(packagedFallback, "tokens.css"));
+      return { dir: packagedFallback, seam: "ds-neutral fallback" };
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+    }
+
+    // Published Harness tarballs contain only dist/, so an intentionally pinned
+    // desktop rollback cannot read the fallback's source files through that
+    // package. Packaging still runs from this repository, where the canonical
+    // committed fallback is available beside harness-desktop.
+    return {
+      dir: join(root, "..", "harness", "web", "src", "styles", "ds-neutral"),
+      seam: "workspace ds-neutral fallback",
+    };
   }
 }
 
@@ -84,7 +111,7 @@ for (const file of ["setup.html", "setup.css", "update.html", "update.css"]) {
 // reference it same-origin (<img src="./icon.png">, covered by img-src 'self').
 await cp(join(root, "assets", "icon.png"), join(outDir, "icon.png"));
 
-const { dir: dsDir, seam } = resolveDesignSystemDir();
+const { dir: dsDir, seam } = await resolveDesignSystemDir();
 
 // tokens.css is the one file flattened and renamed on the way out (the `ds-`
 // prefix marks the files this window does not own). Everything else keeps its
@@ -106,12 +133,21 @@ await cp(join(dsDir, "themes"), join(outDir, "themes"), { recursive: true });
 // DOES ship both, and a unit test pins that, so this tolerance can never quietly
 // cover the seam every build here actually resolves. Degrading to system-ui is
 // what this window did before it loaded any faces at all.
-const fontCss = await copyIfPresent(join(dsDir, "fonts.css"), join(outDir, "ds-fonts.css"));
-const fontFiles = await copyIfPresent(join(dsDir, "assets", "fonts"), join(outDir, "assets", "fonts"), {
-  recursive: true,
-});
+const fontCss = await copyIfPresent(
+  join(dsDir, "fonts.css"),
+  join(outDir, "ds-fonts.css"),
+);
+const fontFiles = await copyIfPresent(
+  join(dsDir, "assets", "fonts"),
+  join(outDir, "assets", "fonts"),
+  {
+    recursive: true,
+  },
+);
 
 console.log(
   `copied renderer assets + design-system tokens (${seam}) → dist/renderer` +
-    (fontCss && fontFiles ? "" : ` — NOTE: ${seam} ships no font layer, this window falls back to system-ui`),
+    (fontCss && fontFiles
+      ? ""
+      : ` — NOTE: ${seam} ships no font layer, this window falls back to system-ui`),
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@electron/rebuild': ^3.7.0
+  '@sapiom/harness-desktop>@sapiom/harness': 0.8.9
 
 importers:
 
@@ -466,8 +467,8 @@ importers:
   packages/harness-desktop:
     dependencies:
       '@sapiom/harness':
-        specifier: workspace:^
-        version: link:../harness
+        specifier: 0.8.9
+        version: 0.8.9(@cfworker/json-schema@4.1.1)
       electron-updater:
         specifier: ^6.8.9
         version: 6.8.9
@@ -2039,6 +2040,44 @@ packages:
     resolution: {integrity: sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==}
     cpu: [x64]
     os: [win32]
+
+  '@sapiom/agent-core@0.13.2':
+    resolution: {integrity: sha512-uFL2c1BWoANoVrpTAMx+IM3ytogO3slrKh3V/T5hxHITMoDzL5MUiHVuPMf2D+6IoCzJC/qTWQwHMUU7UQvl4g==}
+    engines: {node: '>=18.0.0'}
+
+  '@sapiom/agent-runtime@0.7.0':
+    resolution: {integrity: sha512-lQTF7PRIZuP0BepLpW90QE3yAGkwTs0HzeoxkMm0ddVuTPqKni/V2/867Tet/SzT4VnQ0MbuZ86+dhACuWy4ng==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^4.1.0
+
+  '@sapiom/agent@0.12.2':
+    resolution: {integrity: sha512-Ptq10gyrEGzcOLQb0c0S56Hc6EmhzrnEeinY81G0vC+u/T2QEPylsXme0x4iY+wlrGJ5R+aXEggQwkYBFkROsQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.0.0
+
+  '@sapiom/analytics-core@0.2.1':
+    resolution: {integrity: sha512-IZaSdegheySbLxSwmrvcKFKpog3+Ef8IP/hkd7Qjp7uxgo7pfwkmjy9nFH9lXDH4ALeW5+Fhs717+RKwkW1EJA==}
+    engines: {node: '>=18.0.0'}
+
+  '@sapiom/harness@0.8.9':
+    resolution: {integrity: sha512-fJ9jZvVEe1ChhYmrh+qO19tuplv5fhmZ9w56agT2JVk/LisDFeGDqoQIt3YcLZSJcfYYRJ3RND7rXZSSXHNN6g==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@sapiom/mcp@0.13.0':
+    resolution: {integrity: sha512-f9SppXl1GAwRa/yMks0Ng1FSOimonk9C5DyC+RHI2Iv6xKyy+VEGKIGuE/Q+8LOs4y77Ezk+ca97mTdLKh3p3Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  '@sapiom/sandbox-preview@0.1.19':
+    resolution: {integrity: sha512-bxjSACOSNyxNmnCQ01mA/BQqK/iEiOxaDwnV3/c96lMdhQy9LrHJjMlMSlk7CrT6+84cNoMEGMbafSKHqd/UyQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@sapiom/tools@0.33.0':
+    resolution: {integrity: sha512-eJKAuiM1yKPPAAuIJRXdC/uOFB4CEggAvzftHCB6YjJYXGKtee47A9rAnyBVm7PbRL8PJXudhaDyG7mHkSRN6Q==}
+    engines: {node: '>=18.0.0'}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -6963,6 +7002,68 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.0':
     optional: true
+
+  '@sapiom/agent-core@0.13.2(zod@3.25.76)':
+    dependencies:
+      '@sapiom/agent': 0.12.2(zod@3.25.76)
+      '@sapiom/agent-runtime': 0.7.0(zod@3.25.76)
+      '@sapiom/analytics-core': 0.2.1
+      '@sapiom/tools': 0.33.0
+      esbuild: 0.28.1
+    transitivePeerDependencies:
+      - zod
+
+  '@sapiom/agent-runtime@0.7.0(zod@3.25.76)':
+    dependencies:
+      '@sapiom/agent': 0.12.2(zod@3.25.76)
+      ajv: 8.20.0
+      zod: 3.25.76
+
+  '@sapiom/agent@0.12.2(zod@3.25.76)':
+    dependencies:
+      '@sapiom/tools': 0.33.0
+      zod: 3.25.76
+
+  '@sapiom/analytics-core@0.2.1': {}
+
+  '@sapiom/harness@0.8.9(@cfworker/json-schema@4.1.1)':
+    dependencies:
+      '@sapiom/agent': 0.12.2(zod@3.25.76)
+      '@sapiom/agent-core': 0.13.2(zod@3.25.76)
+      '@sapiom/analytics-core': 0.2.1
+      '@sapiom/mcp': 0.13.0(@cfworker/json-schema@4.1.1)
+      ajv: 8.20.0
+      express: 4.22.2
+      express-rate-limit: 7.5.1(express@4.22.2)
+      node-pty: 1.1.0
+      open: 10.2.0
+      ws: 8.21.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  '@sapiom/mcp@0.13.0(@cfworker/json-schema@4.1.1)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@sapiom/agent-core': 0.13.2(zod@3.25.76)
+      '@sapiom/analytics-core': 0.2.1
+      '@sapiom/sandbox-preview': 0.1.19
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  '@sapiom/sandbox-preview@0.1.19':
+    dependencies:
+      '@sapiom/tools': 0.33.0
+      zod: 3.25.76
+
+  '@sapiom/tools@0.33.0':
+    dependencies:
+      '@sapiom/analytics-core': 0.2.1
 
   '@sec-ant/readable-stream@0.4.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 packages:
-  - 'packages/*'
+  - "packages/*"
 
 # node-pty needs its postinstall (chmods spawn-helper +x); pnpm skips build
 # scripts by default, which leaves it silently non-functional on fresh installs.
@@ -10,7 +10,7 @@ onlyBuiltDependencies:
   - node-pty
   - electron
   - esbuild
-  - '@electron/rebuild'
+  - "@electron/rebuild"
 
 # Upgrade the @electron/rebuild that electron-builder bundles (app-builder-lib
 # pins 3.6.1, which drags node-gyp@9.4.1 — its VS detection can't parse recent
@@ -19,4 +19,7 @@ onlyBuiltDependencies:
 # itself, rather than forcing node-gyp@10 under the old 3.6.1, avoids the
 # cross-platform rebuild HANG that the bare node-gyp override caused.
 overrides:
-  '@electron/rebuild': ^3.7.0
+  "@electron/rebuild": ^3.7.0
+  # Keep the stable desktop rollback on the pre-graph Harness while the rest of
+  # the monorepo continues to develop and publish the beta implementation.
+  "@sapiom/harness-desktop>@sapiom/harness": 0.8.9


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Desktop 0.3.6 put the new Project dependency graph on the stable updater channel before its beta validation was complete. Existing 0.3.6 installs cannot be downgraded to 0.3.5, so stable needs a monotonic 0.3.7 release that restores the pre-graph Studio experience.

## Summary and scope

- Override only @sapiom/harness-desktop to package published @sapiom/harness@0.8.9; the rest of the monorepo remains on the current Harness.
- Fall back to the repository's committed design tokens when a published Harness tarball omits source-only token files required by the desktop setup/update renderers.
- Add a patch Changeset that produces Desktop 0.3.7.

The graph implementation remains on main. A follow-up prerelease will remove the override and package it as 0.3.8-beta.1; that beta change is intentionally out of scope here.

## Related work

Related issue or discussion: SAP-2906 and the Desktop 0.3.6 release containment follow-up.

## Validation

```text
pnpm install --frozen-lockfile — pass; Desktop resolves @sapiom/harness 0.8.9
pnpm --filter @sapiom/harness-desktop typecheck — pass
pnpm --filter @sapiom/harness-desktop test — pass, 18 files / 152 tests
pnpm --filter @sapiom/harness-desktop dist — pass; stable latest-linux.yml generated
packages/harness-desktop/scripts/smoke.sh — pass, 13 passed / 1 Windows-only skipped
pnpm changeset status --verbose — pass; plans @sapiom/harness-desktop 0.3.7
pnpm exec prettier --check .changeset/stable-desktop-rollback.md packages/harness-desktop/scripts/copy-renderer.mjs pnpm-workspace.yaml — pass
git diff --check — pass
```

The packaged smoke report confirmed the SPA was served from the app archive, /api/state reported Harness 0.8.9, session creation and node-pty worked, Studio tokens and Geist loaded, runtime shims and deploy bundling worked, and the updater resolved the stable latest channel. Root all-package checks were not rerun because this is isolated to Desktop packaging; the production Desktop build and packaged smoke exercise the affected boundary directly.

### Tests and documentation

No new unit test was added: the existing renderer tests remained green, and the production pack plus Electron smoke test directly exercised both the pinned dependency and the new source-token fallback. The Changeset documents the externally visible rollback.

## Compatibility and release impact

- Breaking or externally visible changes: Desktop 0.3.7 restores the pre-graph stable Studio UI while keeping the version monotonic for existing 0.3.6 installs. npm Harness/CLI consumers are unchanged.
- Changeset: Added for @sapiom/harness-desktop patch release 0.3.7.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex helped implement the scoped packaging override and renderer fallback. I reviewed the complete diff and validated it with a frozen install, typecheck, unit tests, a production installer build, dependency inspection, and the packaged Electron smoke suite.

## Checklist

- [x] I read CONTRIBUTING.md, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
