### PR TITLE
fix(harness): stop a settled identity failure from vetoing the graph cache [SAP-2984]

### DIFF
--- a/.changeset/graph-cache-settled-identity.md
+++ b/.changeset/graph-cache-settled-identity.md
@@ -1,0 +1,28 @@
+---
+"@sapiom/harness": patch
+---
+
+Stop a permanently unreadable agent from holding a whole project's graph at
+"Graph may be incomplete".
+
+An agent that does not declare a name has its source read to recover one. If
+even one agent in a project could not be read, the projection refused to cache
+— so the project reopened as degraded, under the "Graph may be incomplete"
+banner, every time. In practice that is the normal state of a real workspace:
+a companion package with no agent export, or one whose dependencies were never
+installed, can never be named no matter how often it is re-read, and a single
+such directory was enough to mark everything around it incomplete.
+
+The cache now depends on whether the name lookup FINISHED, not on whether it
+found a name. A lookup that completed is settled and no longer blocks caching;
+one that was still running when the projection's time budget expired does
+block it, because caching a placeholder would leave the wrong label on screen
+until the next edit.
+
+The affected agents keep their warnings. The graph stops calling itself
+incomplete; it does not go quiet about what it could not resolve.
+
+Also fixes duplicate agents when Studio is launched through a symlinked
+directory. Agents were registered once under the path as given and again under
+its resolved form, and the duplicate pair made every reference between agents
+ambiguous, silently dropping those connections from the graph.

--- a/.changeset/graph-cache-settled-identity.md
+++ b/.changeset/graph-cache-settled-identity.md
@@ -13,12 +13,12 @@ no matter how often it is re-read, and a single such directory was enough to
 mark everything around it incomplete.
 
 The cache now depends on whether the name lookup can still produce a different
-answer, not on whether it found a name. A lookup with nowhere left to go no
-longer blocks caching. Two cases still do, because for them the answer really
-can change: a lookup that was still running when the projection's time budget
-expired, and one that failed only because the project's dependencies are not
-installed yet — that project keeps its banner and its Retry button, which is
-what clears it once the install lands.
+answer, not on whether it found a name. Only one case is treated as final, the
+one that can be proven: a project with no TypeScript in it has nothing for an
+agent name to be declared in, and no install or re-run will invent one. Every
+other failure still blocks caching, so that project keeps its banner and its
+Retry button — the thing that clears it once dependencies are installed, or
+after a check that ran out of time succeeds on a second attempt.
 
 The affected agents keep their warnings either way. The graph stops calling
 itself incomplete over agents it was never going to resolve; it does not go
@@ -27,4 +27,6 @@ quiet about what it could not resolve.
 Also stops one agent being registered twice when Studio reaches the same
 directory by two different paths — once as given and once with symlinks
 resolved. The duplicate pair made every reference between agents ambiguous,
-silently dropping those connections from the graph.
+silently dropping those connections from the graph. This prevents new
+duplicates; a workspace that already contains a pair from an earlier version
+still needs them removed by hand.

--- a/.changeset/graph-cache-settled-identity.md
+++ b/.changeset/graph-cache-settled-identity.md
@@ -2,27 +2,29 @@
 "@sapiom/harness": patch
 ---
 
-Stop a permanently unreadable agent from holding a whole project's graph at
+Stop an agent that can never be named from holding a whole project's graph at
 "Graph may be incomplete".
 
 An agent that does not declare a name has its source read to recover one. If
-even one agent in a project could not be read, the projection refused to cache
-— so the project reopened as degraded, under the "Graph may be incomplete"
-banner, every time. In practice that is the normal state of a real workspace:
-a companion package with no agent export, or one whose dependencies were never
-installed, can never be named no matter how often it is re-read, and a single
-such directory was enough to mark everything around it incomplete.
+even one agent in a project could not be read, the projection refused to cache,
+so the project reopened as degraded under the "Graph may be incomplete" banner
+every time. A companion package with no agent export in it has nothing to find
+no matter how often it is re-read, and a single such directory was enough to
+mark everything around it incomplete.
 
-The cache now depends on whether the name lookup FINISHED, not on whether it
-found a name. A lookup that completed is settled and no longer blocks caching;
-one that was still running when the projection's time budget expired does
-block it, because caching a placeholder would leave the wrong label on screen
-until the next edit.
+The cache now depends on whether the name lookup can still produce a different
+answer, not on whether it found a name. A lookup with nowhere left to go no
+longer blocks caching. Two cases still do, because for them the answer really
+can change: a lookup that was still running when the projection's time budget
+expired, and one that failed only because the project's dependencies are not
+installed yet — that project keeps its banner and its Retry button, which is
+what clears it once the install lands.
 
-The affected agents keep their warnings. The graph stops calling itself
-incomplete; it does not go quiet about what it could not resolve.
+The affected agents keep their warnings either way. The graph stops calling
+itself incomplete over agents it was never going to resolve; it does not go
+quiet about what it could not resolve.
 
-Also fixes duplicate agents when Studio is launched through a symlinked
-directory. Agents were registered once under the path as given and again under
-its resolved form, and the duplicate pair made every reference between agents
-ambiguous, silently dropping those connections from the graph.
+Also stops one agent being registered twice when Studio reaches the same
+directory by two different paths — once as given and once with symlinks
+resolved. The duplicate pair made every reference between agents ambiguous,
+silently dropping those connections from the graph.

--- a/packages/harness/src/core/definition-name.test.ts
+++ b/packages/harness/src/core/definition-name.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { inspectManifestName, resolveManifestName } from "./definition-name.js";
 
@@ -72,14 +75,72 @@ describe("inspectManifestName", () => {
     ).resolves.toEqual({ status: "absent" });
     await expect(inspectManifestName("/proj/broken", failed)).resolves.toEqual({
       status: "failed",
+      retryable: false,
     });
   });
 
   it("reports a thrown extraction as failed", async () => {
     const extract = vi.fn().mockRejectedValue(new Error("boom"));
 
+    // The extractor told us nothing about why, so keep the retry affordance.
     await expect(inspectManifestName("/proj/broken", extract)).resolves.toEqual(
-      { status: "failed" },
+      { status: "failed", retryable: true },
     );
+  });
+
+  describe("classifying a failure as still clearable", () => {
+    const roots: string[] = [];
+    const failed = () =>
+      vi.fn().mockResolvedValue({
+        result: { ok: false as const, reason: "run npm install first" },
+        cached: false,
+        fingerprint: "0:0",
+      });
+
+    async function project(files: Record<string, string>): Promise<string> {
+      const root = await fs.mkdtemp(path.join(os.tmpdir(), "definition-name-"));
+      roots.push(root);
+      for (const [relative, contents] of Object.entries(files)) {
+        const file = path.join(root, relative);
+        await fs.mkdir(path.dirname(file), { recursive: true });
+        await fs.writeFile(file, contents);
+      }
+      return root;
+    }
+
+    afterEach(async () => {
+      await Promise.all(
+        roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+      );
+    });
+
+    it("is retryable with sources present but nothing installed", async () => {
+      const root = await project({ "index.ts": "export {};\n" });
+      await expect(inspectManifestName(root, failed())).resolves.toEqual({
+        status: "failed",
+        retryable: true,
+      });
+    });
+
+    it("is settled once dependencies are installed", async () => {
+      const root = await project({
+        "index.ts": "export {};\n",
+        "node_modules/.keep": "",
+      });
+      await expect(inspectManifestName(root, failed())).resolves.toEqual({
+        status: "failed",
+        retryable: false,
+      });
+    });
+
+    it("is settled when the project has no TypeScript to name", async () => {
+      // A dashboard companion: no install can produce a `defineAgent` that
+      // was never written, so this failure has nowhere left to go.
+      const root = await project({ "server.js": "module.exports = {};\n" });
+      await expect(inspectManifestName(root, failed())).resolves.toEqual({
+        status: "failed",
+        retryable: false,
+      });
+    });
   });
 });

--- a/packages/harness/src/core/definition-name.test.ts
+++ b/packages/harness/src/core/definition-name.test.ts
@@ -114,7 +114,7 @@ describe("inspectManifestName", () => {
       );
     });
 
-    it("is retryable with sources present but nothing installed", async () => {
+    it("is retryable while the project still has TypeScript to name", async () => {
       const root = await project({ "index.ts": "export {};\n" });
       await expect(inspectManifestName(root, failed())).resolves.toEqual({
         status: "failed",
@@ -122,20 +122,24 @@ describe("inspectManifestName", () => {
       });
     });
 
-    it("is settled once dependencies are installed", async () => {
+    it("stays retryable with dependencies installed", async () => {
+      // Installed deps prove nothing: workspaces hoist `node_modules` to the
+      // repo root, and a check process that crashed or timed out under load
+      // succeeds on the next run. Only "no TypeScript at all" is provable.
       const root = await project({
         "index.ts": "export {};\n",
         "node_modules/.keep": "",
       });
       await expect(inspectManifestName(root, failed())).resolves.toEqual({
         status: "failed",
-        retryable: false,
+        retryable: true,
       });
     });
 
     it("is settled when the project has no TypeScript to name", async () => {
-      // A dashboard companion: no install can produce a `defineAgent` that
-      // was never written, so this failure has nowhere left to go.
+      // A dashboard companion: no install and no re-run can produce a
+      // `defineAgent` that was never written, so this failure is the one we
+      // can prove has nowhere left to go.
       const root = await project({ "server.js": "module.exports = {};\n" });
       await expect(inspectManifestName(root, failed())).resolves.toEqual({
         status: "failed",

--- a/packages/harness/src/core/definition-name.ts
+++ b/packages/harness/src/core/definition-name.ts
@@ -12,9 +12,6 @@
  * a bundle error, the check process timing out) comes back as null and the
  * caller falls back to a weaker name source.
  */
-import * as fs from "node:fs/promises";
-import * as path from "node:path";
-
 import { extractWorkflowGraphCached } from "./canvas-cache.js";
 import { listSourceFiles } from "./canvas-interconnections.js";
 
@@ -25,27 +22,28 @@ export type ManifestNameInspection =
   | { status: "failed"; retryable: boolean };
 
 /**
- * The one extraction failure a later projection of the SAME unchanged source
- * can still clear: there is TypeScript to extract from, but nothing installed
- * to run the extraction with. Failures are deliberately not cached
- * (core/canvas-cache.ts), so re-running after an install succeeds — but the
- * graph watcher only reacts to `.ts`/`.tsx` outside ignored directories, so
- * `node_modules` landing fires nothing. Callers must keep offering a retry.
+ * Whether a later projection of the SAME unchanged source could still name
+ * this agent. Extraction failures are deliberately not cached
+ * (core/canvas-cache.ts), so a re-run is free to succeed — and several causes
+ * do resolve on their own terms: dependencies get installed, a check process
+ * that crashed or timed out under load succeeds on the next attempt. None of
+ * those fire the graph watcher, which only reacts to `.ts`/`.tsx` outside
+ * ignored directories, so the caller must keep offering a manual retry.
  *
- * A project with no TypeScript at all is NOT this case: no install can produce
- * a `defineAgent` that was never written.
+ * `reason` cannot answer this — it is free-form text assembled from an agent's
+ * own error message, a stderr tail, or a timeout string — so the only claim
+ * made here is the one the filesystem proves outright: a project with no
+ * TypeScript in it has no `defineAgent` to find, and no install or re-run
+ * will invent one. Adding a source file changes the answer, and adding one is
+ * precisely what the watcher does see.
+ *
+ * Deliberately one-directional. Guessing "settled" wrongly caches a
+ * provisional label and removes the retry that would have fixed it; guessing
+ * "retryable" wrongly just leaves the project as it behaves today.
  */
-async function installCouldStillName(projectDir: string): Promise<boolean> {
-  let sources: string[];
+async function couldStillBeNamed(projectDir: string): Promise<boolean> {
   try {
-    sources = await listSourceFiles(projectDir);
-  } catch {
-    return false;
-  }
-  if (sources.length === 0) return false;
-  try {
-    await fs.access(path.join(projectDir, "node_modules"));
-    return false;
+    return (await listSourceFiles(projectDir)).length > 0;
   } catch {
     return true;
   }
@@ -64,7 +62,7 @@ export async function inspectManifestName(
   try {
     const { result } = await extract(projectDir);
     if (!result.ok) {
-      return { status: "failed", retryable: await installCouldStillName(projectDir) };
+      return { status: "failed", retryable: await couldStillBeNamed(projectDir) };
     }
     const name = result.graph.manifestName.trim();
     return name === "" ? { status: "absent" } : { status: "found", name };

--- a/packages/harness/src/core/definition-name.ts
+++ b/packages/harness/src/core/definition-name.ts
@@ -12,16 +12,50 @@
  * a bundle error, the check process timing out) comes back as null and the
  * caller falls back to a weaker name source.
  */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
 import { extractWorkflowGraphCached } from "./canvas-cache.js";
+import { listSourceFiles } from "./canvas-interconnections.js";
 
 export type ManifestNameInspection =
   | { status: "found"; name: string }
-  | { status: "absent" | "failed" };
+  | { status: "absent" }
+  /** `retryable`: the same unchanged source could still name this agent. */
+  | { status: "failed"; retryable: boolean };
+
+/**
+ * The one extraction failure a later projection of the SAME unchanged source
+ * can still clear: there is TypeScript to extract from, but nothing installed
+ * to run the extraction with. Failures are deliberately not cached
+ * (core/canvas-cache.ts), so re-running after an install succeeds — but the
+ * graph watcher only reacts to `.ts`/`.tsx` outside ignored directories, so
+ * `node_modules` landing fires nothing. Callers must keep offering a retry.
+ *
+ * A project with no TypeScript at all is NOT this case: no install can produce
+ * a `defineAgent` that was never written.
+ */
+async function installCouldStillName(projectDir: string): Promise<boolean> {
+  let sources: string[];
+  try {
+    sources = await listSourceFiles(projectDir);
+  } catch {
+    return false;
+  }
+  if (sources.length === 0) return false;
+  try {
+    await fs.access(path.join(projectDir, "node_modules"));
+    return false;
+  } catch {
+    return true;
+  }
+}
 
 /**
  * Inspect the declared manifest name while preserving the difference between
  * a valid unnamed agent and an extraction failure. Inventory uses the richer
- * result to avoid warning for the normal unnamed case.
+ * result to avoid warning for the normal unnamed case, and `retryable` to
+ * decide whether the failure can still be cleared without a source edit.
  */
 export async function inspectManifestName(
   projectDir: string,
@@ -29,11 +63,15 @@ export async function inspectManifestName(
 ): Promise<ManifestNameInspection> {
   try {
     const { result } = await extract(projectDir);
-    if (!result.ok) return { status: "failed" };
+    if (!result.ok) {
+      return { status: "failed", retryable: await installCouldStillName(projectDir) };
+    }
     const name = result.graph.manifestName.trim();
     return name === "" ? { status: "absent" } : { status: "found", name };
   } catch {
-    return { status: "failed" };
+    // The extractor itself misbehaved; we learned nothing about why. Assume
+    // recoverable so the caller keeps its retry affordance.
+    return { status: "failed", retryable: true };
   }
 }
 

--- a/packages/harness/src/core/system-graph-inventory.test.ts
+++ b/packages/harness/src/core/system-graph-inventory.test.ts
@@ -220,6 +220,55 @@ describe("HarnessRegistryInventoryProvider", () => {
     expect(JSON.stringify(result.warnings)).not.toContain(WORKSPACE);
   });
 
+  it("caches a project whose extraction failures have all settled", async () => {
+    // A companion package with no `defineAgent` export, or one whose
+    // dependencies were never installed, fails identically on every open.
+    // Letting it veto the cache pinned real workspaces to `degraded` and its
+    // "graph may be incomplete" banner permanently.
+    const inspectManifestName = vi.fn(async (sourceRoot: string) =>
+      sourceRoot.endsWith("/dashboard")
+        ? ({ status: "failed" } as const)
+        : ({ status: "found", name: "growth-manifest" } as const),
+    );
+
+    const result = await provider(
+      [workflow("Growth", "growth", null), workflow("Dashboard", "dashboard", null)],
+      { inspectManifestName },
+    ).listAgents(SCOPE);
+
+    expect(result.cacheable).toBe(true);
+    // The graph becomes cacheable; it does not go quiet about what it could
+    // not resolve.
+    expect(result.warnings).toEqual([
+      {
+        code: "inventory-extraction-failed",
+        agentKey: "local:dashboard",
+        message: "Could not inspect Dashboard; using its local identity.",
+      },
+    ]);
+  });
+
+  it("keeps a project uncacheable while an inspection is still in flight", async () => {
+    // The budget cut this inspection off mid-read. Its name is still
+    // recoverable, so caching the provisional local label would freeze the
+    // wrong text on screen until the next source edit.
+    const started: string[] = [];
+    const inspectManifestName = vi.fn(async (sourceRoot: string) => {
+      started.push(sourceRoot);
+      if (sourceRoot.endsWith("/settled")) return { status: "failed" as const };
+      await new Promise(() => {});
+      return { status: "absent" as const };
+    });
+
+    const result = await provider(
+      [workflow("Settled", "settled", null), workflow("Slow", "slow", null)],
+      { inspectManifestName, manifestInspectionBudgetMs: 20 },
+    ).listAgents(SCOPE);
+
+    expect(started).toEqual([`${WORKSPACE}/settled`, `${WORKSPACE}/slow`]);
+    expect(result.cacheable).toBe(false);
+  });
+
   it("returns partial inventory when the enrichment budget expires", async () => {
     let release!: () => void;
     const gate = new Promise<void>((resolve) => {

--- a/packages/harness/src/core/system-graph-inventory.test.ts
+++ b/packages/harness/src/core/system-graph-inventory.test.ts
@@ -168,7 +168,7 @@ describe("HarnessRegistryInventoryProvider", () => {
       started.push(sourceRoot);
       await gate;
       if (sourceRoot.endsWith("/broken")) {
-        return { status: "failed" as const };
+        return { status: "failed" as const, retryable: false };
       }
       if (sourceRoot.endsWith("/thrown")) {
         throw new Error(`unreadable ${sourceRoot}`);
@@ -227,7 +227,7 @@ describe("HarnessRegistryInventoryProvider", () => {
     // "graph may be incomplete" banner permanently.
     const inspectManifestName = vi.fn(async (sourceRoot: string) =>
       sourceRoot.endsWith("/dashboard")
-        ? ({ status: "failed" } as const)
+        ? ({ status: "failed", retryable: false } as const)
         : ({ status: "found", name: "growth-manifest" } as const),
     );
 
@@ -248,6 +248,31 @@ describe("HarnessRegistryInventoryProvider", () => {
     ]);
   });
 
+  it("keeps a project uncacheable when a failure is still clearable", async () => {
+    // "Run install first" is the one failure a later projection of the SAME
+    // unchanged source can clear, and nothing fires the watcher when
+    // `node_modules` lands. Caching it would strip the degraded banner that
+    // carries the only Retry button, freezing a `local:` label on screen.
+    const inspectManifestName = vi.fn(async (sourceRoot: string) =>
+      sourceRoot.endsWith("/needs-install")
+        ? ({ status: "failed", retryable: true } as const)
+        : ({ status: "found", name: "growth-manifest" } as const),
+    );
+
+    const result = await provider(
+      [
+        workflow("Growth", "growth", null),
+        workflow("Needs install", "needs-install", null),
+      ],
+      { inspectManifestName },
+    ).listAgents(SCOPE);
+
+    expect(result.cacheable).toBe(false);
+    expect(
+      result.warnings.map(({ code, agentKey }) => [code, agentKey]),
+    ).toEqual([["inventory-extraction-failed", "local:needs-install"]]);
+  });
+
   it("keeps a project uncacheable while an inspection is still in flight", async () => {
     // The budget cut this inspection off mid-read. Its name is still
     // recoverable, so caching the provisional local label would freeze the
@@ -255,7 +280,9 @@ describe("HarnessRegistryInventoryProvider", () => {
     const started: string[] = [];
     const inspectManifestName = vi.fn(async (sourceRoot: string) => {
       started.push(sourceRoot);
-      if (sourceRoot.endsWith("/settled")) return { status: "failed" as const };
+      if (sourceRoot.endsWith("/settled")) {
+        return { status: "failed" as const, retryable: false };
+      }
       await new Promise(() => {});
       return { status: "absent" as const };
     });

--- a/packages/harness/src/core/system-graph-inventory.ts
+++ b/packages/harness/src/core/system-graph-inventory.ts
@@ -39,7 +39,14 @@ export interface AgentInventoryWarning {
 
 export interface AgentInventoryResult {
   agents: AgentInventoryItem[];
-  /** False when a later graph open should retry degraded enrichment. */
+  /**
+   * False only while identity work is still in flight, so a later graph open
+   * retries it. An agent that will never be nameable — no `defineAgent`
+   * export, no installed dependencies — keeps its warning but does not veto
+   * the project's cache: re-projecting cannot improve it, and vetoing pinned
+   * every real workspace to `degraded` and its "graph may be incomplete"
+   * banner forever.
+   */
   cacheable: boolean;
   warnings: AgentInventoryWarning[];
 }
@@ -250,7 +257,10 @@ interface PreparedAgent {
   fallbackKey: AgentKey;
   definitionId: number | null;
   definitionSlug: string | null;
+  /** Identity work finished without a name; the agent keeps its warning. */
   extractionFailed: boolean;
+  /** Identity work never finished. Only this may veto the project's cache. */
+  identityPending: boolean;
   label: string;
   resolutionAliases: string[];
   sourceRoot: string;
@@ -397,7 +407,7 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
     warnings.sort(warningOrder);
     return {
       agents,
-      cacheable: prepared.every((agent) => !agent.extractionFailed),
+      cacheable: prepared.every((agent) => !agent.identityPending),
       warnings,
     };
   }
@@ -410,6 +420,11 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
     const definitionSlug = normalizedAlias(workflow.definitionSlug);
     let manifestName: string | null = null;
     let extractionFailed = false;
+    // An inspection that returns has settled: the same source yields the same
+    // answer next time, and a source edit re-projects through the watcher. An
+    // inspector that throws told us nothing about which it was, so it stays
+    // pending — the conservative half of the split.
+    let identityPending = false;
     if (!definitionSlug && this.options.inspectManifestName) {
       try {
         const inspected = await this.options.inspectManifestName(sourceRoot);
@@ -420,6 +435,7 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
         }
       } catch {
         extractionFailed = true;
+        identityPending = true;
       }
     }
 
@@ -438,6 +454,7 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
       definitionId: workflow.definitionId,
       definitionSlug,
       extractionFailed,
+      identityPending,
       label: safeLabel(
         workflow.name,
         definitionSlug ??
@@ -461,7 +478,11 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
       fallbackKey,
       definitionId: workflow.definitionId,
       definitionSlug,
+      // This agent's inspection never finished (deadline miss, or it never
+      // started). Re-projecting can still name it, so it must veto the cache:
+      // caching now would freeze a provisional local label on screen.
       extractionFailed: !definitionSlug,
+      identityPending: !definitionSlug,
       label: safeLabel(
         workflow.name,
         definitionSlug ?? (fallbackKey.slice("local:".length) || "Local agent"),

--- a/packages/harness/src/core/system-graph-inventory.ts
+++ b/packages/harness/src/core/system-graph-inventory.ts
@@ -40,12 +40,12 @@ export interface AgentInventoryWarning {
 export interface AgentInventoryResult {
   agents: AgentInventoryItem[];
   /**
-   * False only while identity work is still in flight, so a later graph open
-   * retries it. An agent that will never be nameable — no `defineAgent`
-   * export, no installed dependencies — keeps its warning but does not veto
-   * the project's cache: re-projecting cannot improve it, and vetoing pinned
-   * every real workspace to `degraded` and its "graph may be incomplete"
-   * banner forever.
+   * False while identity work could still produce a different answer — it is
+   * in flight, or it failed in a way a later projection of the same source
+   * can clear. An agent a re-projection cannot improve — no `defineAgent` to
+   * find — keeps its warning but does not veto the project's cache. Vetoing
+   * on any failure pinned whole workspaces to `degraded` and its "graph may
+   * be incomplete" banner permanently, over agents that were never nameable.
    */
   cacheable: boolean;
   warnings: AgentInventoryWarning[];
@@ -420,20 +420,21 @@ export class HarnessRegistryInventoryProvider implements AgentInventoryProvider 
     const definitionSlug = normalizedAlias(workflow.definitionSlug);
     let manifestName: string | null = null;
     let extractionFailed = false;
-    // An inspection that returns has settled: the same source yields the same
-    // answer next time, and a source edit re-projects through the watcher. An
-    // inspector that throws told us nothing about which it was, so it stays
-    // pending — the conservative half of the split.
     let identityPending = false;
     if (!definitionSlug && this.options.inspectManifestName) {
       try {
         const inspected = await this.options.inspectManifestName(sourceRoot);
         if (inspected.status === "found") {
           manifestName = normalizedAlias(inspected.name);
-        } else {
-          extractionFailed = inspected.status === "failed";
+        } else if (inspected.status === "failed") {
+          extractionFailed = true;
+          // Only a failure the inspector says is still clearable keeps the
+          // project uncacheable. A settled one has nowhere left to go: its
+          // warning stands, and the cache stops paying for it forever.
+          identityPending = inspected.retryable;
         }
       } catch {
+        // The inspector threw, so we learned nothing about which it was.
         extractionFailed = true;
         identityPending = true;
       }

--- a/packages/harness/src/core/workflow-registry.test.ts
+++ b/packages/harness/src/core/workflow-registry.test.ts
@@ -394,6 +394,43 @@ describe("WorkflowRegistry", () => {
  * both halves of what replaced it: the reach, and the reconciliation rule that
  * keeps a *bounded* scan from mistaking "I didn't look there" for "it's gone".
  */
+describe("WorkflowRegistry path identity under symlinks", () => {
+  let tmpRoot: string;
+  let registryPath: string;
+
+  beforeEach(async () => {
+    // Resolve up front: on macOS `os.tmpdir()` is itself a symlink, which
+    // would make every path in the test canonical by accident.
+    tmpRoot = await fs.realpath(
+      await fs.mkdtemp(path.join(os.tmpdir(), "harness-registry-symlink-")),
+    );
+    registryPath = path.join(tmpRoot, "state", "workflows.json");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("connects a symlinked path onto the scanned row instead of duplicating it", async () => {
+    const real = path.join(tmpRoot, "workspace");
+    await writeMarker(path.join(real, "growth"), null, { name: "growth" });
+    const link = path.join(tmpRoot, "linked-workspace");
+    await fs.symlink(real, link, "dir");
+
+    const registry = new WorkflowRegistry(registryPath);
+    await registry.scan(real, new AgentProjectScanBudget());
+    await registry.connectPath(path.join(link, "growth"));
+
+    // One row, still under the spelling the scan stored: a second row for the
+    // same directory collides into `local:` keys and drops every edge, while
+    // rewriting the kept row's path would unbind a session matching on it.
+    expect((await registry.list()).map((workflow) => workflow.path)).toEqual([
+      path.join(real, "growth"),
+    ]);
+  });
+
+});
+
 describe("WorkflowRegistry scan rootedness (the 88-agent accumulation)", () => {
   let tmpRoot: string;
   let registry: WorkflowRegistry;

--- a/packages/harness/src/core/workflow-registry.ts
+++ b/packages/harness/src/core/workflow-registry.ts
@@ -29,6 +29,7 @@ import {
   walkAgentProjectTreeAsync,
 } from "./agent-project-discovery.js";
 import { hasTraversalSegment, resolveWithinRoot } from "./path-safety.js";
+import { canonicalGraphPath } from "./system-graph-inventory.js";
 
 function expandHome(inputPath: string): string {
   if (inputPath === "~") return os.homedir();
@@ -428,8 +429,18 @@ export class WorkflowRegistry {
         starterId: marker?.starterId ?? null,
         source: "connect",
       };
-      const idx = this.workflows.findIndex((workflow) => workflow.path === absolutePath);
-      if (idx >= 0) this.workflows[idx] = info;
+      // Match on the resolved directory, not the spelling given: connecting a
+      // symlinked path to an already-scanned project otherwise registers a
+      // second row for one directory, and the pair collides into `local:`
+      // fallback keys that make every reference between agents ambiguous.
+      // The existing row keeps its own `path` — registry paths are compared by
+      // exact string elsewhere (a session auto-binds on `path === cwd`), so
+      // rewriting one silently unbinds whatever matched it.
+      const canonical = canonicalGraphPath(absolutePath);
+      const idx = this.workflows.findIndex(
+        (workflow) => canonicalGraphPath(workflow.path) === canonical,
+      );
+      if (idx >= 0) this.workflows[idx] = { ...info, path: this.workflows[idx]!.path };
       else this.workflows.push(info);
       await this.persist();
       return info;

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -1210,10 +1210,18 @@ export const startServer = async (
   // archaeology session. Now every scan says its root, its reason, what it
   // found, what it cost, and what it declined to enter.
   const scanWorkflowsAndBroadcast = async (
-    root: string,
+    scanRoot: string,
     reason: WorkflowScanReason,
     options: { refreshGraphs?: () => Promise<void> } = {},
   ): Promise<WorkflowInfo[]> => {
+    // The registry keys rows by path, so two spellings of one directory
+    // register the same agent twice. Only the graph-refresh caller resolved
+    // symlinks: booting under a symlinked launch dir (macOS `os.tmpdir()` is
+    // `/var/...` for `/private/var/...`) registered every agent under the
+    // symlinked path, then the first graph open registered them all again
+    // under the real one. The duplicates collided into `local:` fallback keys,
+    // so every cross-agent target became ambiguous and its edge vanished.
+    const root = canonicalGraphPath(scanRoot);
     const before = workflowsCache;
     const budget = new AgentProjectScanBudget();
     const found = await workflowRegistry.scan(root, budget);

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -1221,6 +1221,9 @@ export const startServer = async (
     // symlinked path, then the first graph open registered them all again
     // under the real one. The duplicates collided into `local:` fallback keys,
     // so every cross-agent target became ambiguous and its edge vanished.
+    // Resolved here rather than inside the registry: registry paths are
+    // compared by exact string elsewhere (a session auto-binds on
+    // `path === cwd`, index.ts:1057), so rewriting stored paths unbinds them.
     const root = canonicalGraphPath(scanRoot);
     const before = workflowsCache;
     const budget = new AgentProjectScanBudget();

--- a/packages/harness/src/server/system-graph-freshness.test.ts
+++ b/packages/harness/src/server/system-graph-freshness.test.ts
@@ -237,4 +237,92 @@ describe("workspace graph freshness wiring", () => {
       expect(manualRetry.revision).toBeGreaterThan(beforeManualRetry.revision);
     },
   );
+
+  it(
+    "registers each agent once when the launch directory is a symlink",
+    { timeout: 30_000 },
+    async () => {
+      // The registry keys rows by path. Boot scanned the launch directory as
+      // given while the first graph open scanned its resolved form, so every
+      // agent registered twice; the duplicates collided into `local:` fallback
+      // keys and each cross-agent target became ambiguous, dropping its edge.
+      // macOS hits this on any `os.tmpdir()` path (`/var` -> `/private/var`).
+      await scaffoldAgent(
+        workspaceRoot,
+        "research",
+        'ctx.sapiom.agents.run({ definition: "growth" });\n',
+      );
+      await scaffoldAgent(workspaceRoot, "growth");
+      const linkedRoot = path.join(tempRoot, "linked-workspace");
+      await fs.symlink(workspaceRoot, linkedRoot, "dir");
+      await fs.writeFile(
+        path.join(stateRoot, "settings.json"),
+        JSON.stringify({ recentDirs: [linkedRoot] }),
+      );
+
+      server = await startServer({
+        port: 0,
+        bootToken: "test-token",
+        telemetryOptIn: false,
+        adapters: {},
+        stateRoot,
+        launchDir: linkedRoot,
+        autoCreateSession: false,
+      });
+      const baseUrl = `http://127.0.0.1:${server.port}`;
+      const headers = { "X-Harness-Token": "test-token" };
+
+      await vi.waitFor(
+        async () => {
+          const response = await fetch(`${baseUrl}/api/workflows`, { headers });
+          const workflows = (await response.json()) as WorkflowInfo[];
+          expect(workflows).toHaveLength(2);
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+
+      const state = (await (
+        await fetch(`${baseUrl}/api/state`, { headers })
+      ).json()) as AppState;
+      const workspaceKey = state.workspaceScopes?.[0]?.workspaceKey;
+      expect(workspaceKey).toBeTruthy();
+
+      const readGraph = async (): Promise<SystemGraphSnapshot> =>
+        (await (
+          await fetch(`${baseUrl}/api/workspaces/${workspaceKey}/system-graph`, {
+            headers,
+          })
+        ).json()) as SystemGraphSnapshot;
+
+      await vi.waitFor(
+        async () => {
+          expect((await readGraph()).state).toBe("ready");
+        },
+        { timeout: 8_000, interval: 150 },
+      );
+
+      // The duplicate rows only appear once a SECOND scan runs under the
+      // resolved spelling, which is what a graph refresh does. Adding an agent
+      // is the cheapest way to make the watcher trigger one.
+      await scaffoldAgent(workspaceRoot, "reporting");
+      await vi.waitFor(
+        async () => {
+          const graph = await readGraph();
+          expect(graph.graph?.nodes.map((node) => node.agentKey)).toEqual([
+            "growth",
+            "reporting",
+            "research",
+          ]);
+          expect(graph.graph?.warnings).toEqual([]);
+          expect(graph.graph?.edges).toEqual([
+            expect.objectContaining({
+              from: "agent:research",
+              to: "agent:growth",
+            }),
+          ]);
+        },
+        { timeout: 10_000, interval: 150 },
+      );
+    },
+  );
 });


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

An agent with no `definitionSlug` has its source parsed to recover a name. The
project's cache gate was `prepared.every((agent) => !agent.extractionFailed)`,
so **one** agent whose source could not be read vetoed the entire project's
cache. `SystemGraphStore.finishBuild` then committed the projection as
`degraded` instead of `ready` — the "Graph may be incomplete" banner and the
`degraded` value of `X-Sapiom-System-Graph-Cache`.

Some of those agents have nothing to find: a dashboard companion with no
`defineAgent` written anywhere in it. Re-projecting cannot improve them, so the
banner was permanent.

**Measured on a real 76-agent / 9-project workspace, not inferred.** 21 of 76
registry rows have `definitionSlug: null`; 16 are named by manifest inspection
and 5 fail. Those 5 held all 76 at `degraded`, and an explicit "Retry"
(`POST …/system-graph/refresh`) came back `degraded` too.

One claim I could **not** reproduce and am therefore not making: that `main`
"re-projects on every open and never caches". It does not — the revision stayed
at `1` across repeated opens. What is permanent is the **degraded label and the
banner**, not repeated projection work.

## Summary and scope

Cache on whether identity work can still produce a **different answer**, not on
whether it succeeded. `PreparedAgent` gains `identityPending` alongside
`extractionFailed`, and `cacheable` gates on the new field. Three cases:

| Case | `identityPending` | Why |
| --- | --- | --- |
| Inspection returned, nothing nameable in the project | `false` | Nowhere left to go. Stops vetoing. |
| Inspection returned `failed` for any other reason | `true` | An install, or a re-run of a check that timed out, could still name it — and nothing re-projects on its own. |
| Budget cut the inspection off mid-read (`mapWithDeadline` → `prepareFallbackAgent`) | `true` | Caching now freezes a provisional `local:` label on screen. |

**Rows 2 and 3 exist because two review rounds found the first version wrong,
and both were right.** Round 1: I had treated every inspection that *returned* as
settled, but `inspectManifestName` also returns `failed` for "no `node_modules`
yet", which a later projection of the same unchanged source clears — extraction
failures are deliberately not cached for exactly that reason
(`core/canvas-cache.ts`). Nothing re-projects on its own: the graph watcher only
reacts to `.ts`/`.tsx` outside ignored directories, so `node_modules` appearing
fires nothing, and the degraded banner carries the **only** Retry button. That
version froze a `local:` label with no way back.

Round 2 then found my fix for it — probing for a local `node_modules` — wrong in
**both** directions: `extractWorkflowGraph` also returns `{ ok: false, reason }`
for a check process that crashed or timed out, so installed-deps-plus-timeout
read as settled (round 1's bug at a different cause); and npm/yarn workspaces
hoist `node_modules` to the repo root, so a package directory has none even when
installed, making every real failure there read retryable and pinning the project
to `degraded` forever — the exact state this PR exists to remove.

`reason` cannot decide it either: it is free-form text assembled from an agent's
own error message, a stderr tail, or a timeout string. So the inference is gone,
and only the claim the filesystem proves outright remains — **a project with no
TypeScript in it has no `defineAgent` to find, and no install or re-run will
invent one.** Adding a source file changes the answer, and that is exactly what
the watcher already sees. The classification is deliberately one-directional:
guessing "settled" wrongly costs a user the retry affordance, guessing
"retryable" wrongly costs nothing beyond today's behaviour. `retryable` is
**required**, not optional, so every construction site states its intent instead
of defaulting into the unsafe half.

`extractionFailed` is untouched and still drives the warnings. Affected agents
keep every `inventory-extraction-failed` warning: the graph becomes cacheable,
it does not go quiet about what it could not resolve.

**The symlink defect — a distinct bug, see "Related work".**
`scanWorkflowsAndBroadcast` resolves its scan root, and `connectPath` now
matches an existing row by resolved directory. The registry keys rows by path
and only the graph-refresh caller resolved symlinks, so booting under a
symlinked launch directory registered every agent under the symlinked path and
the first graph refresh registered them all again under the resolved one. The
duplicates collided into `local:` fallback keys, every cross-agent target became
ambiguous, and its edge silently disappeared.

**What I did NOT do, and why — this contradicts a review suggestion.** Round 1
asked me to move resolution inside `WorkflowRegistry.scan`/`connectPath` and
rewrite stored paths, covering every caller at once. I implemented that, and it
**regresses session auto-bind**: `server/index.ts:1057` matches
`workflow.path === session.cwd` by exact string, `session.cwd` is never
resolved, and `index.ts:1018` calls `workflowRegistry.scan` directly. Six
auto-bind specs plus two others failed (`expected null to be '/var/folders/…'`).
Making that correct means resolving path identity across session binding too,
which is a much larger change than this PR should carry. So the scan root is
still resolved at the server, and `connectPath` matches canonically while
**keeping the existing row's own spelling** — that closes the "+ Connect
duplicates a scanned row" hole without touching path identity. Healing registries
that already contain both spellings is likewise deferred: any rule that picks a
winner changes a stored path, which is the same regression. The changeset now
says so outright rather than reading as an unconditional fix. Worth a follow-up
issue; not worth smuggling into this one.

**Out of scope.** No new contract beyond the `retryable` field, and no changes
to `packages/agent`. The broader package-inventory migration remains open in
**#741** and is not merged or borrowed from here. `relationshipsComplete` still
participates in `cacheable` (`system-graph.ts:413`) with its old all-or-nothing
semantics; that is a separate judgement and I left it alone.

## Related work

Related issue or discussion: SAP-2984. The branch name says `sap-2983` for
historical reasons — Linear assigned SAP-2983 to a different issue after the
branch was pushed. The broader package-inventory migration that also fixes this
incidentally is #741 (not merged, not depended on here).

**A correction to the premise this task was written from, stated plainly.**
`src/server/system-graph-freshness.test.ts` fails deterministically on macOS on
clean `main` (18.2s, `expected false to be true` at line 190) and is green on
Linux CI. I was told it was catching *this* cache bug and should flip green with
the fix. **It is not, and it does not.** Evidence:

1. I instrumented the test and dumped every snapshot it reads. The lifecycle is
   `ready`/`stale` throughout — **never `degraded`**. Every agent in that fixture
   has a `definitionSlug` from its `sapiom.json`, so `inspectManifestName` is
   never called and `extractionFailed` is never set. The `every(...)` gate is not
   exercised by that test at all.
2. **Mutation test.** With `cacheable: true` hard-coded — the maximal version of
   this fix — the test still failed identically at line 190, 18.2s.
3. The real cause is in the dump: after the rename step the nodes are
   `["local:growth", "local:growth~2", "local:research", "local:research~2", …]`
   with two `duplicate-agent-key` warnings. `os.tmpdir()` is `/var/folders/…`
   for `/private/var/folders/…`, the boot scan used the symlinked spelling and
   the graph refresh the resolved one, and the duplicate pair made
   `agent:insights → agent:growth` ambiguous. Re-running the test with a
   realpath'd `tempRoot` on unmodified `main` made it pass in 2.0s.

So it is not a flake, and it was worth chasing — but it was catching a different
bug. Rather than report the discrepancy and leave a deterministically red test
on macOS with a one-line cause identified, I fixed that too, as separate commits.
It is what turns the test green (18.2s red → 2.0s green).

## Validation

```text
pnpm --filter @sapiom/harness test          — 163 files / 2618 tests passed; +3 files / 10 perf passed
pnpm --filter @sapiom/harness typecheck     — clean (tsc --noEmit x2)
pnpm --filter @sapiom/harness lint          — 0 errors, 1 pre-existing warning in rest.test.ts (untouched)
pnpm terminology:check                      — passed (455 files)
pnpm examples:check                         — passed (12 templates)
E2E_PORT=5464 pnpm --filter @sapiom/harness test:ui  — 439/441; both failures re-run green,
                                                 session-tabs.spec.ts:268 passes in isolation (known flake band)

system-graph-freshness.test.ts on macOS     — RED 18.2s before / GREEN 2.0s after
```

**Mutation-tested every guard.** A count-only assertion passes when nothing
happened, so each new spec was proven to fail against the restored bug:

| Mutation | Result |
| --- | --- |
| `identityPending` → `extractionFailed` in the `cacheable` gate | "caches a project whose extraction failures have all settled" FAILS |
| `identityPending: !definitionSlug` → `false` in `prepareFallbackAgent` | new in-flight spec **and** the pre-existing budget-expiry spec FAIL |
| `identityPending = inspected.retryable` → `false` | "keeps a project uncacheable when a failure is still clearable" FAILS |
| `couldStillBeNamed` forced to always-settled | both "is retryable while the project still has TypeScript" and "stays retryable with dependencies installed" FAIL |
| `couldStillBeNamed` forced to always-retryable | "is settled when the project has no TypeScript to name" FAILS |
| `connectPath` matches raw path instead of resolved | "connects a symlinked path onto the scanned row" FAILS |
| `canonicalGraphPath(scanRoot)` → `scanRoot` | symlink spec FAILS with `expected [ 'local:growth', …(4) ]`; freshness test back to 18.2s red |

**Reporting what did not work.** My first version of the symlink spec **survived
its own mutation** — it passed in 181ms with the bug restored, because it
asserted only on the boot scan and the duplicate rows do not exist until a
*second* scan runs under the resolved spelling. Adding an agent after boot (which
makes the watcher trigger that second scan) is what gave it teeth. The table
above is the fixed version.

### Real server

A 76-agent / 9-project workspace, on a dedicated port and `--state-root`. Of the
5 agents that fail inspection, **4 are settled and 1 is retryable** — 4 of them
contain zero TypeScript files — measured directly:

```
4 × {"status":"failed","retryable":false}      1 × {"status":"failed","retryable":true}
```

So on that workspace the vetoing set drops **5 → 1**, and it correctly stays
`degraded` — one project there really does need an install, and the banner is
telling the truth. **My round-1 body claimed this workspace flipped to `ready`;
under the corrected rule it does not, and the earlier screenshot has been
replaced rather than left standing.**

Scratch workspaces isolate each case (no real agent source was modified):

| Workspace | `main` | this PR |
| --- | --- | --- |
| companion with no TypeScript in it | `degraded` / `degraded` | **`ready` / `complete`** |
| agent with TypeScript that fails to extract | `degraded` / `degraded` | `degraded` / `degraded` (correct — keeps its Retry) |

Warnings are identical in both rows; only the lifecycle differs.

**What I did not prove end to end.** I verified that the retryable project keeps
its banner and Retry, and that dropping an empty `node_modules` into it does
*not* flip it to `ready` (correctly — the extraction still fails). I did **not**
stand up a genuinely installable agent to watch Retry recover it to `ready`;
that path rests on `canvas-cache.ts`'s documented contract that failures are
never cached, plus its own tests, not on a run of mine.

Edits mid-run keep re-projecting — the real risk of making this cacheable is a
frozen graph, so I drove it:

```
break dispatcher's target   → rev 5, state=ready, edges=[],  +unresolved-target:dispatcher
add a 2nd unnameable agent  → rev 7, state=ready, +inventory-extraction-failed:local:second-dashboard
restore dispatcher's target → rev 9, state=ready, edges=[agent:dispatcher>agent:reporter]
```

Every edit bumps the revision and the graph never sticks at a cached snapshot.

#### Before — a settled failure holds the project at "Graph may be incomplete"

![before](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/744/before-settled.png)

#### After — banner gone, the warning still reported

![after](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/744/after-settled.png)

#### After — a project whose dependencies are missing keeps its banner and Retry

![pending](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/744/after-pending.png)

### Tests and documentation

Three new specs in `system-graph-inventory.test.ts` (settled failures cache and
keep their warnings; a clearable failure still vetoes; an in-flight inspection
still vetoes), three in `definition-name.test.ts` covering the `retryable`
classification against a real filesystem (including that installed dependencies
do **not** make a failure settled), one in `workflow-registry.test.ts`
(connecting a symlinked path lands on the scanned row), and one in
`system-graph-freshness.test.ts` (a symlinked launch directory registers each
agent once). The symlink spec creates the link explicitly rather than relying on
`os.tmpdir()`, so it reproduces on Linux CI too, where the macOS-only failure
never appears. Both pre-existing `cacheable: false` specs still pass unchanged.
The `cacheable` contract's doc comment and the new `installCouldStillName` helper
state the rule and the failure each prevents. No user-facing docs beyond the
changeset.

## Compatibility and release impact

- Breaking or externally visible changes: None to any API. `ManifestNameInspection`
  is internal to this package; its `failed` variant now carries a required
  `retryable`. Behaviour change: a project whose enrichment failures all have
  nowhere left to go now reports `ready` / `X-Sapiom-System-Graph-Cache:
  complete` instead of `degraded`, and no longer shows the "Graph may be
  incomplete" banner. A project with any TypeScript that still fails to extract
  is unchanged, banner and Retry included. Warnings are unchanged in both cases.
- Changeset: Added — `.changeset/graph-cache-settled-identity.md` (patch,
  `@sapiom/harness`). Rewritten twice under review: the original claimed a
  package "whose dependencies were never installed can never be named" (false),
  and it now also states that the symlink fix prevents new duplicates rather
  than healing a workspace that already contains a pair.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code wrote the diff, the specs, and this description. Verification was
not taken on trust: the red freshness test was reproduced and instrumented
before any code changed, the stated cause was disproved by hard-coding
`cacheable: true` and watching it stay red, every guard was mutation-tested (one
spec survived its own mutation and was rewritten — noted above), and the
before/after numbers come from driving real servers on a dedicated port and
state root rather than from the mock fixtures CI uses. Two review rounds each
found a real correctness bug — in the original rule, then in my first fix for it
— and both are described above rather than quietly corrected; so is the one
suggestion I did not take, with the failing test names as evidence.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
