### PR TITLE
chore(desktop): prepare 0.3.8-beta.1 release branch

### DIFF
--- a/packages/harness-desktop/CHANGELOG.md
+++ b/packages/harness-desktop/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @sapiom/harness-desktop
 
+## 0.3.8-beta.1
+
+### Prerelease Changes
+
+- Package `@sapiom/harness@0.9.0` on the beta channel for validation of the
+  Project dependency graph and Project/Group rail integration.
+
 ## 0.3.7
 
 ### Patch Changes

--- a/packages/harness-desktop/CHANGELOG.md
+++ b/packages/harness-desktop/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Prerelease Changes
 
-- Package `@sapiom/harness@0.9.0` on the beta channel for validation of the
-  Project dependency graph and Project/Group rail integration.
+- Package the current workspace Harness on the beta channel for validation of
+  the Project dependency graph and Project/Group rail integration.
 
 ## 0.3.7
 

--- a/packages/harness-desktop/package.json
+++ b/packages/harness-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sapiom/harness-desktop",
-  "version": "0.3.7",
+  "version": "0.3.8-beta.1",
   "private": true,
   "description": "Agent Studio desktop app — a one-click native host for running Claude Code or Codex in a Sapiom-configured environment. The npx CLI (@sapiom/harness) remains the backup host over the same startServer().",
   "homepage": "https://sapiom.ai",
@@ -10,7 +10,6 @@
   },
   "type": "module",
   "main": "./dist/main/index.js",
-  "desktopHarnessVersion": "0.8.9",
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/copy-renderer.mjs",
     "dev": "node scripts/assert-harness-version.mjs --build && pnpm run build && electron . --dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   '@electron/rebuild': ^3.7.0
-  '@sapiom/harness-desktop>@sapiom/harness': 0.8.9
 
 importers:
 
@@ -467,8 +466,8 @@ importers:
   packages/harness-desktop:
     dependencies:
       '@sapiom/harness':
-        specifier: 0.8.9
-        version: 0.8.9(@cfworker/json-schema@4.1.1)
+        specifier: workspace:^
+        version: link:../harness
       electron-updater:
         specifier: ^6.8.9
         version: 6.8.9
@@ -2040,44 +2039,6 @@ packages:
     resolution: {integrity: sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==}
     cpu: [x64]
     os: [win32]
-
-  '@sapiom/agent-core@0.13.2':
-    resolution: {integrity: sha512-uFL2c1BWoANoVrpTAMx+IM3ytogO3slrKh3V/T5hxHITMoDzL5MUiHVuPMf2D+6IoCzJC/qTWQwHMUU7UQvl4g==}
-    engines: {node: '>=18.0.0'}
-
-  '@sapiom/agent-runtime@0.7.0':
-    resolution: {integrity: sha512-lQTF7PRIZuP0BepLpW90QE3yAGkwTs0HzeoxkMm0ddVuTPqKni/V2/867Tet/SzT4VnQ0MbuZ86+dhACuWy4ng==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^4.1.0
-
-  '@sapiom/agent@0.12.2':
-    resolution: {integrity: sha512-Ptq10gyrEGzcOLQb0c0S56Hc6EmhzrnEeinY81G0vC+u/T2QEPylsXme0x4iY+wlrGJ5R+aXEggQwkYBFkROsQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.0.0
-
-  '@sapiom/analytics-core@0.2.1':
-    resolution: {integrity: sha512-IZaSdegheySbLxSwmrvcKFKpog3+Ef8IP/hkd7Qjp7uxgo7pfwkmjy9nFH9lXDH4ALeW5+Fhs717+RKwkW1EJA==}
-    engines: {node: '>=18.0.0'}
-
-  '@sapiom/harness@0.8.9':
-    resolution: {integrity: sha512-fJ9jZvVEe1ChhYmrh+qO19tuplv5fhmZ9w56agT2JVk/LisDFeGDqoQIt3YcLZSJcfYYRJ3RND7rXZSSXHNN6g==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  '@sapiom/mcp@0.13.0':
-    resolution: {integrity: sha512-f9SppXl1GAwRa/yMks0Ng1FSOimonk9C5DyC+RHI2Iv6xKyy+VEGKIGuE/Q+8LOs4y77Ezk+ca97mTdLKh3p3Q==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
-  '@sapiom/sandbox-preview@0.1.19':
-    resolution: {integrity: sha512-bxjSACOSNyxNmnCQ01mA/BQqK/iEiOxaDwnV3/c96lMdhQy9LrHJjMlMSlk7CrT6+84cNoMEGMbafSKHqd/UyQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@sapiom/tools@0.33.0':
-    resolution: {integrity: sha512-eJKAuiM1yKPPAAuIJRXdC/uOFB4CEggAvzftHCB6YjJYXGKtee47A9rAnyBVm7PbRL8PJXudhaDyG7mHkSRN6Q==}
-    engines: {node: '>=18.0.0'}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -7002,68 +6963,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.0':
     optional: true
-
-  '@sapiom/agent-core@0.13.2(zod@3.25.76)':
-    dependencies:
-      '@sapiom/agent': 0.12.2(zod@3.25.76)
-      '@sapiom/agent-runtime': 0.7.0(zod@3.25.76)
-      '@sapiom/analytics-core': 0.2.1
-      '@sapiom/tools': 0.33.0
-      esbuild: 0.28.1
-    transitivePeerDependencies:
-      - zod
-
-  '@sapiom/agent-runtime@0.7.0(zod@3.25.76)':
-    dependencies:
-      '@sapiom/agent': 0.12.2(zod@3.25.76)
-      ajv: 8.20.0
-      zod: 3.25.76
-
-  '@sapiom/agent@0.12.2(zod@3.25.76)':
-    dependencies:
-      '@sapiom/tools': 0.33.0
-      zod: 3.25.76
-
-  '@sapiom/analytics-core@0.2.1': {}
-
-  '@sapiom/harness@0.8.9(@cfworker/json-schema@4.1.1)':
-    dependencies:
-      '@sapiom/agent': 0.12.2(zod@3.25.76)
-      '@sapiom/agent-core': 0.13.2(zod@3.25.76)
-      '@sapiom/analytics-core': 0.2.1
-      '@sapiom/mcp': 0.13.0(@cfworker/json-schema@4.1.1)
-      ajv: 8.20.0
-      express: 4.22.2
-      express-rate-limit: 7.5.1(express@4.22.2)
-      node-pty: 1.1.0
-      open: 10.2.0
-      ws: 8.21.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@sapiom/mcp@0.13.0(@cfworker/json-schema@4.1.1)':
-    dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
-      '@sapiom/agent-core': 0.13.2(zod@3.25.76)
-      '@sapiom/analytics-core': 0.2.1
-      '@sapiom/sandbox-preview': 0.1.19
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@sapiom/sandbox-preview@0.1.19':
-    dependencies:
-      '@sapiom/tools': 0.33.0
-      zod: 3.25.76
-
-  '@sapiom/tools@0.33.0':
-    dependencies:
-      '@sapiom/analytics-core': 0.2.1
 
   '@sec-ant/readable-stream@0.4.1': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,9 +20,3 @@ onlyBuiltDependencies:
 # cross-platform rebuild HANG that the bare node-gyp override caused.
 overrides:
   "@electron/rebuild": ^3.7.0
-  # Temporary SAP-2906 release split: keep stable Desktop on the pre-graph
-  # Harness. After tagging 0.3.7, remove BOTH this override and Desktop's
-  # desktopHarnessVersion field for 0.3.8-beta.1. With both absent, its dev
-  # preparation builds Harness from the workspace and its packer checks that
-  # deployed workspace version. The rest of the monorepo stays current.
-  "@sapiom/harness-desktop>@sapiom/harness": 0.8.9


### PR DESCRIPTION
> [!IMPORTANT]
> **Release-only PR — do not merge into `main`.** After approval, tag this PR head exactly, publish the beta, then close the PR. Stable `main` remains at Desktop 0.3.7 with the Harness 0.8.9 pin.

## Summary

Prepare the first Project dependency graph beta Desktop release without placing a hand-versioned prerelease on `main`. This branch sets Desktop to 0.3.8-beta.1 and packages the current workspace Harness on the beta update channel.

## Changes

- set `@sapiom/harness-desktop` to `0.3.8-beta.1`
- remove both temporary stable pin mechanisms together: `desktopHarnessVersion` and the selective pnpm override
- update the lockfile back to the workspace Harness link
- add a beta changelog entry that describes the workspace Harness without hard-coding a version
- retain the bundle/version guard introduced in #729

## Why this branch must not merge

Changesets is not in prerelease mode. Merging a manually versioned `0.3.8-beta.1` into `main` would allow a later dependency changeset to rewrite it as stable `0.3.8`. Keeping this as a reviewed release branch isolates the beta while stable `main` and GitHub Latest remain on 0.3.7.

## Required release procedure

1. Wait for this exact head SHA to pass CI and review.
2. Tag this exact head as `harness-desktop-v0.3.8-beta.1`; do not merge it.
3. Monitor Linux, macOS, Windows, and final publication.
4. Verify the GitHub release is a prerelease and `harness-desktop-v0.3.7` remains Latest.
5. Close this PR without merging after release verification.

## Testing

- `pnpm install --frozen-lockfile`
- side-effect-free Harness resolution: workspace Harness, with no implicit build
- explicit Harness preparation build: passed
- Desktop typecheck: passed
- Desktop unit tests: 19 files / 155 tests passed
- Prettier and `git diff --check`: passed
- Linux beta packaging: AppImage, deb, and `beta-linux.yml` generated
- packaged Desktop smoke: 13 passed / 1 expected Windows-only skip
- smoke verified Desktop 0.3.8-beta.1, workspace Harness, and beta update channel

## Review refinements

- made the PR explicitly release-only so Changesets never sees the prerelease on `main`
- removed the brittle `@sapiom/harness@0.9.0` assertion from release prose

## Related

Refs: SAP-2906