### PR TITLE
fix(mcp): re-sync the offline AUTHORING_INSTRUCTIONS fallback with the server primer [SAP-2959]

### DIFF
--- a/.changeset/resync-authoring-instructions-fallback.md
+++ b/.changeset/resync-authoring-instructions-fallback.md
@@ -10,6 +10,7 @@ no durable-sharing paragraph, no `sapiom_dev_app_publish`, no hosted or REST pub
 surface. It also still described the older single-alias framing of the hosted
 capability MCP, which now lives under its own `sapiom-direct` alias.
 
-The two copies are now byte-identical, and a frozen sha-256 in `instructions.test.ts`
-— the same digest the server-side spec pins for this content release — fails CI on a
-one-sided edit instead of letting them drift silently a third time.
+The two copies are now byte-identical, and `instructions.test.ts` pins their sha-256.
+The server-side spec pins the same value against its own copy, so the next content
+release reddens a spec that names this pin rather than letting the two drift silently
+a third time.

--- a/.changeset/resync-authoring-instructions-fallback.md
+++ b/.changeset/resync-authoring-instructions-fallback.md
@@ -1,0 +1,15 @@
+---
+"@sapiom/mcp": patch
+---
+
+Re-sync the offline `AUTHORING_INSTRUCTIONS` fallback with the server's canonical
+primer. The fallback is what the server serves when its startup fetch of
+`GET /v1/mcp/instructions` fails, and it had drifted two content releases behind — so
+exactly the sessions with no other source of truth were told App Links do not exist:
+no durable-sharing paragraph, no `sapiom_dev_app_publish`, no hosted or REST publish
+surface. It also still described the older single-alias framing of the hosted
+capability MCP, which now lives under its own `sapiom-direct` alias.
+
+The two copies are now byte-identical, and a frozen sha-256 in `instructions.test.ts`
+— the same digest the server-side spec pins for this content release — fails CI on a
+one-sided edit instead of letting them drift silently a third time.

--- a/.changeset/resync-authoring-instructions-fallback.md
+++ b/.changeset/resync-authoring-instructions-fallback.md
@@ -2,15 +2,23 @@
 "@sapiom/mcp": patch
 ---
 
-Re-sync the offline `AUTHORING_INSTRUCTIONS` fallback with the server's canonical
-primer. The fallback is what the server serves when its startup fetch of
-`GET /v1/mcp/instructions` fails, and it had drifted two content releases behind — so
-exactly the sessions with no other source of truth were told App Links do not exist:
-no durable-sharing paragraph, no `sapiom_dev_app_publish`, no hosted or REST publish
-surface. It also still described the older single-alias framing of the hosted
-capability MCP, which now lives under its own `sapiom-direct` alias.
+Re-sync the offline `AUTHORING_INSTRUCTIONS` fallback with the primer the server
+actually serves. This is the text an agent gets on connect when the server's startup
+fetch of `GET /v1/mcp/instructions` fails; it had fallen behind, so offline sessions
+were told App Links do not exist.
 
-The two copies are now byte-identical, and `instructions.test.ts` pins their sha-256.
-The server-side spec pins the same value against its own copy, so the next content
-release reddens a spec that names this pin rather than letting the two drift silently
-a third time.
+Added, matching what online sessions already receive:
+
+- **App Links** — publishing a durable `https://apps.sapiom.ai/{org}/{slug}` that
+  outlives the sandbox a preview URL dies with, via `sapiom_dev_app_publish` (needs
+  `@sapiom/mcp` >= 0.13), the hosted `sapiom_app_publish`, or the REST route.
+- The current alias framing: local authoring under `sapiom`, hosted one-off capability
+  calls under the distinct `sapiom-direct` alias.
+- Corrected lifecycle wording for `sapiom_dev_agents_check`, `_run_local`, and
+  `sapiom_authenticate`, and the fuller docs links.
+
+Removed, because the served primer does not carry it: the detailed `ctx.shared` quota
+paragraph (256 KiB limit, `JSON.stringify` measurement, setter-time validation, no
+`delete()`). This fallback had it and the served text did not, so most sessions never
+saw it. It remains documented in `@sapiom/agent`'s README and the scaffold-shipped
+`sapiom-agent-authoring` skill.

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -110,15 +110,21 @@ describe("server instructions", () => {
   it("is byte-identical to the backend primer (frozen sha-256, SAP-2959)", () => {
     // The `contain` assertions above are what let this copy fall two content
     // releases behind the server without anything going red: each one still
-    // passed against the older text. This is the guard that actually binds the
-    // two copies — the digest is the same frozen value the server-side spec pins
-    // for the matching content release, so a one-sided edit reddens one repo or
-    // the other, with no network call from either test suite.
+    // passed against the older text. This digest is what actually binds the two
+    // copies, and it works from both ends: the server-side spec pins this same
+    // value against ITS current primer, so a content release there reddens that
+    // spec and forces its author onto this pin, while an in-place edit here
+    // reddens this one. Neither suite makes a network call.
+    //
+    // Be honest about the limit: neither pin can block a merge in the other
+    // repository, and an author can still move one side alone. What the pair
+    // removes is the silent path — drifting now takes a deliberate edit to a line
+    // that says what it is for.
     //
     // To change the primer: ship the server-side content release, copy its new
-    // body here verbatim, and update both digests in the same pair of PRs. Never
-    // re-point this digest on its own — that just re-blesses the drift the guard
-    // exists to catch.
+    // body here verbatim, and update both pins to the new digest in the same pair
+    // of PRs. Never re-point this digest on its own — that just re-blesses the
+    // drift the guard exists to catch.
     //
     // Current release: 2.8 (App Links + `sapiom_dev_app_publish`).
     const sha256 = createHash("sha256")

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { describe, it, expect } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -40,10 +41,50 @@ describe("server instructions", () => {
     expect(AUTHORING_INSTRUCTIONS).toContain("https://docs.sapiom.ai/agents");
     expect(AUTHORING_INSTRUCTIONS).toContain("AGENTS.md");
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom-agent-authoring");
-    // The two-MCP frame: agents learn the remote MCP exists for direct tool calls
-    expect(AUTHORING_INSTRUCTIONS).toContain("remote MCP");
-    expect(AUTHORING_INSTRUCTIONS).toContain("api.sapiom.ai/v1/mcp");
+  });
+
+  it("keeps local authoring and hosted direct access on distinct aliases", () => {
+    // Two-MCP frame: this server authors agents under the local `sapiom` alias; the
+    // hosted capability MCP answers one-off calls under the distinct `sapiom-direct`
+    // alias. The 2.6-era copy conflated them onto one `sapiom` alias, which is why
+    // the negative assertions below exist.
+    expect(AUTHORING_INSTRUCTIONS).toContain(
+      "`sapiom-dev` is this package's MCP server identity",
+    );
+    expect(AUTHORING_INSTRUCTIONS).toContain(
+      "supported local alias `sapiom` with `claude mcp add sapiom -- npx -y @sapiom/mcp`",
+    );
+    expect(AUTHORING_INSTRUCTIONS).toContain(
+      "claude mcp add --scope user --transport http sapiom-direct https://api.sapiom.ai/v1/mcp",
+    );
     expect(AUTHORING_INSTRUCTIONS).toContain("tool_discover");
+    expect(AUTHORING_INSTRUCTIONS).not.toContain(
+      "claude mcp add sapiom --transport http",
+    );
+    expect(AUTHORING_INSTRUCTIONS).not.toContain("it exposes every capability");
+    expect(AUTHORING_INSTRUCTIONS).not.toContain(
+      "# Sapiom dev MCP (sapiom-dev)",
+    );
+  });
+
+  it("points the preview path at App Links for durable sharing (SAP-2923)", () => {
+    // A preview URL dies with its sandbox. Without a named durable successor here,
+    // App Links are undiscoverable from the one surface every session reads on
+    // connect — and this fallback is the copy served when the live fetch fails,
+    // i.e. the path with no other source of truth.
+    expect(AUTHORING_INSTRUCTIONS).toContain("App Link");
+    expect(AUTHORING_INSTRUCTIONS).toContain(
+      "https://apps.sapiom.ai/{org}/{slug}",
+    );
+    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_app_publish");
+    expect(AUTHORING_INSTRUCTIONS).toContain(
+      "https://docs.sapiom.ai/capabilities/app-links",
+    );
+    // The local one-call path, version-gated: the backend live-fetches this text to
+    // every install, including clients on an older @sapiom/mcp whose server never
+    // advertised the tool. The gate is the part that keeps naming it honest.
+    expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_app_publish");
+    expect(AUTHORING_INSTRUCTIONS).toContain("`@sapiom/mcp` >= 0.13");
   });
 
   it("names the entry step's inputSchema as the agent's public API (SAP-2227)", () => {
@@ -54,55 +95,37 @@ describe("server instructions", () => {
     );
   });
 
-  it("teaches the LLM call-surface rule (SAP-2775) — kept byte-identical to the backend copy", () => {
+  it("teaches the LLM call-surface rule (SAP-2775)", () => {
+    // Stops an authored agent from misusing a one-shot LLM call as an agent loop (or
+    // vice versa) and from string-parsing JSON out of a `thinking`-capable response.
     expect(AUTHORING_INSTRUCTIONS).toContain("ctx.sapiom.llm.run");
     expect(AUTHORING_INSTRUCTIONS).toContain("ctx.sapiom.models.run");
     expect(AUTHORING_INSTRUCTIONS).toContain("models.coding.run");
     expect(AUTHORING_INSTRUCTIONS).toContain("ctx.sapiom.agents.run");
     expect(AUTHORING_INSTRUCTIONS).toContain("You never pick a model");
-    // The internal `workflows`-service naming must never reach this customer-facing
-    // primer — the per-step debugging endpoint lives in the docs guide, not spelled
-    // out here verbatim (matches this package's own scaffold terminology guard).
     expect(AUTHORING_INSTRUCTIONS).toContain("Run Inspector");
     expect(AUTHORING_INSTRUCTIONS).not.toContain("/v1/workflows/");
-    // Structured/forced-tool output has no `text` block — the reply lives in the
-    // `tool_use` block's `input`. Reading only `type === 'text'` there returns
-    // `undefined` and invites exactly the string-parsing fallback this rule bans.
-    expect(AUTHORING_INSTRUCTIONS).toContain("tool_use");
-    // `output` is sugar for a forced tool call — one mechanism, one payload location.
-    expect(AUTHORING_INSTRUCTIONS).toContain("it forces a tool");
-    // The disclosure claim stays scoped: coding runs report honest nulls, and older
-    // servers omit the fields entirely — never a flat "always on the result" promise.
-    expect(AUTHORING_INSTRUCTIONS).toContain("treat missing as unknown");
-    expect(AUTHORING_INSTRUCTIONS).toContain("reports both as `null` today");
-    // "Pin the `smart` label" was a no-op (smart IS the default) and wrong-field on
-    // the sessions surface — it must not come back.
-    expect(AUTHORING_INSTRUCTIONS).not.toContain("If you must pin");
   });
 
-  it("documents the complete ctx.shared quota contract", () => {
-    expect(AUTHORING_INSTRUCTIONS).toContain(
-      "inclusive 256 KiB (262,144-byte) quota",
-    );
-    expect(AUTHORING_INSTRUCTIONS).toContain("measured as compact");
-    expect(AUTHORING_INSTRUCTIONS).toContain("`JSON.stringify` UTF-8 bytes");
-    expect(AUTHORING_INSTRUCTIONS).toContain(
-      "IDs/references here instead of bulk state",
-    );
-    expect(AUTHORING_INSTRUCTIONS).toContain(
-      "`ctx.shared.set()` validates the complete candidate synchronously",
-    );
-    expect(AUTHORING_INSTRUCTIONS).toContain(
-      "construct this SDK version's `InMemoryContextStore`",
-    );
-    expect(AUTHORING_INSTRUCTIONS).toContain(
-      "snapshot unchanged after an oversized or unserializable write",
-    );
-    expect(AUTHORING_INSTRUCTIONS).toContain("structural payload guards");
-    expect(AUTHORING_INSTRUCTIONS).toContain("than `instanceof`");
-    expect(AUTHORING_INSTRUCTIONS).toContain("Hosts that have not adopted");
-    expect(AUTHORING_INSTRUCTIONS).toContain(
-      "There is no `delete()` operation",
+  it("is byte-identical to the backend primer (frozen sha-256, SAP-2959)", () => {
+    // The `contain` assertions above are what let this copy fall two content
+    // releases behind the server without anything going red: each one still
+    // passed against the older text. This is the guard that actually binds the
+    // two copies — the digest is the same frozen value the server-side spec pins
+    // for the matching content release, so a one-sided edit reddens one repo or
+    // the other, with no network call from either test suite.
+    //
+    // To change the primer: ship the server-side content release, copy its new
+    // body here verbatim, and update both digests in the same pair of PRs. Never
+    // re-point this digest on its own — that just re-blesses the drift the guard
+    // exists to catch.
+    //
+    // Current release: 2.8 (App Links + `sapiom_dev_app_publish`).
+    const sha256 = createHash("sha256")
+      .update(AUTHORING_INSTRUCTIONS, "utf8")
+      .digest("hex");
+    expect(sha256).toBe(
+      "7f518d9c4a80122e51d45e9e28dc5f6cacfd3b05f4101aa1a5b8ae5d4494c0df",
     );
   });
 });

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -95,19 +95,57 @@ describe("server instructions", () => {
     );
   });
 
-  it("teaches the LLM call-surface rule (SAP-2775)", () => {
-    // Stops an authored agent from misusing a one-shot LLM call as an agent loop (or
-    // vice versa) and from string-parsing JSON out of a `thinking`-capable response.
+  it("teaches the LLM call-surface rule (SAP-2775) — kept byte-identical to the backend copy", () => {
     expect(AUTHORING_INSTRUCTIONS).toContain("ctx.sapiom.llm.run");
     expect(AUTHORING_INSTRUCTIONS).toContain("ctx.sapiom.models.run");
     expect(AUTHORING_INSTRUCTIONS).toContain("models.coding.run");
     expect(AUTHORING_INSTRUCTIONS).toContain("ctx.sapiom.agents.run");
     expect(AUTHORING_INSTRUCTIONS).toContain("You never pick a model");
+    // The internal `workflows`-service naming must never reach this customer-facing
+    // primer — the per-step debugging endpoint lives in the docs guide, not spelled
+    // out here verbatim (matches this package's own scaffold terminology guard).
     expect(AUTHORING_INSTRUCTIONS).toContain("Run Inspector");
     expect(AUTHORING_INSTRUCTIONS).not.toContain("/v1/workflows/");
+    // Structured/forced-tool output has no `text` block — the reply lives in the
+    // `tool_use` block's `input`. Reading only `type === 'text'` there returns
+    // `undefined` and invites exactly the string-parsing fallback this rule bans.
+    expect(AUTHORING_INSTRUCTIONS).toContain("tool_use");
+    // `output` is sugar for a forced tool call — one mechanism, one payload location.
+    expect(AUTHORING_INSTRUCTIONS).toContain("it forces a tool");
+    // The disclosure claim stays scoped: coding runs report honest nulls, and older
+    // servers omit the fields entirely — never a flat "always on the result" promise.
+    expect(AUTHORING_INSTRUCTIONS).toContain("treat missing as unknown");
+    expect(AUTHORING_INSTRUCTIONS).toContain("reports both as `null` today");
+    // "Pin the `smart` label" was a no-op (smart IS the default) and wrong-field on
+    // the sessions surface — it must not come back.
+    expect(AUTHORING_INSTRUCTIONS).not.toContain("If you must pin");
+  });
+
+  it("carries the served primer's one-line ctx.shared contract (SAP-2959)", () => {
+    // This file used to assert an 11-line `ctx.shared` quota contract: the inclusive
+    // 256 KiB / 262,144-byte limit, compact-`JSON.stringify` measurement, setter-time
+    // validation, no `delete()`, structural guards over `instanceof`. That paragraph
+    // was in THIS fallback and not in the served primer, so online sessions — the vast
+    // majority — never saw it. Syncing to the served text drops it here too.
+    //
+    // That is a consequence of the sync, not an oversight, and it is the direction the
+    // rule requires: the two copies are one canonical text, and the digest below cannot
+    // hold if they differ by a paragraph. The contract still reaches authors through
+    // packages/agent/README.md and the scaffold-shipped `sapiom-agent-authoring` skill.
+    // Putting it back in the primer is a server-side content release, not an edit here.
+    expect(AUTHORING_INSTRUCTIONS).toContain(
+      "Cross-step state: `ctx.shared` — the entry input reaches only the entry step.",
+    );
   });
 
   it("is byte-identical to the backend primer (frozen sha-256, SAP-2959)", () => {
+    // THE SYNC RULE, which lives here rather than in instructions.ts because that
+    // file's JSDoc is emitted into dist/instructions.d.ts and published to npm, where
+    // none of this is actionable for a consumer: AUTHORING_INSTRUCTIONS is duplicated
+    // verbatim from the server's canonical primer (a private companion repo). The
+    // package must work offline, so it cannot import it. The two are one canonical
+    // text — KEEP THEM IDENTICAL whenever either changes.
+    //
     // The `contain` assertions above are what let this copy fall two content
     // releases behind the server without anything going red: each one still
     // passed against the older text. This digest is what actually binds the two

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -9,13 +9,15 @@
  * server's live-fetched copy (a private companion repo) — the two are one
  * canonical text.
  *
- * That rule is now enforced rather than merely stated: instructions.test.ts pins the
- * sha-256 of this string, and the server-side spec freezes the same digest for the
- * matching content release, so editing either copy alone reddens one repo's CI. The
- * guard exists because the rule failed silently for two content releases (SAP-2959):
- * this fallback still described a Sapiom without App Links, which offline sessions —
- * the only ones that read it — were then told did not exist. Changing the primer now
- * means moving both copies and both digests together.
+ * That rule has a machine check now, not just this comment: instructions.test.ts pins
+ * the sha-256 of this string, and the server-side spec pins the same value against its
+ * own current copy — so a content release there reddens a spec that names this pin,
+ * and an in-place edit here reddens ours. Neither can block a merge in the other
+ * repository; what the pair removes is the path where nobody notices. The guard exists
+ * because the rule failed silently for two content releases (SAP-2959): this fallback
+ * still described a Sapiom without App Links, which offline sessions — the only ones
+ * that read it — were then told did not exist. Changing the primer now means moving
+ * both copies and both pins together.
  *
  * Kept intentionally short — it stays in the model's context for the whole session.
  * Deep authoring guidance lives in the scaffold-shipped `sapiom-agent-authoring`

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -9,30 +9,41 @@
  * server's live-fetched copy (a private companion repo) — the two are one
  * canonical text.
  *
+ * That rule is now enforced rather than merely stated: instructions.test.ts pins the
+ * sha-256 of this string, and the server-side spec freezes the same digest for the
+ * matching content release, so editing either copy alone reddens one repo's CI. The
+ * guard exists because the rule failed silently for two content releases (SAP-2959):
+ * this fallback still described a Sapiom without App Links, which offline sessions —
+ * the only ones that read it — were then told did not exist. Changing the primer now
+ * means moving both copies and both digests together.
+ *
  * Kept intentionally short — it stays in the model's context for the whole session.
  * Deep authoring guidance lives in the scaffold-shipped `sapiom-agent-authoring`
  * skill and `AGENTS.md`, and the full reference on docs.sapiom.ai; this primer
  * points there rather than restating them.
  */
-export const AUTHORING_INSTRUCTIONS = `# Sapiom dev MCP (sapiom-dev)
+export const AUTHORING_INSTRUCTIONS = `# Sapiom local authoring MCP
 
-\`sapiom-dev\` is Sapiom's local developer MCP — the terminal surface for building and managing
-your Sapiom projects. Today it drives **agent authoring and sandbox app previews** (more
+\`sapiom-dev\` is this package's MCP server identity. In Claude Code, register it under the
+supported local alias \`sapiom\` with \`claude mcp add sapiom -- npx -y @sapiom/mcp\`.
+It is the terminal surface for building and managing your Sapiom projects. Today it drives
+**agent authoring, sandbox app previews, and durable app publishing** (more
 dev/management tools will land here over time). Agent authoring: build, test, and deploy a
 Sapiom agent — a \`defineAgent({ name, entry, steps })\` (from \`@sapiom/agent\`) where each
 step's \`run(input, ctx)\` does work and returns a directive. All from the terminal; no
 dashboard required.
 
 ## Two ways to use Sapiom
-This server (\`sapiom-dev\`) is where you **author agents** — the \`sapiom_dev_agents_*\` tools
+Use the local \`sapiom\` alias to **author agents** — the \`sapiom_dev_agents_*\` tools
 scaffold, typecheck, run with stubs, and deploy from a local checkout. For a **one-off
-capability call** without an agent (a search, a scrape, one image), or from **hosted clients
-that cannot run npx** (ChatGPT), use Sapiom's **remote MCP** at \`https://api.sapiom.ai/v1/mcp\`
-(\`claude mcp add sapiom --transport http https://api.sapiom.ai/v1/mcp\`) — it exposes every
-capability as a direct \`sapiom_*\` tool (run \`tool_discover\` to find the right one) plus cloud
-workflow tools (\`sapiom_workflow_*\`: create → deploy with a \`files\` map → run → inspect/signal).
+capability call** without an agent (a search, a scrape, one image), use the hosted capability
+MCP under the distinct \`sapiom-direct\` alias:
+\`claude mcp add --scope user --transport http sapiom-direct https://api.sapiom.ai/v1/mcp --header "x-api-key: $SAPIOM_API_KEY"\`.
+Its runtime \`tools/list\` response is authoritative; use \`tool_discover\` to find a direct
+\`sapiom_*\` capability tool. The endpoint may also advertise implemented cloud workflow and
+governance tools, but the supported public authoring route is this local MCP or Agent Studio.
 Rule of thumb: author an agent for anything multi-step, scheduled, or deployable; use the
-remote MCP or the SDK for a single action.
+hosted capability MCP or the TypeScript SDK for a single action.
 
 ## Lifecycle (in order)
 1. Start a project — \`sapiom_dev_agents_scaffold\` (a fresh starter) or \`sapiom_dev_agents_clone\`
@@ -40,19 +51,34 @@ remote MCP or the SDK for a single action.
    READ the project's \`AGENTS.md\` first, plus the \`sapiom-agent-authoring\` skill in
    \`.claude/skills/\` where present (scaffolded projects include it; auto-loads in Claude Code).
    Then \`npm install\`.
-2. Test locally: \`npm run typecheck\` → \`sapiom_dev_agents_check\` (typechecks, imports the
-   definition, and validates its graph; no Sapiom account or service call) →
-   \`sapiom_dev_agents_run_local\` (\`ctx.sapiom.*\` calls are stubbed, so there is no Sapiom
-   capability spend; the author's own local code and side effects remain real).
-3. Before cloud work, run \`sapiom_authenticate\` — browser login caches an API key and makes
-   you an API-key principal. Confirm with \`sapiom_status\`; auth is required for link/deploy/run.
-4. Ship: \`sapiom_dev_agents_link\` → \`_deploy\` → \`_run\` (real, billed) → \`_inspect\`.
+2. Test locally: \`npm run typecheck\` → \`sapiom_dev_agents_check\` (bundles and imports the
+   definition, then validates its graph; top-level author code can execute) →
+   \`sapiom_dev_agents_run_local\` (Sapiom capabilities are stubbed with no Sapiom
+   capability spend; authored code and its ordinary side effects still execute).
+3. Before the first cloud action, call \`sapiom_authenticate\`; browser login caches the shared
+   credential required by link/deploy/run. Confirm with \`sapiom_status\`.
+4. Ship: \`sapiom_dev_agents_link\` → \`_deploy\` → \`_run\` (real cloud execution; costs
+   depend on the work performed) → \`_inspect\`.
 
 ## Preview a web app
 From inside the project: \`sapiom_dev_sandbox_configure\` (writes the validated \`sapiom.json\`
 resource — source, start command, port, optional build/tier/ttl/env) →
 \`sapiom_dev_sandbox_check\` (optional) → \`sapiom_dev_sandbox_preview\` (uploads, builds, starts,
 and returns a live URL; a \`failed\` status carries the build/start logs — fix and retry).
+
+That preview URL dies with its sandbox — the TTL expires and the link stops resolving. For a
+link you can hand to someone, publish an **App Link**: a durable
+\`https://apps.sapiom.ai/{org}/{slug}\` that outlives every sandbox — a visit wakes the app
+from its stored bundle behind a "Starting …" page (cold start: tens of seconds). Durable
+sharing, not always-on hosting. From this project that is \`sapiom_dev_app_publish\` (slug +
+name only — it reads the same \`sapiom.json\` sandbox resource \`_preview\` uses, so source,
+start, port, build and env are already set); it needs \`@sapiom/mcp\` >= 0.13, so if your
+\`tools/list\` does not offer it, upgrade or use the next line. Without a project on disk:
+\`sapiom_app_publish\` on the \`sapiom-direct\` alias above, or
+\`POST /v1/app-links\` → \`PUT …/bundle\` → \`POST …/publish\`. Bundles are text-only UTF-8
+and self-contained; republishing the same slug replaces the app in place at the same URL.
+Org-scoped by default; \`public\` needs an explicit confirmation and a daily spend cap because
+your org pays for every wake. See https://docs.sapiom.ai/capabilities/app-links.
 
 ## Canonical rules (types are the source of truth — run \`npm run typecheck\`)
 - Import \`defineAgent\`, \`defineStep\`, and the directives
@@ -64,18 +90,7 @@ and returns a live URL; a \`failed\` status carries the build/start logs — fix
 - The entry step's \`inputSchema\` is the agent's public API — the dashboard Run form,
   the trigger snippet, and engine-side validation all read it. Declare it with zod
   (\`zod/v4\`); give fields \`.default()\` so a zero-input run still validates.
-- Cross-step state: \`ctx.shared\` — the entry input reaches only the entry step. The whole
-  snapshot has an inclusive 256 KiB (262,144-byte) quota, measured as compact
-  \`JSON.stringify\` UTF-8 bytes; keep IDs/references here instead of bulk state. Hosts that
-  construct this SDK version's \`InMemoryContextStore\` get setter-time validation:
-  \`ctx.shared.set()\` validates the complete candidate synchronously and leaves the previous
-  snapshot unchanged after an oversized or unserializable write. Hosts that have not adopted
-  this store version may enforce only at execution boundaries during rollout. Use
-  structural payload guards rather than \`instanceof\` when catching these errors because
-  host and definition bundles can contain separate SDK copies.
-  There is no \`delete()\` operation; to recover from legacy invalid state, replace an
-  offending key with a compact, JSON-compatible value that brings the complete candidate
-  within the quota.
+- Cross-step state: \`ctx.shared\` — the entry input reaches only the entry step.
 - Capabilities run via the typed \`ctx.sapiom.*\` client (sandboxes, repositories,
   models.coding, fileStorage, search, database, email, domains, memory, and more) —
   don't memorize the catalog; use autocomplete/typecheck. Schedules (cron triggers) are
@@ -101,6 +116,8 @@ and returns a live URL; a \`failed\` status carries the build/start logs — fix
 - **Debugging a run:** open the Run Inspector, or fetch a step's full input/output via
   the per-step endpoint documented in the guide.
 
-Full reference: https://docs.sapiom.ai/agents/quick-start (authoring · capabilities ·
-reference · examples), plus the \`AGENTS.md\` and \`sapiom-agent-authoring\` skill inside
+Full reference: https://docs.sapiom.ai/agents/quick-start,
+https://docs.sapiom.ai/agents/authoring, and
+https://docs.sapiom.ai/guides/connect-claude-code-with-mcp, plus the \`AGENTS.md\` and
+\`sapiom-agent-authoring\` skill inside
 your scaffolded project.`;

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -5,24 +5,16 @@
  *
  * This is the OFFLINE FALLBACK: at startup the server fetches the live copy from
  * `GET {apiURL}/v1/mcp/instructions` (see instructions-fetch.ts) and serves that;
- * this constant is served only when the fetch fails. KEEP IT IDENTICAL to the
- * server's live-fetched copy (a private companion repo) — the two are one
- * canonical text.
- *
- * That rule has a machine check now, not just this comment: instructions.test.ts pins
- * the sha-256 of this string, and the server-side spec pins the same value against its
- * own current copy — so a content release there reddens a spec that names this pin,
- * and an in-place edit here reddens ours. Neither can block a merge in the other
- * repository; what the pair removes is the path where nobody notices. The guard exists
- * because the rule failed silently for two content releases (SAP-2959): this fallback
- * still described a Sapiom without App Links, which offline sessions — the only ones
- * that read it — were then told did not exist. Changing the primer now means moving
- * both copies and both pins together.
+ * this constant is served only when that fetch fails, so it is kept identical to the
+ * served text rather than maintained separately.
  *
  * Kept intentionally short — it stays in the model's context for the whole session.
  * Deep authoring guidance lives in the scaffold-shipped `sapiom-agent-authoring`
  * skill and `AGENTS.md`, and the full reference on docs.sapiom.ai; this primer
  * points there rather than restating them.
+ *
+ * Maintainers: the sync rule, the digest that enforces it, and what that digest can
+ * and cannot catch are documented in instructions.test.ts, which is not published.
  */
 export const AUTHORING_INSTRUCTIONS = `# Sapiom local authoring MCP
 


### PR DESCRIPTION
## What

Re-syncs `packages/mcp/src/instructions.ts` (`AUTHORING_INSTRUCTIONS`) with the canonical server-side primer, moving the offline fallback from 2.6-era text to the current 2.8 release, and adds a frozen sha-256 so the two copies cannot drift silently again.

## Why

`AUTHORING_INSTRUCTIONS` is the copy the MCP server serves when its startup fetch of `GET /v1/mcp/instructions` fails. It is a verbatim duplicate of the server's canonical primer by design — the package must work offline, so it cannot import it — and the only thing enforcing that was a doc comment saying KEEP IT IDENTICAL.

It stopped being true two content releases ago. The fallback was missing both App Links releases:

- **2.7** — the App Links paragraph in "Preview a web app" (a durable `https://apps.sapiom.ai/{org}/{slug}` that outlives the sandbox)
- **2.8** — the shipped `sapiom_dev_app_publish`, version-gated at `@sapiom/mcp >= 0.13`

So the one path with no other source of truth — an offline session, which is precisely the case where the live fetch failed — was told App Links do not exist at all: no durable-sharing paragraph, no local publish tool, no hosted or REST surface. The copy also still carried the pre-2.7 single-alias framing of the hosted capability MCP, which now lives under its own `sapiom-direct` alias.

**The drift ran both ways**, which the ticket's "2.6-era text" framing (and my first description of this PR) obscured. Diffed against `origin/main`, this copy was *behind* on App Links and the alias framing, *level* on the LLM call-surface block, and *ahead* on `ctx.shared` — see Removed below. Blast radius is low either way, since online sessions live-fetch the server text and it wins.

## What the sync removes

The fallback carried an 11-line `ctx.shared` quota contract — the inclusive 256 KiB / 262,144-byte limit, compact-`JSON.stringify` measurement, setter-time validation, no `delete()`, structural guards over `instanceof` — that **is not in the served primer**. Online sessions never saw it; only offline ones did.

Syncing removes it here, and I'm keeping that: the two are one canonical text, the ticket's scope is "copy verbatim," and the digest below cannot hold if the copies differ by a paragraph. It is disclosed rather than silent — there's a test named for the removal, and a Removed section in the changeset. The contract still reaches authors via `packages/agent/README.md` and the scaffold-shipped `sapiom-agent-authoring` skill. Putting it back into the primer is a server-side content release; flagged for the epic rather than reintroducing divergence here.

## Changes

- **`packages/mcp/src/instructions.ts`** — body replaced verbatim with the 2.8 primer; byte-identical to the server copy. Doc comment updated to describe the guard rather than restate a rule that had already failed.
- **`packages/mcp/src/instructions.test.ts`** — new `is byte-identical to the backend primer (frozen sha-256, SAP-2959)` pins `sha256(AUTHORING_INSTRUCTIONS)` to `7f518d9c…4494c0df`, the same digest the server-side spec pins for its current primer. Updates the assertions the old text happened to satisfy (the previous hosted-MCP framing), adds App Links coverage, and adds a test recording the `ctx.shared` removal above.
- **`.changeset/`** — patch release of `@sapiom/mcp`.

## The guard, and why the existing tests missed this

Every `contain` assertion in this file passed against the stale text — they assert what must be present, and nothing noticed what had stopped being copied. So the copy fell two releases behind with a green suite.

The digest is what binds the two copies, but only because **both** ends pin it, which review on the paired server-side PR was right to press on. A pin checked only against its own body is a self-consistency check: it catches an accidental in-place edit here and nothing else. In particular it would not catch the direction that caused this incident — a server-side content release, which touches that repo only.

So the paired PR pins this same digest against the server's *current* primer. Cutting the next release changes that hash and reddens a spec that names this pin, which is the moment its author discovers this body has to move too.

Stated plainly, in the code as well as here: neither pin can block a merge in the other repository, and an author can still move one side alone. What the pair removes is the silent path — drifting now takes a deliberate edit to a line that says what it is for. Re-pointing this digest alone just re-blesses the drift.

This is the fourth reactive heal of the same class of drift (SAP-1367 → SAP-1467 → SAP-2227 → this); the guard is the point of the ticket, not the copy.

## Known-adjacent, deliberately not in this PR

The repo ships three answers on MCP aliases: `docs/mcp-servers.md:7` (Remote `sapiom` / Local `sapiom-dev`), `README.md:141` (`claude mcp add sapiom-dev`), and `packages/mcp/README.md:35` (`claude mcp add sapiom`, agreeing with the primer). Review flagged it here.

It's real, but it isn't this PR's: the alias vocabulary is the canonical primer's, decided server-side in 2.7 and already live to every online session. The contradiction exists on `main` today and this diff doesn't change it — it only moves the offline copy onto the vocabulary the online path already uses. A partial fix would leave `docs/mcp-servers.md` built end-to-end around the inverse mapping, so the repo would still ship three answers; doing it properly is a docs-page rewrite that belongs with SAP-2923. Flagged for the epic.

## Testing

- `vitest run src/instructions.test.ts src/instructions-fetch.test.ts` — 14 passed, including the five regression assertions restored after review (`tool_use`, `"it forces a tool"`, `"treat missing as unknown"`, `` "reports both as `null` today" ``, `not.toContain("If you must pin")`), all verified passing against the new text
- `tsc --noEmit` — clean
- `eslint src --ext .ts` — clean
- `prettier --check` on the touched files — clean
- Independently verified the new body byte-for-byte against the server constant before writing the digest

## Related

- Ticket: SAP-2959
- Epic: SAP-2921 — make App Links discoverable from Studio and docs.sapiom.ai
- Siblings: SAP-2922 (shipped `sapiom_dev_app_publish`, #722), SAP-2923 (the 2.7/2.8 server content releases)
- Precedent: SAP-1486 (#283) did the same sync for the sandbox-preview lifecycle
- A paired server-side PR restores the KEEP THE TWO IDENTICAL rule and adds the matching pin. **This PR should land first** — that one's comments describe the copies as already re-synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2AUF348cx5Mh4N9bbnkSF
