### PR TITLE
test(agent-core): add edge case unit tests for parseExecInput

### DIFF
--- a/packages/agent-core/src/__tests__/client.test.ts
+++ b/packages/agent-core/src/__tests__/client.test.ts
@@ -285,5 +285,18 @@ describe('link', () => {
   it('throws NOT_FOUND when not found and create=false', async () => {
     mockFetch([{ status: 200, body: [] }]);
     await expect(link({ name: 'missing' }, client)).rejects.toMatchObject({ code: 'NOT_FOUND' });
+  
+
+  describe("parseExecInput edge cases", () => {
+    it("throws BAD_INPUT when provided an empty string or empty object json", () => {
+      expect(() => parseExecInput("")).toThrow();
+      expect(() => parseExecInput("{}")).toEqual({});
+    });
+
+    it("throws BAD_INPUT when provided invalid non-string non-object values", () => {
+      expect(() => parseExecInput("123")).toThrow();
+      expect(() => parseExecInput("true")).toThrow();
+    });
   });
+});
 });


### PR DESCRIPTION
### Summary
Adds edge-case unit test coverage for `parseExecInput` in `client.test.ts`.

### Changes Included
- Added test coverage verifying that empty strings and empty JSON objects are handled as expected by `parseExecInput`.
- Added test cases covering invalid non-string and non-object inputs (e.g., JSON primitives like numbers and booleans).

### Motivation
Ensures input parsing handles non-standard and boundary JSON values cleanly without unexpected runtime exceptions across agent workflows.