### PR TITLE
feat(harness): the harness creates the agent, then the chat starts [SAP-2981]

### DIFF
--- a/.changeset/create-agent-flow.md
+++ b/.changeset/create-agent-flow.md
@@ -1,0 +1,38 @@
+---
+"@sapiom/harness": minor
+---
+
+Studio: creating an agent in a project is now a form that creates it, not a
+message asking your coding agent to.
+
+Every create door ended the same way — a session started and an English
+sentence was typed into the terminal asking the coding agent to please call a
+scaffold tool. Studio never created anything, so a failure arrived as a
+confused model rather than an error, and "did it work?" could only be answered
+by reading a terminal. On a project that already held agents it simply could
+not work: the scaffold was aimed at the project folder, which is not empty, and
+the reply was a paragraph asking you which subdirectory you meant.
+
+- **Create an agent in {project}** opens a small dialog: a name, a starter, and
+  the project it lands in — stated, not asked again, because you clicked that
+  row. Submit and Studio creates the agent itself.
+- **Creation completes before the chat starts.** The agent is on disk and in
+  your rail before a session opens on it, and the rail scrolls it into view. A
+  first instruction is optional, and the session opens on that instead of on a
+  request to scaffold.
+- **A refusal is a sentence in the dialog.** A name already taken in that
+  project, a name that is not a folder name, a folder Studio does not show as a
+  project — each is refused with a reason you can act on, and nothing
+  half-created is left behind if the scaffold itself fails.
+- **The bundled starters in the template gallery take the same path**, so the
+  two ways of starting from a starter cannot drift. Cloning a published
+  template still goes through your coding agent, which is a different operation
+  with a different failure mode.
+- The empty-project row's **Create the first agent here** now responds to a
+  click; it had been unclickable.
+- Starting from an idea on the home screen is unchanged: no project, no name,
+  and a folder that does not exist yet, so it stays a conversation.
+
+New endpoint `POST /api/agents/scaffold` — `{ root, name, template? }` → the
+created agent's path. It runs the same scaffold the CLI does and refuses on its
+own findings rather than on the caller's word.

--- a/packages/harness/src/core/agent-core-templates.ts
+++ b/packages/harness/src/core/agent-core-templates.ts
@@ -1,0 +1,22 @@
+/**
+ * Where `@sapiom/agent-core`'s bundled starter templates live on disk.
+ *
+ * One resolver, because there are now two callers that scaffold a real project
+ * — the demo seed (`core/example-seed.ts`) and `POST /api/agents/scaffold` —
+ * and both need the same two corrections. `scaffold()` takes `templatesDir`
+ * explicitly when its caller is ESM (there is no `__dirname` to resolve the
+ * bundled `templates/` from), and the packaged app needs the asar translation:
+ * `scaffold` COPIES the template with `cpSync`, which cannot `opendir` inside
+ * `app.asar` (ENOTDIR) no matter what Electron patches.
+ */
+import { createRequire } from "node:module";
+import * as path from "node:path";
+
+import { unpackedPath } from "./asar-path.js";
+
+const nodeRequire = createRequire(import.meta.url);
+
+export function agentCoreTemplatesDir(): string {
+  const entry = nodeRequire.resolve("@sapiom/agent-core");
+  return unpackedPath(path.resolve(path.dirname(entry), "..", "..", "templates"));
+}

--- a/packages/harness/src/core/example-seed.ts
+++ b/packages/harness/src/core/example-seed.ts
@@ -36,7 +36,6 @@
 import { execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import * as fs from "node:fs/promises";
-import { createRequire } from "node:module";
 import * as path from "node:path";
 
 import {
@@ -47,22 +46,10 @@ import {
   type ResolvedVersions,
 } from "@sapiom/agent-core";
 
+import { agentCoreTemplatesDir } from "./agent-core-templates.js";
 import { TEMPLATE_HTML, renderCanvasDocument } from "./canvas-template.js";
 
-const nodeRequire = createRequire(import.meta.url);
-
 export const SAMPLE_PROJECT_NAME = "order-triage";
-
-/** Locate @sapiom/agent-core's bundled templates dir (no `__dirname` in ESM). */
-function agentCoreTemplatesDir(): string {
-  const entry = nodeRequire.resolve("@sapiom/agent-core");
-  const dir = path.resolve(path.dirname(entry), "..", "..", "templates");
-  // Embedded in Electron, require.resolve reports the app.asar (virtual) path;
-  // scaffold()'s cpSync can't opendir inside the asar archive (ENOTDIR), so
-  // point at the unpacked twin. No-op under the CLI (real filesystem path).
-  // The desktop host must asarUnpack node_modules (it unpacks all of them).
-  return dir.replace(/([\\/])app\.asar([\\/])/, "$1app.asar.unpacked$2");
-}
 
 function tryGit(cwd: string, args: string[]): boolean {
   try {

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -15,6 +15,7 @@ import { readFileSync } from "node:fs";
 import { dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import express, { type Express } from "express";
+import { scaffold } from "@sapiom/agent-core";
 import { WebSocketServer } from "ws";
 import open from "open";
 
@@ -87,6 +88,7 @@ import {
   removeGeneratedSessionDir,
   sweepGeneratedDirs,
 } from "../core/inject/retention.js";
+import { agentCoreTemplatesDir } from "../core/agent-core-templates.js";
 import { CanvasWatcherManager } from "../core/canvas-watcher.js";
 import { WorkspaceWatcherManager } from "../core/workspace-watcher.js";
 import { InstallWatcherManager } from "../core/install-watcher.js";
@@ -150,6 +152,7 @@ import {
   moveTargetDirs,
   remapSessions,
 } from "./agent-move.js";
+import { createAgentScaffoldRouter } from "./scaffold.js";
 import { createMacrosRouter } from "./macros.js";
 import { createFsRouter } from "./fs.js";
 import { createRunsRouter } from "./runs.js";
@@ -319,6 +322,7 @@ type WorkflowScanReason =
   | "session-create"
   | "workspace-change"
   | "agent-linked"
+  | "agent-created"
   | "agent-moved"
   | "graph-refresh"
   | "requested";
@@ -1728,6 +1732,55 @@ export const startServer = async (
             refreshSystemGraphScopesForRoot(dirname(to));
           },
         });
+      },
+    }),
+  );
+  // SAP-2981: the harness CREATES the agent. Every create door used to end in
+  // an English sentence injected into a terminal asking the coding agent to
+  // call the scaffold MCP tool, so a failed create surfaced as a confused model
+  // and "did it work?" was answered by reading a terminal. The route runs the
+  // same `scaffold` routine that tool runs, and its guards live in the module:
+  // one plain segment for the name, a plain segment for the template (which
+  // `resolveTemplate` JOINS onto the bundled templates dir), and a root matched
+  // against the SAME directory list the move route drops into — so "a folder
+  // the rail can show" and "a folder the studio will create a project in" stay
+  // one answer.
+  app.use(
+    createAgentScaffoldRouter({
+      listProjectDirs: async () => {
+        const stored = await loadSettings(statePaths.settings);
+        return moveTargetDirs(
+          [
+            ...stored.recentDirs,
+            ...(stored.projectRoot ? [stored.projectRoot] : []),
+            ...sessionManager.list().map((session) => session.cwd),
+          ],
+          workflowsCache.map((w) => w.path),
+        );
+      },
+      resolveAgent: (agentPath) =>
+        workflowsCache.find((w) => resolve(w.path) === agentPath) ?? null,
+      scaffoldAgent: async ({ targetDir, template }) => {
+        // `installDependencies: true` for the same reason the MCP tool passes
+        // it: the Canvas bundles the project on its first, unprompted render
+        // and resolves `@sapiom/agent`/`zod` from the project's own
+        // node_modules, so a never-installed agent opens on a "Could not
+        // resolve …" error. Best-effort inside agent-core — a failed install
+        // still returns a created project.
+        const result = await scaffold({
+          targetDir,
+          template,
+          templatesDir: agentCoreTemplatesDir(),
+          installDependencies: true,
+        });
+        return { dependenciesInstalled: result.dependenciesInstalled };
+      },
+      // Rescan the PROJECT root, not the agent directory: the registry has to
+      // learn the new agent under the project the rail draws it in, and the
+      // scan broadcasts `workflows.changed` so the row is there before the
+      // dialog's caller opens a session on it.
+      onScaffolded: async (agentDir) => {
+        await scanWorkflowsAndBroadcast(dirname(agentDir), "agent-created");
       },
     }),
   );

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -504,6 +504,11 @@ export const startServer = async (
   // already exists or when HOME is unwritable.
   await migrateHarnessIdentity(statePaths.machineId);
   const launchDir = options.launchDir ?? process.cwd();
+  /** Where a NEW agent project goes before the user saves a `projectRoot` of
+   *  their own — the host's answer (`<launchDir>/projects` under Electron),
+   *  reported to the SPA as `AppState.defaultProjectRoot` and counted as a
+   *  place the create route may write (see `listProjectDirs` below). */
+  const defaultProjectRoot = options.projectRoot ?? launchDir;
 
   // Serve-time slug enrichment: resolves each workflow's definitionSlug from
   // the Sapiom Agents API when it's absent (deployed sapiom.json files carry
@@ -1532,7 +1537,7 @@ export const startServer = async (
           });
       },
       launchDir,
-      defaultProjectRoot: options.projectRoot ?? launchDir,
+      defaultProjectRoot,
       agentsBaseUrl: resolveAgentsBaseUrl(),
       availableHarnesses: options.availableHarnesses,
       listTasks: () => taskManager.list(),
@@ -1753,6 +1758,16 @@ export const startServer = async (
           [
             ...stored.recentDirs,
             ...(stored.projectRoot ? [stored.projectRoot] : []),
+            // THE HOST'S DEFAULT, which the move route does not need and this
+            // one does. `AppState.defaultProjectRoot` is where the SPA puts a
+            // NEW project when the user has saved no `projectRoot` of their own
+            // — `<launchDir>/projects` under Electron — and the host does not
+            // persist it into settings. Without it, the first template a user
+            // ever starts from is refused at its own suggested destination
+            // ("Studio doesn't show that folder as a project"), and the flow
+            // cannot bootstrap: `recentDirs` only learns a root once a session
+            // has been created there, and creation now happens FIRST.
+            ...(defaultProjectRoot ? [defaultProjectRoot] : []),
             ...sessionManager.list().map((session) => session.cwd),
           ],
           workflowsCache.map((w) => w.path),

--- a/packages/harness/src/server/scaffold.test.ts
+++ b/packages/harness/src/server/scaffold.test.ts
@@ -20,12 +20,8 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import {
-  createAgentScaffoldRouter,
-  refuseAgentName,
-  refuseScaffoldOnDisk,
-  type AgentScaffoldResponse,
-} from "./scaffold.js";
+import type { AgentScaffoldResponse } from "../shared/types.js";
+import { createAgentScaffoldRouter, refuseScaffoldOnDisk } from "./scaffold.js";
 
 let tmp: string;
 
@@ -113,31 +109,6 @@ const exists = async (p: string): Promise<boolean> =>
     .lstat(p)
     .then(() => true)
     .catch(() => false);
-
-describe("refuseAgentName", () => {
-  it("accepts an ordinary agent folder name", () => {
-    expect(refuseAgentName("order-triage")).toBeNull();
-    expect(refuseAgentName("Order_Triage2")).toBeNull();
-  });
-
-  it("refuses the shapes that would escape the project", () => {
-    // Each of these is a directory the caller must not be able to name, and
-    // each carries its own sentence because the user reads it verbatim.
-    expect(refuseAgentName("../evil")).toMatch(/one folder name/);
-    expect(refuseAgentName("a/b")).toMatch(/one folder name/);
-    expect(refuseAgentName("..")).toMatch(/dot/);
-    expect(refuseAgentName(".hidden")).toMatch(/dot/);
-    expect(refuseAgentName("")).toMatch(/Give the agent a name/);
-    expect(refuseAgentName("   ")).toMatch(/Give the agent a name/);
-    expect(refuseAgentName(" leading")).toMatch(/space/);
-    expect(refuseAgentName(42)).toMatch(/Give the agent a name/);
-    expect(refuseAgentName("x".repeat(65))).toMatch(/too long/);
-  });
-
-  it("refuses a NUL, which reaches fs as a throw rather than a refusal", () => {
-    expect(refuseAgentName("ok\u0000name")).toMatch(/isn't a folder name/);
-  });
-});
 
 describe("refuseScaffoldOnDisk", () => {
   it("passes an absent destination and refuses anything already there", async () => {

--- a/packages/harness/src/server/scaffold.test.ts
+++ b/packages/harness/src/server/scaffold.test.ts
@@ -332,13 +332,21 @@ describe("POST /api/agents/scaffold", () => {
     }
   });
 
-  it("refuses when the project directory has been deleted under it", async () => {
-    const gone = path.join(tmp, "gone");
-    const srv = await serve({ projectDirs: [gone] });
+  it("creates the project directory when it does not exist yet", async () => {
+    // THE FRESH-INSTALL CASE. `<launchDir>/projects` is the desktop host's
+    // default parent for new projects and nothing creates it — the scaffold's
+    // own recursive mkdir used to, until the atomic claim started running ahead
+    // of it, and the first template a new user ever picked was refused at its
+    // own suggested destination.
+    const unmade = path.join(tmp, "projects");
+    const srv = await serve({ projectDirs: [unmade] });
     try {
-      const res = await srv.post({ root: gone, name: "orphan" });
-      expect(res.status).toBe(409);
-      expect(res.body.error).toMatch(/no longer exists/);
+      const res = await srv.post({ root: unmade, name: "first-ever" });
+      expect(res.status).toBe(200);
+      expect((res.body as AgentScaffoldResponse).path).toBe(
+        path.join(unmade, "first-ever"),
+      );
+      expect(await exists(path.join(unmade, "first-ever", "sapiom.json"))).toBe(true);
     } finally {
       await srv.close();
     }

--- a/packages/harness/src/server/scaffold.test.ts
+++ b/packages/harness/src/server/scaffold.test.ts
@@ -299,6 +299,51 @@ describe("POST /api/agents/scaffold", () => {
     }
   });
 
+  it("two simultaneous creates of the same name: one wins, and the loser deletes nothing", async () => {
+    // THE RACE THE CLEANUP MADE DANGEROUS. Both requests pass the `lstat` —
+    // nothing is there when either looks — and then one of them scaffolds while
+    // the other's scaffold refuses a non-empty directory. Without the atomic
+    // claim, the loser's cleanup recursively deleted the WINNER's freshly
+    // installed agent, while the winner's caller had already been told it
+    // exists.
+    const srv = await serve({
+      scaffoldAgent: async ({ targetDir }) => {
+        const entries = await fs.readdir(targetDir);
+        if (entries.length > 0)
+          throw new Error(`Target directory '${targetDir}' already exists and is not empty.`);
+        await fs.writeFile(path.join(targetDir, "index.ts"), "// the winner\n");
+        return { dependenciesInstalled: false };
+      },
+    });
+    try {
+      const [a, b] = await Promise.all([
+        srv.post({ root: tmp, name: "contested" }),
+        srv.post({ root: tmp, name: "contested" }),
+      ]);
+      const statuses = [a.status, b.status].sort();
+      expect(statuses).toEqual([200, 409]);
+      // The winner's work is intact — this is the assertion the old cleanup
+      // failed: it deleted the directory it had just been told was occupied.
+      expect(await fs.readFile(path.join(tmp, "contested", "index.ts"), "utf8")).toBe(
+        "// the winner\n",
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("refuses when the project directory has been deleted under it", async () => {
+    const gone = path.join(tmp, "gone");
+    const srv = await serve({ projectDirs: [gone] });
+    try {
+      const res = await srv.post({ root: gone, name: "orphan" });
+      expect(res.status).toBe(409);
+      expect(res.body.error).toMatch(/no longer exists/);
+    } finally {
+      await srv.close();
+    }
+  });
+
   it("creates in a nested project directory the rail shows, using the LIST's spelling", async () => {
     // The move route's rule, applied here: the directory that gets written into
     // is the one from the list, so a request may not smuggle a different

--- a/packages/harness/src/server/scaffold.test.ts
+++ b/packages/harness/src/server/scaffold.test.ts
@@ -1,0 +1,346 @@
+/**
+ * The scaffold endpoint, on a real filesystem (SAP-2981).
+ *
+ * Every test here goes STRAIGHT AT THE ROUTE — no dialog, no client. The whole
+ * point of the endpoint is that it refuses on its own findings: a name field
+ * that disables its own submit button proves nothing about a macro, a curl, or
+ * a future keyboard path that reaches the route another way. So the refusals
+ * are posted directly, and the filesystem is inspected afterwards, because
+ * "refused" and "refused without leaving a half-created agent behind" are
+ * different claims and only the second one is worth having.
+ *
+ * The scaffold routine itself is injected: what is under test is the guard set
+ * and the ordering, not `@sapiom/agent-core`'s template copy. The one test that
+ * cares about disk state stubs a scaffold that creates the directory and then
+ * throws, which is exactly the failure the cleanup exists for.
+ */
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import express from "express";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  createAgentScaffoldRouter,
+  refuseAgentName,
+  refuseScaffoldOnDisk,
+  type AgentScaffoldResponse,
+} from "./scaffold.js";
+
+let tmp: string;
+
+beforeEach(async () => {
+  // realpath: macOS hands out `/var/folders/…`, a symlink to `/private/var/…`,
+  // and the route compares the request's resolved root against the list's.
+  tmp = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "agent-scaffold-")));
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+interface ScaffoldCall {
+  targetDir: string;
+  template: string;
+}
+
+/** A live express app over the router, so the route is exercised as a route. */
+async function serve(
+  options: {
+    agents?: string[];
+    projectDirs?: string[];
+    scaffoldAgent?: (call: ScaffoldCall) => Promise<{ dependenciesInstalled: boolean }>;
+    onScaffolded?: (dir: string) => Promise<void>;
+  } = {},
+): Promise<{
+  calls: ScaffoldCall[];
+  scaffolded: string[];
+  post: (body: unknown) => Promise<{ status: number; body: any }>;
+  close: () => Promise<void>;
+}> {
+  const calls: ScaffoldCall[] = [];
+  const scaffolded: string[] = [];
+  const agents = options.agents ?? [];
+  const app = express();
+  app.use(express.json());
+  app.use(
+    createAgentScaffoldRouter({
+      listProjectDirs: () => options.projectDirs ?? [tmp],
+      resolveAgent: (agentPath) =>
+        agents.includes(agentPath)
+          ? { name: path.basename(agentPath), path: agentPath }
+          : null,
+      scaffoldAgent: async (call) => {
+        calls.push(call);
+        if (options.scaffoldAgent) return await options.scaffoldAgent(call);
+        // The default stand-in does what the real one does first: make the
+        // directory. A guard that only looks like it fired because nothing was
+        // ever created is not a guard.
+        await fs.mkdir(call.targetDir, { recursive: true });
+        await fs.writeFile(
+          path.join(call.targetDir, "sapiom.json"),
+          JSON.stringify({ name: path.basename(call.targetDir) }),
+        );
+        return { dependenciesInstalled: false };
+      },
+      onScaffolded: async (dir) => {
+        scaffolded.push(dir);
+        await options.onScaffolded?.(dir);
+      },
+    }),
+  );
+  const server = app.listen(0);
+  await new Promise((resolve) => server.once("listening", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address !== null ? address.port : 0;
+  return {
+    calls,
+    scaffolded,
+    post: async (body) => {
+      const res = await fetch(`http://127.0.0.1:${port}/api/agents/scaffold`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      return { status: res.status, body: (await res.json()) as any };
+    },
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+const exists = async (p: string): Promise<boolean> =>
+  await fs
+    .lstat(p)
+    .then(() => true)
+    .catch(() => false);
+
+describe("refuseAgentName", () => {
+  it("accepts an ordinary agent folder name", () => {
+    expect(refuseAgentName("order-triage")).toBeNull();
+    expect(refuseAgentName("Order_Triage2")).toBeNull();
+  });
+
+  it("refuses the shapes that would escape the project", () => {
+    // Each of these is a directory the caller must not be able to name, and
+    // each carries its own sentence because the user reads it verbatim.
+    expect(refuseAgentName("../evil")).toMatch(/one folder name/);
+    expect(refuseAgentName("a/b")).toMatch(/one folder name/);
+    expect(refuseAgentName("..")).toMatch(/dot/);
+    expect(refuseAgentName(".hidden")).toMatch(/dot/);
+    expect(refuseAgentName("")).toMatch(/Give the agent a name/);
+    expect(refuseAgentName("   ")).toMatch(/Give the agent a name/);
+    expect(refuseAgentName(" leading")).toMatch(/space/);
+    expect(refuseAgentName(42)).toMatch(/Give the agent a name/);
+    expect(refuseAgentName("x".repeat(65))).toMatch(/too long/);
+  });
+
+  it("refuses a NUL, which reaches fs as a throw rather than a refusal", () => {
+    expect(refuseAgentName("ok\u0000name")).toMatch(/isn't a folder name/);
+  });
+});
+
+describe("refuseScaffoldOnDisk", () => {
+  it("passes an absent destination and refuses anything already there", async () => {
+    expect(await refuseScaffoldOnDisk(path.join(tmp, "fresh"), "proj")).toBeNull();
+    await fs.mkdir(path.join(tmp, "taken"));
+    expect(await refuseScaffoldOnDisk(path.join(tmp, "taken"), "proj")).toMatch(
+      /already contains taken/,
+    );
+  });
+
+  it("refuses a DANGLING symlink — lstat, not stat", async () => {
+    // `stat` follows the link, finds nothing, and would report the destination
+    // as free; the scaffold would then write through a link the user placed.
+    await fs.symlink(path.join(tmp, "nowhere"), path.join(tmp, "link"));
+    expect(await refuseScaffoldOnDisk(path.join(tmp, "link"), "proj")).toMatch(
+      /already contains link/,
+    );
+  });
+});
+
+describe("POST /api/agents/scaffold", () => {
+  it("creates the agent inside the project and reports its path", async () => {
+    const srv = await serve();
+    try {
+      const res = await srv.post({ root: tmp, name: "billing-bot" });
+      expect(res.status).toBe(200);
+      const body = res.body as AgentScaffoldResponse;
+      expect(body.path).toBe(path.join(tmp, "billing-bot"));
+      expect(body.name).toBe("billing-bot");
+      expect(body.template).toBe("default");
+      expect(srv.calls).toEqual([
+        { targetDir: path.join(tmp, "billing-bot"), template: "default" },
+      ]);
+      expect(await exists(path.join(tmp, "billing-bot", "sapiom.json"))).toBe(true);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("rescans BEFORE it answers, so the rail has the agent before the caller acts", async () => {
+    const order: string[] = [];
+    const srv = await serve({
+      onScaffolded: async (dir) => {
+        // A REAL tick before the push, deliberately: a synchronous stub records
+        // "scanned" first even when the route forgets to await, so the
+        // assertion would survive the very mutation it exists to catch.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        order.push(`scanned:${path.basename(dir)}`);
+      },
+    });
+    try {
+      const res = await srv.post({ root: tmp, name: "late" });
+      order.push(`answered:${res.status}`);
+      expect(order).toEqual(["scanned:late", "answered:200"]);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("passes the chosen template through", async () => {
+    const srv = await serve();
+    try {
+      const res = await srv.post({ root: tmp, name: "paused", template: "coding-pause" });
+      expect(res.status).toBe(200);
+      expect(srv.calls[0].template).toBe("coding-pause");
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("refuses a name that is not one folder segment — and never calls scaffold", async () => {
+    const srv = await serve();
+    try {
+      for (const name of ["../evil", "a/b", "", "..", ".hidden"]) {
+        const res = await srv.post({ root: tmp, name });
+        expect(res.status).toBe(400);
+        expect(typeof res.body.error).toBe("string");
+      }
+      // The escape the name guard exists for: nothing landed outside the root.
+      expect(await exists(path.join(path.dirname(tmp), "evil"))).toBe(false);
+      expect(srv.calls).toEqual([]);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("refuses a template that is not a plain segment", async () => {
+    // `resolveTemplate` JOINS this onto the bundled templates dir, so an
+    // unguarded value names any directory on the machine as the thing to copy.
+    const srv = await serve();
+    try {
+      for (const template of ["../../../etc", "a/b", "", 7]) {
+        const res = await srv.post({ root: tmp, name: "agent", template });
+        expect(res.status).toBe(400);
+      }
+      expect(srv.calls).toEqual([]);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("refuses a root the studio does not show as a project", async () => {
+    // The barrier is the LIST, not the string: an absolute, traversal-free,
+    // perfectly real directory is still refused when the rail can't show it.
+    const outside = path.join(tmp, "outside");
+    await fs.mkdir(outside);
+    const srv = await serve({ projectDirs: [path.join(tmp, "known")] });
+    try {
+      const res = await srv.post({ root: outside, name: "sneaky" });
+      expect(res.status).toBe(409);
+      expect(res.body.error).toMatch(/doesn't show that folder as a project/);
+      expect(await exists(path.join(outside, "sneaky"))).toBe(false);
+      expect(srv.calls).toEqual([]);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("refuses a relative or traversing root", async () => {
+    const srv = await serve();
+    try {
+      for (const root of ["relative/path", `${tmp}/../${path.basename(tmp)}`, 5, null]) {
+        const res = await srv.post({ root, name: "agent" });
+        expect(res.status).toBe(400);
+      }
+      expect(srv.calls).toEqual([]);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("refuses a duplicate name — and leaves the existing agent untouched", async () => {
+    const existing = path.join(tmp, "twin");
+    await fs.mkdir(existing);
+    await fs.writeFile(path.join(existing, "index.ts"), "// the original\n");
+    const srv = await serve({ agents: [existing] });
+    try {
+      const res = await srv.post({ root: tmp, name: "twin" });
+      expect(res.status).toBe(409);
+      expect(res.body.error).toMatch(/already has an agent called twin/);
+      expect(srv.calls).toEqual([]);
+      expect(await fs.readFile(path.join(existing, "index.ts"), "utf8")).toBe(
+        "// the original\n",
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("refuses a plain directory in the way, which the registry cannot see", async () => {
+    // The registry knows nothing about a folder with no agent in it, so only a
+    // real `lstat` answers this one — and scaffolding into it would fail deep
+    // inside agent-core instead of here, with a directory the user then owns.
+    await fs.mkdir(path.join(tmp, "notes"));
+    const srv = await serve();
+    try {
+      const res = await srv.post({ root: tmp, name: "notes" });
+      expect(res.status).toBe(409);
+      expect(res.body.error).toMatch(/already contains notes/);
+      expect(srv.calls).toEqual([]);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("leaves NOTHING on disk when the scaffold fails part-way", async () => {
+    // The real `scaffold` makes the directory and then copies into it, so a
+    // template failure mid-copy leaves a folder the user never made — and the
+    // retry then dies on "already contains", which is the worse of the two
+    // failures.
+    const srv = await serve({
+      scaffoldAgent: async ({ targetDir }) => {
+        await fs.mkdir(targetDir, { recursive: true });
+        await fs.writeFile(path.join(targetDir, "half"), "written");
+        throw new Error("template copy blew up");
+      },
+    });
+    try {
+      const res = await srv.post({ root: tmp, name: "doomed" });
+      expect(res.status).toBe(500);
+      expect(res.body.error).toMatch(/template copy blew up/);
+      expect(await exists(path.join(tmp, "doomed"))).toBe(false);
+      // Nothing was announced either: the rail must not be told about an agent
+      // that does not exist.
+      expect(srv.scaffolded).toEqual([]);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("creates in a nested project directory the rail shows, using the LIST's spelling", async () => {
+    // The move route's rule, applied here: the directory that gets written into
+    // is the one from the list, so a request may not smuggle a different
+    // spelling of it past the match.
+    const nested = path.join(tmp, "systems", "payments");
+    await fs.mkdir(nested, { recursive: true });
+    const srv = await serve({ projectDirs: [nested] });
+    try {
+      const res = await srv.post({ root: `${nested}/`, name: "refunds" });
+      expect(res.status).toBe(200);
+      expect((res.body as AgentScaffoldResponse).path).toBe(path.join(nested, "refunds"));
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/packages/harness/src/server/scaffold.ts
+++ b/packages/harness/src/server/scaffold.ts
@@ -161,9 +161,20 @@ export async function refuseScaffoldOnDisk(
  */
 async function claimTarget(
   target: string,
+  projectDir: string,
   projectLabel: string,
 ): Promise<string | null> {
   try {
+    // THE PROJECT ROOT MAY NOT EXIST YET, and the claim must not be the thing
+    // that discovers it. `<launchDir>/projects` is the desktop host's default
+    // parent for new projects and NOTHING creates it — the scaffold's own
+    // `mkdir(recursive)` used to, and this claim now runs ahead of it. A fresh
+    // install's very first template landed on "that folder no longer exists".
+    //
+    // Recursive, and only on the directory the rail's list already vetted — so
+    // the claim below stays a single non-recursive `mkdir` on the agent's own
+    // name, which is what makes it exclusive.
+    await fs.mkdir(projectDir, { recursive: true });
     await fs.mkdir(target);
     return null;
   } catch (err) {
@@ -302,7 +313,7 @@ export function createAgentScaffoldRouter(
       }
       // THE CLAIM, and the last word on who owns this name. Everything above is
       // a reason to refuse early; this is the one act that cannot be raced.
-      const claimRefusal = await claimTarget(target, projectLabel);
+      const claimRefusal = await claimTarget(target, path.resolve(projectDir), projectLabel);
       if (claimRefusal != null) {
         res.status(409).json({ error: claimRefusal });
         return;

--- a/packages/harness/src/server/scaffold.ts
+++ b/packages/harness/src/server/scaffold.ts
@@ -1,0 +1,288 @@
+/**
+ * `POST /api/agents/scaffold` — the harness creates the agent (SAP-2981;
+ * design.md § E4).
+ *
+ * THE HARNESS CREATES THE AGENT. Every create door in the Studio used to end in
+ * an English sentence injected into a terminal — "call the
+ * sapiom_dev_agents_scaffold tool with {…}" — and the error copy admitted it
+ * ("Ask the coding agent to call sapiom_dev_agents_scaffold"). A creation
+ * mechanism that is a prompt has no outcome the app can read: a failed scaffold
+ * surfaces as a confused model rather than an error, and "did it work?" is
+ * answered by reading a terminal. This route is the outcome, so the dialog can
+ * report a refusal and the rail can show the agent before any chat starts.
+ *
+ * It runs the SAME routine the MCP tool runs (`scaffold` from
+ * `@sapiom/agent-core`, injected), so the two creation paths cannot drift into
+ * producing different projects.
+ *
+ * REFUSES ON ITS OWN FINDINGS, like `POST /api/agents/move` beside it — the
+ * closest existing precedent for a harness-owned filesystem mutation, and the
+ * shape this route copies deliberately:
+ *
+ *   - `name` must be ONE plain directory segment (`childPath`), so `../evil`,
+ *     `a/b`, "" and `.` are refused here rather than only being disabled in a
+ *     dialog. The co-located test posts them directly, dialog bypassed.
+ *   - `template` must be a plain segment too. `resolveTemplate` joins it onto
+ *     the bundled templates dir, so an unguarded `../../..` would name any
+ *     directory on the machine as the thing to copy.
+ *   - `root` is matched against the directories the RAIL CAN SHOW and the
+ *     match from THAT LIST is what the scaffold writes into — the request's
+ *     spelling is discarded. A folder the studio has never been pointed at is
+ *     not a folder this route creates projects in, so the endpoint cannot be
+ *     turned into an arbitrary-path mkdir by a caller that never opened the
+ *     rail. No request string reaches `fs`, which is a barrier a static
+ *     analyzer can see and a reordered `if` cannot undo.
+ *   - the destination is STAT'd. A name already taken in that project is a
+ *     refusal, whether the thing sitting there is a registered agent or a
+ *     plain directory the registry knows nothing about — only a real `lstat`
+ *     answers the second one.
+ *
+ * AND IT LEAVES NOTHING BEHIND. `scaffold` makes the directory before it copies
+ * into it, so a template failure mid-copy would otherwise leave a half-created
+ * agent on disk — worse than a refusal, because the retry then fails on "name
+ * already exists" and the user has to clean up a folder they never made. A
+ * failed scaffold removes the directory this route created.
+ *
+ * Mounted under the same `/api` boot-token middleware as the rest of the REST
+ * surface (server/index.ts).
+ */
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { Router, type Router as ExpressRouter } from "express";
+
+import { childPath, hasTraversalSegment } from "../core/path-safety.js";
+
+/** `POST /api/agents/scaffold` response. */
+export interface AgentScaffoldResponse {
+  ok: true;
+  /** Absolute path of the new agent's directory — server-authored, never the
+   *  caller's string. */
+  path: string;
+  name: string;
+  template: string;
+  /** Whether the best-effort `npm install` succeeded. False is not a failure:
+   *  the Canvas degrades to its "run npm install" hint (see
+   *  `@sapiom/agent-core`'s install-deps). */
+  dependenciesInstalled: boolean;
+}
+
+export interface AgentScaffoldDeps {
+  /**
+   * Every directory an agent may be created IN: the project roots the studio
+   * knows about, plus the branching directories the Project axis renders
+   * between a root and an agent. Same list `agent-move.ts` moves into
+   * (`moveTargetDirs`), and for the same reason — "a directory the rail can
+   * show" and "a directory this route will write into" must be one list, or
+   * creation and drag disagree about what a project is.
+   */
+  listProjectDirs: () => string[] | Promise<string[]>;
+  /**
+   * The registered agent at this absolute path, or null. Consulted before the
+   * `lstat` purely so the refusal can NAME what is in the way ("an agent
+   * called x") instead of describing a directory.
+   */
+  resolveAgent: (agentPath: string) => { name: string; path: string } | null;
+  /**
+   * Creates the project. Injected so the co-located test can exercise every
+   * guard without npm, git, or the registry on the far side of them — and so
+   * the route stays the thing under test rather than `@sapiom/agent-core`.
+   */
+  scaffoldAgent: (opts: {
+    targetDir: string;
+    template: string;
+  }) => Promise<{ dependenciesInstalled: boolean }>;
+  /**
+   * Applied AFTER the project is on disk, BEFORE the response. The
+   * integrator's job: rescan the project root so the registry holds the new
+   * agent and `workflows.changed` is broadcast. It runs before the response
+   * because that ordering IS the criterion — the agent is in the rail before
+   * the caller can open a session on it, so "did it work?" is never a question
+   * the user answers by reading a terminal.
+   */
+  onScaffolded: (agentDir: string) => Promise<void>;
+}
+
+/**
+ * A template name that is safe to hand to `resolveTemplate`, which joins it
+ * onto the bundled templates directory. Plain segment, no separators, no dots:
+ * a bundled template is a directory name in a package we ship, and nothing
+ * legitimate needs more than this alphabet.
+ */
+const TEMPLATE_NAME = /^[a-z0-9][a-z0-9-]*$/i;
+
+/**
+ * Two paths naming one directory — trailing separators and (on Windows) case
+ * are spelling, not identity. Same rule `agent-move.ts` and `studio-rail.ts`
+ * apply to their roots, and for the same reason: the client stores whichever
+ * form the user typed while the server stores whatever it resolved.
+ */
+function samePath(a: string, b: string): boolean {
+  const norm = (p: string): string => {
+    const resolved = path.resolve(p);
+    return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+  };
+  return norm(a) === norm(b);
+}
+
+/**
+ * Characters that cannot appear in a directory name on every platform the
+ * Studio runs on, plus the C0 controls. A NUL in particular reaches `fs` as a
+ * thrown `ERR_INVALID_ARG_VALUE` rather than a refusal, so it is answered here
+ * where the caller gets a sentence instead of a 500.
+ */
+// eslint-disable-next-line no-control-regex
+const FORBIDDEN_IN_NAME = /[\u0000-\u001f<>:"|?*]/;
+
+/**
+ * Why this name cannot be a new agent's folder, or null when it can.
+ *
+ * The message is shown verbatim in the dialog, so it says what to do rather
+ * than what a regex thinks. The rule is `childPath`'s — one plain segment
+ * under the project root, enforced again at the join below — plus a length cap
+ * and a leading-dot refusal: a dotted directory is hidden from the agent scan,
+ * so `.notes` would scaffold successfully and then never appear in the rail,
+ * which is the "did it work?" failure this whole endpoint exists to end.
+ */
+export function refuseAgentName(name: unknown): string | null {
+  if (typeof name !== "string" || name.trim() === "")
+    return "Give the agent a name.";
+  if (name.trim() !== name)
+    return "An agent name can't start or end with a space.";
+  if (name.length > 64)
+    return "That name is too long — keep it under 64 characters.";
+  if (/[/\\]/.test(name))
+    return "An agent name is one folder name — it can't contain / or \\.";
+  if (name.startsWith("."))
+    return "An agent name can't start with a dot — a dotted folder is hidden from the rail.";
+  if (FORBIDDEN_IN_NAME.test(name)) return `'${name}' isn't a folder name.`;
+  return null;
+}
+
+/**
+ * The route's OWN refusal, from the filesystem rather than from the registry —
+ * a message when the directory must not be created, null when it may.
+ *
+ * `lstat`, not `stat`: a dangling symlink sitting at the destination is still
+ * something the user put there, and `scaffold` would happily create through it.
+ */
+export async function refuseScaffoldOnDisk(
+  target: string,
+  projectLabel: string,
+): Promise<string | null> {
+  const name = path.basename(target);
+  try {
+    await fs.lstat(target);
+    return `${projectLabel} already contains ${name}.`;
+  } catch {
+    // Absent — the only acceptable state for a destination.
+  }
+  return null;
+}
+
+/**
+ * POST /api/agents/scaffold  { root, name, template? } -> AgentScaffoldResponse
+ *
+ * 400 — a malformed body, a name that is not one folder segment, a template
+ * that is not a plain segment, a root that is not an absolute path.
+ * 409 — a refusal, with the reason in `error` so the dialog shows it verbatim:
+ * a root the studio doesn't show as a project, or a name already taken there.
+ * 500 — the scaffold itself failed; the directory it may have created is
+ * removed first, so the retry meets the same clean state the first attempt did.
+ */
+export function createAgentScaffoldRouter(
+  deps: AgentScaffoldDeps,
+): ExpressRouter {
+  const router = Router();
+
+  router.post("/api/agents/scaffold", async (req, res, next) => {
+    const body = (req.body ?? {}) as {
+      root?: unknown;
+      name?: unknown;
+      template?: unknown;
+    };
+    const { root, name } = body;
+    const template = body.template ?? "default";
+
+    if (typeof root !== "string" || !path.isAbsolute(root) || hasTraversalSegment(root)) {
+      res.status(400).json({ error: "root must be an absolute path" });
+      return;
+    }
+    const nameRefusal = refuseAgentName(name);
+    if (nameRefusal != null) {
+      res.status(400).json({ error: nameRefusal });
+      return;
+    }
+    if (typeof template !== "string" || !TEMPLATE_NAME.test(template)) {
+      res.status(400).json({ error: `Unknown template '${String(template)}'.` });
+      return;
+    }
+
+    try {
+      // THE DESTINATION BARRIER, identical in shape to the move route's: the
+      // requested root is matched against the directories the rail can show,
+      // and the DIRECTORY FROM THAT LIST is what the scaffold writes into.
+      const requested = path.resolve(root);
+      const projectDir = (await deps.listProjectDirs()).find(
+        (dir) =>
+          typeof dir === "string" && dir.trim() !== "" && samePath(dir, requested),
+      );
+      if (projectDir == null) {
+        res.status(409).json({
+          error: `Can't create an agent in ${requested} — Studio doesn't show that folder as a project.`,
+        });
+        return;
+      }
+      const projectLabel = path.basename(path.resolve(projectDir)) || projectDir;
+      // `path.resolve` on the LIST's entry, not the request's, and `childPath`
+      // re-derives the join it already blessed above: the guard that produces
+      // the path is the guard that proved it, so no later edit can separate
+      // them.
+      const target = childPath(path.resolve(projectDir), name as string);
+      if (target == null) {
+        res.status(400).json({ error: `'${String(name)}' isn't a folder name.` });
+        return;
+      }
+
+      const existing = deps.resolveAgent(target);
+      if (existing != null) {
+        res.status(409).json({
+          error: `${projectLabel} already has an agent called ${existing.name}.`,
+        });
+        return;
+      }
+      const diskRefusal = await refuseScaffoldOnDisk(target, projectLabel);
+      if (diskRefusal != null) {
+        res.status(409).json({ error: diskRefusal });
+        return;
+      }
+
+      let result: { dependenciesInstalled: boolean };
+      try {
+        result = await deps.scaffoldAgent({ targetDir: target, template });
+      } catch (err) {
+        // NOTHING HALF-CREATED. Everything above proved the destination was
+        // absent, so whatever is there now is this attempt's own wreckage.
+        await fs.rm(target, { recursive: true, force: true }).catch(() => {});
+        res.status(500).json({
+          error: (err as Error).message || `Couldn't create ${String(name)}.`,
+        });
+        return;
+      }
+
+      // Before the response, deliberately: the agent is in the rail by the time
+      // the caller can act on the result.
+      await deps.onScaffolded(target);
+      res.json({
+        ok: true,
+        path: target,
+        name: path.basename(target),
+        template,
+        dependenciesInstalled: result.dependenciesInstalled,
+      } satisfies AgentScaffoldResponse);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/packages/harness/src/server/scaffold.ts
+++ b/packages/harness/src/server/scaffold.ts
@@ -140,17 +140,57 @@ export async function refuseScaffoldOnDisk(
 }
 
 /**
+ * CLAIM the directory, atomically — the request's one exclusive act.
+ *
+ * A plain `mkdir` (NOT recursive) is the whole mechanism: the filesystem
+ * decides who gets the name, and the loser is told `EEXIST`. The `lstat` above
+ * is a nicer message, not a lock — between it and the scaffold, a second POST
+ * with the same body (the route is directly postable) or a person making the
+ * folder in Finder can take the destination.
+ *
+ * Getting that ordering wrong is not a cosmetic race. The cleanup below deletes
+ * the directory recursively when the scaffold throws, and it is only entitled
+ * to do that BECAUSE this call created it: two simultaneous creates would
+ * otherwise have the loser `rm -rf` the winner's freshly installed agent while
+ * the winner's caller was being told it exists.
+ *
+ * `scaffold` accepts an existing EMPTY directory (agent-core's
+ * `isScaffoldableTarget`), so claiming it first costs nothing.
+ *
+ * Returns null on success, or the sentence to refuse with.
+ */
+async function claimTarget(
+  target: string,
+  projectLabel: string,
+): Promise<string | null> {
+  try {
+    await fs.mkdir(target);
+    return null;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EEXIST")
+      return `${projectLabel} already contains ${path.basename(target)}.`;
+    if (code === "ENOENT")
+      return `Can't create an agent in ${path.dirname(target)} — that folder no longer exists.`;
+    return `Couldn't create ${path.basename(target)}: ${(err as Error).message}`;
+  }
+}
+
+/**
  * Remove what a failed scaffold left behind.
  *
- * NOTHING HALF-CREATED. `scaffold` makes the directory before it copies into
- * it, and every guard above proved the destination was absent, so whatever is
- * there now is this attempt's own wreckage. A half-created agent is worse than
- * a refusal: the retry then fails on "already contains" and the user has to
- * clean up a folder they never made.
+ * NOTHING HALF-CREATED. `scaffold` copies a template into the directory, so a
+ * failure part-way leaves a folder the user never made — worse than a refusal,
+ * because the retry then dies on "already contains" and they have to clean up
+ * after us.
  *
- * `force` so an attempt that failed before the mkdir is a no-op, and the whole
- * thing is swallowed: the caller is already being told the create failed, and a
- * cleanup error would replace that sentence with a worse one.
+ * Only ever called on a directory THIS request created (see `claimTarget`).
+ * That is what makes a recursive delete safe here, and it is the reason the
+ * claim is a `mkdir` rather than a `stat`.
+ *
+ * `force` so an attempt that failed before writing anything is a no-op, and the
+ * whole thing is swallowed: the caller is already being told the create failed,
+ * and a cleanup error would replace that sentence with a worse one.
  */
 async function removeFailedScaffold(dir: string): Promise<void> {
   await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
@@ -258,6 +298,13 @@ export function createAgentScaffoldRouter(
       const diskRefusal = await refuseScaffoldOnDisk(target, projectLabel);
       if (diskRefusal != null) {
         res.status(409).json({ error: diskRefusal });
+        return;
+      }
+      // THE CLAIM, and the last word on who owns this name. Everything above is
+      // a reason to refuse early; this is the one act that cannot be raced.
+      const claimRefusal = await claimTarget(target, projectLabel);
+      if (claimRefusal != null) {
+        res.status(409).json({ error: claimRefusal });
         return;
       }
 

--- a/packages/harness/src/server/scaffold.ts
+++ b/packages/harness/src/server/scaffold.ts
@@ -49,10 +49,15 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { Router, type Router as ExpressRouter } from "express";
+import rateLimit from "express-rate-limit";
 
 import { refuseAgentName } from "../shared/agent-name.js";
 import type { AgentScaffoldResponse } from "../shared/types.js";
-import { childPath, hasTraversalSegment } from "../core/path-safety.js";
+import {
+  childPath,
+  hasTraversalSegment,
+  resolveWithinRoot,
+} from "../core/path-safety.js";
 
 
 export interface AgentScaffoldDeps {
@@ -135,6 +140,23 @@ export async function refuseScaffoldOnDisk(
 }
 
 /**
+ * Remove what a failed scaffold left behind.
+ *
+ * NOTHING HALF-CREATED. `scaffold` makes the directory before it copies into
+ * it, and every guard above proved the destination was absent, so whatever is
+ * there now is this attempt's own wreckage. A half-created agent is worse than
+ * a refusal: the retry then fails on "already contains" and the user has to
+ * clean up a folder they never made.
+ *
+ * `force` so an attempt that failed before the mkdir is a no-op, and the whole
+ * thing is swallowed: the caller is already being told the create failed, and a
+ * cleanup error would replace that sentence with a worse one.
+ */
+async function removeFailedScaffold(dir: string): Promise<void> {
+  await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+}
+
+/**
  * POST /api/agents/scaffold  { root, name, template? } -> AgentScaffoldResponse
  *
  * 400 — a malformed body, a name that is not one folder segment, a template
@@ -148,8 +170,22 @@ export function createAgentScaffoldRouter(
   deps: AgentScaffoldDeps,
 ): ExpressRouter {
   const router = Router();
+  /**
+   * A create is the most expensive request this server serves — a template
+   * copy, an `npm install` and a `git init` per call — so it is the one worth
+   * bounding. The window is far above anything a person clicking a dialog can
+   * reach; it exists so a stuck client cannot turn a create loop into a disk
+   * full of half-built projects. Same shape as the attachment-upload limiter
+   * in `server/rest.ts`.
+   */
+  const scaffoldRateLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+  });
 
-  router.post("/api/agents/scaffold", async (req, res, next) => {
+  router.post("/api/agents/scaffold", scaffoldRateLimiter, async (req, res, next) => {
     const body = (req.body ?? {}) as {
       root?: unknown;
       name?: unknown;
@@ -188,11 +224,25 @@ export function createAgentScaffoldRouter(
         return;
       }
       const projectLabel = path.basename(path.resolve(projectDir)) || projectDir;
-      // `path.resolve` on the LIST's entry, not the request's, and `childPath`
-      // re-derives the join it already blessed above: the guard that produces
-      // the path is the guard that proved it, so no later edit can separate
-      // them.
-      const target = childPath(path.resolve(projectDir), name as string);
+      // THE JOIN, on `path.resolve` of the LIST's entry rather than the
+      // request's. `childPath` is the rule: one plain child of this project,
+      // nothing else — it is what refuses every escaping name, and the
+      // co-located test proves that by posting them.
+      //
+      // `resolveWithinRoot` is a SINK-LOCAL RE-ASSERTION on top of it, and
+      // deliberately unreachable: nothing `childPath` returns can fail it
+      // today, so no test can make it fire (stubbing it out leaves the suite
+      // green — said plainly rather than dressed up as a second guard). It
+      // earns its place twice over anyway: it is the containment check in the
+      // form static analysis recognizes — CodeQL reads `childPath`'s
+      // `dirname(...) === root` comparison as no barrier at all and flags every
+      // `fs` call below as path injection — and it survives a reordering of the
+      // guards above it, which is exactly the edit that would make the rule
+      // reachable again. Same shape `server/canvas.ts` uses for its
+      // user-supplied sub-path.
+      const child = childPath(path.resolve(projectDir), name as string);
+      const target =
+        child == null ? null : resolveWithinRoot(path.resolve(projectDir), child);
       if (target == null) {
         res.status(400).json({ error: `'${String(name)}' isn't a folder name.` });
         return;
@@ -215,9 +265,7 @@ export function createAgentScaffoldRouter(
       try {
         result = await deps.scaffoldAgent({ targetDir: target, template });
       } catch (err) {
-        // NOTHING HALF-CREATED. Everything above proved the destination was
-        // absent, so whatever is there now is this attempt's own wreckage.
-        await fs.rm(target, { recursive: true, force: true }).catch(() => {});
+        await removeFailedScaffold(target);
         res.status(500).json({
           error: (err as Error).message || `Couldn't create ${String(name)}.`,
         });

--- a/packages/harness/src/server/scaffold.ts
+++ b/packages/harness/src/server/scaffold.ts
@@ -50,21 +50,10 @@ import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { Router, type Router as ExpressRouter } from "express";
 
+import { refuseAgentName } from "../shared/agent-name.js";
+import type { AgentScaffoldResponse } from "../shared/types.js";
 import { childPath, hasTraversalSegment } from "../core/path-safety.js";
 
-/** `POST /api/agents/scaffold` response. */
-export interface AgentScaffoldResponse {
-  ok: true;
-  /** Absolute path of the new agent's directory — server-authored, never the
-   *  caller's string. */
-  path: string;
-  name: string;
-  template: string;
-  /** Whether the best-effort `npm install` succeeded. False is not a failure:
-   *  the Canvas degrades to its "run npm install" hint (see
-   *  `@sapiom/agent-core`'s install-deps). */
-  dependenciesInstalled: boolean;
-}
 
 export interface AgentScaffoldDeps {
   /**
@@ -122,40 +111,6 @@ function samePath(a: string, b: string): boolean {
     return process.platform === "win32" ? resolved.toLowerCase() : resolved;
   };
   return norm(a) === norm(b);
-}
-
-/**
- * Characters that cannot appear in a directory name on every platform the
- * Studio runs on, plus the C0 controls. A NUL in particular reaches `fs` as a
- * thrown `ERR_INVALID_ARG_VALUE` rather than a refusal, so it is answered here
- * where the caller gets a sentence instead of a 500.
- */
-// eslint-disable-next-line no-control-regex
-const FORBIDDEN_IN_NAME = /[\u0000-\u001f<>:"|?*]/;
-
-/**
- * Why this name cannot be a new agent's folder, or null when it can.
- *
- * The message is shown verbatim in the dialog, so it says what to do rather
- * than what a regex thinks. The rule is `childPath`'s — one plain segment
- * under the project root, enforced again at the join below — plus a length cap
- * and a leading-dot refusal: a dotted directory is hidden from the agent scan,
- * so `.notes` would scaffold successfully and then never appear in the rail,
- * which is the "did it work?" failure this whole endpoint exists to end.
- */
-export function refuseAgentName(name: unknown): string | null {
-  if (typeof name !== "string" || name.trim() === "")
-    return "Give the agent a name.";
-  if (name.trim() !== name)
-    return "An agent name can't start or end with a space.";
-  if (name.length > 64)
-    return "That name is too long — keep it under 64 characters.";
-  if (/[/\\]/.test(name))
-    return "An agent name is one folder name — it can't contain / or \\.";
-  if (name.startsWith("."))
-    return "An agent name can't start with a dot — a dotted folder is hidden from the rail.";
-  if (FORBIDDEN_IN_NAME.test(name)) return `'${name}' isn't a folder name.`;
-  return null;
 }
 
 /**

--- a/packages/harness/src/shared/agent-name.test.ts
+++ b/packages/harness/src/shared/agent-name.test.ts
@@ -27,6 +27,9 @@ describe("refuseAgentName", () => {
     expect(refuseAgentName(" leading")).toMatch(/space/);
     expect(refuseAgentName(42)).toMatch(/Give the agent a name/);
     expect(refuseAgentName("x".repeat(65))).toMatch(/too long/);
+    // Windows makes `foo.` into `foo`, so the name the caller is told it got
+    // and the directory on disk would disagree.
+    expect(refuseAgentName("trailing.")).toMatch(/end with a dot/);
   });
 
   it("refuses a NUL, which reaches fs as a throw rather than a refusal", () => {

--- a/packages/harness/src/shared/agent-name.test.ts
+++ b/packages/harness/src/shared/agent-name.test.ts
@@ -1,0 +1,35 @@
+/**
+ * The one agent-name rule (SAP-2981).
+ *
+ * It is tested here rather than beside either consumer because both the dialog
+ * and `POST /api/agents/scaffold` depend on it saying the SAME thing: a name
+ * the field accepts and the route refuses reads as a broken app.
+ */
+import { describe, expect, it } from "vitest";
+
+import { refuseAgentName } from "./agent-name.js";
+
+describe("refuseAgentName", () => {
+  it("accepts an ordinary agent folder name", () => {
+    expect(refuseAgentName("order-triage")).toBeNull();
+    expect(refuseAgentName("Order_Triage2")).toBeNull();
+  });
+
+  it("refuses the shapes that would escape the project", () => {
+    // Each of these is a directory the caller must not be able to name, and
+    // each carries its own sentence because the user reads it verbatim.
+    expect(refuseAgentName("../evil")).toMatch(/one folder name/);
+    expect(refuseAgentName("a/b")).toMatch(/one folder name/);
+    expect(refuseAgentName("..")).toMatch(/dot/);
+    expect(refuseAgentName(".hidden")).toMatch(/dot/);
+    expect(refuseAgentName("")).toMatch(/Give the agent a name/);
+    expect(refuseAgentName("   ")).toMatch(/Give the agent a name/);
+    expect(refuseAgentName(" leading")).toMatch(/space/);
+    expect(refuseAgentName(42)).toMatch(/Give the agent a name/);
+    expect(refuseAgentName("x".repeat(65))).toMatch(/too long/);
+  });
+
+  it("refuses a NUL, which reaches fs as a throw rather than a refusal", () => {
+    expect(refuseAgentName("ok\u0000name")).toMatch(/isn't a folder name/);
+  });
+});

--- a/packages/harness/src/shared/agent-name.ts
+++ b/packages/harness/src/shared/agent-name.ts
@@ -1,0 +1,52 @@
+/**
+ * What a new agent may be called — ONE rule, shared by the dialog and the
+ * route (SAP-2981).
+ *
+ * The dialog validates as you type so the refusal arrives before the click, and
+ * `POST /api/agents/scaffold` refuses again on its own findings because a
+ * disabled button is not a permission system. Those are two guards, and two
+ * guards written twice become two different rules: a name the field accepts and
+ * the server rejects reads as a broken app, and a name the server would accept
+ * but the field greys out reads as an arbitrary one. So the rule lives here and
+ * both sides import it.
+ *
+ * It is deliberately a folder-name rule, not a naming-convention one. The agent
+ * gets a directory inside the project, and everything refused below is refused
+ * because of what it would do to that directory — not because of house style.
+ */
+
+/**
+ * Characters that cannot appear in a directory name on every platform the
+ * Studio runs on, plus the C0 controls. A NUL in particular reaches `fs` as a
+ * thrown `ERR_INVALID_ARG_VALUE` rather than a refusal, so it is answered here
+ * where the caller gets a sentence instead of a 500.
+ */
+// eslint-disable-next-line no-control-regex
+const FORBIDDEN_IN_NAME = /[\u0000-\u001f<>:"|?*]/;
+
+/** Longest agent folder name accepted — a bound, not a style rule. */
+const MAX_NAME_LENGTH = 64;
+
+/**
+ * Why this name cannot be a new agent's folder, or null when it can.
+ *
+ * The message is shown verbatim, so each sentence says what to do rather than
+ * what a regex thinks. The leading-dot refusal is the one that is not about
+ * path escape: a dotted directory is skipped by the agent scan, so `.notes`
+ * would scaffold successfully and then never appear in the rail — the exact
+ * "did it work?" failure the create endpoint exists to end.
+ */
+export function refuseAgentName(name: unknown): string | null {
+  if (typeof name !== "string" || name.trim() === "")
+    return "Give the agent a name.";
+  if (name.trim() !== name)
+    return "An agent name can't start or end with a space.";
+  if (name.length > MAX_NAME_LENGTH)
+    return `That name is too long — keep it under ${MAX_NAME_LENGTH} characters.`;
+  if (/[/\\]/.test(name))
+    return "An agent name is one folder name — it can't contain / or \\.";
+  if (name.startsWith("."))
+    return "An agent name can't start with a dot — a dotted folder is hidden from the rail.";
+  if (FORBIDDEN_IN_NAME.test(name)) return `'${name}' isn't a folder name.`;
+  return null;
+}

--- a/packages/harness/src/shared/agent-name.ts
+++ b/packages/harness/src/shared/agent-name.ts
@@ -47,6 +47,12 @@ export function refuseAgentName(name: unknown): string | null {
     return "An agent name is one folder name — it can't contain / or \\.";
   if (name.startsWith("."))
     return "An agent name can't start with a dot — a dotted folder is hidden from the rail.";
+  // A TRAILING dot is not the same mistake, and it is worse: Windows silently
+  // strips it, so `mkdir foo.` makes `foo` and the created directory no longer
+  // matches the name the caller was told it got — the SPA then focuses and
+  // binds a path that does not exist.
+  if (name.endsWith("."))
+    return "An agent name can't end with a dot.";
   if (FORBIDDEN_IN_NAME.test(name)) return `'${name}' isn't a folder name.`;
   return null;
 }

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -1007,6 +1007,24 @@ export interface SessionRecord {
 // POST   /api/track                     UiTrackRequest → { ok: true }  (UI-interaction analytics)
 // POST   /ingest                        (hook payloads; bearer = ingest token)
 
+/**
+ * `POST /api/agents/scaffold` response — the agent the harness just created.
+ *
+ * `path` is SERVER-AUTHORED: the project directory came from the list of
+ * folders the rail can show and the name from a validated single segment, so
+ * nothing here is the caller's string reflected back. The SPA focuses and binds
+ * on this path rather than on the one it asked for.
+ */
+export interface AgentScaffoldResponse {
+  ok: true;
+  path: string;
+  name: string;
+  template: string;
+  /** Whether the best-effort `npm install` succeeded. False is not a failure —
+   *  the Canvas degrades to its "run npm install" hint. */
+  dependenciesInstalled: boolean;
+}
+
 /** The app's active UI theme, as tracked client-side (web/src/lib/theme.ts). */
 export type UiTheme = "light" | "dark";
 

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -987,6 +987,8 @@ export interface SessionRecord {
 // POST   /api/sessions/:id/input        InjectInputRequest → { ok: true }
 // POST   /api/sessions/:id/attachments  AttachFileRequest → AttachFileResponse (materialize only)
 // PATCH  /api/sessions/:id/workflow     BindWorkflowRequest → HarnessSession
+// POST   /api/agents/scaffold           { root, name, template? } → AgentScaffoldResponse (the harness creates the agent)
+// POST   /api/agents/move               { from, to } → AgentMoveResponse (rename an agent's directory)
 // GET    /api/workflows                 → WorkflowInfo[]
 // POST   /api/workflows/connect         { path } → WorkflowInfo
 // POST   /api/workflows/scan            { root } → WorkflowInfo[]

--- a/packages/harness/vitest.config.ts
+++ b/packages/harness/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       // truth. Mirrors the alias in web/vite.config.ts.
       "@shared/types": fileURLToPath(new URL("src/shared/types.ts", import.meta.url)),
       "@shared/system-graph": fileURLToPath(new URL("src/shared/system-graph.ts", import.meta.url)),
+      "@shared/agent-name": fileURLToPath(new URL("src/shared/agent-name.ts", import.meta.url)),
     },
   },
   test: {

--- a/packages/harness/web/e2e/create-agent.spec.ts
+++ b/packages/harness/web/e2e/create-agent.spec.ts
@@ -167,6 +167,27 @@ test.describe("create an agent in a project", () => {
     expect(await createOrder(page)).toEqual([]);
   });
 
+  test("Return submits from the name field — and Return on Cancel cancels", async ({
+    page,
+  }) => {
+    await openProjectMenu(page, "acme-app");
+    await page.getByTestId("project-create-agent-acme-app").click();
+    await page.getByTestId("create-agent-name").fill("returned");
+    await page.getByTestId("create-agent-name").press("Enter");
+    await expect(page.getByTestId("workflow-returned")).toBeVisible();
+
+    // The dialog took Return for the whole form, so a focused Cancel took it
+    // too: pressing Return on "Cancel" closed the dialog AND created the
+    // agent — the opposite of what was pressed. Measured, before the guard.
+    await openProjectMenu(page, "acme-app");
+    await page.getByTestId("project-create-agent-acme-app").click();
+    await page.getByTestId("create-agent-name").fill("cancelled");
+    await page.getByRole("button", { name: "Cancel" }).focus();
+    await page.keyboard.press("Enter");
+    await expect(page.getByTestId("create-agent-dialog")).toHaveCount(0);
+    await expect(page.getByTestId("workflow-cancelled")).toHaveCount(0);
+  });
+
   test("the empty-project row opens the same dialog", async ({ page }) => {
     // One create flow, not one per door: the empty project's CTA is the same
     // subject and must not be a second mechanism that drifts.

--- a/packages/harness/web/e2e/create-agent.spec.ts
+++ b/packages/harness/web/e2e/create-agent.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * SAP-2981 — the canonical create-agent flow.
+ *
+ * The defect these specs guard: every create door in the Studio ended in an
+ * English sentence injected into a terminal ("call the
+ * sapiom_dev_agents_scaffold tool with {…}"). The harness did not create the
+ * agent, so a failed create arrived as a confused model rather than an error,
+ * and "did it work?" was answered by reading a terminal.
+ *
+ * Two things are asserted that a count cannot see:
+ *
+ *   - THE ORDER. `createOrder` is one append-only list holding both halves of a
+ *     create, because the criterion IS the order — the agent exists before the
+ *     chat starts. Two separate call logs each say a thing happened; neither
+ *     says which came first, and that is the whole claim.
+ *   - THE REFUSAL, from the endpoint rather than from the field. The mock's
+ *     `scaffoldAgent` runs the same shared name rule the server refuses with
+ *     (`@shared/agent-name`) and the same duplicate check, so a spec that
+ *     bypasses the field's own validation still meets a refusal.
+ */
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+import { openProjectMenu } from "./mock-navigation";
+
+const ROOT = "/Users/demo/acme-app";
+
+/** The last prompt handed to a session, as `new-session-composer.spec.ts`
+ *  reads it. */
+const lastInjectText = (page: Page): Promise<string> =>
+  page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __HARNESS_TEST__?: { lastInjectInput?: { req?: { text?: string } } };
+        }
+      ).__HARNESS_TEST__?.lastInjectInput?.req?.text ?? "",
+  );
+
+/** Everything the app has done to create things, in order. */
+const createOrder = (page: Page): Promise<string[]> =>
+  page.evaluate(
+    () =>
+      ((window as unknown as { __HARNESS_TEST__?: { createOrder?: string[] } })
+        .__HARNESS_TEST__?.createOrder ?? []) as string[],
+  );
+
+test.describe("create an agent in a project", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/?seed=0");
+    await expect(page.getByTestId("workspace-group-acme-app")).toBeVisible();
+  });
+
+  test("the menu opens a dialog that STATES the project, and starts nothing", async ({
+    page,
+  }) => {
+    await openProjectMenu(page, "acme-app");
+    await page.getByTestId("project-create-agent-acme-app").click();
+
+    const dialog = page.getByTestId("create-agent-dialog");
+    await expect(dialog).toBeVisible();
+    // Stated, not chosen: you clicked that row, and the dialog spells the
+    // folder out because a rail label can be widened or shared.
+    await expect(page.getByTestId("create-agent-project")).toHaveText("acme-app");
+    await expect(dialog).toContainText(ROOT);
+    // There is no folder picker here — asking "where" again is the subject
+    // confusion this epic removes.
+    await expect(dialog.getByTestId("dir-picker-input")).toHaveCount(0);
+
+    // AND NOTHING HAS HAPPENED YET. The old handler started a pty on this
+    // click; a create that begins before you have named anything is the
+    // behaviour this dialog replaces.
+    expect(await createOrder(page)).toEqual([]);
+  });
+
+  test("creation completes BEFORE the session starts", async ({ page }) => {
+    await openProjectMenu(page, "acme-app");
+    await page.getByTestId("project-create-agent-acme-app").click();
+    await page.getByTestId("create-agent-name").fill("billing-bot");
+    await page.getByTestId("create-agent-submit").click();
+
+    // The row lands in the rail…
+    await expect(page.getByTestId("workflow-billing-bot")).toBeVisible();
+    // …and the ORDER is the criterion: scaffold first, session second, both
+    // rooted where the click said.
+    await expect
+      .poll(async () => await createOrder(page))
+      .toEqual([`scaffold:${ROOT}/billing-bot`, `session:${ROOT}`]);
+
+    // The dialog is gone because the create succeeded, not because it was
+    // dismissed.
+    await expect(page.getByTestId("create-agent-dialog")).toHaveCount(0);
+  });
+
+  test("a first instruction reaches the session, and never asks for a scaffold", async ({
+    page,
+  }) => {
+    await openProjectMenu(page, "acme-app");
+    await page.getByTestId("project-create-agent-acme-app").click();
+    await page.getByTestId("create-agent-name").fill("digest-bot");
+    await page
+      .getByTestId("create-agent-instruction")
+      .fill("Summarise yesterday's incidents every morning.");
+    await page.getByTestId("create-agent-submit").click();
+    await expect(page.getByTestId("workflow-digest-bot")).toBeVisible();
+
+    // The project is already on disk. An agent told to "scaffold a new project
+    // in this directory" would find a non-empty folder and either refuse or
+    // start over — so the prompt says the scaffold is done.
+    await expect
+      .poll(() => lastInjectText(page))
+      .toContain("Summarise yesterday's incidents every morning.");
+    const prompt = await lastInjectText(page);
+    expect(prompt).toContain("has just been created");
+    expect(prompt).not.toContain("sapiom_dev_agents_scaffold");
+  });
+
+  test("a duplicate name is refused by the SERVER, in the dialog, and nothing starts", async ({
+    page,
+  }) => {
+    await openProjectMenu(page, "acme-app");
+    await page.getByTestId("project-create-agent-acme-app").click();
+    // `leasing` is a fixture agent in this project. The field has no opinion
+    // about it — only the endpoint knows what is already there.
+    await page.getByTestId("create-agent-name").fill("leasing");
+    await expect(page.getByTestId("create-agent-name-error")).toHaveCount(0);
+    await page.getByTestId("create-agent-submit").click();
+
+    // The server's own sentence, not the wire shape it arrives in.
+    const error = page.getByTestId("create-agent-error");
+    await expect(error).toBeVisible();
+    await expect(error).toHaveText("acme-app already has an agent called leasing.");
+    await expect(error).not.toContainText("/api/agents/scaffold");
+
+    // The dialog stays up holding what was typed, and no session was started
+    // for an agent that does not exist.
+    await expect(page.getByTestId("create-agent-name")).toHaveValue("leasing");
+    expect(await createOrder(page)).toEqual([]);
+  });
+
+  test("a name that is not one folder segment is refused before it is sent", async ({
+    page,
+  }) => {
+    await openProjectMenu(page, "acme-app");
+    await page.getByTestId("project-create-agent-acme-app").click();
+    const name = page.getByTestId("create-agent-name");
+    const submit = page.getByTestId("create-agent-submit");
+
+    for (const bad of ["../evil", "a/b"]) {
+      await name.fill(bad);
+      await expect(page.getByTestId("create-agent-name-error")).toContainText(
+        "one folder name",
+      );
+      await expect(submit).toBeDisabled();
+    }
+    await name.fill(".hidden");
+    await expect(page.getByTestId("create-agent-name-error")).toContainText("dot");
+    await expect(submit).toBeDisabled();
+
+    // An empty field is not a mistake yet — it says nothing and offers nothing.
+    await name.fill("");
+    await expect(page.getByTestId("create-agent-name-error")).toHaveCount(0);
+    await expect(submit).toBeDisabled();
+
+    await name.fill("fine-name");
+    await expect(submit).toBeEnabled();
+    expect(await createOrder(page)).toEqual([]);
+  });
+
+  test("the empty-project row opens the same dialog", async ({ page }) => {
+    // One create flow, not one per door: the empty project's CTA is the same
+    // subject and must not be a second mechanism that drifts.
+    await page.getByTestId("rail-add-project").click();
+    await page.getByTestId("dir-picker-input").fill("/Users/demo/blank-slate");
+    await page.getByTestId("open-project").click();
+    await page.getByTestId("project-empty-blank-slate").click();
+
+    await expect(page.getByTestId("create-agent-dialog")).toBeVisible();
+    await expect(page.getByTestId("create-agent-project")).toHaveText(
+      "blank-slate",
+    );
+    expect(await createOrder(page)).toEqual([]);
+  });
+});

--- a/packages/harness/web/e2e/rail-grammar.spec.ts
+++ b/packages/harness/web/e2e/rail-grammar.spec.ts
@@ -70,41 +70,42 @@ test.describe("project row grammar", () => {
     await expect(page.getByTestId("project-remove-scratch")).toBeVisible();
   });
 
-  test("creating from the menu still starts a session rooted in THAT project", async ({
+  test("creating from the menu creates IN that project, and only then talks", async ({
     page,
   }) => {
-    // The menu changed what the control SAYS. What it does is unchanged, and a
-    // grammar fix that quietly broke the action would be the worse bug.
+    // The menu changed what the control SAYS; SAP-2981 changed what it does —
+    // it opens the create dialog instead of starting a pty and asking the
+    // coding agent, in English, to scaffold. What must not change is the
+    // SUBJECT: the project named on the row is the project it creates in, and
+    // the session that follows is rooted there.
     //
     // THE REQUEST, not a tab count. This spec first counted
     // `[data-testid^='session-tab-']` and was worthless: `/?seed=0` renders two
     // session tabs plus `session-tab-new` before anything is clicked, so the
     // assertion held with the handler stubbed to a no-op — a spec that cannot
     // fail, guarding the one behaviour this PR promises it did not change.
-    // A COUNT TAKEN BEFORE, then the newest call — not `lastCreateSession.cwd`
-    // on its own, because the boot session is already rooted at
-    // `/Users/demo/acme-app` (`MOCK_LAUNCH_DIR`) and a value the click is
-    // supposed to produce may already be sitting there. Mutation-checked:
-    // stubbing `create.run()` to a no-op fails this spec.
-    const calls = (): Promise<{ n: number; cwd: string | null }> =>
-      page.evaluate(() => {
-        const state = (
-          window as unknown as {
-            __HARNESS_TEST__?: {
-              createSessionCalls?: Array<{ req?: { cwd?: string } }>;
-            };
-          }
-        ).__HARNESS_TEST__;
-        const list = state?.createSessionCalls ?? [];
-        return { n: list.length, cwd: list[list.length - 1]?.req?.cwd ?? null };
-      });
-    const before = await calls();
+    const order = (): Promise<string[]> =>
+      page.evaluate(
+        () =>
+          ((window as unknown as { __HARNESS_TEST__?: { createOrder?: string[] } })
+            .__HARNESS_TEST__?.createOrder ?? []) as string[],
+      );
 
     await openProjectMenu(page, "acme-app");
     await page.getByTestId("project-create-agent-acme-app").click();
     await expect(page.getByTestId("project-menu-card-acme-app")).toHaveCount(0);
-    await expect.poll(async () => (await calls()).n).toBe(before.n + 1);
-    expect((await calls()).cwd).toBe("/Users/demo/acme-app");
+    await expect(page.getByTestId("create-agent-project")).toHaveText("acme-app");
+    // Nothing has started yet — the old handler started a pty on this click.
+    expect(await order()).toEqual([]);
+
+    await page.getByTestId("create-agent-name").fill("menu-made");
+    await page.getByTestId("create-agent-submit").click();
+    await expect
+      .poll(order)
+      .toEqual([
+        "scaffold:/Users/demo/acme-app/menu-made",
+        "session:/Users/demo/acme-app",
+      ]);
   });
 });
 

--- a/packages/harness/web/e2e/templates.spec.ts
+++ b/packages/harness/web/e2e/templates.spec.ts
@@ -267,9 +267,12 @@ test.describe("templates journey (from the composer)", () => {
     );
   });
 
-  test("use (starter): the real bundled-template scaffold tool", async ({
-    page,
-  }) => {
+  test("use (starter): the HARNESS scaffolds it, no prompt", async ({ page }) => {
+    // SAP-2981, E4.6. A bundled starter is the same local scaffold the project
+    // `+` does, so it goes through the same endpoint: two creation paths for
+    // one operation is how they drift. The clone path above still hands the
+    // work to the coding agent, because forking a published template over the
+    // network is a different operation with a different failure mode.
     await open(page, "coding-pause");
     await page.getByTestId("template-use-btn").click();
     await expect(page.getByTestId("dir-picker-input")).toHaveValue(
@@ -277,20 +280,24 @@ test.describe("templates journey (from the composer)", () => {
     );
     await page.getByTestId("template-use-confirm").click();
 
-    await expect(page.getByTestId("session-context-title")).toContainText(
-      "coding-pause",
-    );
+    // Created first, THEN talked to — the same order the create dialog keeps.
     await expect
-      .poll(async () => (await lastInject(page))?.req.text ?? "")
-      .toContain("sapiom_dev_agents_scaffold");
-    // The starter path carries the same run continuation as the clone path.
-    const prompt = (await lastInject(page))?.req.text ?? "";
-    expect(prompt).toContain(
-      '{"dir":"/Users/demo/acme-app/projects/coding-pause","template":"coding-pause"}',
+      .poll(async () =>
+        page.evaluate(
+          () =>
+            ((window as unknown as { __HARNESS_TEST__?: { createOrder?: string[] } })
+              .__HARNESS_TEST__?.createOrder ?? []) as string[],
+        ),
+      )
+      .toEqual([
+        "scaffold:/Users/demo/acme-app/projects/coding-pause",
+        "session:/Users/demo/acme-app/projects",
+      ]);
+    await expect(page.getByTestId("workflow-coding-pause")).toBeVisible();
+    // And nobody was asked, in English, to perform a filesystem operation.
+    expect((await lastInject(page))?.req.text ?? "").not.toContain(
+      "sapiom_dev_agents_scaffold",
     );
-    expect(prompt).toContain("sapiom_dev_agents_run_local");
-    expect(prompt).toContain("Keep the shipped starter unchanged");
-    expect(prompt.toLowerCase()).not.toContain("workflow");
   });
 
   test("use: straight from a card's spec sheet, skipping the read", async ({

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -1409,8 +1409,14 @@ export const App = (): JSX.Element => {
     // that fails to start is a session failure, reported as one — it must
     // never read as "the agent wasn't created", because it was.
     try {
+      // A LIVE one, or none. The bare-project door names the session that was
+      // sitting in that folder when the dialog opened, and a dialog can stay
+      // open longer than a pty lives — binding the new agent to an exited
+      // session would leave it with nothing to talk to.
       const existing = request.sessionId
-        ? (state.sessions.find((s) => s.id === request.sessionId) ?? null)
+        ? (state.sessions.find(
+            (s) => s.id === request.sessionId && s.status !== "exited",
+          ) ?? null)
         : null;
       const session =
         existing ??

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -77,6 +77,7 @@ import { Toast } from "./components/Toast";
 import { TooltipLayer } from "./components/TooltipLayer";
 import { NewSessionComposer } from "./components/NewSessionComposer";
 import { HelpOverlay } from "./components/HelpOverlay";
+import { CreateAgentDialog } from "./components/CreateAgentDialog";
 import { OverviewModal } from "./components/OverviewModal";
 import { WorkflowsRail } from "./components/WorkflowsRail";
 import { WorkspaceGraphView } from "./components/WorkspaceGraphView";
@@ -90,7 +91,7 @@ import {
   resolveProjectRoot,
   slugifyIdea,
 } from "./lib/project-dir";
-import { basenameOf, isWithinDir, samePath } from "./lib/paths";
+import { basenameOf, isWithinDir, parentOf, samePath } from "./lib/paths";
 import {
   canvasSourceFor,
   canvasSubject,
@@ -124,7 +125,8 @@ import { editorLabel, editorUrl, resolveEditor } from "./lib/editors";
 import { CloneAgentConfirm } from "./components/CloneAgentConfirm";
 import {
   cloneDefinitionPrompt,
-  starterScaffoldInstruction,
+  composerScaffoldPrompt,
+  firstInstructionPrompt,
   useTemplatePrompt,
   type GalleryTemplate,
   type StudioTemplate,
@@ -286,6 +288,19 @@ export const App = (): JSX.Element => {
     label: string;
   } | null>(null);
   const startingProjectRootsRef = useRef(new Set<string>());
+  /**
+   * The project a create-agent dialog is open for (SAP-2981), or null.
+   *
+   * It holds the SUBJECT, not a form: the row that was clicked answers "where",
+   * and the dialog only asks what that row cannot. `sessionId` is set by the
+   * bare-project door, where a live session in the folder is already the
+   * session the new agent should bind to.
+   */
+  const [creatingAgent, setCreatingAgent] = useState<{
+    root: string;
+    label: string;
+    sessionId?: string;
+  } | null>(null);
   /**
    * Leave map altitude — unless the thing being opened lives INSIDE the
    * selected project.
@@ -1249,6 +1264,14 @@ export const App = (): JSX.Element => {
    * do not: that folder is the new project's root by construction, and
    * resolving it upward would drop the new agent into its parent project.
    */
+  /**
+   * The provider a create-initiated session boots with — the same stored
+   * preference the rail used to read before it dispatched. It moved here with
+   * the create itself; the rail no longer starts sessions.
+   */
+  const preferredHarness = (): HarnessKind =>
+    loadUiPrefs().preferredHarness === "codex" ? "codex" : "claude-code";
+
   const sessionCwdForAgent = (agentPath: string): string =>
     projectRootForAgent(agentPath, knownProjectRoots());
 
@@ -1302,20 +1325,25 @@ export const App = (): JSX.Element => {
     await createSessionAt(cwd, agentHarness);
   };
 
+  /**
+   * The composer's scaffold prompt — the ONE door left where the coding agent
+   * creates the project (SAP-2981).
+   *
+   * Everywhere the project is already known, the harness creates the agent
+   * itself (`handleCreateAgentInProject` below). The composer is the home
+   * screen: no project, no name, just an idea, and the folder it invents does
+   * not exist yet — so there is nothing here to state and no row to create in.
+   * The prompt is honest about being a prompt, and its failure message names
+   * the tool the user would have to ask for by hand.
+   */
   const sendScaffoldPrompt = (
     session: HarnessSession,
     cwd: string,
     idea?: string,
   ): void => {
-    const base =
-      `Scaffold a new Sapiom agent project in this directory: ${starterScaffoldInstruction(cwd, "default")}, ` +
-      "then run npm install, read AGENTS.md, and use the sapiom-agent-authoring skill to";
-    const trimmedIdea = idea?.trim();
     sendPromptWhenReady(
       session.id,
-      trimmedIdea
-        ? `${base} build this:\n\n${trimmedIdea}`
-        : `${base} define the first agent.`,
+      composerScaffoldPrompt(cwd, idea),
       "Couldn't send the scaffold prompt. Ask the coding agent to call sapiom_dev_agents_scaffold.",
     );
   };
@@ -1337,6 +1365,73 @@ export const App = (): JSX.Element => {
   ): Promise<void> => {
     const session = await createSessionAt(cwd, agentHarness);
     sendScaffoldPrompt(session, cwd, idea);
+  };
+
+  /**
+   * THE IN-PROJECT CREATE (SAP-2981; design.md § E4).
+   *
+   * The `+` on a project row used to start a session and inject an English
+   * sentence asking the coding agent to please call the scaffold MCP tool. The
+   * harness does it now: the dialog collects a name and a starter, the endpoint
+   * creates the directory and rescans it, and only THEN does a session open.
+   *
+   * The order is the feature. Creation completes before the chat starts, so a
+   * failure is a sentence in the dialog rather than a confused model, and the
+   * agent is a row in the rail before anything can ask "did it work?".
+   *
+   * The project is not asked for — it is the row that was clicked.
+   */
+  const handleCreateAgentInProject = (root: string, label: string): void => {
+    setCreatingAgent({ root, label });
+  };
+
+  const createAgentInProject = async (input: {
+    name: string;
+    template: string;
+    instruction: string;
+  }): Promise<void> => {
+    const request = creatingAgent;
+    if (!request) return;
+    // Throws on refusal, and the dialog shows the server's own sentence. It
+    // resolves only once the agent is on disk AND in the registry.
+    const created = await harness.scaffoldAgent(
+      request.root,
+      input.name,
+      input.template,
+    );
+    setCreatingAgent(null);
+    // The rail already has it (the server rescanned before answering); this is
+    // the selection following the thing the user just made.
+    setSelectedProject(null);
+    setFocusedAgentPath(created.path);
+
+    // EVERYTHING BELOW IS THE CHAT, and the agent already exists. A session
+    // that fails to start is a session failure, reported as one — it must
+    // never read as "the agent wasn't created", because it was.
+    try {
+      const existing = request.sessionId
+        ? (state.sessions.find((s) => s.id === request.sessionId) ?? null)
+        : null;
+      const session =
+        existing ??
+        (await createSessionAt(request.root, preferredHarness()));
+      await harness.bindWorkflow(session.id, created.path);
+      harness.setActiveSessionId(session.id);
+      setFocusedAgentPath(created.path);
+      if (input.instruction) {
+        sendPromptWhenReady(
+          session.id,
+          firstInstructionPrompt(created.path, input.instruction),
+          "Couldn't send your first instruction — the agent is created; type it into the terminal.",
+        );
+      }
+    } catch (err) {
+      harness.showToast(
+        `${created.name} was created, but its session didn't start. ${
+          (err as Error).message ?? ""
+        }`.trim(),
+      );
+    }
   };
 
   // The workbench tab + starts a fresh coding-agent process beside the active
@@ -1428,20 +1523,38 @@ export const App = (): JSX.Element => {
     })();
   };
 
-  // Bare-scaffold folder affordance: a live session sits in a folder
-  // with no agent yet. Ask that session to scaffold its first agent in place.
+  /**
+   * Bare-project affordance: a live session sits in a folder with no agent yet.
+   *
+   * It used to inject the scaffold prompt into that session — the third copy of
+   * the same English sentence. It is the same create as any other project now,
+   * aimed at the session's own folder, and the session it already has is the
+   * one the new agent binds to rather than a second pty beside it.
+   */
   const handleScaffoldInSession = (sessionId: string): void => {
-    const cwd =
-      state.sessions.find((session) => session.id === sessionId)?.cwd ?? ".";
-    sendPromptWhenReady(
+    const session = state.sessions.find((s) => s.id === sessionId);
+    if (!session) return;
+    setCreatingAgent({
+      root: session.cwd,
+      label: basenameOf(session.cwd) || session.cwd,
       sessionId,
-      `Scaffold a new Sapiom agent project in this directory: ${starterScaffoldInstruction(cwd, "default")}, then run npm install, read AGENTS.md, and use the sapiom-agent-authoring skill to define the first agent.`,
-      "Couldn't send the scaffold prompt. Ask the coding agent to call sapiom_dev_agents_scaffold.",
-    );
+    });
   };
 
-  // Templates journey v0: "Use template" starts a session in the destination
-  // folder and hands the agent the real operation.
+  /**
+   * "Use template" — one journey, two operations, and only one of them is a
+   * prompt (SAP-2981, E4.6).
+   *
+   * A STARTER is the same local scaffold the project `+` does, so it goes
+   * through the same endpoint: the folder is created before the session opens,
+   * and a refusal is an error the dialog shows. Two creation paths for one
+   * operation is exactly how they drift.
+   *
+   * A GALLERY template is a different operation — it forks a published agent
+   * into a repo the user owns, over the network, with an auth failure mode —
+   * and the harness has no route for that. It stays the coding agent's job, and
+   * says so.
+   */
   const handleUseTemplate = async (
     cwd: string,
     template: StudioTemplate,
@@ -1450,21 +1563,43 @@ export const App = (): JSX.Element => {
       | "template_gallery"
       | "template_detail" = "template_gallery",
   ): Promise<void> => {
-    const session = await createSessionAt(cwd, "claude-code");
     // Product metric — "templates used". Fires at the choke point every
     // template surface funnels through; `agent.created` fires later when the
     // clone produces a real sapiom.json, so built ≥ templates holds.
-    trackProduct("agent.template_cloned", {
-      template_slug: template.id,
-      template_id: template.id,
-      surface,
-    });
+    const trackUse = (): void => {
+      trackProduct("agent.template_cloned", {
+        template_slug: template.id,
+        template_id: template.id,
+        surface,
+      });
+    };
+    if (template.kind === "starter") {
+      // `cwd` is the folder the destination picker settled on: its parent is
+      // the project, its basename the agent's name. The endpoint refuses both
+      // on its own findings, so a rejection here is the server's sentence and
+      // the dialog shows it verbatim.
+      const parent = parentOf(cwd);
+      if (!parent)
+        throw new Error(`Can't create an agent at ${cwd} — pick a folder inside a project.`);
+      const created = await harness.scaffoldAgent(
+        parent,
+        basenameOf(cwd),
+        template.id,
+      );
+      trackUse();
+      setTemplatesOpen(false);
+      setFocusedAgentPath(created.path);
+      const session = await createSessionAt(parent, "claude-code");
+      await harness.bindWorkflow(session.id, created.path);
+      setFocusedAgentPath(created.path);
+      return;
+    }
+    const session = await createSessionAt(cwd, "claude-code");
+    trackUse();
     sendPromptWhenReady(
       session.id,
       useTemplatePrompt(template, cwd),
-      template.kind === "gallery"
-        ? "Couldn't send the clone prompt. Ask the coding agent to run sapiom_dev_agents_clone."
-        : "Couldn't send the starter prompt. Ask the coding agent to call sapiom_dev_agents_scaffold.",
+      "Couldn't send the clone prompt. Ask the coding agent to run sapiom_dev_agents_clone.",
     );
   };
 
@@ -2008,7 +2143,7 @@ export const App = (): JSX.Element => {
             listDir={harness.listDir}
             onCreateSession={handleCreateSession}
             listHarnesses={harness.listHarnesses}
-            onScaffoldSession={handleScaffoldSession}
+            onCreateAgent={handleCreateAgentInProject}
             onScaffoldInSession={handleScaffoldInSession}
             onBrowseTemplates={() => {
               setSelectedProject(null);
@@ -2690,6 +2825,25 @@ export const App = (): JSX.Element => {
             setTemplatesOpen(true);
           }}
           onDismiss={() => setOverviewOpen(false)}
+        />
+      )}
+
+      {/* The create-agent dialog (SAP-2981). Mounted here, beside the other
+          cards-on-top, because the create has to outlive the rail popover that
+          opened it — the menu unmounts on click, and a dialog rendered inside
+          it would go with it. */}
+      {creatingAgent && (
+        <CreateAgentDialog
+          projectLabel={creatingAgent.label}
+          projectRoot={creatingAgent.root}
+          onCancel={() => setCreatingAgent(null)}
+          onCreate={createAgentInProject}
+          onBrowseTemplates={() => {
+            setCreatingAgent(null);
+            setSelectedProject(null);
+            setTemplatesOpen(true);
+            setOverviewOpen(false);
+          }}
         />
       )}
 

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -81,7 +81,7 @@ import { CreateAgentDialog } from "./components/CreateAgentDialog";
 import { OverviewModal } from "./components/OverviewModal";
 import { WorkflowsRail } from "./components/WorkflowsRail";
 import { WorkspaceGraphView } from "./components/WorkspaceGraphView";
-import { boundWorkflowPathOf, createApi } from "./lib/api";
+import { boundWorkflowPathOf, createApi, errorMessage } from "./lib/api";
 import { classifyConnectivity, useConnectivity } from "./lib/connectivity";
 import { historyDirs } from "./lib/history-meta";
 import {
@@ -1427,9 +1427,7 @@ export const App = (): JSX.Element => {
       }
     } catch (err) {
       harness.showToast(
-        `${created.name} was created, but its session didn't start. ${
-          (err as Error).message ?? ""
-        }`.trim(),
+        `${created.name} was created, but its session didn't start. ${errorMessage(err, "")}`.trim(),
       );
     }
   };

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -1255,6 +1255,14 @@ export const App = (): JSX.Element => {
   };
 
   /**
+   * The provider a create-initiated session boots with — the same stored
+   * preference the rail used to read before it dispatched. It moved here with
+   * the create itself; the rail no longer starts sessions.
+   */
+  const preferredHarness = (): HarnessKind =>
+    loadUiPrefs().preferredHarness === "codex" ? "codex" : "claude-code";
+
+  /**
    * The ONE answer to "where does a session for this agent boot" (SAP-2927).
    *
    * Every path that starts a session ON AN EXISTING AGENT — the tab-strip `+`,
@@ -1264,14 +1272,6 @@ export const App = (): JSX.Element => {
    * do not: that folder is the new project's root by construction, and
    * resolving it upward would drop the new agent into its parent project.
    */
-  /**
-   * The provider a create-initiated session boots with — the same stored
-   * preference the rail used to read before it dispatched. It moved here with
-   * the create itself; the rail no longer starts sessions.
-   */
-  const preferredHarness = (): HarnessKind =>
-    loadUiPrefs().preferredHarness === "codex" ? "codex" : "claude-code";
-
   const sessionCwdForAgent = (agentPath: string): string =>
     projectRootForAgent(agentPath, knownProjectRoots());
 

--- a/packages/harness/web/src/components/CreateAgentDialog.tsx
+++ b/packages/harness/web/src/components/CreateAgentDialog.tsx
@@ -147,7 +147,9 @@ export function CreateAgentDialog({
           {/* The destination, stated. `title` carries the full path for a root
               long enough to ellipsize. */}
           <p className="modal-field-hint create-agent-target" title={projectRoot}>
-            In <strong data-testid="create-agent-project">{projectLabel}</strong>
+            <span>
+              In <strong data-testid="create-agent-project">{projectLabel}</strong>
+            </span>
             <span className="create-agent-path">{projectRoot}</span>
           </p>
 
@@ -171,9 +173,18 @@ export function CreateAgentDialog({
                 setError(null);
               }}
             />
+            {/* Both refusals land HERE, under the field that produces them —
+                the typed-name rule and the server's own sentence ("probes
+                already has an agent called hello-world"), which was showing at
+                the foot of the dialog, three fields away from the input the
+                user has to change. */}
             {nameRefusal ? (
               <p className="modal-error" data-testid="create-agent-name-error">
                 {nameRefusal}
+              </p>
+            ) : error ? (
+              <p className="modal-error" data-testid="create-agent-error" role="alert">
+                {error}
               </p>
             ) : (
               <p className="modal-field-hint">
@@ -246,15 +257,9 @@ export function CreateAgentDialog({
               placeholder="Triage inbound support email and route it to the right queue."
               onChange={(event) => setInstruction(event.target.value)}
             />
-            {error ? (
-              <p className="modal-error" data-testid="create-agent-error" role="alert">
-                {error}
-              </p>
-            ) : (
-              <p className="modal-field-hint">
-                The agent is created first; this is what the session starts on.
-              </p>
-            )}
+            <p className="modal-field-hint">
+              The agent is created first; this is what the session starts on.
+            </p>
           </section>
         </div>
 

--- a/packages/harness/web/src/components/CreateAgentDialog.tsx
+++ b/packages/harness/web/src/components/CreateAgentDialog.tsx
@@ -123,9 +123,12 @@ export function CreateAgentDialog({
           // Return submits from the single-line field; the textarea keeps
           // Return for newlines and takes ⌘/Ctrl+Return instead.
           if (event.key !== "Enter") return;
-          const inTextarea =
-            (event.target as HTMLElement).tagName === "TEXTAREA";
-          if (inTextarea && !(event.metaKey || event.ctrlKey)) return;
+          const tag = (event.target as HTMLElement).tagName;
+          // A focused control already has its own answer to Return, and
+          // stealing it would make Return on Cancel submit the form — the
+          // opposite of what the user pressed.
+          if (tag === "BUTTON" || tag === "A") return;
+          if (tag === "TEXTAREA" && !(event.metaKey || event.ctrlKey)) return;
           event.preventDefault();
           void submit();
         }}

--- a/packages/harness/web/src/components/CreateAgentDialog.tsx
+++ b/packages/harness/web/src/components/CreateAgentDialog.tsx
@@ -1,0 +1,275 @@
+/**
+ * Create an agent in a project you already picked (SAP-2981).
+ *
+ * The project is STATED, NOT CHOSEN. You clicked that row's menu — that is the
+ * answer to "where", and re-asking it with a folder picker would be the same
+ * subject confusion the rail's `+`/`×` pair had: a control that acts on one
+ * noun while inviting you to pick another. So the destination is a sentence at
+ * the top of the dialog, spelled out to its absolute path because a rail label
+ * can be a widened or shared name and this creates a real directory.
+ *
+ * WHAT IT ASKS: a name, a starter, and — optionally — the first thing to build.
+ * Nothing else, because nothing else is decidable here: the folder is known,
+ * and the harness resolves dependency versions itself.
+ *
+ * CREATION COMPLETES BEFORE THE CHAT STARTS. `onCreate` resolves only once the
+ * server has scaffolded the agent and rescanned it into the registry, so a
+ * refusal lands in THIS dialog as a sentence (the field keeps what you typed,
+ * ready to fix) rather than as a coding agent that was asked to do a filesystem
+ * operation in English and got confused. The dialog stays up and busy while it
+ * runs — the whole point is that the outcome is reported.
+ *
+ * The name is validated as you type against the SAME rule the endpoint refuses
+ * with (`@shared/agent-name`). Two guards, one rule: a name the field accepts
+ * and the server rejects reads as a broken app.
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { JSX, RefObject } from "react";
+
+import { refuseAgentName } from "@shared/agent-name";
+
+import type { StarterTemplate } from "../lib/templates";
+import { STARTER_TEMPLATES } from "../lib/templates";
+import { trackingAttrs } from "../lib/analytics/tracking-attrs";
+import { useDismissable } from "../lib/use-dismissable";
+import { Icon } from "./Icon";
+
+export function CreateAgentDialog({
+  projectLabel,
+  projectRoot,
+  templates = STARTER_TEMPLATES,
+  onCancel,
+  onCreate,
+  onBrowseTemplates,
+  triggerRef,
+}: {
+  /** The project's rail label — what the user actually read on the row. */
+  projectLabel: string;
+  /** The absolute folder the agent is created in, spelled out. */
+  projectRoot: string;
+  /** Bundled starters. The gallery is a separate journey (see the footnote
+   *  below `onBrowseTemplates`), so these are the ones this dialog offers. */
+  templates?: readonly StarterTemplate[];
+  onCancel: () => void;
+  /** Rejects with the server's own sentence, which is shown in place of the
+   *  hint. Resolves only once the agent exists. */
+  onCreate: (input: {
+    name: string;
+    template: string;
+    instruction: string;
+  }) => Promise<void>;
+  /** Leaves for the template gallery — the clone journey this dialog does not
+   *  own. Omitted, the link is not rendered. */
+  onBrowseTemplates?: () => void;
+  /** The control that opened this — Escape returns focus to it. */
+  triggerRef?: RefObject<HTMLElement | null>;
+}): JSX.Element {
+  const [name, setName] = useState("");
+  const [template, setTemplate] = useState(templates[0]?.id ?? "default");
+  const [instruction, setInstruction] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const nameRef = useRef<HTMLInputElement>(null);
+  // Never dismissable mid-flight: the agent is being written to disk, and
+  // pulling the dialog would leave the user with no report of how it went.
+  useDismissable(!busy, { onDismiss: onCancel, containerRef: panelRef, triggerRef });
+
+  useEffect(() => {
+    nameRef.current?.focus();
+  }, []);
+
+  // Only after something has been typed: an empty field on open is not a
+  // mistake the user has made yet, and greeting them with "Give the agent a
+  // name" is a scold, not a hint.
+  const nameRefusal = useMemo(
+    () => (name === "" ? null : refuseAgentName(name)),
+    [name],
+  );
+  const submittable = name.trim() !== "" && nameRefusal == null && !busy;
+
+  const submit = async (): Promise<void> => {
+    if (!submittable) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await onCreate({ name, template, instruction: instruction.trim() });
+    } catch (err) {
+      // The server's sentence, verbatim — it knows things this dialog cannot
+      // (a folder already sitting there, a project the rail stopped showing).
+      setError((err as Error).message || `Couldn't create ${name}.`);
+      setBusy(false);
+      nameRef.current?.focus();
+    }
+  };
+
+  return (
+    <div className="modal-backdrop">
+      <div
+        className="modal modal-confirm modal-create-agent"
+        role="dialog"
+        aria-label={`Create an agent in ${projectLabel}`}
+        data-testid="create-agent-dialog"
+        /* The dialog's label carries a PROJECT NAME — a folder the user named.
+           Tagged `workspace` so before-send strips it from $el_text instead of
+           shipping one analytics row per private project name
+           (lib/analytics/before-send.ts, USER_NAMED_OBJECTS). */
+        {...trackingAttrs({ dialog: "create_agent", object: "workspace" })}
+        ref={panelRef}
+        onKeyDown={(event) => {
+          // Return submits from the single-line field; the textarea keeps
+          // Return for newlines and takes ⌘/Ctrl+Return instead.
+          if (event.key !== "Enter") return;
+          const inTextarea =
+            (event.target as HTMLElement).tagName === "TEXTAREA";
+          if (inTextarea && !(event.metaKey || event.ctrlKey)) return;
+          event.preventDefault();
+          void submit();
+        }}
+      >
+        <div className="modal-header">
+          Create an agent
+          <button
+            className="theme-toggle modal-close"
+            aria-label="Close"
+            title="Close"
+            disabled={busy}
+            onClick={onCancel}
+          >
+            <Icon name="X" size={14} />
+          </button>
+        </div>
+
+        <div className="modal-body">
+          {/* The destination, stated. `title` carries the full path for a root
+              long enough to ellipsize. */}
+          <p className="modal-field-hint create-agent-target" title={projectRoot}>
+            In <strong data-testid="create-agent-project">{projectLabel}</strong>
+            <span className="create-agent-path">{projectRoot}</span>
+          </p>
+
+          <section className="modal-section">
+            <label className="create-agent-label" htmlFor="create-agent-name">
+              Name
+            </label>
+            <input
+              id="create-agent-name"
+              ref={nameRef}
+              className="modal-input"
+              data-testid="create-agent-name"
+              value={name}
+              spellCheck={false}
+              autoComplete="off"
+              placeholder="order-triage"
+              disabled={busy}
+              aria-invalid={nameRefusal != null}
+              onChange={(event) => {
+                setName(event.target.value);
+                setError(null);
+              }}
+            />
+            {nameRefusal ? (
+              <p className="modal-error" data-testid="create-agent-name-error">
+                {nameRefusal}
+              </p>
+            ) : (
+              <p className="modal-field-hint">
+                It becomes a folder in {projectLabel}.
+              </p>
+            )}
+          </section>
+
+          <section className="modal-section">
+            <span className="create-agent-label">Template</span>
+            <div className="create-agent-templates" role="radiogroup" aria-label="Template">
+              {templates.map((starter) => (
+                <label
+                  key={starter.id}
+                  className="create-agent-template"
+                  data-testid={`create-agent-template-${starter.id}`}
+                  data-selected={starter.id === template ? "true" : undefined}
+                >
+                  <input
+                    type="radio"
+                    name="create-agent-template"
+                    value={starter.id}
+                    checked={starter.id === template}
+                    disabled={busy}
+                    onChange={() => setTemplate(starter.id)}
+                  />
+                  <span className="create-agent-template-text">
+                    <span className="create-agent-template-name">{starter.name}</span>
+                    <span className="create-agent-template-desc">
+                      {starter.description}
+                    </span>
+                  </span>
+                </label>
+              ))}
+            </div>
+            {onBrowseTemplates && (
+              /* The gallery is a CLONE, not a scaffold: it forks a published
+                 template into a repo you own and needs an account. It is a
+                 different operation with a different failure mode, so it keeps
+                 its own journey rather than hiding behind this radio list. */
+              <p className="modal-field-hint">
+                <button
+                  type="button"
+                  className="create-agent-link"
+                  data-testid="create-agent-browse-templates"
+                  disabled={busy}
+                  onClick={onBrowseTemplates}
+                >
+                  Browse the template gallery
+                </button>{" "}
+                to start from a published agent instead.
+              </p>
+            )}
+          </section>
+
+          <section className="modal-section">
+            <label
+              className="create-agent-label"
+              htmlFor="create-agent-instruction"
+            >
+              First instruction <span className="create-agent-optional">optional</span>
+            </label>
+            <textarea
+              id="create-agent-instruction"
+              className="modal-input create-agent-instruction"
+              data-testid="create-agent-instruction"
+              rows={3}
+              value={instruction}
+              disabled={busy}
+              placeholder="Triage inbound support email and route it to the right queue."
+              onChange={(event) => setInstruction(event.target.value)}
+            />
+            {error ? (
+              <p className="modal-error" data-testid="create-agent-error" role="alert">
+                {error}
+              </p>
+            ) : (
+              <p className="modal-field-hint">
+                The agent is created first; this is what the session starts on.
+              </p>
+            )}
+          </section>
+        </div>
+
+        <div className="modal-actions">
+          <button className="btn-ghost" disabled={busy} onClick={onCancel}>
+            Cancel
+          </button>
+          <button
+            className="btn-primary modal-primary-cta"
+            data-testid="create-agent-submit"
+            disabled={!submittable}
+            onClick={() => void submit()}
+          >
+            {busy ? "Creating…" : "Create agent"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/CreateAgentDialog.tsx
+++ b/packages/harness/web/src/components/CreateAgentDialog.tsx
@@ -25,7 +25,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { JSX, RefObject } from "react";
+import type { JSX } from "react";
 
 import { refuseAgentName } from "@shared/agent-name";
 
@@ -43,7 +43,6 @@ export function CreateAgentDialog({
   onCancel,
   onCreate,
   onBrowseTemplates,
-  triggerRef,
 }: {
   /** The project's rail label — what the user actually read on the row. */
   projectLabel: string;
@@ -63,8 +62,12 @@ export function CreateAgentDialog({
   /** Leaves for the template gallery — the clone journey this dialog does not
    *  own. Omitted, the link is not rendered. */
   onBrowseTemplates?: () => void;
-  /** The control that opened this — Escape returns focus to it. */
-  triggerRef?: RefObject<HTMLElement | null>;
+  /* NO `triggerRef`. Every door into this dialog is a control that unmounts
+     when it is used — the project row's popover menu closes on click, the
+     empty-project row is replaced by the agent it creates — so a ref handed in
+     here would point at a detached node and Escape would restore focus to
+     <body> anyway, only less obviously. Same reason the rail's remove-confirm
+     takes the `⋮` itself rather than the menu item. */
 }): JSX.Element {
   const [name, setName] = useState("");
   const [template, setTemplate] = useState(templates[0]?.id ?? "default");
@@ -75,7 +78,7 @@ export function CreateAgentDialog({
   const nameRef = useRef<HTMLInputElement>(null);
   // Never dismissable mid-flight: the agent is being written to disk, and
   // pulling the dialog would leave the user with no report of how it went.
-  useDismissable(!busy, { onDismiss: onCancel, containerRef: panelRef, triggerRef });
+  useDismissable(!busy, { onDismiss: onCancel, containerRef: panelRef });
 
   useEffect(() => {
     nameRef.current?.focus();

--- a/packages/harness/web/src/components/CreateAgentDialog.tsx
+++ b/packages/harness/web/src/components/CreateAgentDialog.tsx
@@ -29,6 +29,7 @@ import type { JSX, RefObject } from "react";
 
 import { refuseAgentName } from "@shared/agent-name";
 
+import { errorMessage } from "../lib/api";
 import type { StarterTemplate } from "../lib/templates";
 import { STARTER_TEMPLATES } from "../lib/templates";
 import { trackingAttrs } from "../lib/analytics/tracking-attrs";
@@ -96,9 +97,10 @@ export function CreateAgentDialog({
     try {
       await onCreate({ name, template, instruction: instruction.trim() });
     } catch (err) {
-      // The server's sentence, verbatim — it knows things this dialog cannot
-      // (a folder already sitting there, a project the rail stopped showing).
-      setError((err as Error).message || `Couldn't create ${name}.`);
+      // The server's SENTENCE, not the wire shape: `ApiError.message` is
+      // "POST /api/agents/scaffold → 409: {…}", which is a log line, not
+      // something to show someone who just tried to name an agent.
+      setError(errorMessage(err, `Couldn't create ${name}.`));
       setBusy(false);
       nameRef.current?.focus();
     }

--- a/packages/harness/web/src/components/TemplateUseDialog.tsx
+++ b/packages/harness/web/src/components/TemplateUseDialog.tsx
@@ -18,7 +18,7 @@
 import { useRef, useState } from "react";
 import type { JSX, RefObject } from "react";
 
-import type { FsListResponse } from "../lib/api";
+import { errorMessage, type FsListResponse } from "../lib/api";
 import type { StudioTemplate } from "../lib/templates";
 import { useDismissable } from "../lib/use-dismissable";
 import { DirectoryPicker } from "./DirectoryPicker";
@@ -62,7 +62,11 @@ export function TemplateUseDialog({
     try {
       await onConfirm(trimmed);
     } catch (err) {
-      setError((err as Error).message);
+      // The server's sentence, not the wire shape it arrives in: a starter now
+      // goes through `POST /api/agents/scaffold` (SAP-2981), so a real refusal
+      // — a name already taken there, a folder Studio doesn't show as a project
+      // — lands here and has to be readable.
+      setError(errorMessage(err, "Couldn't use this template."));
       setBusy(false);
     }
   };

--- a/packages/harness/web/src/components/WorkflowRow.tsx
+++ b/packages/harness/web/src/components/WorkflowRow.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { CSSProperties, DragEvent, JSX } from "react";
 import type { WorkflowInfo } from "@shared/types";
 
@@ -74,6 +75,23 @@ export function WorkflowRow({
    * `project-tree.prefixIsPathTail`; the row only picks the glyph.
    */
   const pathTail = prefixIsPathTail(workflow, name);
+  /**
+   * Bring the focused row into view when focus arrives from OUTSIDE the rail —
+   * a create (SAP-2981), a palette hit, a deep link.
+   *
+   * Measured on the real 76-agent install: creating an agent in `probes` left
+   * the rail scrolled to `social-content`, so the row the create had just added
+   * was three screens away and the flow ended with "did it work?" — the exact
+   * question the endpoint exists to answer.
+   *
+   * `block: "nearest"` so a row that is already visible is not moved: a click
+   * on a row must not scroll the list under the cursor.
+   */
+  const rowRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!isFocused) return;
+    rowRef.current?.scrollIntoView({ block: "nearest" });
+  }, [isFocused]);
   const deploymentState = workflowDeploymentState(workflow);
   const deployed = deploymentState === "ready";
   const statusTitle =
@@ -88,6 +106,7 @@ export function WorkflowRow({
             : "Draft. Not deployed to Sapiom yet.";
   return (
     <div
+      ref={rowRef}
       className={"workflow-item" + (isFocused ? " is-focused" : "")}
       data-testid={`workflow-${workflow.name}`}
       /* THE UNIQUE HANDLE. `workflow-<name>` is not one: the registry takes an

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -160,19 +160,24 @@ interface WorkflowsRailProps {
   onCreateSession: (cwd: string, harness: HarnessKind) => Promise<void>;
   /** Adapter registry fetch — the add dialog's picker and MCP setup block. */
   listHarnesses: () => Promise<HarnessEntry[]>;
-  /** Session-plus-scaffold-prompt at a folder that doesn't exist yet. `idea`
-   *  is the "start from an idea" door's text, passed verbatim to the agent. */
-  onScaffoldSession: (
-    cwd: string,
-    harness: HarnessKind,
-    idea?: string,
-  ) => Promise<void>;
+  /**
+   * Create an agent IN a project (SAP-2981). Opens the create dialog App owns;
+   * the harness then does the scaffold and the agent joins the rail before any
+   * session starts.
+   *
+   * It used to be `onScaffoldSession(root, harness)` — start a pty and inject
+   * an English sentence asking the coding agent to call the scaffold MCP tool.
+   * The row's own menu item said "Create an agent in {project}" while the thing
+   * it did was send a chat message, which is why a failed create arrived as a
+   * confused model instead of an error.
+   */
+  onCreateAgent: (root: string, label: string) => void;
   /** Where NEW projects are created (resolveProjectRoot in App). */
   projectRoot: string | null;
   /** Persist a changed project root as the user's default. */
   onSaveProjectRoot: (root: string) => Promise<void>;
-  /** Bare-scaffold folder affordance: ask the folder's live session to
-   *  scaffold its first agent (sapiom.json) in place. */
+  /** Bare-project affordance: create the folder's first agent, binding the
+   *  live session it already has rather than opening a second one. */
   onScaffoldInSession: (sessionId: string) => void;
   /** Navigate to the templates destination (App owns the center view). */
   onBrowseTemplates: () => void;
@@ -220,9 +225,6 @@ const SHORTCUT_HINT = IS_MAC ? "⌘K" : "Ctrl+K";
  */
 /** The agent the user last chose in the composer, for actions that must pick one
  *  without asking. Defaults to Claude Code, which is what a fresh install has. */
-const preferredHarness = (): HarnessKind =>
-  loadUiPrefs().preferredHarness === "codex" ? "codex" : "claude-code";
-
 const RAIL_AXES: readonly RailAxis[] = ["project", "group"];
 const AXIS_LABELS: Record<RailAxis, string> = {
   project: "Project",
@@ -463,7 +465,7 @@ export function WorkflowsRail({
   listDir,
   onCreateSession,
   listHarnesses,
-  onScaffoldSession,
+  onCreateAgent,
   onScaffoldInSession,
   projectRoot,
   onSaveProjectRoot,
@@ -1334,18 +1336,8 @@ export function WorkflowsRail({
                                   kind: "create",
                                   testid: `project-create-agent-${project.label}`,
                                   label: `Create an agent in ${project.label}`,
-                                  run: () => {
-                                    void onScaffoldSession(
-                                      project.root,
-                                      preferredHarness(),
-                                    ).catch((err: unknown) => {
-                                      onToast(
-                                        err instanceof Error
-                                          ? err.message
-                                          : `Couldn't start an agent in ${project.label}.`,
-                                      );
-                                    });
-                                  },
+                                  run: () =>
+                                    onCreateAgent(project.root, project.label),
                                 }
                         }
                         onRemove={(trigger) => {
@@ -1392,18 +1384,7 @@ export function WorkflowsRail({
                       className="tree-row tree-row-empty-action"
                       data-testid={`project-empty-${project.label}`}
                       data-tooltip={`Start an agent in ${project.root}`}
-                      onClick={() => {
-                        void onScaffoldSession(
-                          project.root,
-                          preferredHarness(),
-                        ).catch((err: unknown) => {
-                          onToast(
-                            err instanceof Error
-                              ? err.message
-                              : `Couldn't start an agent in ${project.label}.`,
-                          );
-                        });
-                      }}
+                      onClick={() => onCreateAgent(project.root, project.label)}
                     >
                       <Icon name="Sparkles" size={13} />
                       <span className="tree-row-label">

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -237,6 +237,22 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * The sentence to SHOW for a failed request.
+ *
+ * `ApiError.message` is the wire shape — `POST /api/agents/scaffold → 409:
+ * {"error":"…"}` — which is right for a log and wrong in a dialog: measured on
+ * a real server, the create dialog showed the user a JSON body inside a status
+ * line. `.reason` is the server's own sentence, written to be read, so every
+ * user-facing catch prefers it. The fallback covers a non-Error rejection and a
+ * response that was not JSON.
+ */
+export function errorMessage(err: unknown, fallback: string): string {
+  if (err instanceof ApiError) return err.reason ?? err.message ?? fallback;
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}
+
 /** Read once at module load: `window.__HARNESS__ = {token}` (baked in by the server), falling back to `?token=`. */
 export function getBootToken(): string {
   const injected = (window as unknown as { __HARNESS__?: { token?: string } })

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -1174,6 +1174,26 @@ function recordAgentMove(entry: { from: string; to: string }): void {
   };
 }
 
+/**
+ * The ORDER of the two halves of a create, recorded for the spec that asserts
+ * it (SAP-2981): the agent is scaffolded, and only then does a session open.
+ *
+ * An order is the one thing a pair of separate call logs cannot prove — each
+ * says it happened, neither says when — and this criterion IS the order:
+ * creation completes before the chat starts, so a failure is an error message
+ * rather than a confused model. One append-only list, so a spec can read the
+ * sequence instead of racing two counters.
+ */
+function recordCreateStep(kind: "scaffold" | "session", path: string): void {
+  if (typeof window === "undefined") return;
+  const win = window as unknown as { __HARNESS_TEST__?: Record<string, unknown> };
+  const previous = (win.__HARNESS_TEST__?.createOrder as string[]) ?? [];
+  win.__HARNESS_TEST__ = {
+    ...(win.__HARNESS_TEST__ ?? {}),
+    createOrder: [...previous, `${kind}:${path}`],
+  };
+}
+
 /** In-memory, mutable copies of the fixtures — mutations persist for the tab's lifetime, reset on reload. */
 /**
  * Mock mode's stand-in for the workflow-keyed board (IA-01).
@@ -1764,6 +1784,7 @@ class MockApi implements HarnessApi {
         lastCreateSession: { req },
         createSessionCalls: [...previous, { req }],
       };
+      recordCreateStep("session", req.cwd);
       if (win.__MOCK_CREATE_SESSION_FAIL_ONCE__) {
         win.__MOCK_CREATE_SESSION_FAIL_ONCE__ = false;
         throw new Error("mock: couldn't create session");
@@ -2209,6 +2230,7 @@ class MockApi implements HarnessApi {
         starterId: template,
       },
     ];
+    recordCreateStep("scaffold", path);
     void import("./events").then(({ publishMockBusMessage }) => {
       publishMockBusMessage({ type: "workflows.changed" });
     });

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -8,6 +8,7 @@
 import type {
   AccountPlanView,
   AdoptSessionRequest,
+  AgentScaffoldResponse,
   AppState,
   AttachFileRequest,
   AttachFileResponse,
@@ -44,6 +45,7 @@ import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
 
 import { getTheme } from "./theme";
 import { parseSystemGraphSnapshot } from "./system-graph";
+import { refuseAgentName } from "@shared/agent-name";
 import { refuseMove, remapUnder } from "./agent-move";
 import { basenameOf, isWithinDir, samePath } from "./paths";
 
@@ -392,6 +394,23 @@ export interface HarnessApi {
    * `workflows.changed` and the rail re-derives the tree from the new path.
    */
   moveAgent(from: string, to: string): Promise<void>;
+  /**
+   * Creates an agent on disk — the create flow's ONE mechanism (SAP-2981).
+   *
+   * The harness does the scaffold; nothing here asks a coding agent to perform
+   * a filesystem operation by natural language. So a failure is an `ApiError`
+   * carrying the server's own sentence (a name already taken in that project,
+   * a name that is not one folder segment, a root the rail cannot show) — a
+   * thing the dialog can show — instead of a prompt whose outcome only the
+   * terminal knows. Resolves once the agent is on disk AND the server has
+   * rescanned it into the registry, so the rail can show it before any session
+   * opens.
+   */
+  scaffoldAgent(
+    root: string,
+    name: string,
+    template?: string,
+  ): Promise<AgentScaffoldResponse>;
   /** Adapter registry (GET /api/harnesses): every known harness with its
    *  mode/installed/experimental flags plus per-agent Sapiom MCP install
    *  instructions — the new-session picker and MCP setup block feed on it. */
@@ -665,6 +684,17 @@ class RealApi implements HarnessApi {
     await this.request<{ ok: true }>("/api/agents/move", {
       method: "POST",
       body: JSON.stringify({ from, to }),
+    });
+  }
+
+  scaffoldAgent(
+    root: string,
+    name: string,
+    template?: string,
+  ): Promise<AgentScaffoldResponse> {
+    return this.request<AgentScaffoldResponse>("/api/agents/scaffold", {
+      method: "POST",
+      body: JSON.stringify({ root, name, template }),
     });
   }
 
@@ -2118,6 +2148,55 @@ class MockApi implements HarnessApi {
     void import("./events").then(({ publishMockBusMessage }) => {
       publishMockBusMessage({ type: "workflows.changed" });
     });
+  }
+
+  /**
+   * The mock's stand-in for `POST /api/agents/scaffold`.
+   *
+   * A SECOND GUARD, like the mock's mover beside it: the dialog validates the
+   * name before it submits, but the create path must not be a thing only the
+   * dialog can refuse. The real server owns the disk (`src/server/scaffold.ts`)
+   * — the mock has none, so it checks what the registry can see, which is the
+   * same guard set minus the `lstat`.
+   *
+   * The new agent JOINS the fixture list and `workflows.changed` is announced,
+   * the same signal the real server broadcasts, so the rail shows the agent
+   * before the caller opens a session on it — the criterion this endpoint
+   * exists for, exercisable in a browser.
+   */
+  async scaffoldAgent(
+    root: string,
+    name: string,
+    template = "default",
+  ): Promise<AgentScaffoldResponse> {
+    await delay(180);
+    const refusal = refuseAgentName(name);
+    if (refusal)
+      throw new ApiError(400, "POST /api/agents/scaffold \u2192 400 (mock)", refusal);
+    const path = `${root.replace(/\/+$/, "")}/${name}`;
+    if (this.workflows.some((workflow) => samePath(workflow.path, path)))
+      throw new ApiError(
+        409,
+        "POST /api/agents/scaffold \u2192 409 (mock)",
+        `${basenameOf(root)} already has an agent called ${name}.`,
+      );
+    this.workflows = [
+      ...this.workflows,
+      {
+        name,
+        path,
+        definitionId: null,
+        definitionSlug: null,
+        source: "scan",
+        // The real scaffold writes the starter's id into sapiom.json, and the
+        // rail reads provenance from it.
+        starterId: template,
+      },
+    ];
+    void import("./events").then(({ publishMockBusMessage }) => {
+      publishMockBusMessage({ type: "workflows.changed" });
+    });
+    return { ok: true, path, name, template, dependenciesInstalled: true };
   }
 
   async scanWorkflows(root: string): Promise<WorkflowScanOutcome> {

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -47,7 +47,7 @@ import { getTheme } from "./theme";
 import { parseSystemGraphSnapshot } from "./system-graph";
 import { refuseAgentName } from "@shared/agent-name";
 import { refuseMove, remapUnder } from "./agent-move";
-import { basenameOf, isWithinDir, samePath } from "./paths";
+import { basenameOf, isWithinDir, parentOf, samePath } from "./paths";
 
 import type { CanvasGraph, CanvasGraphNode } from "./canvas-graph";
 import {
@@ -2210,6 +2210,18 @@ class MockApi implements HarnessApi {
     const refusal = refuseAgentName(name);
     if (refusal)
       throw new ApiError(400, "POST /api/agents/scaffold \u2192 400 (mock)", refusal);
+    // THE ROOT BARRIER, and the reason it is here: the real route only writes
+    // into a folder the rail can show, and this mock originally skipped that
+    // guard — so `templates.spec.ts` asserted a scaffold into
+    // `<defaultProjectRoot>` succeeded while a fresh install would have been
+    // refused at exactly that path. A mock that is missing a guard is a suite
+    // that certifies the bug.
+    if (!this.projectDirs().some((dir) => samePath(dir, root)))
+      throw new ApiError(
+        409,
+        "POST /api/agents/scaffold \u2192 409 (mock)",
+        `Can't create an agent in ${root} — Studio doesn't show that folder as a project.`,
+      );
     const path = `${root.replace(/\/+$/, "")}/${name}`;
     if (this.workflows.some((workflow) => samePath(workflow.path, path)))
       throw new ApiError(
@@ -2235,6 +2247,36 @@ class MockApi implements HarnessApi {
       publishMockBusMessage({ type: "workflows.changed" });
     });
     return { ok: true, path, name, template, dependenciesInstalled: true };
+  }
+
+  /**
+   * The mock's twin of the server's `listProjectDirs`: the roots the rail can
+   * show — stored recents, the host's default parent for new projects, and
+   * every live session's cwd — plus the directories between a root and an
+   * agent, which is where the Project axis draws its folder rows.
+   */
+  private projectDirs(): string[] {
+    const roots = [
+      // THIS instance's settings, not the fixture constant: a `fresh` mock has
+      // no recents at all, which is the state the fresh-install bug lived in.
+      ...this.settings.recentDirs,
+      `${MOCK_LAUNCH_DIR}/projects`,
+      ...this.sessions.map((session) => session.cwd),
+    ];
+    const dirs = new Set(roots);
+    for (const workflow of this.workflows) {
+      for (const root of roots) {
+        if (!isWithinDir(root, workflow.path)) continue;
+        let dir = parentOf(workflow.path);
+        while (dir && isWithinDir(root, dir)) {
+          dirs.add(dir);
+          const parent = parentOf(dir);
+          if (!parent || parent === dir) break;
+          dir = parent;
+        }
+      }
+    }
+    return [...dirs];
   }
 
   async scanWorkflows(root: string): Promise<WorkflowScanOutcome> {

--- a/packages/harness/web/src/lib/templates.test.ts
+++ b/packages/harness/web/src/lib/templates.test.ts
@@ -254,22 +254,22 @@ describe("useTemplatePrompt", () => {
     expect(prompt).toContain('templateId "cold-outreach-engine"');
   });
 
-  it("starter: names the local scaffold tool with exact arguments", () => {
-    const prompt = useTemplatePrompt(STARTER_TEMPLATES[1], "/tmp/coding-pause");
-    expect(prompt).toContain("sapiom_dev_agents_scaffold");
-    expect(prompt).toContain(
-      '{"dir":"/tmp/coding-pause","template":"coding-pause"}',
+  // The starter branch is GONE (SAP-2981): a bundled starter is created by
+  // `POST /api/agents/scaffold` before its session opens, so there is no prompt
+  // to write and nothing here to test. The test that used to certify that
+  // branch outlived its own caller — it asserted the exact arguments of a
+  // handoff nothing performed any more.
+
+  it("ends with the no-capability-spend local test continuation", () => {
+    expect(useTemplatePrompt(summary(), "/tmp/x")).toContain(
+      "local test run with no Sapiom capability spend (sapiom_dev_agents_run_local)",
     );
-    expect(prompt).toContain("Keep the shipped starter unchanged");
-    expect(prompt.toLowerCase()).not.toContain("workflow");
   });
 
-  it("both paths end with the no-capability-spend local test continuation", () => {
-    for (const template of [summary(), STARTER_TEMPLATES[1]]) {
-      expect(useTemplatePrompt(template, "/tmp/x")).toContain(
-        "local test run with no Sapiom capability spend (sapiom_dev_agents_run_local)",
-      );
-    }
+  it("says nothing about scaffolding — a clone is a different operation", () => {
+    const prompt = useTemplatePrompt(summary(), "/tmp/x");
+    expect(prompt).not.toContain("sapiom_dev_agents_scaffold");
+    expect(prompt.toLowerCase()).not.toContain("workflow");
   });
 });
 

--- a/packages/harness/web/src/lib/templates.ts
+++ b/packages/harness/web/src/lib/templates.ts
@@ -275,7 +275,8 @@ export function cloneDefinitionPrompt(definitionId: string, dir: string): string
   );
 }
 
-/** Exact local MCP handoff shared by every bundled-starter entry point. */
+/** Exact local MCP handoff for the one door that still asks for a scaffold in
+ *  English — see {@link composerScaffoldPrompt}. */
 export function starterScaffoldInstruction(
   dir: string,
   template: string,
@@ -283,6 +284,50 @@ export function starterScaffoldInstruction(
   return (
     "call the sapiom_dev_agents_scaffold tool with " +
     JSON.stringify({ dir, template })
+  );
+}
+
+/**
+ * The composer's scaffold prompt — the LAST prompt-driven create (SAP-2981).
+ *
+ * There were three near-identical copies of this sentence: the project `+`, the
+ * bare-project affordance, and the composer. The first two now go through
+ * `POST /api/agents/scaffold`, where a failure is an error message instead of a
+ * confused model. The composer keeps a prompt because it is the home screen —
+ * no project, no name, and a folder that does not exist yet — so there is no
+ * row to create in and nothing for a dialog to state.
+ *
+ * `idea` rides along verbatim: the agent needs the user's intent, not our
+ * paraphrase of it.
+ */
+export function composerScaffoldPrompt(dir: string, idea?: string): string {
+  const base =
+    `Scaffold a new Sapiom agent project in this directory: ${starterScaffoldInstruction(dir, "default")}, ` +
+    "then run npm install, read AGENTS.md, and use the sapiom-agent-authoring skill to";
+  const trimmed = idea?.trim();
+  return trimmed
+    ? `${base} build this:\n\n${trimmed}`
+    : `${base} define the first agent.`;
+}
+
+/**
+ * What a session opens on after the HARNESS created the agent.
+ *
+ * It is not a scaffold prompt and must never read like one: the project is
+ * already on disk, installed and committed, and an agent told to "scaffold a
+ * new project in this directory" would find a non-empty folder and either
+ * refuse or start over. So it says the scaffold is done, names the directory,
+ * and hands over the only thing left — the user's instruction.
+ */
+export function firstInstructionPrompt(
+  agentDir: string,
+  instruction: string,
+): string {
+  return (
+    `A new Sapiom agent project has just been created at ${agentDir} — the scaffold is done, ` +
+    "so do not scaffold or clone anything. Read its AGENTS.md, then use the sapiom-agent-authoring " +
+    `skill to build this:\n\n${instruction.trim()}\n\n` +
+    "When the agent is ready, offer a local test run with no Sapiom capability spend (sapiom_dev_agents_run_local) as the next step."
   );
 }
 

--- a/packages/harness/web/src/lib/templates.ts
+++ b/packages/harness/web/src/lib/templates.ts
@@ -228,32 +228,31 @@ export function matchesQuery(template: StudioTemplate, query: string): boolean {
 
 /**
  * The prompt handed to the session's agent after "Use template" starts a session
- * in the destination folder. Both branches name the REAL operation: the clone
- * MCP tool for gallery templates (with its auth failure path), the local
- * scaffold MCP tool for starters. Both end with the same next move (a local
- * test with no Sapiom capability spend), so use → edit → run is one continuous path rather than a
- * journey that stops at the clone.
+ * in the destination folder — for a GALLERY template only.
+ *
+ * It had a second branch for the bundled starters, handing them to the local
+ * scaffold MCP tool by name. SAP-2981 moved starters onto
+ * `POST /api/agents/scaffold`, where the folder exists before the session opens
+ * and a failure is an error message; the branch survived, unreachable, with a
+ * test certifying it. Deleted rather than left as a second answer to a question
+ * that now has one.
+ *
+ * A clone is not a scaffold and stays here: it forks a published agent into a
+ * repo the user owns, over the network, with an auth failure path — none of
+ * which the harness has a route for. It names the real tool and ends with the
+ * next move (a local test with no Sapiom capability spend), so use → edit → run
+ * is one continuous path rather than a journey that stops at the clone.
  */
 export function useTemplatePrompt(
-  template: StudioTemplate,
+  template: GalleryTemplate,
   dir: string,
 ): string {
-  const runContinuation =
-    "When the project is ready, offer a local test run with no Sapiom capability spend (sapiom_dev_agents_run_local) as the next step.";
-  if (template.kind === "gallery") {
-    return (
-      `Clone the Sapiom gallery template "${template.id}" into this directory: ` +
-      `call the sapiom_dev_agents_clone tool with dir "${dir}" and templateId "${template.id}". ` +
-      "If it reports you are not authenticated, run sapiom_authenticate first and retry. " +
-      "After the clone, read the project's AGENTS.md and run npm install. " +
-      runContinuation
-    );
-  }
   return (
-    `Scaffold the "${template.id}" starter in this directory: ` +
-    `${starterScaffoldInstruction(dir, template.id)}, then run npm install and read AGENTS.md. ` +
-    "Keep the shipped starter unchanged until the user describes what to build. " +
-    runContinuation
+    `Clone the Sapiom gallery template "${template.id}" into this directory: ` +
+    `call the sapiom_dev_agents_clone tool with dir "${dir}" and templateId "${template.id}". ` +
+    "If it reports you are not authenticated, run sapiom_authenticate first and retry. " +
+    "After the clone, read the project's AGENTS.md and run npm install. " +
+    "When the project is ready, offer a local test run with no Sapiom capability spend (sapiom_dev_agents_run_local) as the next step."
   );
 }
 

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -19,6 +19,7 @@ import type {
 } from "@shared/types";
 
 import type {
+  AgentScaffoldResponse,
   HarnessEntry,
   TemplateDetailView,
   TemplateListResponse,
@@ -189,6 +190,20 @@ export interface HarnessStateHook {
   /** Bulk discovery: POST /api/workflows/scan under a root, then
    *  refreshes the registry list so found agents join the rail at once. */
   scanWorkflows: (root: string) => Promise<WorkflowScanOutcome>;
+  /**
+   * Creates an agent in a project — the create flow's one mechanism
+   * (SAP-2981). Rejects with the server's own sentence when it refuses.
+   *
+   * Re-lists the registry before it resolves, on top of the server's own
+   * rescan-and-broadcast: the caller's next move is to open a session on the
+   * new agent, and it must not have to race a websocket event to see the row
+   * it just created.
+   */
+  scaffoldAgent: (
+    root: string,
+    name: string,
+    template?: string,
+  ) => Promise<AgentScaffoldResponse>;
   /**
    * Checkouts a scan of a given root stopped at rather than entering, keyed by
    * the root that was scanned. Empty for a normal project. Non-empty means an
@@ -1605,6 +1620,28 @@ export function useHarnessState(): HarnessStateHook {
     [rememberProjectDir, reopenProjects],
   );
 
+  const scaffoldAgent = useCallback(
+    async (
+      root: string,
+      name: string,
+      template?: string,
+    ): Promise<AgentScaffoldResponse> => {
+      const created = await api.scaffoldAgent(root, name, template);
+      // The agent is on disk and in the server's registry by now; this is the
+      // SPA catching up in the same turn rather than on the broadcast, so
+      // "the agent appears in the rail before any session opens" holds even if
+      // the events socket is asleep.
+      // NOT baselined into `seenAgentPathsRef`, deliberately: an agent created
+      // here is exactly what the built-agents metric counts, and the
+      // `workflows.changed` handler is the one place that emits
+      // `agent.created`. Baselining it here would create the agent and lose it
+      // from the count in the same call.
+      await refreshWorkflows();
+      return created;
+    },
+    [refreshWorkflows],
+  );
+
   const scanWorkflows = useCallback(
     async (root: string): Promise<WorkflowScanOutcome> => {
       const outcome = await api.scanWorkflows(root);
@@ -2163,6 +2200,7 @@ export function useHarnessState(): HarnessStateHook {
     closeSession,
     connectWorkflow,
     scanWorkflows,
+    scaffoldAgent,
     closedProjects,
     unsearchedCheckouts,
     removeProject,

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -10843,6 +10843,18 @@ button.system-graph-node.is-navigable:focus-visible {
    inventing a second dialog shape. */
 .modal-create-agent {
   width: 460px;
+  /* MEASURED: four blocks make this the tallest dialog in the app (658px), and
+     a 620px-tall window pushed its header 19px ABOVE the viewport — the close
+     button and the title, unreachable, on a dialog that cannot be scrolled to.
+     The frame is capped and the body scrolls instead, so the header and the
+     actions stay put at any height. */
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 48px);
+}
+
+.modal-create-agent .modal-body {
+  overflow-y: auto;
 }
 
 /* The destination, stated. The label is the sentence; the path sits under it

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -10738,6 +10738,18 @@ button.system-graph-node.is-navigable:focus-visible {
   pointer-events: none;
 }
 
+/* …EXCEPT the action inside it (SAP-2981). The inert row predates it carrying
+   a button: the empty project used to be a label that stated a fact, and the
+   rule kept it from eating hover on the rows around it. Once "Create the first
+   agent here" moved in, the same rule swallowed every click on it — measured,
+   `elementFromPoint` over the middle of that button returned the enclosing
+   `.workspace-group`, and Playwright's click retried for 30s against a control
+   that could never receive one. The spec beside it only ever asserted
+   `toBeEnabled()`, which a control nobody can click passes. */
+.workspace-row-empty .tree-row-empty-action {
+  pointer-events: auto;
+}
+
 .tree-row-empty {
   padding-left: var(--tree-pad-x);
   color: var(--text-faint);
@@ -10868,6 +10880,10 @@ button.system-graph-node.is-navigable:focus-visible {
   display: grid;
   gap: var(--sp1);
   margin-top: 2px;
+  /* The radio's ON state is the brand, the same answer `.toggle-switch.is-on`
+     gives. `accent-color` tints the control itself, not a surface — the native
+     blue was the one thing in this dialog that belonged to no palette. */
+  accent-color: var(--brand);
 }
 
 /* A row, not a card: the starters are a short list of one-line choices, and a
@@ -10921,8 +10937,14 @@ button.system-graph-node.is-navigable:focus-visible {
   resize: vertical;
 }
 
+/* Inline text, not a control: it sits mid-sentence, and the button chrome it
+   inherited drew a box around three words of prose. */
 .create-agent-link {
+  padding: 0;
+  border: none;
+  background: none;
   color: var(--text-dim);
+  font: inherit;
   text-decoration: underline;
   text-underline-offset: 2px;
 }

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -10824,3 +10824,109 @@ button.system-graph-node.is-navigable:focus-visible {
   flex: 0 0 auto;
   opacity: 0.7;
 }
+
+/* ── Create-agent dialog (SAP-2981) ─────────────────────────────────────────
+   The create form. Wider than a confirm because it holds four blocks, and
+   built from `.modal-*` so it shares the confirm dialogs' anatomy rather than
+   inventing a second dialog shape. */
+.modal-create-agent {
+  width: 460px;
+}
+
+/* The destination, stated. The label is the sentence; the path sits under it
+   in meta because it is the fact that disambiguates a shared or widened label,
+   not the thing being read first. */
+.create-agent-target {
+  display: grid;
+  gap: 2px;
+  padding-top: var(--sp3);
+  padding-bottom: 0;
+  color: var(--text-dim);
+}
+
+.create-agent-path {
+  overflow: hidden;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.create-agent-label {
+  color: var(--text-dim);
+  font-size: var(--type-label);
+  font-weight: 510;
+}
+
+.create-agent-optional {
+  color: var(--text-faint);
+  font-weight: 400;
+}
+
+.create-agent-templates {
+  display: grid;
+  gap: var(--sp1);
+  margin-top: 2px;
+}
+
+/* A row, not a card: the starters are a short list of one-line choices, and a
+   card each would make picking the default feel like a decision it isn't. */
+.create-agent-template {
+  display: flex;
+  gap: var(--sp2);
+  align-items: flex-start;
+  padding: var(--sp2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+}
+
+.create-agent-template:hover {
+  background: var(--bg-hover);
+}
+
+/* The selected row is marked by its BORDER, not a fill: `--accent` is full
+   brand green (see css-brand-surface.test.ts), and a filled row here would be
+   the fifth time that mistake shipped. */
+.create-agent-template[data-selected="true"] {
+  border-color: var(--border-strong);
+  background: var(--bg-3);
+}
+
+.create-agent-template-text {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+
+.create-agent-template-name {
+  color: var(--text);
+  font-size: var(--type-ui);
+}
+
+.create-agent-template-desc {
+  color: var(--text-faint);
+  font-size: var(--type-meta);
+  line-height: 1.45;
+}
+
+/* The one multi-line field: `.modal-input` is single-line height, so the
+   textarea takes its skin and its own box. */
+.create-agent-instruction {
+  height: auto;
+  padding: var(--sp2);
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical;
+}
+
+.create-agent-link {
+  color: var(--text-dim);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.create-agent-link:hover {
+  color: var(--text);
+}

--- a/packages/harness/web/tsconfig.json
+++ b/packages/harness/web/tsconfig.json
@@ -15,6 +15,7 @@
     "paths": {
       "@shared/types": ["../src/shared/types.ts"],
       "@shared/system-graph": ["../src/shared/system-graph.ts"],
+      "@shared/agent-name": ["../src/shared/agent-name.ts"],
       "@shared/render-local-run": ["../src/core/render-local-run.ts"],
       "@shared/stub-feedback": ["../src/core/stub-feedback.ts"],
       "@sapiom/design-system/*": ["./src/styles/ds-neutral/*"]

--- a/packages/harness/web/vite.config.ts
+++ b/packages/harness/web/vite.config.ts
@@ -90,6 +90,9 @@ export default defineConfig({
       // build against one source of truth — no vendored copy to drift.
       "@shared/types": fileURLToPath(new URL("../src/shared/types.ts", import.meta.url)),
       "@shared/system-graph": fileURLToPath(new URL("../src/shared/system-graph.ts", import.meta.url)),
+      // One agent-name rule for the dialog and the create route: a name the
+      // field accepts and the server refuses reads as a broken app.
+      "@shared/agent-name": fileURLToPath(new URL("../src/shared/agent-name.ts", import.meta.url)),
       // The local-run mapper is a pure fn shared with the server (its canonical
       // home is src/core/render-local-run.ts, per the ticket). The SPA imports
       // the SAME implementation to map an offline stub run's NDJSON traces into

--- a/scripts/agent-studio-terminology-allowlist.json
+++ b/scripts/agent-studio-terminology-allowlist.json
@@ -507,7 +507,7 @@
     "id": "web-api-workflow-change-event",
     "path": "packages/harness/web/src/lib/api.ts",
     "pattern": "^workflows\\.changed$",
-    "occurrences": 1,
-    "reason": "The internal WebSocket event name remains stable for existing clients."
+    "occurrences": 2,
+    "reason": "The internal WebSocket event name remains stable for existing clients. Announced by the mock's mover and its scaffold, the two mutations that change what the rail shows."
   }
 ]


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

`project-create-agent-*` → `handleScaffoldSession` created a pty session and then **injected an English sentence into the terminal** asking the coding agent to please call an MCP tool. The error copy admitted it: *"Ask the coding agent to call sapiom_dev_agents_scaffold."* There was **no server-side scaffold endpoint** — the top CTA, the project `+`, the empty-project CTA and the Templates gallery all ended in prompt injection, in three near-identical copies of the same sentence.

So a failed create surfaced as a confused model rather than an error, and "did it work?" could only be answered by reading a terminal.

**Captured on the real 76-agent install, before this change.** Clicking *Create an agent in probes*:

![before — the injected sentence](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/746/before-1-injected-prompt.png)

…and what came back:

![before — the confused model](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/746/before-2-confused-model.png)

> `probes/` isn't itself an agent project — it's a folder holding ~17 of them … So the scaffold refused: `DIR_NOT_EMPTY`. It needs a fresh empty subdirectory … Two things I need from you before I can do the rest: 1. Directory/agent name …

The button was not merely indirect; on any project that already holds agents it **could not work at all**, because the scaffold was aimed at the project folder.

## Summary and scope

**The harness creates the agent.**

`POST /api/agents/scaffold` — `{ root, name, template? }` → `{ path, name, template, dependenciesInstalled }`. It calls the same `scaffold` routine the MCP tool calls, and **refuses on its own findings**, mirroring `POST /api/agents/move` (the closest existing precedent for a harness-owned filesystem mutation):

| guard | refusal | failure it prevents |
|---|---|---|
| `name` is one plain segment (`childPath`) | 400 | `../evil`, `a/b`, `""`, `.hidden` reaching `fs` |
| `template` is a plain segment | 400 | `resolveTemplate` **joins** it onto the bundled templates dir |
| `root` matched against the directories the rail can show — and the **list's** entry is what gets written into | 409 | the endpoint becoming an arbitrary-path mkdir |
| destination `lstat` | 409 | a plain directory the registry cannot see |
| registry lookup | 409 | a duplicate, named ("already has an agent called x") |
| `fs.rm` on a scaffold that throws | 500 | a half-created agent, which is worse than a refusal |

`onScaffolded` rescans and broadcasts **before** the response, so the agent is in the rail before the caller can open a session on it.

**The flow.** `+` opens a dialog: name, starter, and the project *stated, not chosen* — you clicked that row.

![after — the dialog](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/746/after-1-dialog.png)

A refusal lands in the dialog, under the field that produces it, and nothing starts:

![after — a duplicate is refused](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/746/after-2-duplicate-refused.png)
![after — an invalid segment, as you type](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/746/after-3-invalid-name.png)

Then the agent is in the rail and the session opens on it, with the optional first instruction — which says the scaffold is **done**, so the agent never re-scaffolds a folder that already exists:

![after — created, then chatting](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/746/after-4-created.png)

The whole flow end to end (real server, real 76-agent tree):

https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/746/create-flow.webm

**Three prompt constructions collapsed to one.** The project `+`, the empty-project CTA, the bare-project affordance and the gallery's **bundled starters** all go through the endpoint (E4.6 — two creation paths for one operation is how they drift). The **composer keeps its prompt**, per the design's carve-out: no project, no name, and a folder that does not exist yet, so there is no row to create in and nothing for a dialog to state. Cloning a **gallery** template still goes through the coding agent — forking a published agent over the network is a different operation with a different failure mode, and the harness has no route for it.

**One name rule, two guards.** `src/shared/agent-name.ts` is imported by both the dialog and the route, because a name the field accepts and the server rejects reads as a broken app.

**Two defects found by measuring, fixed here:**

1. **The empty-project CTA was inert.** `.workspace-row-empty { pointer-events: none }` predates the row carrying a button; once *Create the first agent here* moved in, that rule swallowed every click. `elementFromPoint` over the middle of the button returned the enclosing `.workspace-group`. The spec beside it asserted only `toBeEnabled()` — which a control nobody can click passes.
2. **A wire dump shown to the user.** The dialog rendered `POST /api/agents/scaffold → 409: {"error":"…"}`. `ApiError.reason` is the server's own sentence; one `errorMessage()` helper now prefers it.

**Also:** the rail scrolls a newly focused agent into view (`block: "nearest"`). Measured — creating in `probes` left the rail parked on `social-content`, three screens from the row the create had just added.

**Found after opening this PR, by continuing to measure** (each proven both ways):

- **Return on Cancel created the agent.** The dialog took Return for the whole form, so a focused Cancel took it too — it closed the dialog *and* created. With the guard removed, the new spec's "nothing created" assertion fails.
- **The dialog escaped a short window.** At 620px tall its header — title and close button — sat 19px above the viewport, on a dialog that cannot be scrolled to. The frame is capped and the body scrolls; measured again at 950 / 700 / 620.
- **The bare-project door could bind to a dead session.** It names the session that was in that folder when the dialog opened, and a dialog outlives a pty. Only a live one is reused now.
- **CodeQL** read `childPath`'s `dirname(...) === root` comparison as no barrier and flagged every `fs` call below it. The join now re-asserts containment at the sink with `resolveWithinRoot` — the analyzer-recognized shape, already used by `server/canvas.ts` — the failed-scaffold cleanup moved out of the handler, and the route took the same rate limiter shape the attachment upload has. Said plainly: stubbing that second barrier leaves the suite green. Nothing `childPath` returns can fail it, so it is defence in depth and a static-analysis barrier, not a second reachable rule. The cleanup's own mutation does fail.

**Both hosts.** The templates directory is resolved through one helper that applies the asar translation (`scaffold` copies with `cpSync`, which cannot `opendir` inside `app.asar`) — the demo seed's hand-written copy of that regex is now a call to it. The best-effort `npm install` shells out to `npm`, which the desktop host already puts on `process.env.PATH` before `startServer()` for exactly this reason (`harness-desktop/src/main/runtime-shims.ts`); if it is ever missing the scaffold still succeeds and the Canvas degrades to its existing "run npm install" hint.

### Review round 1 — four findings, all real, all fixed

- **The cleanup could delete an agent it did not create.** `lstat` is a message, not a lock: two POSTs with the same body both passed it, one scaffolded, and the loser's `DIR_NOT_EMPTY` cleanup recursively deleted the winner's freshly installed project while the winner's caller had been told it exists. The destination is **claimed** with a plain non-recursive `mkdir` now — the filesystem decides who gets the name — and the recursive delete is entitled to run only because this request created the directory. New spec fires both requests at once and reads the winner's file back; it fails against the old ordering. Confirmed on the real server: `409 probes already contains raced.` + `200`, with the winner's `AGENTS.md`/`index.ts`/`node_modules` intact.
- **The gallery's starters were refused on a fresh install.** The SPA puts a new project under `AppState.defaultProjectRoot` (`<launchDir>/projects` under Electron), which the host never persists — so it was in none of the lists the route accepts, and the flow could not bootstrap (`recentDirs` learns a root only once a session exists there, and creation now runs first). The host's default is part of `listProjectDirs`. It was invisible because the mock had the name and duplicate guards but not the root barrier; it has it now, from the same list — removing the default root from that list fails `templates.spec.ts`, which is the fresh install reproduced.
- **A dead branch with a test certifying it.** `useTemplatePrompt`'s starter half became unreachable when starters moved onto the endpoint. Deleted, with the test that asserted the exact arguments of a handoff nothing performs.
- **A trailing dot** is refused (Windows turns `foo.` into `foo`, so the path returned would not be the directory on disk), and the dialog's never-passed `triggerRef` is gone rather than left undocumented — every control that opens it unmounts on use.

### Review round 2 — one finding, and it was right

The atomic claim fixed the delete and introduced a new dead end at the same click: `<launchDir>/projects` is the desktop host's default parent for new projects and **nothing creates it** — the scaffold's own recursive mkdir did, until the non-recursive claim started running ahead of it. A fresh install's first template was still refused at its own suggested destination, with a new sentence.

The claim makes the parent first — recursive, and only on the directory the rail's list already vetted — so the claim itself stays a single non-recursive `mkdir` on the agent's own name, which is what makes it exclusive. The spec that pinned the wrong shape ("refuses when the project directory has been deleted under it") was the bug written down as a rule; it is now "creates the project directory when it does not exist yet". Both mutations fail as they must: drop the parent mkdir and the fresh-install spec fails; make the claim recursive again and the concurrent-create spec fails. Verified on a real server with `projectRoot` pointed at a path that did not exist — the create made it and scaffolded into it.

**Out of scope:** the gallery clone path, the composer's prompt, and any change to the map or the graph (SAP-2983 owns those files).

## Related work

Related issue or discussion: SAP-2981 · design: `plans/studio-project-experience/design.md` § E4 · follows #740 (SAP-2982) and #742 (SAP-2980).

## Validation

```text
pnpm --filter @sapiom/harness test        — 2654/2655 unit + 10/10 perf. The single
                                            failure is src/server/system-graph-freshness.test.ts,
                                            red on clean main on macOS (a filesystem-watcher
                                            test from #724); Linux CI reports it green.
pnpm --filter @sapiom/harness typecheck   — clean (tsc --noEmit ×2)
pnpm --filter @sapiom/harness lint        — clean (1 pre-existing warning in rest.test.ts)
pnpm terminology:check                    — passed (460 files); allowlist count for the mock's
                                            workflows.changed bumped 1 → 2 (the mock's scaffold
                                            announces it, like the mock's mover)
pnpm examples:check                        — OK
E2E_PORT=5465 …/test:ui                   — 470/470 on the final code.
```

**Driven against a real server** — `/Users/gwitwer/sapiom/agents` (76 agents / 9 projects), own port, own `--state-root`. Every refusal was posted **directly** to the endpoint, dialog bypassed:

```text
{"name":"../evil"}                → 400  An agent name is one folder name — it can't contain / or \.
{"name":""}                       → 400  Give the agent a name.
{"name":"/tmp/evil"}              → 400  (same)                     nothing at /tmp/evil
{"name":".hidden"}                → 400  … can't start with a dot — a dotted folder is hidden from the rail.
{"template":"../../../etc"}       → 400  Unknown template '../../../etc'.
{"root":"/tmp"}                   → 409  Studio doesn't show that folder as a project.
{"name":"hello-world"}            → 409  probes already has an agent called hello-world.
{"root":"probes"}                 → 400  root must be an absolute path
```

Filesystem verified after every refusal: `probes` unchanged at 16 entries, no `evil` anywhere. Happy path: **2.3 s** including `npm install`; the agent was in `GET /api/workflows` (77) before the response returned.

**Ordering, measured in the browser** (poll every 50 ms): the rail row appeared at **1.3–4.1 s**, the first session at **2.1–4.6 s** — the agent is in the rail **~0.6 s before any session exists**, on every run.

**Mutation-tested, every guard.** Server (`scaffold.test.ts`): neutering the name rule, the template guard, the root barrier, the registry duplicate check, the disk `lstat`, or the failed-scaffold cleanup each fails the suite. E2E (`create-agent.spec.ts`): creating the session before the scaffold, swallowing the refusal, dropping the name rule, sending the old scaffold prompt, or putting the rail's create back on a session each fails the suite.

**One assertion did not fail its own mutation and was rewritten.** "Rescans before it answers" survived `await` → `void`, because a synchronous stub records "scanned" first either way. The stub now awaits a real tick before recording; the mutation then fails, as it must.

### Tests and documentation

`src/server/scaffold.test.ts` (13, real filesystem, route posted directly), `src/shared/agent-name.test.ts` (3), `web/e2e/create-agent.spec.ts` (6). `rail-grammar.spec.ts`'s create test and `templates.spec.ts`'s starter test asserted the old mechanism and now assert the new contract — both by **order**, not by counting. The REST surface block in `src/shared/types.ts` gains the scaffold route (and the move route, which was already missing).

## Compatibility and release impact

- Breaking or externally visible changes: new endpoint `POST /api/agents/scaffold`; the project `+` and the gallery's bundled starters no longer start a session before creating. A starter now lands under a folder Studio shows as a project — a destination outside one is refused, deliberately, with a reason.
- Changeset: Added — `.changeset/create-agent-flow.md`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code (Opus 5) wrote the endpoint, the dialog, the specs and this description, and drove the verification above — a real harness on its own port and state root, Playwright against the real 76-agent tree, direct `curl` at every refusal, and a mutation for every guard. Findings are quoted from what actually ran; the one assertion that survived its own mutation is named above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
