### PR TITLE
chore(desktop): drop the temporary Harness 0.8.9 pin [SAP-2906]

### DIFF
--- a/.changeset/desktop-drop-harness-pin.md
+++ b/.changeset/desktop-drop-harness-pin.md
@@ -1,0 +1,23 @@
+---
+"@sapiom/harness-desktop": minor
+---
+
+Ship the current Agent Studio experience on the stable desktop channel again, by
+removing the temporary `@sapiom/harness@0.8.9` pin. The app now bundles the
+workspace Harness, so the Project rail rebuild and the dependency graph reach
+stable users for the first time.
+
+**Correcting the record for 0.3.8.** That release's changelog claims
+`@sapiom/harness@0.10.0`, and it did not ship it. The entry was generated from the
+workspace dependency graph, which could not see the `pnpm` override pinning the
+desktop app to `0.8.9` — so `0.3.8` carried the same Agent Studio SPA as `0.3.7`
+despite what its notes said. Nothing was wrong with the build; the pin was
+deliberate (see `0.3.7`) and only its removal was missed. This release is the one
+that actually delivers the newer Studio.
+
+**Rows you had may disappear on upgrade, and no files are touched.** The rail now
+derives its project list from one rule: a project is a directory you chose that
+holds agents. Remembered folders that were an agent's own directory, and folders
+known only because a session once ran there, stop being drawn. On one real install
+this cut 42 project rows to 3 with all 89 agents still visible. Nothing is
+deleted — any folder is one **Add a project** away from coming back.

--- a/packages/harness-desktop/package.json
+++ b/packages/harness-desktop/package.json
@@ -10,7 +10,6 @@
   },
   "type": "module",
   "main": "./dist/main/index.js",
-  "desktopHarnessVersion": "0.8.9",
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node scripts/copy-renderer.mjs",
     "dev": "node scripts/assert-harness-version.mjs --build && pnpm run build && electron . --dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   '@electron/rebuild': ^3.7.0
-  '@sapiom/harness-desktop>@sapiom/harness': 0.8.9
 
 importers:
 
@@ -467,8 +466,8 @@ importers:
   packages/harness-desktop:
     dependencies:
       '@sapiom/harness':
-        specifier: 0.8.9
-        version: 0.8.9(@cfworker/json-schema@4.1.1)
+        specifier: workspace:^
+        version: link:../harness
       electron-updater:
         specifier: ^6.8.9
         version: 6.8.9
@@ -1121,7 +1120,7 @@ packages:
     engines: {node: '>=12'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -2040,44 +2039,6 @@ packages:
     resolution: {integrity: sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==}
     cpu: [x64]
     os: [win32]
-
-  '@sapiom/agent-core@0.13.2':
-    resolution: {integrity: sha512-uFL2c1BWoANoVrpTAMx+IM3ytogO3slrKh3V/T5hxHITMoDzL5MUiHVuPMf2D+6IoCzJC/qTWQwHMUU7UQvl4g==}
-    engines: {node: '>=18.0.0'}
-
-  '@sapiom/agent-runtime@0.7.0':
-    resolution: {integrity: sha512-lQTF7PRIZuP0BepLpW90QE3yAGkwTs0HzeoxkMm0ddVuTPqKni/V2/867Tet/SzT4VnQ0MbuZ86+dhACuWy4ng==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^4.1.0
-
-  '@sapiom/agent@0.12.2':
-    resolution: {integrity: sha512-Ptq10gyrEGzcOLQb0c0S56Hc6EmhzrnEeinY81G0vC+u/T2QEPylsXme0x4iY+wlrGJ5R+aXEggQwkYBFkROsQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.0.0
-
-  '@sapiom/analytics-core@0.2.1':
-    resolution: {integrity: sha512-IZaSdegheySbLxSwmrvcKFKpog3+Ef8IP/hkd7Qjp7uxgo7pfwkmjy9nFH9lXDH4ALeW5+Fhs717+RKwkW1EJA==}
-    engines: {node: '>=18.0.0'}
-
-  '@sapiom/harness@0.8.9':
-    resolution: {integrity: sha512-fJ9jZvVEe1ChhYmrh+qO19tuplv5fhmZ9w56agT2JVk/LisDFeGDqoQIt3YcLZSJcfYYRJ3RND7rXZSSXHNN6g==}
-    engines: {node: '>=20.0.0'}
-    hasBin: true
-
-  '@sapiom/mcp@0.13.0':
-    resolution: {integrity: sha512-f9SppXl1GAwRa/yMks0Ng1FSOimonk9C5DyC+RHI2Iv6xKyy+VEGKIGuE/Q+8LOs4y77Ezk+ca97mTdLKh3p3Q==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
-  '@sapiom/sandbox-preview@0.1.19':
-    resolution: {integrity: sha512-bxjSACOSNyxNmnCQ01mA/BQqK/iEiOxaDwnV3/c96lMdhQy9LrHJjMlMSlk7CrT6+84cNoMEGMbafSKHqd/UyQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@sapiom/tools@0.33.0':
-    resolution: {integrity: sha512-eJKAuiM1yKPPAAuIJRXdC/uOFB4CEggAvzftHCB6YjJYXGKtee47A9rAnyBVm7PbRL8PJXudhaDyG7mHkSRN6Q==}
-    engines: {node: '>=18.0.0'}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -7002,68 +6963,6 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.62.0':
     optional: true
-
-  '@sapiom/agent-core@0.13.2(zod@3.25.76)':
-    dependencies:
-      '@sapiom/agent': 0.12.2(zod@3.25.76)
-      '@sapiom/agent-runtime': 0.7.0(zod@3.25.76)
-      '@sapiom/analytics-core': 0.2.1
-      '@sapiom/tools': 0.33.0
-      esbuild: 0.28.1
-    transitivePeerDependencies:
-      - zod
-
-  '@sapiom/agent-runtime@0.7.0(zod@3.25.76)':
-    dependencies:
-      '@sapiom/agent': 0.12.2(zod@3.25.76)
-      ajv: 8.20.0
-      zod: 3.25.76
-
-  '@sapiom/agent@0.12.2(zod@3.25.76)':
-    dependencies:
-      '@sapiom/tools': 0.33.0
-      zod: 3.25.76
-
-  '@sapiom/analytics-core@0.2.1': {}
-
-  '@sapiom/harness@0.8.9(@cfworker/json-schema@4.1.1)':
-    dependencies:
-      '@sapiom/agent': 0.12.2(zod@3.25.76)
-      '@sapiom/agent-core': 0.13.2(zod@3.25.76)
-      '@sapiom/analytics-core': 0.2.1
-      '@sapiom/mcp': 0.13.0(@cfworker/json-schema@4.1.1)
-      ajv: 8.20.0
-      express: 4.22.2
-      express-rate-limit: 7.5.1(express@4.22.2)
-      node-pty: 1.1.0
-      open: 10.2.0
-      ws: 8.21.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@sapiom/mcp@0.13.0(@cfworker/json-schema@4.1.1)':
-    dependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
-      '@sapiom/agent-core': 0.13.2(zod@3.25.76)
-      '@sapiom/analytics-core': 0.2.1
-      '@sapiom/sandbox-preview': 0.1.19
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@cfworker/json-schema'
-      - supports-color
-
-  '@sapiom/sandbox-preview@0.1.19':
-    dependencies:
-      '@sapiom/tools': 0.33.0
-      zod: 3.25.76
-
-  '@sapiom/tools@0.33.0':
-    dependencies:
-      '@sapiom/analytics-core': 0.2.1
 
   '@sec-ant/readable-stream@0.4.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1120,7 +1120,7 @@ packages:
     engines: {node: '>=12'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,9 +20,3 @@ onlyBuiltDependencies:
 # cross-platform rebuild HANG that the bare node-gyp override caused.
 overrides:
   "@electron/rebuild": ^3.7.0
-  # Temporary SAP-2906 release split: keep stable Desktop on the pre-graph
-  # Harness. After tagging 0.3.7, remove BOTH this override and Desktop's
-  # desktopHarnessVersion field for 0.3.8-beta.1. With both absent, its dev
-  # preparation builds Harness from the workspace and its packer checks that
-  # deployed workspace version. The rest of the monorepo stays current.
-  "@sapiom/harness-desktop>@sapiom/harness": 0.8.9


### PR DESCRIPTION
## Why

The SAP-2906 release split kept stable Desktop on the pre-graph Harness with a pnpm override plus a `desktopHarnessVersion` guard. Its own comment said what should happen next:

> *"After tagging 0.3.7, remove BOTH this override and Desktop's `desktopHarnessVersion` field for 0.3.8-beta.1."*

[#730](https://github.com/sapiom/sapiom-js/pull/730) would have done that on `main` and was **closed unmerged**. The beta was tagged off that branch instead, SAP-2906 was marked Done, and `main` kept the pin.

The cost was silent: **0.3.8 shipped as a stable final still bundling Harness 0.8.9**, so the Studio rail rebuild in 0.10.0 — the reason that release was cut — is not in it. Its SPA is byte-for-byte the same generation as 0.3.7's. It also leaves `0.3.8-beta.1` (Harness 0.9.0) semver-*below* a final carrying an *older* SPA, so the final supersedes the beta with a downgrade.

## Changes

Two deletions and the lockfile:

- `pnpm-workspace.yaml` — drop the `"@sapiom/harness-desktop>@sapiom/harness": 0.8.9` override
- `packages/harness-desktop/package.json` — drop `"desktopHarnessVersion": "0.8.9"`

No new machinery. `harness-version.mjs` already resolves `configuredVersion ?? workspaceHarnessPackage.version`, so removing the field makes the guard track the workspace Harness and then verify the packaged bundle really resolved it — the fallback the cleanup was designed around.

## Delivery lane

Standard. No migrations, no infrastructure, no integrations. Changes only which Harness the desktop app bundles.

## Tests

With the pin removed:

- `harness-desktop` resolves `@sapiom/harness` **0.10.0**
- guard: `[harness-version] desktop development dependency: @sapiom/harness 0.10.0 matches the workspace Harness`
- `pnpm --filter @sapiom/harness-desktop test` → **19 files, 155 tests passing**
- the built SPA bundle contains the rail rebuild's "Create new agent" copy — i.e. the payload is verifiably present, not just the version number

Note the workspace Harness must be built before the desktop suite runs (`pnpm --filter "@sapiom/harness..." build`); with the pin in place it resolved a prebuilt npm tarball instead. CI already builds topologically.

## Production signal

The next desktop tag. Ship it as **`v0.3.9-beta.1`** rather than straight to stable — 0.10.0's own changeset warns *"Rows you had may disappear on upgrade… on one real install this cut 42 project rows to 3"*, which is precisely what a pre-release channel is for. Confirm the rail renders against a real multi-project workspace, then promote to `v0.3.9`.

Depends on [#736](https://github.com/sapiom/sapiom-js/pull/736) for the beta to be installable at all — the `harness-desktop-v*` namespace makes pre-release tags invisible to the updater.

Fix-forward: if 0.10.0's rail misbehaves on a real workspace, re-add the override and `desktopHarnessVersion` pinning to the last good Harness and cut the next patch; the guard fails the build loudly rather than silently shipping a mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sZDBYwf1SJBVxH5wPYyfc