### PR TITLE
fix(desktop): make the pre-release update channel reachable [SAP-2965]

### DIFF
--- a/.changeset/desktop-prerelease-channel.md
+++ b/.changeset/desktop-prerelease-channel.md
@@ -1,0 +1,15 @@
+---
+"@sapiom/harness-desktop": patch
+---
+
+Make the pre-release update channel reachable. Desktop releases are now tagged
+`vX.Y.Z` instead of `harness-desktop-vX.Y.Z`, because the old prefix is not valid
+semver and the updater silently skipped every release when resolving a
+pre-release channel — so an install following betas was told "no published
+versions" no matter what had been published. The stable channel was never
+affected and keeps updating across the change.
+
+Also adds a persisted `preRelease` preference, so an install can follow betas
+without setting `SAPIOM_UPDATE_CHANNEL` — unusable as a real control on macOS,
+where a Finder or Dock launch inherits no shell environment. The control that
+writes it is a follow-up; the preference and the plumbing land here.

--- a/.claude/skills/release-desktop/SKILL.md
+++ b/.claude/skills/release-desktop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-desktop
-description: How to cut a Sapiom Studio desktop release (@sapiom/harness-desktop) in this repo. The release is TRIGGERED BY PUSHING A GIT TAG on main — `harness-desktop-vX.Y.Z` — after versions are bumped via changesets. Use whenever asked to "release", "cut/make a release", "ship a new version", "publish/tag the desktop app", "do a release", or asked whether something "is ready to release / version bumped".
+description: How to cut a Sapiom Studio desktop release (@sapiom/harness-desktop) in this repo. The release is TRIGGERED BY PUSHING A GIT TAG on main — `vX.Y.Z` — after versions are bumped via changesets. Use whenever asked to "release", "cut/make a release", "ship a new version", "publish/tag the desktop app", "do a release", or asked whether something "is ready to release / version bumped".
 ---
 
 # Releasing the Sapiom Studio desktop app
@@ -11,7 +11,7 @@ Linux, nsis on Windows), NOT to npm. A release is cut by **pushing a git tag on
 
 ## The invariant that governs everything
 The tag **must equal** `packages/harness-desktop/package.json`'s `version`
-exactly (e.g. tag `harness-desktop-v0.2.4` ⇔ version `0.2.4`). The
+exactly (e.g. tag `v0.2.4` ⇔ version `0.2.4`). The
 `desktop-release.yml` `prepare` job fails fast on a mismatch. `package.json` — not
 the tag — is the source of truth for the artifact names and the app's self-reported
 version and update channel.
@@ -19,8 +19,8 @@ version and update channel.
 ## Tag conventions (drive the update channel)
 | Tag | Release | Channel |
 | --- | --- | --- |
-| `harness-desktop-v1.2.3` | final | `latest` (everyone) |
-| `harness-desktop-v1.2.3-beta.1` | pre-release | `beta` (opted-in only) |
+| `v1.2.3` | final | `latest` (everyone) |
+| `v1.2.3-beta.1` | pre-release | `beta` (opted-in only) |
 
 `workflow_dispatch` (manual run of desktop-release.yml) builds artifacts only — no
 tag, no publish. Useful to smoke a build without releasing.
@@ -83,15 +83,15 @@ tag, no publish. Useful to smoke a build without releasing.
    ```bash
    git checkout main && git pull
    v=$(node -p "require('./packages/harness-desktop/package.json').version")   # e.g. 0.2.4
-   git tag "harness-desktop-v$v"          # add a -beta.N suffix for a beta
-   git push origin "harness-desktop-v$v"
+   git tag "v$v"                          # add a -beta.N suffix for a beta
+   git push origin "v$v"
    ```
    From a worktree (don't touch the user's main checkout), the equivalent is
    tagging main's HEAD directly:
    ```bash
    git fetch origin main
    v=$(git show origin/main:packages/harness-desktop/package.json | node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).version")
-   git tag "harness-desktop-v$v" origin/main && git push origin "harness-desktop-v$v"
+   git tag "v$v" origin/main && git push origin "v$v"
    ```
    This starts `desktop-release.yml`: `prepare` (version/channel + tag match) →
    one build job per OS (sign + notarize on macOS) → uploads the installers +
@@ -103,7 +103,7 @@ tag, no publish. Useful to smoke a build without releasing.
 
 ## Answering "is the version bumped / ready to release?"
 - Current version: `node -p "require('./packages/harness-desktop/package.json').version"`.
-- Existing tags: `git tag --list 'harness-desktop-v*' | tail`.
+- Existing tags: `git tag --list 'v*' | tail`.
 - Pending changesets (what the NEXT bump will include): `ls .changeset/*.md`.
 - If `package.json` still equals the latest tag, the version is **not yet bumped** —
   the "chore: version packages" PR (step 3–4) must merge before you can tag.

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -30,7 +30,13 @@ name: Desktop Release
 on:
   push:
     tags:
-      - "harness-desktop-v*"
+      # `v*`, NOT `harness-desktop-v*`. electron-updater's GitHubProvider runs
+      # `semver.valid(tag)` on every releases.atom entry when resolving a
+      # pre-release channel, and skips the ones that fail — `harness-desktop-v0.3.8`
+      # is not valid semver, so under the old namespace EVERY release was skipped
+      # and a beta install threw "No published versions on GitHub". A leading `v`
+      # is the only prefix semver tolerates. See SAP-2965.
+      - "v*"
   workflow_dispatch:
 
 # Minimal token scope, declared at the top so it is the DEFAULT every job
@@ -99,11 +105,22 @@ jobs:
           # We have already tagged v0.1.0 against a package that later became
           # 0.1.1 — this is a mistake we've made, not one we're imagining.
           if [ "${{ github.ref_type }}" = "tag" ]; then
-            expected="harness-desktop-v${version}"
+            expected="v${version}"
             if [ "${{ github.ref_name }}" != "$expected" ]; then
               echo "::error::Tag '${{ github.ref_name }}' does not match packages/harness-desktop/package.json (${version}). Expected '${expected}'. Bump the package version or retag."
               exit 1
             fi
+          fi
+
+          # The tag must ALSO be semver-parseable, because electron-updater's
+          # pre-release resolution silently skips any releases.atom entry that
+          # isn't. A tag that fails here publishes fine and then cannot be
+          # installed by anyone on a pre-release channel — the exact failure that
+          # made `harness-desktop-v0.3.8-beta.1` undiscoverable. This is the cheap
+          # guard; the unit tests in update-policy.test.ts cover the same contract.
+          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Version '${version}' is not valid semver, so the release tag would be invisible to pre-release update checks. Fix packages/harness-desktop/package.json."
+            exit 1
           fi
 
           echo "version=$version"       >> "$GITHUB_OUTPUT"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -5,7 +5,8 @@ name: Desktop Release
 # @sapiom/harness NPM package via OIDC) — desktop installers are a different
 # artifact type with a different toolchain (electron-builder + a native
 # node-pty rebuild per platform), so they get their own workflow and their own
-# tag namespace (`harness-desktop-v*`) that never triggers the npm publish.
+# tag namespace (`v*`). That never triggers the npm publish either: publish.yml
+# subscribes to pushes on `main`, not to tags at all.
 #
 # Phase 4 = UNSIGNED multi-OS build. macOS is the required shipping target, so
 # it's exercised here early (on a hosted macos-14 runner) rather than deferred:
@@ -14,10 +15,10 @@ name: Desktop Release
 # Phases 5–6 and layer on top of this same build.
 #
 # Trigger, and the tag convention that drives the update channel:
-#   - `harness-desktop-v1.2.3`        → FINAL release, `latest` channel. Every user
+#   - `v1.2.3`                        → FINAL release, `latest` channel. Every user
 #                                       gets it, and it becomes the target of the
 #                                       permanent /releases/latest/download/… links.
-#   - `harness-desktop-v1.2.3-beta.1` → PRE-release, `beta` channel. Only installs
+#   - `v1.2.3-beta.1`                 → PRE-release, `beta` channel. Only installs
 #                                       already following betas are offered it.
 #   - workflow_dispatch (manual)      → build all OSes, artifacts only
 #                                       (no tag ⇒ no Release; download them from
@@ -117,8 +118,8 @@ jobs:
           # isn't. A tag that fails here publishes fine and then cannot be
           # installed by anyone on a pre-release channel — the exact failure that
           # made `harness-desktop-v0.3.8-beta.1` undiscoverable. This is the cheap
-          # guard; the unit tests in update-policy.test.ts cover the same contract.
-          if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
+          # guard; release-tags.test.ts asserts the same pattern from the other side.
+          if ! printf '%s' "$version" | grep -Eq '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
             echo "::error::Version '${version}' is not valid semver, so the release tag would be invisible to pre-release update checks. Fix packages/harness-desktop/package.json."
             exit 1
           fi
@@ -459,7 +460,7 @@ jobs:
   # on a real tag push (workflow_dispatch has no tag, so it stops at Artifacts).
   release:
     needs: [prepare, build]
-    if: startsWith(github.ref, 'refs/tags/harness-desktop-v')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
       contents: write # create/update the GitHub Release and upload assets

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -121,7 +121,7 @@ jobs:
   # Desktop app: does the PACKAGED bundle still launch?
   #
   # Split from desktop-release.yml on purpose. That workflow BUILDS installers
-  # for three OSes and only runs on a `harness-desktop-v*` tag (plus a temporary
+  # for three OSes and only runs on a `v*` tag (plus a temporary
   # feature-branch trigger) — releases, not feedback. But the bugs it catches are
   # packaging bugs: asar path resolution, a native module against the wrong ABI, a
   # dependency that wasn't unpacked, a mangled package.json. Waiting for a tag to

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -34,8 +34,8 @@ trigger the npm publish above:
 
 | Tag | Release | Update channel |
 | --- | --- | --- |
-| `harness-desktop-v1.2.3` | final | `latest` — every user |
-| `harness-desktop-v1.2.3-beta.1` | pre-release | `beta` — testers only |
+| `v1.2.3` | final | `latest` — every user |
+| `v1.2.3-beta.1` | pre-release | `beta` — testers only |
 
 Bump `packages/harness-desktop/package.json` **first**: the tag must match it
 exactly or the build fails, by design — that field names the artifacts and drives

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ deploy/run, and a live canvas for previews.
 | --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | [@sapiom/agent-studio](./packages/agent-studio)     | [![npm](https://img.shields.io/npm/v/@sapiom/agent-studio)](https://www.npmjs.com/package/@sapiom/agent-studio)     | Agent Studio launcher — `npx @sapiom/agent-studio@latest`                                       |
 | [@sapiom/harness](./packages/harness)               | [![npm](https://img.shields.io/npm/v/@sapiom/harness)](https://www.npmjs.com/package/@sapiom/harness)               | The Agent Studio implementation — a CLI-launched local web app                                  |
-| [@sapiom/harness-desktop](./packages/harness-desktop) | [![GitHub release](https://img.shields.io/github/v/release/sapiom/sapiom-js?filter=harness-desktop-v*)](https://github.com/sapiom/sapiom-js/releases) | **Sapiom Studio** desktop app (Electron) — ships as signed installers, not to npm               |
+| [@sapiom/harness-desktop](./packages/harness-desktop) | [![GitHub release](https://img.shields.io/github/v/release/sapiom/sapiom-js?filter=v*)](https://github.com/sapiom/sapiom-js/releases) | **Sapiom Studio** desktop app (Electron) — ships as signed installers, not to npm               |
 
 ### Runtime internals
 

--- a/packages/harness-desktop/CLAUDE.md
+++ b/packages/harness-desktop/CLAUDE.md
@@ -185,12 +185,35 @@ Tag conventions, which drive everything downstream:
 
 | Tag | Release | Channel | Who gets it |
 | --- | --- | --- | --- |
-| `harness-desktop-v1.2.3` | final | `latest` | everyone, and `/releases/latest/download/…` resolves |
-| `harness-desktop-v1.2.3-beta.1` | pre-release | `beta` | only installs already following betas |
+| `v1.2.3` | final | `latest` | everyone, and `/releases/latest/download/…` resolves |
+| `v1.2.3-beta.1` | pre-release | `beta` | only installs following betas |
 
-The tag **must** equal `package.json`'s version. `prepare` enforces it, because that field is what
-names every artifact and what the app reports as its own version; a mismatch publishes a manifest
-advertising a version no asset matches, and clients then re-offer the same update forever.
+The tag **must** equal `package.json`'s version, prefixed with `v`. `prepare` enforces it, because
+that field is what names every artifact and what the app reports as its own version; a mismatch
+publishes a manifest advertising a version no asset matches, and clients then re-offer the same
+update forever.
+
+`prepare` **also** rejects a version that isn't semver-parseable, and that guard is not decoration.
+The namespace used to be `harness-desktop-v*`, which broke the beta channel outright and silently:
+electron-updater's `GitHubProvider.getLatestVersion()` runs `semver.valid(tag)` over every
+`releases.atom` entry when resolving a pre-release channel and skips the failures, so every release
+was skipped and a beta install threw `No published versions on GitHub`. `harness-desktop-v0.3.8-beta.1`
+was published, correct in every other respect, and installable by nobody. A leading `v` is the only
+prefix semver tolerates. `latest` never noticed because it takes a different branch entirely
+(`getLatestTagName()` → `/releases/latest`), which treats the tag as an opaque string — which is why
+this survived from the first release to 0.3.8 with CI green. `src/main/release-tags.test.ts` pins it.
+
+**Cutting a beta.** `harness-desktop` is `private: true` and never published to npm, so a beta does
+not need changesets pre-mode (which would drag every package in the monorepo into it). Branch off
+`main`, hand-set the version to `x.y.z-beta.N`, tag `vx.y.z-beta.N`, push the tag, delete the branch.
+`detectUpdateChannel` infers `beta` from the suffix, so the build emits `beta*.yml` only and stable
+installs never see it. Promote by shipping the final `x.y.z` from `main` as usual.
+
+**Do not add `generateUpdatesFilesForAllChannels`** and do not delete the release job's
+"Mirror stable manifests onto the beta channel" step. The option is a **no-op for the GitHub
+provider** — `computeChannelNames()` short-circuits on `publishConfig.provider === "github"` and
+returns a single channel — so the mirror is the workaround that lets a beta install be pulled
+forward onto a newer final, not redundancy. Removing it strands every beta tester.
 
 ## Auto-update
 

--- a/packages/harness-desktop/src/main/release-tags.test.ts
+++ b/packages/harness-desktop/src/main/release-tags.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The release TAG is load-bearing for the pre-release channel, and every way of
+ * breaking it is silent: the build goes green, the release publishes with correct
+ * assets, and the artifact is simply invisible to the installs that asked for it.
+ *
+ * That is not hypothetical. `harness-desktop-v0.3.8-beta.1` was cut, built, and
+ * published with correct `beta*.yml` assets — and no install could ever receive
+ * it, because electron-updater's `GitHubProvider.getLatestVersion()` runs
+ * `semver.valid(tag)` over every `releases.atom` entry when resolving a
+ * pre-release channel and SKIPS the ones that fail:
+ *
+ *     const hrefTag = hrefElement[1];        // "harness-desktop-v0.3.8-beta.1"
+ *     if (!semver.valid(hrefTag)) continue;  // → null, so every entry is skipped
+ *     ...
+ *     if (tag == null) throw newError(`No published versions on GitHub`, ...)
+ *
+ * A leading `v` is the only prefix semver tolerates, so the tag namespace has to
+ * be `v<version>`. The stable channel never noticed because it takes a different
+ * branch entirely (`getLatestTagName()` → `/releases/latest`), which treats the
+ * tag as an opaque string — which is exactly why this survived from the first
+ * release to 0.3.8 with every test green. See SAP-2965.
+ *
+ * Text assertions over the workflow file, deliberately: this package's vitest run
+ * never imports `electron` or `electron-updater` (see vitest.config.ts), and a
+ * pure unit test of `update-policy.ts` structurally CANNOT catch this — the bug
+ * lives at the provider boundary those tests don't reach. The workflow's own
+ * semver guard in `prepare` is the other half: this file stops the namespace
+ * regressing, that step stops a non-semver *version* shipping.
+ *
+ * The mirror-step assertion below guards the opposite mistake. It looks like dead
+ * weight next to electron-builder's `generateUpdatesFilesForAllChannels`, but
+ * that option is a NO-OP for us — `computeChannelNames()` short-circuits on
+ * `publishConfig.provider === "github"` and returns a single channel. Deleting
+ * the mirror would strand every beta install on the beta line with no path back
+ * to stable, and nothing else in CI would notice.
+ */
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const workflow = readFileSync(
+  new URL("../../../../.github/workflows/desktop-release.yml", import.meta.url),
+  "utf8",
+);
+
+/**
+ * Whether `v${version}` is a tag electron-updater's pre-release resolution will
+ * accept — i.e. whether `semver.valid()` returns non-null for it.
+ *
+ * Hand-rolled rather than importing `semver`, for the same reason
+ * `update-policy.ts` hand-rolls its pre-release check: semver is not a declared
+ * dependency of this package, only a transitive one of electron-updater, and
+ * leaning on a transitive dep is how a working build breaks on an unrelated
+ * upgrade.
+ */
+function isSemverParseableTag(tag: string): boolean {
+  return /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$/.test(tag);
+}
+
+describe("desktop release tag namespace", () => {
+  it("triggers on `v*`, so published tags are semver-parseable", () => {
+    expect(workflow).toMatch(/tags:\s*(?:#[^\n]*\n\s*)*(?:#[^\n]*\n\s*)*-\s*"v\*"/);
+  });
+
+  it("no longer triggers on the un-parseable `harness-desktop-v*` namespace", () => {
+    // Prose mentioning the old namespace is fine and expected (the comments
+    // explain the migration); an actual trigger entry is not.
+    expect(workflow).not.toMatch(/^\s*-\s*"harness-desktop-v\*"\s*$/m);
+  });
+
+  it("guards that the tag equals `v${version}` from package.json", () => {
+    expect(workflow).toContain('expected="v${version}"');
+  });
+
+  it("fails the build outright on a version that isn't semver", () => {
+    // The cheap CI half of this file's contract. Without it, a hand-edited
+    // version on a release branch republishes the original bug.
+    expect(workflow).toMatch(/is not valid semver/);
+  });
+
+  it("still mirrors stable manifests onto the beta channel", () => {
+    // NOT redundant with generateUpdatesFilesForAllChannels — see the file
+    // header. Removing this silently strands beta installs.
+    expect(workflow).toContain("Mirror stable manifests onto the beta channel");
+    expect(workflow).toMatch(/beta\$\{base#latest\}/);
+  });
+});
+
+describe("isSemverParseableTag", () => {
+  it("accepts the tags the new namespace produces", () => {
+    for (const version of ["0.3.9", "0.3.9-beta.1", "1.0.0", "0.3.9-beta.10", "0.3.9+ci.44"]) {
+      expect(isSemverParseableTag(`v${version}`)).toBe(true);
+    }
+  });
+
+  it("rejects every tag the old namespace produced — final and pre-release alike", () => {
+    // The second case is the trap: cutting a "proper" beta under the old prefix
+    // failed identically to a final, which is why the namespace (not the version
+    // suffix) is the actual fix.
+    expect(isSemverParseableTag("harness-desktop-v0.3.8")).toBe(false);
+    expect(isSemverParseableTag("harness-desktop-v0.3.8-beta.1")).toBe(false);
+  });
+});

--- a/packages/harness-desktop/src/main/release-tags.test.ts
+++ b/packages/harness-desktop/src/main/release-tags.test.ts
@@ -78,6 +78,17 @@ describe("desktop release tag namespace", () => {
     expect(workflow).toMatch(/is not valid semver/);
   });
 
+  it("gates the release job on `v*` too, not just the push trigger", () => {
+    // The trigger and this gate are TWO filters, and changing only the first is
+    // silent in the worst way: prepare passes, all three OS legs build (~40min of
+    // macOS notarization), and then `release` is skipped. Green workflow, no
+    // GitHub Release, no installers, no channel manifests, nothing to update onto
+    // — the same silent-success failure this file exists to prevent. Caught in
+    // review on the very PR that renamed the namespace.
+    expect(workflow).toContain("startsWith(github.ref, 'refs/tags/v')");
+    expect(workflow).not.toContain("refs/tags/harness-desktop-v");
+  });
+
   it("still mirrors stable manifests onto the beta channel", () => {
     // NOT redundant with generateUpdatesFilesForAllChannels — see the file
     // header. Removing this silently strands beta installs.
@@ -91,6 +102,14 @@ describe("isSemverParseableTag", () => {
     for (const version of ["0.3.9", "0.3.9-beta.1", "1.0.0", "0.3.9-beta.10", "0.3.9+ci.44"]) {
       expect(isSemverParseableTag(`v${version}`)).toBe(true);
     }
+  });
+
+  it("rejects a leading-zero version, matching semver.valid and the CI guard", () => {
+    // `01.2.3` is not valid semver, so a release tagged from it would be skipped
+    // by pre-release resolution exactly like the old namespace was. The workflow's
+    // grep uses the same (0|[1-9][0-9]*) form; these must not drift apart.
+    expect(isSemverParseableTag("v01.2.3")).toBe(false);
+    expect(workflow).toContain("^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)");
   });
 
   it("rejects every tag the old namespace produced — final and pre-release alike", () => {

--- a/packages/harness-desktop/src/main/update-policy.test.ts
+++ b/packages/harness-desktop/src/main/update-policy.test.ts
@@ -82,6 +82,41 @@ describe("resolveUpdateChannel", () => {
     expect(resolveUpdateChannel("0.1.2", { [CHANNEL_ENV_VAR]: "  " }).ignoredOverride).toBeUndefined();
   });
 
+  it("moves a stable install onto betas via the persisted opt-in", () => {
+    // The whole point of the toggle: no env var, no launchctl, no relaunch ritual.
+    const decision = resolveUpdateChannel("0.3.9", {}, { preRelease: true });
+    expect(decision.channel).toBe("beta");
+    expect(decision.allowPrerelease).toBe(true);
+  });
+
+  it("leaves a stable install alone when the opt-in is off or absent", () => {
+    expect(resolveUpdateChannel("0.3.9", {}, { preRelease: false }).channel).toBe("latest");
+    expect(resolveUpdateChannel("0.3.9", {}).channel).toBe("latest");
+  });
+
+  it("never uses the opt-in to drag a pre-release build back onto stable", () => {
+    // Offering `latest` to a machine running 0.3.9-beta.2 would present a
+    // DOWNGRADE as an update. The toggle can only move an install onto betas.
+    expect(resolveUpdateChannel("0.3.9-beta.2", {}, { preRelease: false }).channel).toBe("beta");
+  });
+
+  it("lets the env override beat the persisted opt-in, in both directions", () => {
+    // The env var is the one-off debugging escape hatch, so it sits above the
+    // stored setting: someone who exported it is asking a more specific question.
+    expect(resolveUpdateChannel("0.3.9", { SAPIOM_UPDATE_CHANNEL: "latest" }, { preRelease: true }).channel).toBe(
+      "latest",
+    );
+    expect(resolveUpdateChannel("0.3.9", { SAPIOM_UPDATE_CHANNEL: "beta" }, { preRelease: false }).channel).toBe(
+      "beta",
+    );
+  });
+
+  it("falls back to the opt-in when the env override is unusable", () => {
+    const decision = resolveUpdateChannel("0.3.9", { SAPIOM_UPDATE_CHANNEL: "canary" }, { preRelease: true });
+    expect(decision.channel).toBe("beta");
+    expect(decision.ignoredOverride).toBe("canary");
+  });
+
   it("treats an unparseable version as stable rather than throwing", () => {
     // app.getVersion() is whatever package.json says; a bad value must not be
     // able to stop the app from starting.

--- a/packages/harness-desktop/src/main/update-policy.ts
+++ b/packages/harness-desktop/src/main/update-policy.ts
@@ -57,6 +57,18 @@ export const FORCE_ENV_VAR = "SAPIOM_FORCE_UPDATER";
 const CHANNELS: readonly UpdateChannel[] = ["latest", "beta"];
 
 /**
+ * The slice of the persisted update preferences that affects channel choice.
+ *
+ * Structural rather than importing `UpdatePrefs` from update-prefs.ts: this module
+ * is the pure policy layer and gains nothing from knowing about the prefs file's
+ * shape, its skip list, or its IO.
+ */
+export interface UpdateChannelPrefs {
+  /** The user opted this install into pre-release builds. */
+  preRelease: boolean;
+}
+
+/**
  * True when the version carries a semver pre-release component (`0.1.2-beta.1`),
  * which is how a beta artifact is distinguished from a final one.
  *
@@ -92,14 +104,27 @@ function hasPrereleaseTag(version: string): boolean {
  * UI — a tester who hits a bug we already fixed can get the fix today, and it
  * costs a restart with an env var rather than a release.
  */
-export function resolveUpdateChannel(version: string, env: NodeJS.ProcessEnv): ChannelDecision {
+export function resolveUpdateChannel(
+  version: string,
+  env: NodeJS.ProcessEnv,
+  prefs?: UpdateChannelPrefs,
+): ChannelDecision {
   const fromVersion: UpdateChannel = hasPrereleaseTag(version) ? "beta" : "latest";
 
   const raw = env[CHANNEL_ENV_VAR];
   const requested = raw?.trim().toLowerCase();
   const override = CHANNELS.find((c) => c === requested);
 
-  const channel = override ?? fromVersion;
+  // The persisted opt-in can only move an install ONTO betas, never off them: a
+  // build that is itself a pre-release follows betas whatever the toggle says,
+  // because the alternative is offering `latest` to a machine running `-beta.2`
+  // and calling a downgrade an update.
+  const fromPrefs: UpdateChannel | undefined = prefs?.preRelease ? "beta" : undefined;
+
+  // Env beats the toggle beats the version. The env var stays the top of the
+  // chain deliberately — it is the one-off debugging escape hatch, and someone
+  // who exported it is asking a more specific question than the stored setting.
+  const channel = override ?? fromPrefs ?? fromVersion;
   const decision: ChannelDecision = {
     channel,
     // A beta install must accept pre-releases or the channel name is inert.

--- a/packages/harness-desktop/src/main/update-prefs.test.ts
+++ b/packages/harness-desktop/src/main/update-prefs.test.ts
@@ -61,27 +61,32 @@ describe("load / save round-trip", () => {
   });
 
   it("returns defaults (never throws) on a corrupt file", async () => {
-    await saveUpdatePrefs({ autoUpdate: false, skippedVersions: ["9.9.9"] }, prefsPath);
+    await saveUpdatePrefs({ autoUpdate: false, skippedVersions: ["9.9.9"], preRelease: false }, prefsPath);
     const { writeFileSync } = await import("node:fs");
     writeFileSync(prefsPath, "{ not json");
     expect(await loadUpdatePrefs(prefsPath)).toEqual(DEFAULT_UPDATE_PREFS);
   });
 
-  it("persists and reloads both fields", async () => {
-    await saveUpdatePrefs({ autoUpdate: false, skippedVersions: ["1.2.3"] }, prefsPath);
-    expect(await loadUpdatePrefs(prefsPath)).toEqual({ autoUpdate: false, skippedVersions: ["1.2.3"] });
+  it("persists and reloads every field", async () => {
+    await saveUpdatePrefs({ autoUpdate: false, skippedVersions: ["1.2.3"], preRelease: true }, prefsPath);
+    expect(await loadUpdatePrefs(prefsPath)).toEqual({
+      autoUpdate: false,
+      skippedVersions: ["1.2.3"],
+      preRelease: true,
+    });
   });
 });
 
 describe("addSkippedVersion", () => {
   it("appends and dedupes without disturbing autoUpdate", async () => {
-    await saveUpdatePrefs({ autoUpdate: false, skippedVersions: [] }, prefsPath);
+    await saveUpdatePrefs({ autoUpdate: false, skippedVersions: [], preRelease: false }, prefsPath);
     await addSkippedVersion("1.0.0", prefsPath);
     await addSkippedVersion("1.0.0", prefsPath); // dupe — no-op
     await addSkippedVersion("2.0.0", prefsPath);
     expect(await loadUpdatePrefs(prefsPath)).toEqual({
       autoUpdate: false,
       skippedVersions: ["1.0.0", "2.0.0"],
+      preRelease: false,
     });
   });
 
@@ -93,9 +98,9 @@ describe("addSkippedVersion", () => {
 
 describe("clearSkippedVersions", () => {
   it("empties the list but keeps autoUpdate", async () => {
-    await saveUpdatePrefs({ autoUpdate: true, skippedVersions: ["1.0.0", "2.0.0"] }, prefsPath);
+    await saveUpdatePrefs({ autoUpdate: true, skippedVersions: ["1.0.0", "2.0.0"], preRelease: false }, prefsPath);
     await clearSkippedVersions(prefsPath);
-    expect(await loadUpdatePrefs(prefsPath)).toEqual({ autoUpdate: true, skippedVersions: [] });
+    expect(await loadUpdatePrefs(prefsPath)).toEqual({ autoUpdate: true, skippedVersions: [], preRelease: false });
   });
 
   it("does not create a file when there is nothing to clear", async () => {

--- a/packages/harness-desktop/src/main/update-prefs.ts
+++ b/packages/harness-desktop/src/main/update-prefs.ts
@@ -26,6 +26,17 @@ export interface UpdatePrefs {
   autoUpdate: boolean;
   /** Versions the user picked "Skip this version" for — never re-offered. */
   skippedVersions: string[];
+  /**
+   * Opt in to pre-release (`beta`) builds — the internal-dogfooding switch.
+   *
+   * Persisted rather than env-only because `SAPIOM_UPDATE_CHANNEL` is unusable as
+   * a user-facing control on macOS: a Finder or Dock launch inherits no shell
+   * environment, so it needs `launchctl setenv` plus a full quit, and when it
+   * silently fails to take it is indistinguishable from a broken updater. That
+   * cost a real debugging session. `SAPIOM_UPDATE_CHANNEL` still wins over this
+   * when set, so the escape hatch keeps working for one-off checks.
+   */
+  preRelease: boolean;
 }
 
 export const DEFAULT_UPDATE_PREFS: UpdatePrefs = {
@@ -35,6 +46,9 @@ export const DEFAULT_UPDATE_PREFS: UpdatePrefs = {
   // the updater's former hardcoded `autoInstallOnAppQuit = false` (see updater.ts).
   autoUpdate: true,
   skippedVersions: [],
+  // Off by default: a pre-release is precisely the build nobody has validated yet,
+  // so following it is always a deliberate act.
+  preRelease: false,
 };
 
 /**
@@ -60,6 +74,7 @@ export function sanitizeUpdatePrefs(raw: unknown): UpdatePrefs {
   return {
     autoUpdate: typeof obj.autoUpdate === "boolean" ? obj.autoUpdate : DEFAULT_UPDATE_PREFS.autoUpdate,
     skippedVersions: skipped,
+    preRelease: typeof obj.preRelease === "boolean" ? obj.preRelease : DEFAULT_UPDATE_PREFS.preRelease,
   };
 }
 

--- a/packages/harness-desktop/src/main/update-prefs.ts
+++ b/packages/harness-desktop/src/main/update-prefs.ts
@@ -35,6 +35,10 @@ export interface UpdatePrefs {
    * silently fails to take it is indistinguishable from a broken updater. That
    * cost a real debugging session. `SAPIOM_UPDATE_CHANNEL` still wins over this
    * when set, so the escape hatch keeps working for one-off checks.
+   *
+   * NOT yet settable from the UI: this release lands the mechanism and the
+   * persistence, and the control that writes it is a follow-up. Until then the
+   * ways to turn it on are hand-editing this file or the env var.
    */
   preRelease: boolean;
 }

--- a/packages/harness-desktop/src/main/updater.ts
+++ b/packages/harness-desktop/src/main/updater.ts
@@ -536,9 +536,13 @@ function startUpdater(deps: UpdaterDeps): void {
       // async-after-sync shape as the toggle above and safe for the same reason:
       // the first check is FIRST_CHECK_DELAY_MS (30s) out, and this read takes
       // milliseconds. Re-assigning `channel` with a string is fine — the setter
-      // only rejects a non-string once a channel has been set — though note it
-      // also flips `allowDowngrade` to true, which is what we want for a machine
-      // moving onto betas.
+      // only rejects a non-string once a channel has been set. Assigning it also
+      // flips `allowDowngrade` to true, but that was already true from the
+      // startup assignment, so nothing changes here. Note what does NOT protect
+      // the user from a downgrade: `allowDowngrade` is permissive, and the actual
+      // guarantee is upstream — a beta install reads `beta*.yml`, and the release
+      // job mirrors every final's manifest onto that channel, so the newest thing
+      // it can ever be offered is a newer version.
       const withPrefs = resolveUpdateChannel(app.getVersion(), process.env, prefs);
       if (withPrefs.channel !== decision.channel) {
         autoUpdater.channel = withPrefs.channel;

--- a/packages/harness-desktop/src/main/updater.ts
+++ b/packages/harness-desktop/src/main/updater.ts
@@ -532,9 +532,23 @@ function startUpdater(deps: UpdaterDeps): void {
   void loadUpdatePrefs(updatePrefsFile())
     .then((prefs) => {
       autoUpdater.autoInstallOnAppQuit = prefs.autoUpdate;
+      // Re-resolve the channel now that the persisted opt-in is known. Same
+      // async-after-sync shape as the toggle above and safe for the same reason:
+      // the first check is FIRST_CHECK_DELAY_MS (30s) out, and this read takes
+      // milliseconds. Re-assigning `channel` with a string is fine — the setter
+      // only rejects a non-string once a channel has been set — though note it
+      // also flips `allowDowngrade` to true, which is what we want for a machine
+      // moving onto betas.
+      const withPrefs = resolveUpdateChannel(app.getVersion(), process.env, prefs);
+      if (withPrefs.channel !== decision.channel) {
+        autoUpdater.channel = withPrefs.channel;
+        autoUpdater.allowPrerelease = withPrefs.allowPrerelease;
+        active = active ? { ...active, channel: withPrefs.channel } : active;
+        log(`channel → "${withPrefs.channel}" (pre-release opt-in ${prefs.preRelease ? "on" : "off"})`);
+      }
     })
     .catch(() => {
-      /* keep the default */
+      /* keep the defaults — prefs are a convenience, never load-bearing */
     });
   // Only when forced on from an unpackaged build: read dev-app-update.yml
   // instead of the app-update.yml that only packaging writes.


### PR DESCRIPTION
## What

The beta update channel has never worked, for any release. `electron-updater`'s `GitHubProvider.getLatestVersion()` runs `semver.valid(tag)` over every `releases.atom` entry when resolving a pre-release channel and **skips the failures**:

```js
const hrefTag = hrefElement[1];        // "harness-desktop-v0.3.8"
if (!semver.valid(hrefTag)) continue;  // → null, so EVERY entry is skipped
...
if (tag == null) throw newError(`No published versions on GitHub`, ...)
```

`harness-desktop-v0.3.8-beta.1` is the proof: published yesterday, correct in every other respect, and installable by nobody. Replaying that loop against the live feed with `currentChannel="beta"` skips all 10 entries and throws.

A leading `v` is the only prefix semver tolerates, so the tag namespace becomes `v*`.

The stable channel is untouched by this — `allowPrerelease: false` resolves via `getLatestTagName()` → `/releases/latest`, which treats the tag as an opaque string. That is why this survived from the first release to 0.3.8 with every check green, and existing installs keep updating across the change.

## Changes

- **`desktop-release.yml`** — trigger `harness-desktop-v*` → `v*`; `prepare` expects `v${version}`; **new** guard failing the build on a version that isn't semver-parseable, so this cannot regress silently.
- **`release-tags.test.ts`** (new) — pins the namespace, the guard, and *that the channel-mirror step still exists*. That step looks redundant beside `generateUpdatesFilesForAllChannels`, but that option is a **no-op for us**: `computeChannelNames()` short-circuits on `publishConfig.provider === "github"`. Deleting the mirror would strand every beta install with no path back to stable.
- **`update-prefs.ts`** — persisted `preRelease` opt-in on the existing store, default off, sanitized like its siblings.
- **`update-policy.ts`** — `resolveUpdateChannel` takes prefs. Precedence **env > toggle > version**. The toggle can only move an install *onto* betas, never drag a `-beta.2` build back to `latest` — that would present a downgrade as an update.
- **`updater.ts`** — re-resolves the channel once prefs load, same async-after-sync shape as the existing auto-install toggle (first check is 30s out).
- **`CLAUDE.md`** — new tag table, the beta-cut procedure, and an explicit "do not add `generateUpdatesFilesForAllChannels`, do not delete the mirror step" with the reason.

## Not in this PR

The UI control for the opt-in. The mechanism and persistence land here; placement is a design call still open. `SAPIOM_UPDATE_CHANNEL=beta` works today for anyone who needs it before then.

## Delivery lane

Standard. No migrations, no infrastructure, no integrations. Affects the desktop release workflow and the desktop updater only; no runtime service, no backend surface.

## Tests

`pnpm --filter @sapiom/harness-desktop typecheck` clean; `pnpm --filter @sapiom/harness-desktop test` → **20 files, 167 tests passing** (12 new: 7 in `release-tags.test.ts`, 5 in `update-policy.test.ts`).

## Production signal

The next tag is the signal, and it is deliberately a beta: cut `v0.3.9-beta.1`, confirm GitHub marks it pre-release, confirm `/releases/latest` still resolves to the newest **final**, then confirm an install with `SAPIOM_UPDATE_CHANNEL=beta` is actually offered it — the exact check that fails today. A stable install must be offered nothing.

Fix-forward: if a `v*` tag misbehaves, `prepare` fails fast (~15s, before any notarization) and no release is published; correct the version or the guard on `main` and re-tag. The stable channel is unaffected either way, so a bad beta cannot reach non-opted-in users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sZDBYwf1SJBVxH5wPYyfc