### PR TITLE
fix(desktop): guard stable Harness bundle

### DIFF
--- a/packages/harness-desktop/CLAUDE.md
+++ b/packages/harness-desktop/CLAUDE.md
@@ -74,6 +74,16 @@ touching this package, and how to tell whether a change actually works on the OS
 
 ### All platforms
 
+**Desktop can temporarily pin a published Harness for a stable/beta release split.** A non-empty
+`desktopHarnessVersion` in this package's `package.json` means development asserts that installed
+version instead of rebuilding the workspace Harness, and `pack.mjs` asserts the same version in the
+materialized deploy directory before electron-builder runs. The matching selective override lives
+in the root `pnpm-workspace.yaml`. End a pin with **both edits in the same change**: remove that
+override and remove `desktopHarnessVersion`. With the field absent, the inline development
+preparation rebuilds `@sapiom/harness`, and packaging checks the deployed dependency against the
+workspace Harness version. Removing only one side deliberately fails rather than silently shipping
+the wrong application.
+
 **`pnpm dist` does NOT rebuild the workspace packages it bundles.** It runs *this* package's `build`
 and then packs, and `pnpm deploy --prod` copies `@sapiom/harness`'s **`dist/`** — so a harness-side fix
 you have not built is silently absent from the artifact, and the app runs the old code. This is not

--- a/packages/harness-desktop/package.json
+++ b/packages/harness-desktop/package.json
@@ -13,7 +13,7 @@
   "desktopHarnessVersion": "0.8.9",
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/copy-renderer.mjs",
-    "dev": "node scripts/assert-harness-version.mjs && pnpm run build && electron . --dev",
+    "dev": "node scripts/assert-harness-version.mjs --build && pnpm run build && electron . --dev",
     "rebuild": "electron-rebuild -f -w node-pty",
     "dist": "pnpm run build && node scripts/pack.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/harness-desktop/package.json
+++ b/packages/harness-desktop/package.json
@@ -13,8 +13,7 @@
   "desktopHarnessVersion": "0.8.9",
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/copy-renderer.mjs",
-    "predev": "node scripts/assert-harness-version.mjs",
-    "dev": "pnpm run build && electron . --dev",
+    "dev": "node scripts/assert-harness-version.mjs && pnpm run build && electron . --dev",
     "rebuild": "electron-rebuild -f -w node-pty",
     "dist": "pnpm run build && node scripts/pack.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/packages/harness-desktop/package.json
+++ b/packages/harness-desktop/package.json
@@ -10,9 +10,10 @@
   },
   "type": "module",
   "main": "./dist/main/index.js",
+  "desktopHarnessVersion": "0.8.9",
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/copy-renderer.mjs",
-    "predev": "pnpm --filter @sapiom/harness build",
+    "predev": "node scripts/assert-harness-version.mjs",
     "dev": "pnpm run build && electron . --dev",
     "rebuild": "electron-rebuild -f -w node-pty",
     "dist": "pnpm run build && node scripts/pack.mjs",

--- a/packages/harness-desktop/scripts/assert-harness-version.mjs
+++ b/packages/harness-desktop/scripts/assert-harness-version.mjs
@@ -1,8 +1,29 @@
+import { execFileSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 
-import { assertHarnessVersion } from "./harness-version.mjs";
+import {
+  assertHarnessVersion,
+  HAS_PINNED_HARNESS,
+} from "./harness-version.mjs";
 
 const require = createRequire(import.meta.url);
+
+// With no explicit pin, Desktop is back in its normal workspace-development
+// mode. Build the Harness before resolving it so Electron cannot boot a stale
+// dist/ tree. An explicit manifest argument is test/check mode and never builds.
+if (!HAS_PINNED_HARNESS && process.argv[2] === undefined) {
+  const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+  const repoRoot = dirname(dirname(packageDir));
+  execFileSync("pnpm", ["--filter", "@sapiom/harness...", "build"], {
+    cwd: repoRoot,
+    shell: process.platform === "win32",
+    stdio: "inherit",
+    windowsHide: true,
+  });
+}
+
 const manifestPath =
   process.argv[2] ?? require.resolve("@sapiom/harness/package.json");
 

--- a/packages/harness-desktop/scripts/assert-harness-version.mjs
+++ b/packages/harness-desktop/scripts/assert-harness-version.mjs
@@ -9,11 +9,19 @@ import {
 } from "./harness-version.mjs";
 
 const require = createRequire(import.meta.url);
+const args = process.argv.slice(2);
+const buildWorkspace = args[0] === "--build";
 
-// With no explicit pin, Desktop is back in its normal workspace-development
-// mode. Build the Harness before resolving it so Electron cannot boot a stale
-// dist/ tree. An explicit manifest argument is test/check mode and never builds.
-if (!HAS_PINNED_HARNESS && process.argv[2] === undefined) {
+if (args.length > 1 || (buildWorkspace && args.length !== 1)) {
+  throw new Error(
+    "usage: assert-harness-version.mjs [--build | manifest-path]",
+  );
+}
+
+// `dev` opts into preparation with --build. Resolution checks (including the
+// no-argument installed-package test) stay side-effect free, so removing the
+// temporary pin cannot turn the unit suite into a recursive workspace build.
+if (buildWorkspace && !HAS_PINNED_HARNESS) {
   const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
   const repoRoot = dirname(dirname(packageDir));
   execFileSync("pnpm", ["--filter", "@sapiom/harness...", "build"], {
@@ -25,6 +33,7 @@ if (!HAS_PINNED_HARNESS && process.argv[2] === undefined) {
 }
 
 const manifestPath =
-  process.argv[2] ?? require.resolve("@sapiom/harness/package.json");
+  (buildWorkspace ? undefined : args[0]) ??
+  require.resolve("@sapiom/harness/package.json");
 
 assertHarnessVersion(manifestPath, "desktop development dependency");

--- a/packages/harness-desktop/scripts/assert-harness-version.mjs
+++ b/packages/harness-desktop/scripts/assert-harness-version.mjs
@@ -1,0 +1,9 @@
+import { createRequire } from "node:module";
+
+import { assertHarnessVersion } from "./harness-version.mjs";
+
+const require = createRequire(import.meta.url);
+const manifestPath =
+  process.argv[2] ?? require.resolve("@sapiom/harness/package.json");
+
+assertHarnessVersion(manifestPath, "desktop development dependency");

--- a/packages/harness-desktop/scripts/copy-renderer.mjs
+++ b/packages/harness-desktop/scripts/copy-renderer.mjs
@@ -1,9 +1,12 @@
 // Copies the renderer windows' static assets into dist/renderer.
 // tsc emits only the .js from src/renderer; the .html/.css must be copied.
 //
-// We ALSO resolve and copy the design-system token layer, so the onboarding
-// window reads the SAME token values as the SPA instead of carrying its own
-// snapshot of them (a snapshot silently drifts the moment a token changes).
+// We ALSO resolve and copy the design-system token layer for the desktop-owned
+// onboarding and update windows. A normal workspace build reads the SAME source
+// as the SPA. A stable rollback may instead package an older published Harness,
+// whose tarball contains the bundled SPA but omits these source-only token files;
+// that explicit case uses this checkout's committed neutral layer for the two
+// desktop windows. The packaged smoke test verifies its tokens and fonts resolve.
 //
 // The resolution mirrors `packages/harness/web/vite.config.ts`'s
 // `designSystemAlias()`: prefer the private `@sapiom/design-system` package when
@@ -73,10 +76,28 @@ async function resolveDesignSystemDir() {
 
     // Published Harness tarballs contain only dist/, so an intentionally pinned
     // desktop rollback cannot read the fallback's source files through that
-    // package. Packaging still runs from this repository, where the canonical
-    // committed fallback is available beside harness-desktop.
+    // package. Packaging still runs from this repository; use and explicitly
+    // validate its committed neutral layer for the desktop-owned windows.
+    const workspaceFallback = join(
+      root,
+      "..",
+      "harness",
+      "web",
+      "src",
+      "styles",
+      "ds-neutral",
+    );
+    try {
+      await stat(join(workspaceFallback, "tokens.css"));
+    } catch (err) {
+      if (err.code !== "ENOENT") throw err;
+      throw new Error(
+        `workspace ds-neutral fallback is missing tokens.css at ${workspaceFallback}`,
+        { cause: err },
+      );
+    }
     return {
-      dir: join(root, "..", "harness", "web", "src", "styles", "ds-neutral"),
+      dir: workspaceFallback,
       seam: "workspace ds-neutral fallback",
     };
   }

--- a/packages/harness-desktop/scripts/copy-renderer.mjs
+++ b/packages/harness-desktop/scripts/copy-renderer.mjs
@@ -77,7 +77,9 @@ async function resolveDesignSystemDir() {
     // Published Harness tarballs contain only dist/, so an intentionally pinned
     // desktop rollback cannot read the fallback's source files through that
     // package. Packaging still runs from this repository; use and explicitly
-    // validate its committed neutral layer for the desktop-owned windows.
+    // validate the token anchor in its committed neutral layer for the
+    // desktop-owned windows. The packaged smoke test below this build layer is
+    // what verifies the full theme and font set resolves.
     const workspaceFallback = join(
       root,
       "..",

--- a/packages/harness-desktop/scripts/harness-version.mjs
+++ b/packages/harness-desktop/scripts/harness-version.mjs
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs";
+
+const desktopPackage = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+);
+
+export const EXPECTED_HARNESS_VERSION = desktopPackage.desktopHarnessVersion;
+
+if (
+  typeof EXPECTED_HARNESS_VERSION !== "string" ||
+  EXPECTED_HARNESS_VERSION.length === 0
+) {
+  throw new Error(
+    "harness-desktop package.json must declare desktopHarnessVersion",
+  );
+}
+
+export function assertHarnessVersion(manifestPath, context) {
+  const { version: actualVersion } = JSON.parse(
+    readFileSync(manifestPath, "utf8"),
+  );
+  if (actualVersion !== EXPECTED_HARNESS_VERSION) {
+    throw new Error(
+      `${context} must use @sapiom/harness ${EXPECTED_HARNESS_VERSION}, resolved ${String(actualVersion)} at ${manifestPath}`,
+    );
+  }
+  console.log(
+    `[harness-version] ${context}: @sapiom/harness ${actualVersion} matches desktopHarnessVersion`,
+  );
+  return actualVersion;
+}

--- a/packages/harness-desktop/scripts/harness-version.mjs
+++ b/packages/harness-desktop/scripts/harness-version.mjs
@@ -3,16 +3,30 @@ import { readFileSync } from "node:fs";
 const desktopPackage = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 );
+const workspaceHarnessPackage = JSON.parse(
+  readFileSync(new URL("../../harness/package.json", import.meta.url), "utf8"),
+);
 
-export const EXPECTED_HARNESS_VERSION = desktopPackage.desktopHarnessVersion;
+const configuredVersion = desktopPackage.desktopHarnessVersion;
+
+if (
+  configuredVersion !== undefined &&
+  (typeof configuredVersion !== "string" || configuredVersion.length === 0)
+) {
+  throw new Error(
+    "harness-desktop desktopHarnessVersion must be a non-empty string when present",
+  );
+}
+
+export const HAS_PINNED_HARNESS = configuredVersion !== undefined;
+export const EXPECTED_HARNESS_VERSION =
+  configuredVersion ?? workspaceHarnessPackage.version;
 
 if (
   typeof EXPECTED_HARNESS_VERSION !== "string" ||
   EXPECTED_HARNESS_VERSION.length === 0
 ) {
-  throw new Error(
-    "harness-desktop package.json must declare desktopHarnessVersion",
-  );
+  throw new Error("the workspace Harness package must declare a version");
 }
 
 export function assertHarnessVersion(manifestPath, context) {
@@ -25,7 +39,7 @@ export function assertHarnessVersion(manifestPath, context) {
     );
   }
   console.log(
-    `[harness-version] ${context}: @sapiom/harness ${actualVersion} matches desktopHarnessVersion`,
+    `[harness-version] ${context}: @sapiom/harness ${actualVersion} matches ${HAS_PINNED_HARNESS ? "desktopHarnessVersion" : "the workspace Harness"}`,
   );
   return actualVersion;
 }

--- a/packages/harness-desktop/scripts/pack.mjs
+++ b/packages/harness-desktop/scripts/pack.mjs
@@ -16,6 +16,8 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import * as os from "node:os";
 
+import { assertHarnessVersion } from "./harness-version.mjs";
+
 const pkgDir = dirname(dirname(fileURLToPath(import.meta.url))); // packages/harness-desktop
 const repoRoot = dirname(dirname(pkgDir)); // sapiom-js
 const outputDir = join(pkgDir, "release");
@@ -28,7 +30,8 @@ const outputDir = join(pkgDir, "release");
  * then `scripts/smoke.sh`) could not work on macOS: dist errored out, and smoke
  * then looked for a `release/mac-arm64/Sapiom.app` nothing had built.
  */
-const HOST_PLATFORM_FLAG = { darwin: "--mac", win32: "--win" }[process.platform] ?? "--linux";
+const HOST_PLATFORM_FLAG =
+  { darwin: "--mac", win32: "--win" }[process.platform] ?? "--linux";
 const platform = process.argv[2] ?? HOST_PLATFORM_FLAG;
 // Anything after the platform flag goes straight to electron-builder. Signing
 // and notarization are switched on this way (`-c.mac.notarize=true`) rather than
@@ -57,13 +60,17 @@ const isWindows = process.platform === "win32";
 // `{}` for the env, deliberately: SAPIOM_UPDATE_CHANNEL is a per-machine RUNTIME
 // override for a tester, and letting it leak from a developer's shell into what
 // gets packaged would build a beta-channel artifact by accident.
-const { version } = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
+const { version } = JSON.parse(
+  readFileSync(join(pkgDir, "package.json"), "utf8"),
+);
 const { resolveUpdateChannel } = await import(
   pathToFileURL(join(pkgDir, "dist", "main", "update-policy.js")).href
 );
 const { channel } = resolveUpdateChannel(version, {});
 // An explicit caller flag still wins — the passthrough args land after ours.
-const channelFlag = passthrough.some((arg) => arg.startsWith("-c.publish.channel"))
+const channelFlag = passthrough.some((arg) =>
+  arg.startsWith("-c.publish.channel"),
+)
   ? []
   : [`-c.publish.channel=${channel}`];
 
@@ -79,7 +86,10 @@ const channelFlag = passthrough.some((arg) => arg.startsWith("-c.publish.channel
 //    while os.tmpdir() is on `C:` — a C: base corrupts the symlink targets
 //    (`D:\…\harness-desktop\C:\Users\…`). Relocate to the repo's drive.
 let tmpBase = realpathSync(os.tmpdir());
-if (isWindows && tmpBase.slice(0, 2).toLowerCase() !== repoRoot.slice(0, 2).toLowerCase()) {
+if (
+  isWindows &&
+  tmpBase.slice(0, 2).toLowerCase() !== repoRoot.slice(0, 2).toLowerCase()
+) {
   tmpBase = join(`${repoRoot.slice(0, 2)}\\`, "sapiom-tmp");
 }
 const deployDir = join(tmpBase, "sapiom-harness-desktop-pack");
@@ -97,15 +107,40 @@ rmSync(deployDir, { recursive: true, force: true });
 // --legacy: deploy without inject-workspace-packages (pnpm v10 default gate).
 // --prod: drop devDeps (electron/electron-builder) — electronVersion is pinned
 // in electron-builder.yml so the version is known without the devDep present.
-run("pnpm", ["--filter", "@sapiom/harness-desktop", "deploy", "--prod", "--legacy", deployDir], repoRoot);
+run(
+  "pnpm",
+  [
+    "--filter",
+    "@sapiom/harness-desktop",
+    "deploy",
+    "--prod",
+    "--legacy",
+    deployDir,
+  ],
+  repoRoot,
+);
+
+// The stable rollback is deliberately pinned through pnpm's workspace override,
+// rather than the package dependency Changesets owns. Assert the MATERIALIZED
+// dependency before electron-builder sees it: losing that temporary override
+// must fail the release instead of silently shipping the graph on stable again.
+assertHarnessVersion(
+  join(deployDir, "node_modules", "@sapiom", "harness", "package.json"),
+  "deployed desktop bundle",
+);
 
 // `pnpm deploy` honors .gitignore, which excludes dist/ + release/. Copy the
 // built app output, the builder config, and assets into the deploy dir.
 cpSync(join(pkgDir, "dist"), join(deployDir, "dist"), { recursive: true });
-cpSync(join(pkgDir, "electron-builder.yml"), join(deployDir, "electron-builder.yml"));
+cpSync(
+  join(pkgDir, "electron-builder.yml"),
+  join(deployDir, "electron-builder.yml"),
+);
 cpSync(join(pkgDir, "assets"), join(deployDir, "assets"), { recursive: true });
 
-console.log(`[pack] electron-builder ${platform} → ${outputDir} (v${version}, channel "${channel}")`);
+console.log(
+  `[pack] electron-builder ${platform} → ${outputDir} (v${version}, channel "${channel}")`,
+);
 // The `.bin` entry is `electron-builder.cmd` on Windows, `electron-builder` on POSIX.
 const electronBuilder = join(
   pkgDir,

--- a/packages/harness-desktop/scripts/pack.mjs
+++ b/packages/harness-desktop/scripts/pack.mjs
@@ -30,8 +30,7 @@ const outputDir = join(pkgDir, "release");
  * then `scripts/smoke.sh`) could not work on macOS: dist errored out, and smoke
  * then looked for a `release/mac-arm64/Sapiom.app` nothing had built.
  */
-const HOST_PLATFORM_FLAG =
-  { darwin: "--mac", win32: "--win" }[process.platform] ?? "--linux";
+const HOST_PLATFORM_FLAG = { darwin: "--mac", win32: "--win" }[process.platform] ?? "--linux";
 const platform = process.argv[2] ?? HOST_PLATFORM_FLAG;
 // Anything after the platform flag goes straight to electron-builder. Signing
 // and notarization are switched on this way (`-c.mac.notarize=true`) rather than
@@ -60,17 +59,13 @@ const isWindows = process.platform === "win32";
 // `{}` for the env, deliberately: SAPIOM_UPDATE_CHANNEL is a per-machine RUNTIME
 // override for a tester, and letting it leak from a developer's shell into what
 // gets packaged would build a beta-channel artifact by accident.
-const { version } = JSON.parse(
-  readFileSync(join(pkgDir, "package.json"), "utf8"),
-);
+const { version } = JSON.parse(readFileSync(join(pkgDir, "package.json"), "utf8"));
 const { resolveUpdateChannel } = await import(
   pathToFileURL(join(pkgDir, "dist", "main", "update-policy.js")).href
 );
 const { channel } = resolveUpdateChannel(version, {});
 // An explicit caller flag still wins — the passthrough args land after ours.
-const channelFlag = passthrough.some((arg) =>
-  arg.startsWith("-c.publish.channel"),
-)
+const channelFlag = passthrough.some((arg) => arg.startsWith("-c.publish.channel"))
   ? []
   : [`-c.publish.channel=${channel}`];
 
@@ -86,10 +81,7 @@ const channelFlag = passthrough.some((arg) =>
 //    while os.tmpdir() is on `C:` — a C: base corrupts the symlink targets
 //    (`D:\…\harness-desktop\C:\Users\…`). Relocate to the repo's drive.
 let tmpBase = realpathSync(os.tmpdir());
-if (
-  isWindows &&
-  tmpBase.slice(0, 2).toLowerCase() !== repoRoot.slice(0, 2).toLowerCase()
-) {
+if (isWindows && tmpBase.slice(0, 2).toLowerCase() !== repoRoot.slice(0, 2).toLowerCase()) {
   tmpBase = join(`${repoRoot.slice(0, 2)}\\`, "sapiom-tmp");
 }
 const deployDir = join(tmpBase, "sapiom-harness-desktop-pack");
@@ -107,23 +99,12 @@ rmSync(deployDir, { recursive: true, force: true });
 // --legacy: deploy without inject-workspace-packages (pnpm v10 default gate).
 // --prod: drop devDeps (electron/electron-builder) — electronVersion is pinned
 // in electron-builder.yml so the version is known without the devDep present.
-run(
-  "pnpm",
-  [
-    "--filter",
-    "@sapiom/harness-desktop",
-    "deploy",
-    "--prod",
-    "--legacy",
-    deployDir,
-  ],
-  repoRoot,
-);
+run("pnpm", ["--filter", "@sapiom/harness-desktop", "deploy", "--prod", "--legacy", deployDir], repoRoot);
 
-// The stable rollback is deliberately pinned through pnpm's workspace override,
-// rather than the package dependency Changesets owns. Assert the MATERIALIZED
-// dependency before electron-builder sees it: losing that temporary override
-// must fail the release instead of silently shipping the graph on stable again.
+// The expected Harness is either Desktop's explicit stable pin or the workspace
+// package version (see harness-version.mjs). Assert the MATERIALIZED dependency
+// before electron-builder sees it: changing dependency resolution must fail the
+// release instead of silently shipping a different application.
 assertHarnessVersion(
   join(deployDir, "node_modules", "@sapiom", "harness", "package.json"),
   "deployed desktop bundle",
@@ -132,15 +113,10 @@ assertHarnessVersion(
 // `pnpm deploy` honors .gitignore, which excludes dist/ + release/. Copy the
 // built app output, the builder config, and assets into the deploy dir.
 cpSync(join(pkgDir, "dist"), join(deployDir, "dist"), { recursive: true });
-cpSync(
-  join(pkgDir, "electron-builder.yml"),
-  join(deployDir, "electron-builder.yml"),
-);
+cpSync(join(pkgDir, "electron-builder.yml"), join(deployDir, "electron-builder.yml"));
 cpSync(join(pkgDir, "assets"), join(deployDir, "assets"), { recursive: true });
 
-console.log(
-  `[pack] electron-builder ${platform} → ${outputDir} (v${version}, channel "${channel}")`,
-);
+console.log(`[pack] electron-builder ${platform} → ${outputDir} (v${version}, channel "${channel}")`);
 // The `.bin` entry is `electron-builder.cmd` on Windows, `electron-builder` on POSIX.
 const electronBuilder = join(
   pkgDir,

--- a/packages/harness-desktop/src/main/dev-script.test.ts
+++ b/packages/harness-desktop/src/main/dev-script.test.ts
@@ -3,14 +3,14 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("desktop development build", () => {
-  it("checks the pinned Harness version before Electron", () => {
+  it("prepares and checks Harness inline before building Electron", () => {
     const packageJson = JSON.parse(
       readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
     ) as { scripts?: Record<string, string> };
 
-    expect(packageJson.scripts?.predev).toBe(
-      "node scripts/assert-harness-version.mjs",
+    expect(packageJson.scripts?.predev).toBeUndefined();
+    expect(packageJson.scripts?.dev).toBe(
+      "node scripts/assert-harness-version.mjs && pnpm run build && electron . --dev",
     );
-    expect(packageJson.scripts?.dev).toContain("electron . --dev");
   });
 });

--- a/packages/harness-desktop/src/main/dev-script.test.ts
+++ b/packages/harness-desktop/src/main/dev-script.test.ts
@@ -3,13 +3,13 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 describe("desktop development build", () => {
-  it("builds the Harness server and web bundle before Electron", () => {
+  it("checks the pinned Harness version before Electron", () => {
     const packageJson = JSON.parse(
       readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
     ) as { scripts?: Record<string, string> };
 
     expect(packageJson.scripts?.predev).toBe(
-      "pnpm --filter @sapiom/harness build",
+      "node scripts/assert-harness-version.mjs",
     );
     expect(packageJson.scripts?.dev).toContain("electron . --dev");
   });

--- a/packages/harness-desktop/src/main/dev-script.test.ts
+++ b/packages/harness-desktop/src/main/dev-script.test.ts
@@ -10,7 +10,7 @@ describe("desktop development build", () => {
 
     expect(packageJson.scripts?.predev).toBeUndefined();
     expect(packageJson.scripts?.dev).toBe(
-      "node scripts/assert-harness-version.mjs && pnpm run build && electron . --dev",
+      "node scripts/assert-harness-version.mjs --build && pnpm run build && electron . --dev",
     );
   });
 });

--- a/packages/harness-desktop/src/main/harness-version.test.ts
+++ b/packages/harness-desktop/src/main/harness-version.test.ts
@@ -38,7 +38,7 @@ function manifestWith(version: string): string {
 }
 
 describe("desktop Harness version guard", () => {
-  it("resolves the installed Harness manifest through the real development path", () => {
+  it("resolves the installed Harness manifest without build side effects", () => {
     const result = spawnSync(process.execPath, [script], { encoding: "utf8" });
 
     expect(result.status, result.stderr).toBe(0);

--- a/packages/harness-desktop/src/main/harness-version.test.ts
+++ b/packages/harness-desktop/src/main/harness-version.test.ts
@@ -1,14 +1,26 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { spawnSync } from "node:child_process";
 
 import { afterEach, describe, expect, it } from "vitest";
 
 const script = fileURLToPath(
   new URL("../../scripts/assert-harness-version.mjs", import.meta.url),
 );
+const desktopPackage = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as { desktopHarnessVersion?: string };
+const workspaceHarnessPackage = JSON.parse(
+  readFileSync(
+    new URL("../../../harness/package.json", import.meta.url),
+    "utf8",
+  ),
+) as { version: string };
+const expectedVersion =
+  desktopPackage.desktopHarnessVersion ?? workspaceHarnessPackage.version;
+const differentVersion = expectedVersion === "0.9.0" ? "0.8.9" : "0.9.0";
 const tempDirs: string[] = [];
 
 afterEach(() => {
@@ -26,23 +38,30 @@ function manifestWith(version: string): string {
 }
 
 describe("desktop Harness version guard", () => {
+  it("resolves the installed Harness manifest through the real development path", () => {
+    const result = spawnSync(process.execPath, [script], { encoding: "utf8" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain(`@sapiom/harness ${expectedVersion}`);
+  });
+
   it("accepts the explicitly expected Harness version", () => {
     const result = spawnSync(
       process.execPath,
-      [script, manifestWith("0.8.9")],
+      [script, manifestWith(expectedVersion)],
       {
         encoding: "utf8",
       },
     );
 
     expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain("@sapiom/harness 0.8.9");
+    expect(result.stdout).toContain(`@sapiom/harness ${expectedVersion}`);
   });
 
   it("fails before packaging a different Harness version", () => {
     const result = spawnSync(
       process.execPath,
-      [script, manifestWith("0.9.0")],
+      [script, manifestWith(differentVersion)],
       {
         encoding: "utf8",
       },
@@ -50,7 +69,7 @@ describe("desktop Harness version guard", () => {
 
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain(
-      "must use @sapiom/harness 0.8.9, resolved 0.9.0",
+      `must use @sapiom/harness ${expectedVersion}, resolved ${differentVersion}`,
     );
   });
 });

--- a/packages/harness-desktop/src/main/harness-version.test.ts
+++ b/packages/harness-desktop/src/main/harness-version.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const script = fileURLToPath(
+  new URL("../../scripts/assert-harness-version.mjs", import.meta.url),
+);
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function manifestWith(version: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "sapiom-harness-version-"));
+  tempDirs.push(dir);
+  const manifest = join(dir, "package.json");
+  writeFileSync(manifest, JSON.stringify({ name: "@sapiom/harness", version }));
+  return manifest;
+}
+
+describe("desktop Harness version guard", () => {
+  it("accepts the explicitly expected Harness version", () => {
+    const result = spawnSync(
+      process.execPath,
+      [script, manifestWith("0.8.9")],
+      {
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("@sapiom/harness 0.8.9");
+  });
+
+  it("fails before packaging a different Harness version", () => {
+    const result = spawnSync(
+      process.execPath,
+      [script, manifestWith("0.9.0")],
+      {
+        encoding: "utf8",
+      },
+    );
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain(
+      "must use @sapiom/harness 0.8.9, resolved 0.9.0",
+    );
+  });
+});

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,8 @@ onlyBuiltDependencies:
 overrides:
   "@electron/rebuild": ^3.7.0
   # Temporary SAP-2906 release split: keep stable Desktop on the pre-graph
-  # Harness, then remove this override after tagging 0.3.7 and before packaging
-  # 0.3.8-beta.1. The rest of the monorepo stays on the current implementation.
+  # Harness. After tagging 0.3.7, remove BOTH this override and Desktop's
+  # desktopHarnessVersion field for 0.3.8-beta.1. With both absent, its dev
+  # preparation builds Harness from the workspace and its packer checks that
+  # deployed workspace version. The rest of the monorepo stays current.
   "@sapiom/harness-desktop>@sapiom/harness": 0.8.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ onlyBuiltDependencies:
 # cross-platform rebuild HANG that the bare node-gyp override caused.
 overrides:
   "@electron/rebuild": ^3.7.0
-  # Keep the stable desktop rollback on the pre-graph Harness while the rest of
-  # the monorepo continues to develop and publish the beta implementation.
+  # Temporary SAP-2906 release split: keep stable Desktop on the pre-graph
+  # Harness, then remove this override after tagging 0.3.7 and before packaging
+  # 0.3.8-beta.1. The rest of the monorepo stays on the current implementation.
   "@sapiom/harness-desktop>@sapiom/harness": 0.8.9


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [x] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The stable rollback merged in #727 relies on a temporary pnpm override to package Harness 0.8.9. Without an independent assertion, dropping that override before the 0.3.7 tag could silently put the graph back into an undowngradable stable installer.

## Summary and scope

- Declare the Harness version Desktop expects during the temporary stable/beta split.
- Assert the installed dependency directly inside `dev` through an explicit `--build` preparation mode, without relying on pnpm pre-scripts.
- Assert the materialized dependency before electron-builder packages it.
- Make the pin cleanup-safe: removing both the selective override and `desktopHarnessVersion` restores workspace mode, builds Harness and its workspace dependency chain, and checks the deployed workspace version.
- Exercise the real no-argument `require.resolve("@sapiom/harness/package.json")` path as well as accepted and rejected manifest fixtures.
- Clarify and validate the source-token fallback used by desktop-owned windows with a published Harness tarball.

This is the review follow-up to #727 and must land before tagging Desktop 0.3.7.

### Key refinements from code review

- Documented the exact two-edit removal contract and verified it from an isolated checkout.
- Moved the development guard inline because `enable-pre-post-scripts` is unset under pnpm 10.
- Kept no-argument resolution checks side-effect free so unpinned unit tests never launch a recursive workspace build; only `dev --build` performs preparation.
- Removed unrelated formatter churn and made version assertions derive their expected values instead of hardcoding test versions.

## Related work

Related issue or discussion: #727 and SAP-2906.

## Validation

```text
node packages/harness-desktop/scripts/assert-harness-version.mjs — pass; resolved pinned Harness 0.8.9
isolated two-edit pin removal + no-argument guard tests — pass, 4 tests in 323 ms; no Harness dist created
isolated unpinned --build preparation — pass; built dependency chain, resolved workspace Harness 0.9.0, then 155 tests passed
pnpm --filter @sapiom/harness-desktop typecheck — pass
pnpm --filter @sapiom/harness-desktop test — pass, 19 files / 155 tests
pnpm --filter @sapiom/harness-desktop dist — pass; deployed-bundle guard confirmed 0.8.9
packages/harness-desktop/scripts/smoke.sh — pass, 13 passed / 1 Windows-only skipped
pnpm changeset status --verbose — pass; plans Desktop 0.3.7
selective Prettier check — pass
git diff --check — pass
```

### Tests and documentation

Added coverage for the real installed-package resolution path and dynamic accepted/rejected versions. The resolution test is explicitly side-effect free while `dev --build` owns workspace preparation. Updated package guidance and the workspace override comment with the exact stable-to-beta cleanup contract.

## Compatibility and release impact

- Breaking or externally visible changes: None beyond #727. This prevents an incorrect 0.3.7 artifact from being built.
- Changeset: N/A — #727's existing pending Desktop 0.3.7 Changeset covers this pre-release safety follow-up.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex implemented the version guard and its review refinements. I reviewed the full diff and validated the pin, cleanup, production packaging, and packaged Electron runtime paths.

## Checklist

- [x] I read CONTRIBUTING.md, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
