### PR TITLE
feat(harness): resolve static invocations with package program

### DIFF
--- a/.changeset/rich-agents-invoke.md
+++ b/.changeset/rich-agents-invoke.md
@@ -1,0 +1,6 @@
+"@sapiom/harness": patch
+---
+
+Resolve direct static agent invocations through one package-wide TypeScript
+Program so graph evidence can follow imports, re-exports, aliases, and simple
+wrappers without inventing unresolved or dynamic edges.

--- a/packages/harness/src/core/system-graph-invocation-evidence.ts
+++ b/packages/harness/src/core/system-graph-invocation-evidence.ts
@@ -30,7 +30,7 @@ import type { AgentInvocationProviderResult } from "./system-graph-relationships
 
 export const DIRECT_INVOCATION_EVIDENCE_PRODUCER = {
   id: "sapiom.harness.direct-invocation",
-  version: "1.0.0",
+  version: "2.0.0",
 } as const satisfies PackageGraphEvidenceProducer;
 
 const DIGEST = /^sha256:[0-9a-f]{64}$/;

--- a/packages/harness/src/core/system-graph-relationships.test.ts
+++ b/packages/harness/src/core/system-graph-relationships.test.ts
@@ -51,6 +51,35 @@ async function callerWithSource(source: string): Promise<AgentInventoryItem> {
   };
 }
 
+async function packageWithCallers(
+  files: Record<string, string>,
+  agents: readonly string[],
+): Promise<AgentInventoryItem[]> {
+  const root = await fs.mkdtemp(
+    path.join(os.tmpdir(), "system-graph-package-invocations-test-"),
+  );
+  temporaryRoots.push(root);
+  for (const [name, content] of Object.entries(files)) {
+    await fs.mkdir(path.dirname(path.join(root, name)), { recursive: true });
+    await fs.writeFile(path.join(root, name), content);
+  }
+  return agents.map((agentKey, index) => {
+    const sourceRoot = path.join(root, "agents", agentKey);
+    return {
+      agentKey,
+      identityStatus: "canonical",
+      definitionId: index + 1,
+      definitionSlug: agentKey,
+      label: agentKey,
+      resolutionAliases: [agentKey],
+      sourceRoot,
+      workflowPath: sourceRoot,
+      path: `agents/${agentKey}`,
+      entrypoint: "index.ts",
+    };
+  });
+}
+
 afterEach(async () => {
   await Promise.all(
     temporaryRoots
@@ -235,6 +264,126 @@ await agents.run({
       path.join(external, "edge.ts"),
       expect.any(Number),
     );
+  });
+
+  it("resolves re-exported namespaces and shared wrapper functions with one package program", async () => {
+    const [coordinator, research] = await packageWithCallers(
+      {
+        "node_modules/@sapiom/tools/index.d.ts": `
+export declare const agents: {
+  run(spec: { definition: string }): Promise<unknown>;
+  launch(spec: { definition: string }): Promise<unknown>;
+};
+`,
+        "shared/sapiom.ts": `
+export { agents as routedAgents } from "@sapiom/tools";
+`,
+        "shared/router.ts": `
+import { routedAgents } from "./sapiom";
+
+export function launchGrowth() {
+  return routedAgents.launch({ definition: "growth" });
+}
+
+export function runNamed(definition: string) {
+  return routedAgents.run({ definition });
+}
+`,
+        "agents/coordinator/index.ts": `
+import { launchGrowth, runNamed } from "../../shared/router";
+
+await launchGrowth();
+await runNamed("research");
+`,
+        "agents/research/index.ts": "export const idle = true;\n",
+      },
+      ["coordinator", "research"],
+    );
+    const provider = new SourceAgentInvocationProvider();
+    provider.retainCallers([coordinator!, research!]);
+
+    const coordinatorResult = await provider.listInvocations(coordinator!);
+    const researchResult = await provider.listInvocations(research!);
+
+    expect(coordinatorResult.invocations).toEqual([
+      {
+        target: "growth",
+        mode: "async",
+        evidence: [{ file: "index.ts", line: 4, column: 7 }],
+      },
+      {
+        target: "research",
+        mode: "blocking",
+        evidence: [{ file: "index.ts", line: 5, column: 7 }],
+      },
+    ]);
+    expect(coordinatorResult.warnings).toEqual([]);
+    expect(researchResult.invocations).toEqual([]);
+    expect(researchResult.warnings).toEqual([]);
+    expect(coordinatorResult.sourceFingerprint).toBe(
+      researchResult.sourceFingerprint,
+    );
+  });
+
+  it("does not emit wrapper internals as duplicate evidence for the same basis", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+function runResearch() {
+  return agents.run({ definition: "research" });
+}
+
+await runResearch();
+`,
+      },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.invocations).toEqual([
+      {
+        target: "research",
+        mode: "blocking",
+        evidence: [{ file: "index.ts", line: 8, column: 7 }],
+      },
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("keeps dynamically invoked wrapper targets partial without guessing an edge", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+const target = Math.random() > 0.5 ? "research" : "growth";
+function runNamed(definition: string) {
+  return agents.run({ definition });
+}
+
+await runNamed(target);
+`,
+      },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.invocations).toEqual([]);
+    expect(result.warnings).toEqual([
+      {
+        code: "dynamic-target",
+        mode: "blocking",
+        evidence: { file: "index.ts", line: 9, column: 7 },
+      },
+    ]);
   });
 });
 

--- a/packages/harness/src/core/system-graph-relationships.test.ts
+++ b/packages/harness/src/core/system-graph-relationships.test.ts
@@ -11,6 +11,10 @@ import {
   type AgentInvocationProvider,
   type AgentInvocationProviderResult,
 } from "./system-graph-relationships.js";
+import {
+  clearCanonicalGraphPathCacheForTest,
+  setCanonicalGraphPathProbeForTest,
+} from "./canonical-graph-path.js";
 
 const temporaryRoots: string[] = [];
 const EMPTY_RESULT: AgentInvocationProviderResult = {
@@ -82,6 +86,7 @@ async function packageWithCallers(
 }
 
 afterEach(async () => {
+  clearCanonicalGraphPathCacheForTest();
   await Promise.all(
     temporaryRoots
       .splice(0)
@@ -393,6 +398,54 @@ await runNamed("research");
     );
   });
 
+  it("does not canonicalize external or symlink import candidates during Program resolution", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "system-graph-host-boundary-test-"),
+    );
+    const external = await fs.mkdtemp(
+      path.join(os.tmpdir(), "system-graph-host-external-test-"),
+    );
+    temporaryRoots.push(root, external);
+    await fs.mkdir(path.join(root, "agents", "coordinator"), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(root, "shared"), { recursive: true });
+    await fs.writeFile(
+      path.join(external, "secret.ts"),
+      'ctx.sapiom.agents.run({ definition: "outside" });\n',
+    );
+    await fs.symlink(
+      path.join(external, "secret.ts"),
+      path.join(root, "shared", "link.ts"),
+    );
+    const externalSpecifier = path
+      .relative(path.join(root, "agents", "coordinator"), path.join(external, "secret"))
+      .split(path.sep)
+      .join(path.posix.sep);
+    await fs.writeFile(
+      path.join(root, "agents", "coordinator", "index.ts"),
+      `import "${externalSpecifier}";\nimport "../../shared/link";\n`,
+    );
+    const probed: string[] = [];
+    setCanonicalGraphPathProbeForTest((candidate) => probed.push(candidate));
+
+    const result = await createSystemGraphPackageCompilerResult({
+      packageRoot: root,
+    });
+    result.program.getSemanticDiagnostics();
+
+    expect(
+      probed.filter(
+        (candidate) =>
+          candidate.startsWith(external) ||
+          candidate.includes(`${path.sep}shared${path.sep}link`),
+      ),
+    ).toEqual([]);
+    expect([...result.sources.keys()]).not.toContain(
+      path.join(root, "shared", "link.ts"),
+    );
+  });
+
   it("resolves computed methods, method aliases, assignments, and destructuring", async () => {
     const [coordinator] = await packageWithCallers(
       {
@@ -461,6 +514,84 @@ agents[picked]({ definition: "never-guessed" });
         code: "dynamic-target",
         mode: "async",
         evidence: { file: "index.ts", line: 19, column: 1 },
+      },
+    ]);
+  });
+
+  it("degrades reassigned method aliases instead of applying the final write globally", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+let invoke = agents.run;
+invoke({ definition: "before" });
+invoke = agents.launch;
+invoke({ definition: "after" });
+`,
+      },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.invocations).toEqual([]);
+    expect(result.warnings).toEqual([
+      {
+        code: "dynamic-target",
+        mode: "blocking",
+        evidence: { file: "index.ts", line: 5, column: 1 },
+      },
+      {
+        code: "dynamic-target",
+        mode: "async",
+        evidence: { file: "index.ts", line: 5, column: 1 },
+      },
+      {
+        code: "dynamic-target",
+        mode: "blocking",
+        evidence: { file: "index.ts", line: 7, column: 1 },
+      },
+      {
+        code: "dynamic-target",
+        mode: "async",
+        evidence: { file: "index.ts", line: 7, column: 1 },
+      },
+    ]);
+  });
+
+  it("degrades method aliases reassigned to local values without guessing edges", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+const local = () => null;
+let invoke = agents.run;
+invoke = local;
+invoke({ definition: "not-an-agent-call" });
+`,
+      },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.invocations).toEqual([]);
+    expect(result.warnings).toEqual([
+      {
+        code: "dynamic-target",
+        mode: "blocking",
+        evidence: { file: "index.ts", line: 7, column: 1 },
+      },
+      {
+        code: "dynamic-target",
+        mode: "async",
+        evidence: { file: "index.ts", line: 7, column: 1 },
       },
     ]);
   });
@@ -636,6 +767,41 @@ export function route() {
 
     expect(first.invocations[0]?.target).toBe("first");
     expect(second.invocations[0]?.target).toBe("second");
+  });
+
+  it("invalidates cached package evidence when admitted tools declarations change", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "node_modules/@sapiom/tools/index.d.ts": `
+export declare const agents: {
+  run(spec: { definition: string }): Promise<unknown>;
+};
+`,
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+await agents.run({ definition: "research" });
+`,
+      },
+      ["coordinator"],
+    );
+    const provider = new CachedAgentInvocationProvider(
+      new SourceAgentInvocationProvider(),
+    );
+
+    const first = await provider.listInvocations(coordinator!);
+    await fs.writeFile(
+      path.resolve(coordinator!.sourceRoot, "../../node_modules/@sapiom/tools/index.d.ts"),
+      `
+export declare const agents: {
+  run(spec: { definition: string; version?: 2 }): Promise<unknown>;
+};
+`,
+    );
+    const second = await provider.listInvocations(coordinator!);
+
+    expect(second.invocations).toEqual(first.invocations);
+    expect(second.sourceFingerprint).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(second.sourceFingerprint).not.toBe(first.sourceFingerprint);
   });
 
   it("does not retain a failed caller result", async () => {

--- a/packages/harness/src/core/system-graph-relationships.test.ts
+++ b/packages/harness/src/core/system-graph-relationships.test.ts
@@ -818,6 +818,154 @@ invoke({ definition: "research" });
     expect(result.warnings).toEqual([]);
   });
 
+  it("resolves 2k acyclic alias chains below the cap", async () => {
+    const chainLength = 2_000;
+    const lines = [
+      'import { agents } from "@sapiom/tools";',
+      "",
+      "const alias0 = agents.launch;",
+      ...Array.from(
+        { length: chainLength },
+        (_, index) => `const alias${index + 1} = alias${index};`,
+      ),
+      `alias${chainLength}({ definition: "research" });`,
+    ];
+    const [coordinator] = await packageWithCallers(
+      { "agents/coordinator/index.ts": `${lines.join("\n")}\n` },
+      ["coordinator"],
+    );
+
+    const started = performance.now();
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+    const elapsed = performance.now() - started;
+
+    expect(elapsed).toBeLessThan(5_000);
+    expect(result.invocations).toEqual([
+      {
+        target: "research",
+        mode: "async",
+        evidence: [{ file: "index.ts", line: chainLength + 4, column: 1 }],
+      },
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("degrades duplicate-edge diamonds without path expansion", async () => {
+    const depth = 20;
+    const lines = [
+      'import { agents } from "@sapiom/tools";',
+      "",
+      "const alias0 = agents.run;",
+      ...Array.from(
+        { length: depth },
+        (_, index) =>
+          `let alias${index + 1} = alias${index};\nalias${index + 1} = alias${index};`,
+      ),
+      `alias${depth}({ definition: "research" });`,
+    ];
+    const [coordinator] = await packageWithCallers(
+      { "agents/coordinator/index.ts": `${lines.join("\n")}\n` },
+      ["coordinator"],
+    );
+
+    const started = performance.now();
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+    const elapsed = performance.now() - started;
+
+    expect(elapsed).toBeLessThan(2_000);
+    expect(result.invocations).toEqual([]);
+    expect(result.warnings).toEqual([
+      {
+        code: "dynamic-target",
+        mode: "blocking",
+        evidence: { file: "index.ts", line: depth * 2 + 4, column: 1 },
+      },
+      {
+        code: "dynamic-target",
+        mode: "async",
+        evidence: { file: "index.ts", line: depth * 2 + 4, column: 1 },
+      },
+    ]);
+  });
+
+  it("keeps deeper duplicate-edge diamonds bounded", async () => {
+    const depth = 200;
+    const lines = [
+      'import { agents } from "@sapiom/tools";',
+      "",
+      "const alias0 = agents.run;",
+      ...Array.from(
+        { length: depth },
+        (_, index) =>
+          `let alias${index + 1} = alias${index};\nalias${index + 1} = alias${index};`,
+      ),
+      `alias${depth}({ definition: "research" });`,
+    ];
+    const [coordinator] = await packageWithCallers(
+      { "agents/coordinator/index.ts": `${lines.join("\n")}\n` },
+      ["coordinator"],
+    );
+
+    const started = performance.now();
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+    const elapsed = performance.now() - started;
+
+    expect(elapsed).toBeLessThan(5_000);
+    expect(result.invocations).toEqual([]);
+    expect(result.warnings).toEqual([
+      {
+        code: "dynamic-target",
+        mode: "blocking",
+        evidence: { file: "index.ts", line: depth * 2 + 4, column: 1 },
+      },
+      {
+        code: "dynamic-target",
+        mode: "async",
+        evidence: { file: "index.ts", line: depth * 2 + 4, column: 1 },
+      },
+    ]);
+  });
+
+  it("degrades mixed blocking and async alias branches without guessing", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+const run = agents.run;
+const launch = agents.launch;
+const invoke = Math.random() > 0.5 ? run : launch;
+invoke({ definition: "research" });
+`,
+      },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.invocations).toEqual([]);
+    expect(result.warnings).toEqual([
+      {
+        code: "dynamic-target",
+        mode: "blocking",
+        evidence: { file: "index.ts", line: 7, column: 1 },
+      },
+      {
+        code: "dynamic-target",
+        mode: "async",
+        evidence: { file: "index.ts", line: 7, column: 1 },
+      },
+    ]);
+  });
+
   it("resolves aliases independently of declaration order", async () => {
     const [coordinator] = await packageWithCallers(
       {
@@ -881,7 +1029,7 @@ second({ definition: "research" });
   });
 
   it("degrades alias graphs beyond deterministic caps", async () => {
-    const chainLength = 2_050;
+    const chainLength = 3_000;
     const lines = [
       'import { agents } from "@sapiom/tools";',
       "",

--- a/packages/harness/src/core/system-graph-relationships.test.ts
+++ b/packages/harness/src/core/system-graph-relationships.test.ts
@@ -8,6 +8,7 @@ import {
   CachedAgentInvocationProvider,
   SourceAgentInvocationProvider,
   createSystemGraphPackageCompilerResult,
+  setToolsDeclarationAdmissionProbeForTest,
   type AgentInvocationProvider,
   type AgentInvocationProviderResult,
 } from "./system-graph-relationships.js";
@@ -87,6 +88,7 @@ async function packageWithCallers(
 
 afterEach(async () => {
   clearCanonicalGraphPathCacheForTest();
+  setToolsDeclarationAdmissionProbeForTest(null);
   await Promise.all(
     temporaryRoots
       .splice(0)
@@ -501,6 +503,186 @@ await agents.run({ definition: "research" });
     ).toEqual([]);
   });
 
+  it("handles regular and missing tools declarations deterministically", async () => {
+    const [regular] = await packageWithCallers(
+      {
+        "node_modules/@sapiom/tools/index.d.ts": `
+export declare const agents: {
+  run(spec: { definition: string }): Promise<unknown>;
+};
+`,
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+await agents.run({ definition: "research" });
+`,
+      },
+      ["coordinator"],
+    );
+    const missingRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "system-graph-missing-tools-test-"),
+    );
+    temporaryRoots.push(missingRoot);
+    await fs.mkdir(path.join(missingRoot, "agents", "coordinator"), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(missingRoot, "agents", "coordinator", "index.ts"),
+      "export const idle = true;\n",
+    );
+
+    const regularResult = await createSystemGraphPackageCompilerResult({
+      packageRoot: path.resolve(regular!.sourceRoot, "../.."),
+    });
+    const missingResult = await createSystemGraphPackageCompilerResult({
+      packageRoot: missingRoot,
+    });
+
+    expect(regularResult.complete).toBe(true);
+    expect([...regularResult.sources.keys()]).toContain(
+      path.resolve(regular!.sourceRoot, "../../node_modules/@sapiom/tools/index.d.ts"),
+    );
+    expect(missingResult.complete).toBe(true);
+    expect([...missingResult.sources.keys()]).not.toContain(
+      path.join(missingRoot, "node_modules", "@sapiom", "tools", "index.d.ts"),
+    );
+  });
+
+  it("marks directory and symlink tools declarations partial without reading them", async () => {
+    const cases: Array<{
+      name: string;
+      setup: (root: string, external: string) => Promise<void>;
+    }> = [
+      {
+        name: "directory",
+        setup: async (root) => {
+          await fs.mkdir(
+            path.join(root, "node_modules", "@sapiom", "tools", "index.d.ts"),
+            { recursive: true },
+          );
+        },
+      },
+      {
+        name: "dangling-final-symlink",
+        setup: async (root) => {
+          await fs.mkdir(path.join(root, "node_modules", "@sapiom", "tools"), {
+            recursive: true,
+          });
+          await fs.symlink(
+            path.join(root, "missing.d.ts"),
+            path.join(root, "node_modules", "@sapiom", "tools", "index.d.ts"),
+          );
+        },
+      },
+      {
+        name: "internal-final-symlink",
+        setup: async (root) => {
+          await fs.mkdir(path.join(root, "node_modules", "@sapiom", "tools"), {
+            recursive: true,
+          });
+          await fs.writeFile(path.join(root, "internal.d.ts"), "export {};\n");
+          await fs.symlink(
+            path.join(root, "internal.d.ts"),
+            path.join(root, "node_modules", "@sapiom", "tools", "index.d.ts"),
+          );
+        },
+      },
+      {
+        name: "external-final-symlink",
+        setup: async (root, external) => {
+          await fs.mkdir(path.join(root, "node_modules", "@sapiom", "tools"), {
+            recursive: true,
+          });
+          await fs.writeFile(path.join(external, "index.d.ts"), "export {};\n");
+          await fs.symlink(
+            path.join(external, "index.d.ts"),
+            path.join(root, "node_modules", "@sapiom", "tools", "index.d.ts"),
+          );
+        },
+      },
+    ];
+
+    for (const entry of cases) {
+      const root = await fs.mkdtemp(
+        path.join(os.tmpdir(), `system-graph-tools-${entry.name}-`),
+      );
+      const external = await fs.mkdtemp(
+        path.join(os.tmpdir(), `system-graph-tools-${entry.name}-external-`),
+      );
+      temporaryRoots.push(root, external);
+      await fs.mkdir(path.join(root, "agents", "coordinator"), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(root, "agents", "coordinator", "index.ts"),
+        "export const idle = true;\n",
+      );
+      await entry.setup(root, external);
+      const onBytesRead = vi.fn();
+
+      const result = await createSystemGraphPackageCompilerResult({
+        packageRoot: root,
+        readHooks: { onBytesRead },
+      });
+
+      expect(result.complete, entry.name).toBe(false);
+      expect(onBytesRead).not.toHaveBeenCalledWith(
+        path.join(root, "node_modules", "@sapiom", "tools", "index.d.ts"),
+        expect.any(Number),
+      );
+    }
+  });
+
+  it("rejects a symlinked tools declaration ancestor before descendant probes", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "system-graph-tools-ancestor-test-"),
+    );
+    const external = await fs.mkdtemp(
+      path.join(os.tmpdir(), "system-graph-tools-ancestor-external-test-"),
+    );
+    temporaryRoots.push(root, external);
+    await fs.mkdir(path.join(root, "agents", "coordinator"), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(root, "agents", "coordinator", "index.ts"),
+      "export const idle = true;\n",
+    );
+    await fs.mkdir(path.join(root, "node_modules", "@sapiom"), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(external, "tools"), { recursive: true });
+    await fs.writeFile(
+      path.join(external, "tools", "index.d.ts"),
+      "export {};\n",
+    );
+    await fs.symlink(
+      path.join(external, "tools"),
+      path.join(root, "node_modules", "@sapiom", "tools"),
+      "dir",
+    );
+    const descendant = path.join(
+      root,
+      "node_modules",
+      "@sapiom",
+      "tools",
+      "index.d.ts",
+    );
+    const onBytesRead = vi.fn();
+    const lstatPaths: string[] = [];
+    setToolsDeclarationAdmissionProbeForTest((candidate) => {
+      lstatPaths.push(candidate);
+    });
+
+    const result = await createSystemGraphPackageCompilerResult({
+      packageRoot: root,
+      readHooks: { onBytesRead },
+    });
+
+    expect(result.complete).toBe(false);
+    expect(lstatPaths).not.toContain(descendant);
+    expect(onBytesRead).not.toHaveBeenCalledWith(descendant, expect.any(Number));
+  });
+
   it("resolves computed methods, method aliases, assignments, and destructuring", async () => {
     const [coordinator] = await packageWithCallers(
       {
@@ -600,6 +782,138 @@ invoke({ definition: "research" });
       },
     ]);
     expect(result.warnings).toEqual([]);
+  });
+
+  it("resolves long acyclic alias chains within bounded work", async () => {
+    const chainLength = 1_000;
+    const lines = [
+      'import { agents } from "@sapiom/tools";',
+      "",
+      "const alias0 = agents.run;",
+      ...Array.from(
+        { length: chainLength },
+        (_, index) => `const alias${index + 1} = alias${index};`,
+      ),
+      `alias${chainLength}({ definition: "research" });`,
+    ];
+    const [coordinator] = await packageWithCallers(
+      { "agents/coordinator/index.ts": `${lines.join("\n")}\n` },
+      ["coordinator"],
+    );
+
+    const started = performance.now();
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+    const elapsed = performance.now() - started;
+
+    expect(elapsed).toBeLessThan(5_000);
+    expect(result.invocations).toEqual([
+      {
+        target: "research",
+        mode: "blocking",
+        evidence: [{ file: "index.ts", line: chainLength + 4, column: 1 }],
+      },
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("resolves aliases independently of declaration order", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+const invoke = run;
+const run = agents.run;
+invoke({ definition: "research" });
+`,
+      },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.invocations).toEqual([
+      {
+        target: "research",
+        mode: "blocking",
+        evidence: [{ file: "index.ts", line: 6, column: 1 }],
+      },
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("degrades method alias cycles, including anchored cycles", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+let first = agents.run;
+let second = first;
+first = second;
+second({ definition: "research" });
+`,
+      },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.invocations).toEqual([]);
+    expect(result.warnings).toEqual([
+      {
+        code: "dynamic-target",
+        mode: "blocking",
+        evidence: { file: "index.ts", line: 7, column: 1 },
+      },
+      {
+        code: "dynamic-target",
+        mode: "async",
+        evidence: { file: "index.ts", line: 7, column: 1 },
+      },
+    ]);
+  });
+
+  it("degrades alias graphs beyond deterministic caps", async () => {
+    const chainLength = 2_050;
+    const lines = [
+      'import { agents } from "@sapiom/tools";',
+      "",
+      "const alias0 = agents.run;",
+      ...Array.from(
+        { length: chainLength },
+        (_, index) => `const alias${index + 1} = alias${index};`,
+      ),
+      `alias${chainLength}({ definition: "research" });`,
+    ];
+    const [coordinator] = await packageWithCallers(
+      { "agents/coordinator/index.ts": `${lines.join("\n")}\n` },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.invocations).toEqual([]);
+    expect(result.warnings).toEqual([
+      {
+        code: "dynamic-target",
+        mode: "blocking",
+        evidence: { file: "index.ts", line: chainLength + 4, column: 1 },
+      },
+      {
+        code: "dynamic-target",
+        mode: "async",
+        evidence: { file: "index.ts", line: chainLength + 4, column: 1 },
+      },
+    ]);
   });
 
   it("degrades ambiguous transitive method aliases instead of silently completing", async () => {

--- a/packages/harness/src/core/system-graph-relationships.test.ts
+++ b/packages/harness/src/core/system-graph-relationships.test.ts
@@ -446,6 +446,61 @@ await runNamed("research");
     );
   });
 
+  it("marks an existing inadmissible tools declaration partial without canonicalizing it", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "system-graph-tools-boundary-test-"),
+    );
+    const external = await fs.mkdtemp(
+      path.join(os.tmpdir(), "system-graph-tools-external-test-"),
+    );
+    temporaryRoots.push(root, external);
+    await fs.mkdir(path.join(root, "node_modules", "@sapiom", "tools"), {
+      recursive: true,
+    });
+    await fs.mkdir(path.join(root, "agents", "coordinator"), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(external, "index.d.ts"),
+      `
+export declare const agents: {
+  run(spec: { definition: string }): Promise<unknown>;
+};
+`,
+    );
+    await fs.symlink(
+      path.join(external, "index.d.ts"),
+      path.join(root, "node_modules", "@sapiom", "tools", "index.d.ts"),
+    );
+    await fs.writeFile(
+      path.join(root, "agents", "coordinator", "index.ts"),
+      `
+import { agents } from "@sapiom/tools";
+await agents.run({ definition: "research" });
+`,
+    );
+    const probed: string[] = [];
+    setCanonicalGraphPathProbeForTest((candidate) => probed.push(candidate));
+
+    const result = await createSystemGraphPackageCompilerResult({
+      packageRoot: root,
+    });
+
+    expect(result.complete).toBe(false);
+    expect(result.observedPaths).toContain(
+      path.join(root, "node_modules", "@sapiom", "tools", "index.d.ts"),
+    );
+    expect(
+      probed.filter(
+        (candidate) =>
+          candidate.startsWith(external) ||
+          candidate.includes(
+            `${path.sep}node_modules${path.sep}@sapiom${path.sep}tools`,
+          ),
+      ),
+    ).toEqual([]);
+  });
+
   it("resolves computed methods, method aliases, assignments, and destructuring", async () => {
     const [coordinator] = await packageWithCallers(
       {
@@ -514,6 +569,69 @@ agents[picked]({ definition: "never-guessed" });
         code: "dynamic-target",
         mode: "async",
         evidence: { file: "index.ts", line: 19, column: 1 },
+      },
+    ]);
+  });
+
+  it("resolves transitive method aliases through deterministic fixpoint", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+const run = agents.run;
+const invoke = run;
+invoke({ definition: "research" });
+`,
+      },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.complete).toBe(true);
+    expect(result.invocations).toEqual([
+      {
+        target: "research",
+        mode: "blocking",
+        evidence: [{ file: "index.ts", line: 6, column: 1 }],
+      },
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("degrades ambiguous transitive method aliases instead of silently completing", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+const run = agents.run;
+const local = () => null;
+const invoke = Math.random() > 0.5 ? run : local;
+invoke({ definition: "research" });
+`,
+      },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.invocations).toEqual([]);
+    expect(result.warnings).toEqual([
+      {
+        code: "dynamic-target",
+        mode: "blocking",
+        evidence: { file: "index.ts", line: 7, column: 1 },
+      },
+      {
+        code: "dynamic-target",
+        mode: "async",
+        evidence: { file: "index.ts", line: 7, column: 1 },
       },
     ]);
   });

--- a/packages/harness/src/core/system-graph-relationships.test.ts
+++ b/packages/harness/src/core/system-graph-relationships.test.ts
@@ -7,6 +7,7 @@ import type { AgentInventoryItem } from "./system-graph-inventory.js";
 import {
   CachedAgentInvocationProvider,
   SourceAgentInvocationProvider,
+  createSystemGraphPackageCompilerResult,
   type AgentInvocationProvider,
   type AgentInvocationProviderResult,
 } from "./system-graph-relationships.js";
@@ -325,6 +326,145 @@ await runNamed("research");
     );
   });
 
+  it("keeps same-key retained callers independent across packages", async () => {
+    const [[first], [second]] = await Promise.all([
+      packageWithCallers(
+        {
+          "agents/router/index.ts":
+            'ctx.sapiom.agents.run({ definition: "first-target" });\n',
+        },
+        ["router"],
+      ),
+      packageWithCallers(
+        {
+          "agents/router/index.ts":
+            'ctx.sapiom.agents.run({ definition: "second-target" });\n',
+        },
+        ["router"],
+      ),
+    ]);
+    const provider = new SourceAgentInvocationProvider();
+    provider.retainCallers([first!, second!]);
+
+    await expect(provider.listInvocations(first!)).resolves.toMatchObject({
+      invocations: [{ target: "first-target", mode: "blocking" }],
+    });
+    await expect(provider.listInvocations(second!)).resolves.toMatchObject({
+      invocations: [{ target: "second-target", mode: "blocking" }],
+    });
+  });
+
+  it("keeps external imports outside the bounded compiler snapshot", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "system-graph-package-boundary-test-"),
+    );
+    const external = await fs.mkdtemp(
+      path.join(os.tmpdir(), "system-graph-external-import-test-"),
+    );
+    temporaryRoots.push(root, external);
+    await fs.mkdir(path.join(root, "agents", "coordinator"), {
+      recursive: true,
+    });
+    await fs.writeFile(
+      path.join(external, "secret.ts"),
+      'ctx.sapiom.agents.run({ definition: "outside" });\n',
+    );
+    const specifier = path
+      .relative(path.join(root, "agents", "coordinator"), path.join(external, "secret"))
+      .split(path.sep)
+      .join(path.posix.sep);
+    await fs.writeFile(
+      path.join(root, "agents", "coordinator", "index.ts"),
+      `import "${specifier}";\n`,
+    );
+    const onBytesRead = vi.fn();
+
+    const result = await createSystemGraphPackageCompilerResult({
+      packageRoot: root,
+      readHooks: { onBytesRead },
+    });
+
+    expect([...result.sources.keys()]).not.toContain(
+      path.join(external, "secret.ts"),
+    );
+    expect(onBytesRead).not.toHaveBeenCalledWith(
+      path.join(external, "secret.ts"),
+      expect.any(Number),
+    );
+  });
+
+  it("resolves computed methods, method aliases, assignments, and destructuring", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+const method = "run" as const;
+agents[method]({ definition: "computed" });
+
+const runAlias = agents.run;
+runAlias({ definition: "variable" });
+
+let launchAlias: typeof agents.launch;
+launchAlias = agents.launch;
+launchAlias({ definition: "assigned" });
+
+const { run, launch: kick } = agents;
+run({ definition: "destructured" });
+kick({ definition: "renamed" });
+
+const picked = Math.random() > 0.5 ? "run" : "bogus";
+agents[picked]({ definition: "never-guessed" });
+`,
+      },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.invocations).toEqual([
+      {
+        target: "computed",
+        mode: "blocking",
+        evidence: [{ file: "index.ts", line: 5, column: 1 }],
+      },
+      {
+        target: "variable",
+        mode: "blocking",
+        evidence: [{ file: "index.ts", line: 8, column: 1 }],
+      },
+      {
+        target: "assigned",
+        mode: "async",
+        evidence: [{ file: "index.ts", line: 12, column: 1 }],
+      },
+      {
+        target: "destructured",
+        mode: "blocking",
+        evidence: [{ file: "index.ts", line: 15, column: 1 }],
+      },
+      {
+        target: "renamed",
+        mode: "async",
+        evidence: [{ file: "index.ts", line: 16, column: 1 }],
+      },
+    ]);
+    expect(result.warnings).toEqual([
+      {
+        code: "dynamic-target",
+        mode: "blocking",
+        evidence: { file: "index.ts", line: 19, column: 1 },
+      },
+      {
+        code: "dynamic-target",
+        mode: "async",
+        evidence: { file: "index.ts", line: 19, column: 1 },
+      },
+    ]);
+  });
+
   it("does not emit wrapper internals as duplicate evidence for the same basis", async () => {
     const [coordinator] = await packageWithCallers(
       {
@@ -350,6 +490,39 @@ await runResearch();
         target: "research",
         mode: "blocking",
         evidence: [{ file: "index.ts", line: 8, column: 7 }],
+      },
+    ]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("uses wrapper parameter symbols instead of shadowed names", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+function runNamed(definition: string) {
+  {
+    const definition = "shadowed-local";
+    return agents.run({ definition });
+  }
+}
+
+await runNamed("argument-target");
+`,
+      },
+      ["coordinator"],
+    );
+
+    const result = await new SourceAgentInvocationProvider().listInvocations(
+      coordinator!,
+    );
+
+    expect(result.invocations).toEqual([
+      {
+        target: "shadowed-local",
+        mode: "blocking",
+        evidence: [{ file: "index.ts", line: 11, column: 7 }],
       },
     ]);
     expect(result.warnings).toEqual([]);
@@ -427,6 +600,42 @@ describe("CachedAgentInvocationProvider", () => {
     await provider.listInvocations(caller);
 
     expect(inner.listInvocations).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidates cached package evidence when a shared helper changes", async () => {
+    const [coordinator] = await packageWithCallers(
+      {
+        "shared/router.ts": `
+import { agents } from "@sapiom/tools";
+export function route() {
+  return agents.run({ definition: "first" });
+}
+`,
+        "agents/coordinator/index.ts": `
+import { route } from "../../shared/router";
+await route();
+`,
+      },
+      ["coordinator"],
+    );
+    const provider = new CachedAgentInvocationProvider(
+      new SourceAgentInvocationProvider(),
+    );
+
+    const first = await provider.listInvocations(coordinator!);
+    await fs.writeFile(
+      path.resolve(coordinator!.sourceRoot, "../../shared/router.ts"),
+      `
+import { agents } from "@sapiom/tools";
+export function route() {
+  return agents.run({ definition: "second" });
+}
+`,
+    );
+    const second = await provider.listInvocations(coordinator!);
+
+    expect(first.invocations[0]?.target).toBe("first");
+    expect(second.invocations[0]?.target).toBe("second");
   });
 
   it("does not retain a failed caller result", async () => {

--- a/packages/harness/src/core/system-graph-relationships.ts
+++ b/packages/harness/src/core/system-graph-relationships.ts
@@ -1,7 +1,10 @@
+import { createHash } from "node:crypto";
 import * as path from "node:path";
+import ts from "typescript";
 
 import {
-  scanWorkflowSources,
+  listSourceFilesWithObservations,
+  readWorkflowSourceFile,
   type AgentInvocationDetectionWarning,
   type AgentInvocationMode,
   type SourceEvidence,
@@ -195,6 +198,11 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
   }
 
   retainCallers(callers: readonly AgentInventoryItem[]): void {
+    try {
+      this.inner.retainCallers?.(callers);
+    } catch {
+      // Inner cache pruning is an optimization and cannot affect projection.
+    }
     const retained = new Set(
       callers.map((caller) => canonicalGraphPath(caller.sourceRoot)),
     );
@@ -472,45 +480,729 @@ const MODE_ORDER: Record<AgentInvocationMode, number> = {
   async: 1,
 };
 
-/**
- * V0 per-agent filesystem adapter for literal direct invocations.
- *
- * It scans only the caller's inventoried source root. It remains syntax-only
- * and has no inventory target resolution, input-provenance analysis, package
- * router scan, renderer, transport, deployment, or session dependencies.
- */
-export class SourceAgentInvocationProvider implements AgentInvocationProvider {
-  constructor(private readonly readHooks: WorkflowSourceReadHooks = {}) {}
+const PROGRAM_SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"]);
 
-  async listInvocations(
-    caller: AgentInventoryItem,
-  ): Promise<AgentInvocationProviderResult> {
-    const scan = await scanWorkflowSources(
-      caller.sourceRoot,
-      new Set(),
-      this.readHooks,
+type TargetResult = { kind: "literal"; slug: string } | { kind: "dynamic" };
+type WrapperTargetResult =
+  | TargetResult
+  | { kind: "parameter"; index: number };
+
+interface PackageInvocation {
+  target: string;
+  mode: AgentInvocationMode;
+  evidence: SourceEvidence;
+}
+
+interface PackageInvocationScan {
+  invocations: PackageInvocation[];
+  groupedInvocations: AgentInvocationCandidate[];
+  warnings: AgentInvocationDetectionWarning[];
+  observedPaths: string[];
+  complete: boolean;
+  sourceFingerprint: `sha256:${string}`;
+}
+
+function packageRootForCaller(caller: AgentInventoryItem): string {
+  if (caller.path === ".") return canonicalGraphPath(caller.sourceRoot);
+  const depth = caller.path.split("/").filter(Boolean).length;
+  return canonicalGraphPath(
+    path.resolve(caller.sourceRoot, ...Array.from({ length: depth }, () => "..")),
+  );
+}
+
+function commonSourceRoot(callers: readonly AgentInventoryItem[]): string {
+  const roots = callers
+    .map(packageRootForCaller)
+    .sort();
+  const [first] = roots;
+  if (!first) return process.cwd();
+  const segments = first.split(path.sep);
+  for (const root of roots.slice(1)) {
+    const candidate = root.split(path.sep);
+    let index = 0;
+    while (index < segments.length && segments[index] === candidate[index]) {
+      index += 1;
+    }
+    segments.length = index;
+  }
+  return segments.length === 0 ? path.parse(first).root : segments.join(path.sep);
+}
+
+function unwrapTsExpression(expression: ts.Expression): ts.Expression {
+  if (
+    ts.isParenthesizedExpression(expression) ||
+    ts.isAsExpression(expression) ||
+    ts.isTypeAssertionExpression(expression) ||
+    ts.isSatisfiesExpression(expression) ||
+    ts.isNonNullExpression(expression)
+  ) {
+    return unwrapTsExpression(expression.expression);
+  }
+  return expression;
+}
+
+function propertyAccessName(expression: ts.Expression): string | null {
+  const current = unwrapTsExpression(expression);
+  return ts.isIdentifier(current) ? current.text : null;
+}
+
+function objectPropertyName(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text;
+  return null;
+}
+
+function moduleSpecifierText(declaration: ts.Node): string | null {
+  let statement: ts.Node | undefined = declaration;
+  while (
+    statement &&
+    !ts.isImportDeclaration(statement) &&
+    !ts.isExportDeclaration(statement) &&
+    !ts.isSourceFile(statement)
+  ) {
+    statement = statement.parent;
+  }
+  if (
+    statement &&
+    ts.isImportDeclaration(statement) &&
+    ts.isStringLiteral(statement.moduleSpecifier)
+  ) {
+    return statement.moduleSpecifier.text;
+  }
+  if (
+    statement &&
+    ts.isExportDeclaration(statement) &&
+    statement.moduleSpecifier &&
+    ts.isStringLiteral(statement.moduleSpecifier)
+  ) {
+    return statement.moduleSpecifier.text;
+  }
+  return null;
+}
+
+function importedName(declaration: ts.Declaration): string | null {
+  if (ts.isImportSpecifier(declaration) || ts.isExportSpecifier(declaration)) {
+    return declaration.propertyName?.text ?? declaration.name.text;
+  }
+  return null;
+}
+
+function declarationName(declaration: ts.Declaration): string | null {
+  const name = (declaration as { name?: ts.Node }).name;
+  return name && ts.isIdentifier(name) ? name.text : null;
+}
+
+function isSapiomToolsDeclaration(declaration: ts.Declaration): boolean {
+  return declaration
+    .getSourceFile()
+    .fileName.split(path.sep)
+    .join(path.posix.sep)
+    .includes("/node_modules/@sapiom/tools/");
+}
+
+function aliasedSymbol(
+  checker: ts.TypeChecker,
+  symbol: ts.Symbol | undefined,
+): ts.Symbol | undefined {
+  if (!symbol) return undefined;
+  return symbol.flags & ts.SymbolFlags.Alias
+    ? checker.getAliasedSymbol(symbol)
+    : symbol;
+}
+
+function resolvesSapiomNamespace(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  expected: "agents" | "orchestrations",
+  seen = new Set<ts.Symbol>(),
+): boolean {
+  const current = unwrapTsExpression(expression);
+  if (ts.isPropertyAccessExpression(current)) {
+    const namespace = objectPropertyName(current.name);
+    if (namespace !== expected) return false;
+    const owner = unwrapTsExpression(current.expression);
+    if (!ts.isIdentifier(owner)) return false;
+    const ownerSymbol = aliasedSymbol(checker, checker.getSymbolAtLocation(owner));
+    return (
+      ownerSymbol?.declarations?.some(
+        (declaration) =>
+          ts.isNamespaceImport(declaration) &&
+          moduleSpecifierText(declaration) === "@sapiom/tools",
+      ) ?? false
     );
-    const grouped = new Map<string, AgentInvocationCandidate>();
+  }
+  if (!ts.isIdentifier(current)) return false;
 
-    for (const detectedInvocation of scan.invocations) {
-      const key = `${detectedInvocation.slug}\0${detectedInvocation.mode}`;
-      const candidate = grouped.get(key);
-      if (candidate) {
-        candidate.evidence.push(detectedInvocation.evidence);
+  const rawSymbol = checker.getSymbolAtLocation(current);
+  const candidates = [
+    rawSymbol,
+    rawSymbol ? aliasedSymbol(checker, rawSymbol) : undefined,
+  ].filter((symbol): symbol is ts.Symbol => symbol !== undefined);
+  for (const symbol of candidates) {
+    if (seen.has(symbol)) continue;
+    seen.add(symbol);
+    for (const declaration of symbol.declarations ?? []) {
+      if (
+        (ts.isImportSpecifier(declaration) ||
+          ts.isExportSpecifier(declaration)) &&
+        moduleSpecifierText(declaration) === "@sapiom/tools" &&
+        importedName(declaration) === expected
+      ) {
+        return true;
+      }
+      if (
+        isSapiomToolsDeclaration(declaration) &&
+        declarationName(declaration) === expected
+      ) {
+        return true;
+      }
+      if (
+        ts.isVariableDeclaration(declaration) &&
+        declaration.initializer &&
+        resolvesSapiomNamespace(declaration.initializer, checker, expected, seen)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function packageInvocationMode(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): AgentInvocationMode | null {
+  const expression = unwrapTsExpression(call.expression);
+  if (!ts.isPropertyAccessExpression(expression) || expression.questionDotToken) {
+    return null;
+  }
+
+  const method = expression.name.text;
+  if (method !== "run" && method !== "launch") return null;
+  const receiver = unwrapTsExpression(expression.expression);
+  if (ts.isPropertyAccessExpression(receiver) && receiver.name.text === "agents") {
+    const context = unwrapTsExpression(receiver.expression);
+    if (
+      ts.isPropertyAccessExpression(context) &&
+      context.name.text === "sapiom" &&
+      propertyAccessName(context.expression) === "ctx"
+    ) {
+      return method === "run" ? "blocking" : "async";
+    }
+  }
+  if (resolvesSapiomNamespace(receiver, checker, "agents")) {
+    return method === "run" ? "blocking" : "async";
+  }
+  if (method === "launch" && resolvesSapiomNamespace(receiver, checker, "orchestrations")) {
+    return "async";
+  }
+  return null;
+}
+
+function symbolStringLiteral(
+  checker: ts.TypeChecker,
+  expression: ts.Expression,
+  seen = new Set<ts.Symbol>(),
+): string | null {
+  const current = unwrapTsExpression(expression);
+  if (ts.isStringLiteral(current) || ts.isNoSubstitutionTemplateLiteral(current)) {
+    return current.text;
+  }
+  if (!ts.isIdentifier(current)) return null;
+  const symbol = aliasedSymbol(checker, checker.getSymbolAtLocation(current));
+  if (!symbol || seen.has(symbol)) return null;
+  seen.add(symbol);
+  for (const declaration of symbol.declarations ?? []) {
+    if (
+      ts.isVariableDeclaration(declaration) &&
+      declaration.initializer &&
+      (ts.getCombinedNodeFlags(declaration) & ts.NodeFlags.Const) !== 0
+    ) {
+          const resolved = symbolStringLiteral(
+            checker,
+            declaration.initializer,
+            seen,
+          );
+      if (resolved !== null) return resolved;
+    }
+  }
+  return null;
+}
+
+function resolvedObjectLiteral(
+  checker: ts.TypeChecker,
+  expression: ts.Expression,
+  seen = new Set<ts.Symbol>(),
+): ts.ObjectLiteralExpression | null {
+  const current = unwrapTsExpression(expression);
+  if (ts.isObjectLiteralExpression(current)) return current;
+  if (!ts.isIdentifier(current)) return null;
+  const symbol = aliasedSymbol(checker, checker.getSymbolAtLocation(current));
+  if (!symbol || seen.has(symbol)) return null;
+  seen.add(symbol);
+  for (const declaration of symbol.declarations ?? []) {
+    if (
+      ts.isVariableDeclaration(declaration) &&
+      declaration.initializer &&
+      (ts.getCombinedNodeFlags(declaration) & ts.NodeFlags.Const) !== 0
+    ) {
+      const resolved = resolvedObjectLiteral(
+        checker,
+        declaration.initializer,
+        seen,
+      );
+      if (resolved) return resolved;
+    }
+  }
+  return null;
+}
+
+function staticDefinitionTarget(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): TargetResult {
+  const argument = call.arguments[0];
+  if (!argument) return { kind: "dynamic" };
+  const object = resolvedObjectLiteral(checker, argument);
+  if (!object) return { kind: "dynamic" };
+
+  let result: TargetResult = { kind: "dynamic" };
+  for (const property of object.properties) {
+    if (ts.isSpreadAssignment(property)) {
+      result = { kind: "dynamic" };
+      continue;
+    }
+    if (!property.name || objectPropertyName(property.name) !== "definition") {
+      continue;
+    }
+    if (ts.isShorthandPropertyAssignment(property)) {
+      const resolved = symbolStringLiteral(checker, property.name);
+      result =
+        resolved === null
+          ? { kind: "dynamic" }
+          : { kind: "literal", slug: resolved };
+      continue;
+    }
+    if (!ts.isPropertyAssignment(property)) {
+      result = { kind: "dynamic" };
+      continue;
+    }
+    const resolved = symbolStringLiteral(checker, property.initializer);
+    result =
+      resolved === null
+        ? { kind: "dynamic" }
+        : { kind: "literal", slug: resolved };
+  }
+  return result;
+}
+
+function parameterTarget(
+  expression: ts.Expression,
+  parameters: readonly ts.ParameterDeclaration[],
+): WrapperTargetResult | null {
+  const current = unwrapTsExpression(expression);
+  if (!ts.isIdentifier(current)) return null;
+  const index = parameters.findIndex(
+    (parameter) =>
+      ts.isIdentifier(parameter.name) && parameter.name.text === current.text,
+  );
+  return index === -1 ? null : { kind: "parameter", index };
+}
+
+function wrapperDefinitionTarget(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+  parameters: readonly ts.ParameterDeclaration[],
+): WrapperTargetResult {
+  const argument = call.arguments[0];
+  if (!argument) return { kind: "dynamic" };
+  const object = resolvedObjectLiteral(checker, argument);
+  if (!object) return { kind: "dynamic" };
+
+  let result: WrapperTargetResult = { kind: "dynamic" };
+  for (const property of object.properties) {
+    if (ts.isSpreadAssignment(property)) {
+      result = { kind: "dynamic" };
+      continue;
+    }
+    if (!property.name || objectPropertyName(property.name) !== "definition") {
+      continue;
+    }
+    if (ts.isShorthandPropertyAssignment(property)) {
+      const parameter = parameterTarget(property.name, parameters);
+      if (parameter) {
+        result = parameter;
+        continue;
+      }
+      const resolved = symbolStringLiteral(checker, property.name);
+      result =
+        resolved === null
+          ? { kind: "dynamic" }
+          : { kind: "literal", slug: resolved };
+      continue;
+    }
+    if (!ts.isPropertyAssignment(property)) {
+      result = { kind: "dynamic" };
+      continue;
+    }
+    const parameter = parameterTarget(property.initializer, parameters);
+    if (parameter) {
+      result = parameter;
+      continue;
+    }
+    const resolved = symbolStringLiteral(checker, property.initializer);
+    result =
+      resolved === null
+        ? { kind: "dynamic" }
+        : { kind: "literal", slug: resolved };
+  }
+  return result;
+}
+
+function relativeProgramEvidence(
+  root: string,
+  file: string,
+  sourceFile: ts.SourceFile,
+  position: number,
+): SourceEvidence {
+  const location = sourceFile.getLineAndCharacterOfPosition(position);
+  return {
+    file: path.relative(root, file).split(path.sep).join(path.posix.sep),
+    line: location.line + 1,
+    column: location.character + 1,
+  };
+}
+
+function owningCaller(
+  file: string,
+  callers: readonly AgentInventoryItem[],
+): AgentInventoryItem | null {
+  const matches = callers.filter((caller) => {
+    const relative = path.relative(caller.sourceRoot, file);
+    return (
+      relative !== "" &&
+      relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative)
+    );
+  });
+  return (
+    matches.sort(
+      (left, right) => right.sourceRoot.length - left.sourceRoot.length,
+    )[0] ?? null
+  );
+}
+
+function stableScanFingerprint(
+  files: readonly { file: string; content: string | null }[],
+  complete: boolean,
+): `sha256:${string}` {
+  const sources = files
+    .map(({ file, content }) => ({
+      file,
+      contentDigest:
+        content === null
+          ? null
+          : `sha256:${createHash("sha256").update(content).digest("hex")}`,
+    }))
+    .sort((left, right) => left.file.localeCompare(right.file));
+  return `sha256:${createHash("sha256")
+    .update(JSON.stringify({ protocol: 2, complete, sources }))
+    .digest("hex")}`;
+}
+
+function createPackageProgram(rootNames: readonly string[]): ts.Program {
+  return ts.createProgram([...rootNames], {
+    allowJs: false,
+    esModuleInterop: true,
+    jsx: ts.JsxEmit.ReactJSX,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noEmit: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2022,
+  });
+}
+
+function symbolKey(symbol: ts.Symbol | undefined): string | null {
+  const declarations = symbol?.declarations;
+  if (!declarations || declarations.length === 0) return null;
+  const declaration = declarations[0]!;
+  const sourceFile = declaration.getSourceFile();
+  return `${sourceFile.fileName}:${declaration.pos}:${declaration.end}`;
+}
+
+function directInvocationsInFunction(
+  node: ts.Node,
+  checker: ts.TypeChecker,
+): Array<{ target: WrapperTargetResult; mode: AgentInvocationMode }> {
+  const invocations: Array<{ target: WrapperTargetResult; mode: AgentInvocationMode }> = [];
+  const body =
+    (ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isMethodDeclaration(node)) &&
+    node.body
+      ? node.body
+      : null;
+  if (!body) return invocations;
+  const parameters =
+    (ts.isFunctionDeclaration(node) ||
+      ts.isFunctionExpression(node) ||
+      ts.isArrowFunction(node) ||
+      ts.isMethodDeclaration(node))
+      ? node.parameters
+      : [];
+  const visit = (child: ts.Node): void => {
+    if (child !== body && ts.isFunctionLike(child)) return;
+    if (ts.isCallExpression(child)) {
+      const mode = packageInvocationMode(child, checker);
+      if (mode) {
+        const target = wrapperDefinitionTarget(child, checker, parameters);
+        invocations.push({ target, mode });
+      }
+    }
+    ts.forEachChild(child, visit);
+  };
+  visit(body);
+  return invocations;
+}
+
+function functionLikeFromDeclaration(
+  declaration: ts.Declaration,
+): ts.Node | null {
+  if (ts.isFunctionDeclaration(declaration)) return declaration;
+  if (
+    ts.isVariableDeclaration(declaration) &&
+    declaration.initializer &&
+    (ts.isArrowFunction(declaration.initializer) ||
+      ts.isFunctionExpression(declaration.initializer))
+  ) {
+    return declaration.initializer;
+  }
+  return null;
+}
+
+function containingWrapperKey(
+  node: ts.Node,
+  checker: ts.TypeChecker,
+  wrappers: ReadonlyMap<string, readonly { target: WrapperTargetResult; mode: AgentInvocationMode }[]>,
+  sourceFile: ts.SourceFile,
+): string | null {
+  for (let ancestor = node.parent; ancestor && ancestor !== sourceFile; ancestor = ancestor.parent) {
+    if (
+      ts.isFunctionDeclaration(ancestor) ||
+      ts.isFunctionExpression(ancestor) ||
+      ts.isArrowFunction(ancestor)
+    ) {
+      const declaration = ts.isArrowFunction(ancestor) || ts.isFunctionExpression(ancestor)
+        ? ancestor.parent
+        : ancestor;
+      const symbol =
+        ts.isFunctionDeclaration(declaration) && declaration.name
+          ? checker.getSymbolAtLocation(declaration.name)
+          : ts.isVariableDeclaration(declaration) && ts.isIdentifier(declaration.name)
+            ? checker.getSymbolAtLocation(declaration.name)
+            : undefined;
+      const key = symbolKey(aliasedSymbol(checker, symbol));
+      if (key && wrappers.has(key)) return key;
+    }
+  }
+  return null;
+}
+
+function resolveWrapperInvocationTarget(
+  target: WrapperTargetResult,
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): string | null {
+  if (target.kind === "literal") return target.slug;
+  if (target.kind !== "parameter") return null;
+  const argument = call.arguments[target.index];
+  return argument ? symbolStringLiteral(checker, argument) : null;
+}
+
+async function scanPackageInvocations(
+  callers: readonly AgentInventoryItem[],
+  readHooks: WorkflowSourceReadHooks,
+): Promise<Map<string, AgentInvocationProviderResult>> {
+  const orderedCallers = [...callers].sort((left, right) =>
+    left.agentKey.localeCompare(right.agentKey),
+  );
+  const byAgentKey = new Map<string, PackageInvocationScan>();
+  const rootNames: string[] = [];
+  const observed = new Set<string>();
+  let complete = true;
+  for (const caller of orderedCallers) {
+    const sourceSet = await listSourceFilesWithObservations(caller.sourceRoot);
+    if (!sourceSet.complete) complete = false;
+    sourceSet.files.forEach((file) => rootNames.push(file));
+    sourceSet.observedPaths.forEach((path) => observed.add(path));
+    byAgentKey.set(caller.agentKey, {
+      invocations: [],
+      groupedInvocations: [],
+      warnings: [],
+      observedPaths: [...sourceSet.observedPaths],
+      complete: sourceSet.complete,
+      sourceFingerprint: `sha256:${"0".repeat(64)}`,
+    });
+  }
+  const program = createPackageProgram([...new Set(rootNames)].sort());
+  const checker = program.getTypeChecker();
+  const workspaceRoot = commonSourceRoot(orderedCallers);
+  const sourceFiles = program
+    .getSourceFiles()
+    .filter(
+      (sourceFile) =>
+        !sourceFile.isDeclarationFile &&
+        PROGRAM_SOURCE_EXTENSIONS.has(path.extname(sourceFile.fileName)) &&
+        !sourceFile.fileName.includes(`${path.sep}node_modules${path.sep}`) &&
+        path.relative(workspaceRoot, sourceFile.fileName) !== ".." &&
+        !path
+          .relative(workspaceRoot, sourceFile.fileName)
+          .startsWith(`..${path.sep}`),
+    )
+    .sort((left, right) => left.fileName.localeCompare(right.fileName));
+  const contents = new Map<string, string | null>();
+  for (const sourceFile of sourceFiles) {
+    observed.add(sourceFile.fileName);
+    const owner = owningCaller(sourceFile.fileName, orderedCallers);
+    const content = owner
+      ? await readWorkflowSourceFile(
+          owner.sourceRoot,
+          sourceFile.fileName,
+          readHooks,
+        )
+      : sourceFile.text;
+    if (content === null) complete = false;
+    contents.set(sourceFile.fileName, content);
+  }
+
+  const wrappers = new Map<
+    string,
+    Array<{ target: WrapperTargetResult; mode: AgentInvocationMode }>
+  >();
+  for (const sourceFile of sourceFiles) {
+    if (contents.get(sourceFile.fileName) === null) continue;
+    const visit = (node: ts.Node): void => {
+      const callable = functionLikeFromDeclaration(node as ts.Declaration);
+      if (callable) {
+        const symbol =
+          ts.isFunctionDeclaration(node) && node.name
+            ? checker.getSymbolAtLocation(node.name)
+            : ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)
+              ? checker.getSymbolAtLocation(node.name)
+              : undefined;
+        const key = symbolKey(aliasedSymbol(checker, symbol));
+        const invocations = directInvocationsInFunction(callable, checker);
+        if (key && invocations.length > 0) wrappers.set(key, invocations);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
+  for (const sourceFile of sourceFiles) {
+    if (contents.get(sourceFile.fileName) === null) continue;
+    const caller = owningCaller(sourceFile.fileName, orderedCallers);
+    if (!caller) continue;
+    const scan = byAgentKey.get(caller.agentKey)!;
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node)) {
+        const mode = packageInvocationMode(node, checker);
+        const position = node.expression.getStart(sourceFile);
+        if (mode) {
+          if (containingWrapperKey(node, checker, wrappers, sourceFile)) {
+            ts.forEachChild(node, visit);
+            return;
+          }
+          const evidence = relativeProgramEvidence(
+            caller.sourceRoot,
+            sourceFile.fileName,
+            sourceFile,
+            position,
+          );
+          const target = staticDefinitionTarget(node, checker);
+          if (target.kind === "literal") {
+            scan.invocations.push({ target: target.slug, mode, evidence });
+          } else {
+            scan.warnings.push({ code: "dynamic-target", mode, evidence });
+          }
+        } else {
+          const expression = unwrapTsExpression(node.expression);
+          const symbol =
+            ts.isIdentifier(expression) || ts.isPropertyAccessExpression(expression)
+              ? aliasedSymbol(checker, checker.getSymbolAtLocation(expression))
+              : undefined;
+          const wrapper = wrappers.get(symbolKey(symbol) ?? "");
+          if (wrapper) {
+            const evidence = relativeProgramEvidence(
+              caller.sourceRoot,
+              sourceFile.fileName,
+              sourceFile,
+              position,
+            );
+            for (const invocation of wrapper) {
+              const target = resolveWrapperInvocationTarget(
+                invocation.target,
+                node,
+                checker,
+              );
+              if (target === null) {
+                scan.warnings.push({
+                  code: "dynamic-target",
+                  mode: invocation.mode,
+                  evidence,
+                });
+              } else {
+                scan.invocations.push({
+                  target,
+                  mode: invocation.mode,
+                  evidence,
+                });
+              }
+            }
+          }
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
+  const fingerprint = stableScanFingerprint(
+    sourceFiles.map((sourceFile) => ({
+      file: path.relative(workspaceRoot, sourceFile.fileName).split(path.sep).join(path.posix.sep),
+      content: contents.get(sourceFile.fileName) ?? sourceFile.text,
+    })),
+    complete,
+  );
+  for (const scan of byAgentKey.values()) {
+    scan.observedPaths = [
+      ...new Set([...scan.observedPaths, ...observed]),
+    ].sort();
+    scan.complete = scan.complete && complete;
+    scan.sourceFingerprint = fingerprint;
+    const grouped = new Map<string, AgentInvocationCandidate>();
+    for (const invocation of scan.invocations.sort((left, right) =>
+      evidenceOrder(left.evidence, right.evidence),
+    )) {
+      const key = `${invocation.target}\0${invocation.mode}`;
+      const existing = grouped.get(key);
+      if (existing) {
+        existing.evidence.push(invocation.evidence);
       } else {
         grouped.set(key, {
-          target: detectedInvocation.slug,
-          mode: detectedInvocation.mode,
-          evidence: [detectedInvocation.evidence],
+          target: invocation.target,
+          mode: invocation.mode,
+          evidence: [invocation.evidence],
         });
       }
     }
-
-    const invocations = [...grouped.values()];
-    for (const candidate of invocations) {
+    scan.groupedInvocations = [...grouped.values()];
+    for (const candidate of scan.groupedInvocations) {
       candidate.evidence.sort(evidenceOrder);
     }
-    invocations.sort(
+    scan.groupedInvocations.sort(
       (left, right) =>
         left.evidence[0]!.file.localeCompare(right.evidence[0]!.file) ||
         left.evidence[0]!.line - right.evidence[0]!.line ||
@@ -518,13 +1210,75 @@ export class SourceAgentInvocationProvider implements AgentInvocationProvider {
         MODE_ORDER[left.mode] - MODE_ORDER[right.mode] ||
         left.target.localeCompare(right.target),
     );
+    scan.warnings.sort((left, right) =>
+      evidenceOrder(left.evidence, right.evidence),
+    );
+  }
+  return new Map(
+    [...byAgentKey].map(([agentKey, scan]) => [
+      agentKey,
+      {
+        invocations: scan.groupedInvocations,
+        warnings: scan.warnings,
+        observedPaths: scan.observedPaths,
+        complete: scan.complete,
+        sourceFingerprint: scan.sourceFingerprint,
+      },
+    ]),
+  );
+}
+/**
+ * V0 per-agent filesystem adapter for literal direct invocations.
+ *
+ * It builds one package-wide TypeScript Program for the retained caller set so
+ * imports, re-exports, and simple static wrappers are resolved consistently.
+ * Inventory target resolution, input-provenance analysis, runtime dispatch,
+ * renderer, transport, deployment, and session dependencies stay outside this
+ * provider.
+ */
+export class SourceAgentInvocationProvider implements AgentInvocationProvider {
+  private retainedCallers: readonly AgentInventoryItem[] = [];
+  private inFlight:
+    | {
+        key: string;
+        result: Promise<Map<string, AgentInvocationProviderResult>>;
+      }
+    | null = null;
 
-    return {
-      invocations,
-      warnings: scan.invocationWarnings,
-      observedPaths: scan.observedPaths,
-      complete: scan.complete,
-      sourceFingerprint: scan.sourceFingerprint,
-    };
+  constructor(private readonly readHooks: WorkflowSourceReadHooks = {}) {}
+
+  retainCallers(callers: readonly AgentInventoryItem[]): void {
+    this.retainedCallers = [...callers].sort((left, right) =>
+      left.agentKey.localeCompare(right.agentKey),
+    );
+  }
+
+  async listInvocations(
+    caller: AgentInventoryItem,
+  ): Promise<AgentInvocationProviderResult> {
+    const callers = this.retainedCallers.some(
+      (candidate) => candidate.agentKey === caller.agentKey,
+    )
+      ? this.retainedCallers
+      : [caller];
+    const key = callers
+      .map((candidate) => `${candidate.agentKey}\0${candidate.sourceRoot}`)
+      .sort()
+      .join("\0");
+    if (!this.inFlight || this.inFlight.key !== key) {
+      const result = scanPackageInvocations(callers, this.readHooks).finally(() => {
+        if (this.inFlight?.key === key) this.inFlight = null;
+      });
+      this.inFlight = { key, result };
+    }
+    const packageResult = await this.inFlight.result;
+    return (
+      packageResult.get(caller.agentKey) ?? {
+        invocations: [],
+        warnings: [],
+        observedPaths: [],
+        complete: false,
+      }
+    );
   }
 }

--- a/packages/harness/src/core/system-graph-relationships.ts
+++ b/packages/harness/src/core/system-graph-relationships.ts
@@ -10,7 +10,6 @@ import {
   type SourceEvidence,
   type WorkflowSourceReadHooks,
 } from "./canvas-interconnections.js";
-import { fingerprintWorkflowSources } from "./canvas-cache.js";
 import { canonicalGraphPath } from "./canonical-graph-path.js";
 import type { AgentInventoryItem } from "./system-graph-inventory.js";
 
@@ -123,7 +122,7 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
     private readonly inner: AgentInvocationProvider = new SourceAgentInvocationProvider(),
     private readonly fingerprint: (
       sourceRoot: string,
-    ) => Promise<string> = fingerprintWorkflowSources,
+    ) => Promise<string> = fingerprintSystemGraphPackageSources,
     private readonly options: CachedAgentInvocationProviderOptions = {},
   ) {}
 
@@ -577,6 +576,9 @@ type InvocationMethodAliasMap = ReadonlyMap<
   string,
   SystemGraphInvocationMethodResolution
 >;
+type InvocationMethodWrite =
+  | { kind: "method"; resolution: SystemGraphInvocationMethodResolution }
+  | { kind: "non-method" };
 
 interface PackageInvocation {
   target: string;
@@ -916,46 +918,66 @@ function invocationMethodFromName(
   return null;
 }
 
-function methodAliasFromExpression(
-  expression: ts.Expression,
-  checker: ts.TypeChecker,
-  methodAliases: InvocationMethodAliasMap,
-): SystemGraphInvocationMethodResolution | null {
-  const direct = directInvocationMethodResolution(expression, checker);
-  if (direct?.kind === "resolved") return direct;
-  const current = unwrapTsExpression(expression);
-  if (!ts.isIdentifier(current) && !ts.isPropertyAccessExpression(current)) {
-    return null;
-  }
-  const symbol = aliasedSymbol(checker, checker.getSymbolAtLocation(current));
-  const key = symbolKey(symbol);
-  const aliased = key ? methodAliases.get(key) ?? null : null;
-  return aliased?.kind === "resolved" ? aliased : null;
-}
-
-function addMethodAlias(
-  methodAliases: Map<string, SystemGraphInvocationMethodResolution>,
+function symbolWriteKey(
   checker: ts.TypeChecker,
   name: ts.Node,
-  resolution: SystemGraphInvocationMethodResolution | null,
-): void {
-  if (
-    !resolution ||
-    resolution.kind !== "resolved" ||
-    (!ts.isIdentifier(name) && !ts.isPropertyAccessExpression(name))
-  ) {
-    return;
+): string | null {
+  if (!ts.isIdentifier(name) && !ts.isPropertyAccessExpression(name)) {
+    return null;
   }
-  const key = symbolKey(
-    aliasedSymbol(checker, checker.getSymbolAtLocation(name)),
-  );
-  if (key) methodAliases.set(key, resolution);
+  return symbolKey(aliasedSymbol(checker, checker.getSymbolAtLocation(name)));
+}
+
+function methodWriteFromExpression(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  resolvedAliases: InvocationMethodAliasMap,
+): InvocationMethodWrite {
+  const direct = directInvocationMethodResolution(expression, checker);
+  if (direct) return { kind: "method", resolution: direct };
+  const current = unwrapTsExpression(expression);
+  if (ts.isConditionalExpression(current)) {
+    const whenTrue = methodWriteFromExpression(
+      current.whenTrue,
+      checker,
+      resolvedAliases,
+    );
+    const whenFalse = methodWriteFromExpression(
+      current.whenFalse,
+      checker,
+      resolvedAliases,
+    );
+    return whenTrue.kind === "method" || whenFalse.kind === "method"
+      ? { kind: "method", resolution: { kind: "dynamic", modes: ["blocking", "async"] } }
+      : { kind: "non-method" };
+  }
+  if (!ts.isIdentifier(current) && !ts.isPropertyAccessExpression(current)) {
+    return { kind: "non-method" };
+  }
+  const key = symbolWriteKey(checker, current);
+  const aliased = key ? resolvedAliases.get(key) ?? null : null;
+  return aliased
+    ? { kind: "method", resolution: aliased }
+    : { kind: "non-method" };
+}
+
+function addMethodAliasWrite(
+  writes: Map<string, InvocationMethodWrite[]>,
+  checker: ts.TypeChecker,
+  name: ts.Node,
+  write: InvocationMethodWrite,
+): void {
+  const key = symbolWriteKey(checker, name);
+  if (!key) return;
+  const existing = writes.get(key) ?? [];
+  existing.push(write);
+  writes.set(key, existing);
 }
 
 function collectDestructuredMethodAliases(
   declaration: ts.VariableDeclaration,
   checker: ts.TypeChecker,
-  methodAliases: Map<string, SystemGraphInvocationMethodResolution>,
+  writes: Map<string, InvocationMethodWrite[]>,
 ): void {
   if (!declaration.initializer || !ts.isObjectBindingPattern(declaration.name)) {
     return;
@@ -973,11 +995,13 @@ function collectDestructuredMethodAliases(
       ? objectPropertyName(element.propertyName)
       : element.name.text;
     if (!method) continue;
-    addMethodAlias(
-      methodAliases,
+    const resolution = invocationMethodFromName(namespace, method);
+    if (!resolution) continue;
+    addMethodAliasWrite(
+      writes,
       checker,
       element.name,
-      invocationMethodFromName(namespace, method),
+      { kind: "method", resolution },
     );
   }
 }
@@ -986,16 +1010,17 @@ function collectInvocationMethodAliases(
   sourceFiles: readonly ts.SourceFile[],
   checker: ts.TypeChecker,
 ): InvocationMethodAliasMap {
+  const writes = new Map<string, InvocationMethodWrite[]>();
   const methodAliases = new Map<string, SystemGraphInvocationMethodResolution>();
   const visit = (node: ts.Node): void => {
     if (ts.isVariableDeclaration(node)) {
-      collectDestructuredMethodAliases(node, checker, methodAliases);
+      collectDestructuredMethodAliases(node, checker, writes);
       if (node.initializer) {
-        addMethodAlias(
-          methodAliases,
+        addMethodAliasWrite(
+          writes,
           checker,
           node.name,
-          methodAliasFromExpression(node.initializer, checker, methodAliases),
+          methodWriteFromExpression(node.initializer, checker, methodAliases),
         );
       }
     } else if (
@@ -1004,17 +1029,33 @@ function collectInvocationMethodAliases(
     ) {
       const left = unwrapTsExpression(node.left);
       if (ts.isIdentifier(left) || ts.isPropertyAccessExpression(left)) {
-        addMethodAlias(
-          methodAliases,
+        addMethodAliasWrite(
+          writes,
           checker,
           left,
-          methodAliasFromExpression(node.right, checker, methodAliases),
+          methodWriteFromExpression(node.right, checker, methodAliases),
         );
       }
     }
     ts.forEachChild(node, visit);
   };
   for (const sourceFile of sourceFiles) visit(sourceFile);
+  for (const [key, symbolWrites] of writes) {
+    const methodWrites = symbolWrites.filter(
+      (write): write is Extract<InvocationMethodWrite, { kind: "method" }> =>
+        write.kind === "method",
+    );
+    if (methodWrites.length === 0) continue;
+    const hasNonMethodWrite = symbolWrites.some((write) => write.kind === "non-method");
+    methodAliases.set(
+      key,
+      methodWrites.length === 1 &&
+        !hasNonMethodWrite &&
+        methodWrites[0]!.resolution.kind === "resolved"
+        ? methodWrites[0]!.resolution
+        : { kind: "dynamic", modes: ["blocking", "async"] },
+    );
+  }
   return methodAliases;
 }
 
@@ -1191,22 +1232,31 @@ function owningCaller(
   );
 }
 
-function stableScanFingerprint(
-  files: readonly { file: string; content: string | null }[],
-  complete: boolean,
-): `sha256:${string}` {
-  const sources = files
-    .map(({ file, content }) => ({
-      file,
-      contentDigest:
-        content === null
-          ? null
-          : `sha256:${createHash("sha256").update(content).digest("hex")}`,
-    }))
-    .sort((left, right) => left.file.localeCompare(right.file));
-  return `sha256:${createHash("sha256")
-    .update(JSON.stringify({ protocol: 2, complete, sources }))
-    .digest("hex")}`;
+function lexicalAbsolutePath(fileName: string, base: string): string {
+  return path.normalize(
+    path.isAbsolute(fileName) ? fileName : path.resolve(base, fileName),
+  );
+}
+
+function containedLexicalPath(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" ||
+    (relative !== ".." &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
+}
+
+function snapshotMemberPath(
+  snapshot: PackageSourceSnapshot,
+  fileName: string,
+): string | null {
+  const candidate = lexicalAbsolutePath(fileName, snapshot.packageRoot);
+  return containedLexicalPath(snapshot.packageRoot, candidate) &&
+    snapshot.files.has(candidate)
+    ? candidate
+    : null;
 }
 
 async function snapshotPackageSources(
@@ -1271,23 +1321,27 @@ function createPackageProgram(snapshot: PackageSourceSnapshot): ts.Program {
   };
   const host = ts.createCompilerHost(compilerOptions, true);
   const sourceFiles = snapshot.files;
-  const hostPath = (fileName: string): string =>
-    canonicalGraphPath(
-      path.isAbsolute(fileName)
-        ? fileName
-        : path.resolve(snapshot.packageRoot, fileName),
-    );
   const hasFile = (fileName: string): boolean =>
-    sourceFiles.has(hostPath(fileName));
+    snapshotMemberPath(snapshot, fileName) !== null;
   return ts.createProgram([...sourceFiles.keys()].sort(), compilerOptions, {
     ...host,
     getCurrentDirectory: () => snapshot.packageRoot,
-    getCanonicalFileName: hostPath,
+    getCanonicalFileName: (fileName) =>
+      lexicalAbsolutePath(fileName, snapshot.packageRoot),
     fileExists: hasFile,
-    readFile: (fileName) => sourceFiles.get(hostPath(fileName)),
-    realpath: hostPath,
+    readFile: (fileName) => {
+      const member = snapshotMemberPath(snapshot, fileName);
+      return member ? sourceFiles.get(member) : undefined;
+    },
+    realpath: (fileName) => lexicalAbsolutePath(fileName, snapshot.packageRoot),
     directoryExists: (directoryName) => {
-      const canonicalDirectory = hostPath(directoryName);
+      const canonicalDirectory = lexicalAbsolutePath(
+        directoryName,
+        snapshot.packageRoot,
+      );
+      if (!containedLexicalPath(snapshot.packageRoot, canonicalDirectory)) {
+        return false;
+      }
       return [...sourceFiles.keys()].some((fileName) => {
         const relative = path.relative(canonicalDirectory, fileName);
         return (
@@ -1299,7 +1353,13 @@ function createPackageProgram(snapshot: PackageSourceSnapshot): ts.Program {
       });
     },
     getDirectories: (directoryName) => {
-      const canonicalDirectory = hostPath(directoryName);
+      const canonicalDirectory = lexicalAbsolutePath(
+        directoryName,
+        snapshot.packageRoot,
+      );
+      if (!containedLexicalPath(snapshot.packageRoot, canonicalDirectory)) {
+        return [];
+      }
       const directories = new Set<string>();
       for (const fileName of sourceFiles.keys()) {
         const relative = path.relative(canonicalDirectory, fileName);
@@ -1317,16 +1377,17 @@ function createPackageProgram(snapshot: PackageSourceSnapshot): ts.Program {
       return [...directories].sort();
     },
     getSourceFile: (fileName, languageVersion) => {
-      const canonicalFile = hostPath(fileName);
-      const content = sourceFiles.get(canonicalFile);
+      const member = snapshotMemberPath(snapshot, fileName);
+      if (!member) return undefined;
+      const content = sourceFiles.get(member);
       return content === undefined
         ? undefined
         : ts.createSourceFile(
-            canonicalFile,
+            member,
             content,
             languageVersion,
             true,
-            path.extname(canonicalFile) === ".tsx"
+            path.extname(member) === ".tsx"
               ? ts.ScriptKind.TSX
               : ts.ScriptKind.TS,
           );
@@ -1337,15 +1398,40 @@ function createPackageProgram(snapshot: PackageSourceSnapshot): ts.Program {
 function packageSourceFingerprint(
   snapshot: PackageSourceSnapshot,
 ): `sha256:${string}` {
-  return stableScanFingerprint(
-    [...snapshot.files].map(([file, content]) => ({
+  const sources = [...snapshot.files]
+    .map(([file, content]) => ({
       file: path
         .relative(snapshot.packageRoot, file)
         .split(path.sep)
         .join(path.posix.sep),
-      content,
-    })),
-    snapshot.complete,
+      contentDigest: `sha256:${createHash("sha256")
+        .update(content)
+        .digest("hex")}`,
+    }))
+    .sort((left, right) => left.file.localeCompare(right.file));
+  const observedPaths = snapshot.observedPaths
+    .map((file) =>
+      path.relative(snapshot.packageRoot, file).split(path.sep).join(path.posix.sep),
+    )
+    .sort();
+  return `sha256:${createHash("sha256")
+    .update(
+      JSON.stringify({
+        protocol: 3,
+        complete: snapshot.complete,
+        observedPaths,
+        sources,
+      }),
+    )
+    .digest("hex")}`;
+}
+
+export async function fingerprintSystemGraphPackageSources(
+  packageRoot: string,
+  readHooks: WorkflowSourceReadHooks = {},
+): Promise<`sha256:${string}`> {
+  return packageSourceFingerprint(
+    await snapshotPackageSources(packageRoot, readHooks),
   );
 }
 
@@ -1359,7 +1445,7 @@ export async function createSystemGraphPackageCompilerResult({
   const checker = program.getTypeChecker();
   const sourceFilesByPath = new Map(
     program.getSourceFiles().map((sourceFile) => [
-      canonicalGraphPath(sourceFile.fileName),
+      lexicalAbsolutePath(sourceFile.fileName, snapshot.packageRoot),
       sourceFile,
     ]),
   );

--- a/packages/harness/src/core/system-graph-relationships.ts
+++ b/packages/harness/src/core/system-graph-relationships.ts
@@ -6,7 +6,6 @@ import ts from "typescript";
 import {
   listSourceFilesWithObservations,
   readWorkflowSourceFile,
-  workflowSourceFileMetadata,
   type AgentInvocationDetectionWarning,
   type AgentInvocationMode,
   type SourceEvidence,
@@ -533,6 +532,9 @@ const MODE_ORDER: Record<AgentInvocationMode, number> = {
 };
 
 const PROGRAM_SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".mts", ".cts"]);
+const INVOCATION_ALIAS_MAX_VERTICES = 2_048;
+const INVOCATION_ALIAS_MAX_EDGES = 8_192;
+const INVOCATION_ALIAS_MAX_WORK = 32_768;
 
 type TargetResult = { kind: "literal"; slug: string } | { kind: "dynamic" };
 type WrapperTargetResult =
@@ -603,6 +605,14 @@ interface PackageSourceSnapshot {
   files: ReadonlyMap<string, string>;
   observedPaths: readonly string[];
   complete: boolean;
+}
+
+let toolsDeclarationAdmissionProbeForTest: ((path: string) => void) | null = null;
+
+export function setToolsDeclarationAdmissionProbeForTest(
+  next: ((path: string) => void) | null,
+): void {
+  toolsDeclarationAdmissionProbeForTest = next;
 }
 
 function packageRootForCaller(caller: AgentInventoryItem): string {
@@ -1038,52 +1048,122 @@ function collectInvocationMethodAliases(
   };
   for (const sourceFile of sourceFiles) visit(sourceFile);
 
-  const resolveWrites = (
-    key: string,
-    seen = new Set<string>(),
-  ): {
+  let edgeCount = 0;
+  for (const symbolWrites of writes.values()) {
+    edgeCount += symbolWrites.filter((write) => write.kind === "alias").length;
+  }
+  const dynamicMethod = {
+    kind: "dynamic",
+    modes: ["blocking", "async"],
+  } as const satisfies SystemGraphInvocationMethodResolution;
+  if (
+    writes.size > INVOCATION_ALIAS_MAX_VERTICES ||
+    edgeCount > INVOCATION_ALIAS_MAX_EDGES
+  ) {
+    return new Map(
+      [...writes.keys()].map((key) => [key, dynamicMethod]),
+    );
+  }
+
+  interface AliasResolution {
     resolutions: SystemGraphInvocationMethodResolution[];
     nonMethod: boolean;
     unresolved: boolean;
-  } => {
-    const symbolWrites = writes.get(key);
-    if (!symbolWrites || symbolWrites.length === 0) {
-      return { resolutions: [], nonMethod: false, unresolved: true };
-    }
-    if (seen.has(key)) {
-      return { resolutions: [], nonMethod: false, unresolved: true };
-    }
-    const nextSeen = new Set(seen);
-    nextSeen.add(key);
-    const resolutions: SystemGraphInvocationMethodResolution[] = [];
-    let nonMethod = false;
-    let unresolved = false;
-    for (const write of symbolWrites) {
-      if (write.kind === "method") {
-        resolutions.push(write.resolution);
-      } else if (write.kind === "non-method") {
-        nonMethod = true;
-      } else {
-        const resolved = resolveWrites(write.key, nextSeen);
-        resolutions.push(...resolved.resolutions);
-        nonMethod ||= resolved.nonMethod;
-        unresolved ||= resolved.unresolved;
+  }
+  const resolved = new Map<string, AliasResolution>();
+  const visiting = new Set<string>();
+  const resolvedState = new Set<string>();
+  let work = 0;
+  const dynamicAliasResolution = (): AliasResolution => ({
+    resolutions: [dynamicMethod],
+    nonMethod: false,
+    unresolved: true,
+  });
+
+  const resolveAlias = (start: string): AliasResolution => {
+    const cached = resolved.get(start);
+    if (cached) return cached;
+    const stack: Array<{ key: string; expanded: boolean }> = [
+      { key: start, expanded: false },
+    ];
+    while (stack.length > 0) {
+      work += 1;
+      if (work > INVOCATION_ALIAS_MAX_WORK) {
+        for (const key of writes.keys()) {
+          resolved.set(key, dynamicAliasResolution());
+          resolvedState.add(key);
+          visiting.delete(key);
+        }
+        return resolved.get(start)!;
       }
+      const frame = stack.pop()!;
+      if (resolved.has(frame.key)) continue;
+      const symbolWrites = writes.get(frame.key);
+      if (!symbolWrites || symbolWrites.length === 0) {
+        resolved.set(frame.key, {
+          resolutions: [],
+          nonMethod: false,
+          unresolved: true,
+        });
+        resolvedState.add(frame.key);
+        visiting.delete(frame.key);
+        continue;
+      }
+      if (!frame.expanded) {
+        if (visiting.has(frame.key)) {
+          resolved.set(frame.key, dynamicAliasResolution());
+          resolvedState.add(frame.key);
+          visiting.delete(frame.key);
+          continue;
+        }
+        if (resolvedState.has(frame.key)) continue;
+        visiting.add(frame.key);
+        stack.push({ key: frame.key, expanded: true });
+        for (const write of symbolWrites) {
+          if (write.kind !== "alias") continue;
+          if (visiting.has(write.key)) {
+            resolved.set(write.key, dynamicAliasResolution());
+            resolvedState.add(write.key);
+            visiting.delete(write.key);
+          } else if (!resolved.has(write.key)) {
+            stack.push({ key: write.key, expanded: false });
+          }
+        }
+        continue;
+      }
+      const resolutions: SystemGraphInvocationMethodResolution[] = [];
+      let nonMethod = false;
+      let unresolved = false;
+      for (const write of symbolWrites) {
+        if (write.kind === "method") {
+          resolutions.push(write.resolution);
+        } else if (write.kind === "non-method") {
+          nonMethod = true;
+        } else {
+          const alias = resolved.get(write.key) ?? dynamicAliasResolution();
+          resolutions.push(...alias.resolutions);
+          nonMethod ||= alias.nonMethod;
+          unresolved ||= alias.unresolved;
+        }
+      }
+      resolved.set(frame.key, { resolutions, nonMethod, unresolved });
+      resolvedState.add(frame.key);
+      visiting.delete(frame.key);
     }
-    return { resolutions, nonMethod, unresolved };
+    return resolved.get(start) ?? dynamicAliasResolution();
   };
 
   for (const [key, symbolWrites] of writes) {
-    const resolved = resolveWrites(key);
-    if (resolved.resolutions.length === 0) continue;
+    const alias = resolveAlias(key);
+    if (alias.resolutions.length === 0) continue;
     methodAliases.set(
       key,
       symbolWrites.length === 1 &&
-        resolved.resolutions.length === 1 &&
-        !resolved.nonMethod &&
-        !resolved.unresolved &&
-        resolved.resolutions[0]!.kind === "resolved"
-        ? resolved.resolutions[0]!
+        alias.resolutions.length === 1 &&
+        !alias.nonMethod &&
+        !alias.unresolved &&
+        alias.resolutions[0]!.kind === "resolved"
+        ? alias.resolutions[0]!
         : { kind: "dynamic", modes: ["blocking", "async"] },
     );
   }
@@ -1290,6 +1370,31 @@ function snapshotMemberPath(
     : null;
 }
 
+async function admittedToolsDeclarationPath(
+  packageRoot: string,
+): Promise<"absent" | "inadmissible" | { status: "regular"; path: string }> {
+  let current = packageRoot;
+  const segments = ["node_modules", "@sapiom", "tools", "index.d.ts"];
+  for (let index = 0; index < segments.length; index += 1) {
+    current = path.join(current, segments[index]!);
+    let stat: import("node:fs").Stats;
+    try {
+      toolsDeclarationAdmissionProbeForTest?.(current);
+      stat = await fs.lstat(current);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      return code === "ENOENT" || code === "ENOTDIR"
+        ? "absent"
+        : "inadmissible";
+    }
+    if (stat.isSymbolicLink()) return "inadmissible";
+    const final = index === segments.length - 1;
+    if (final) return stat.isFile() ? { status: "regular", path: current } : "inadmissible";
+    if (!stat.isDirectory()) return "inadmissible";
+  }
+  return "absent";
+}
+
 async function snapshotPackageSources(
   packageRoot: string,
   readHooks: WorkflowSourceReadHooks,
@@ -1312,48 +1417,29 @@ async function snapshotPackageSources(
     }
     files.set(canonicalFile, content);
   }
-  const toolsDeclaration = lexicalAbsolutePath(
-    path.join(
-      canonicalPackageRoot,
-      "node_modules",
-      "@sapiom",
-      "tools",
-      "index.d.ts",
-    ),
+  const toolsDeclaration = path.join(
     canonicalPackageRoot,
+    "node_modules",
+    "@sapiom",
+    "tools",
+    "index.d.ts",
   );
-  let toolsDeclarationExists = true;
-  try {
-    await fs.lstat(toolsDeclaration);
-  } catch (error) {
-    const code = (error as NodeJS.ErrnoException).code;
-    if (code === "ENOENT" || code === "ENOTDIR") {
-      toolsDeclarationExists = false;
-    } else {
-      complete = false;
-      observedPaths.add(toolsDeclaration);
-    }
-  }
-  if (toolsDeclarationExists) {
-    const toolsDeclarationMetadata = await workflowSourceFileMetadata(
+  const toolsDeclarationAdmission =
+    await admittedToolsDeclarationPath(canonicalPackageRoot);
+  if (toolsDeclarationAdmission === "inadmissible") {
+    complete = false;
+    observedPaths.add(toolsDeclaration);
+  } else if (toolsDeclarationAdmission !== "absent") {
+    const toolsDeclarationSource = await readWorkflowSourceFile(
       canonicalPackageRoot,
-      toolsDeclaration,
+      toolsDeclarationAdmission.path,
+      readHooks,
     );
-    if (toolsDeclarationMetadata.status === "regular") {
-      const toolsDeclarationSource = await readWorkflowSourceFile(
-        canonicalPackageRoot,
-        toolsDeclaration,
-        readHooks,
-      );
-      if (toolsDeclarationSource === null) {
-        complete = false;
-      } else {
-        files.set(toolsDeclaration, toolsDeclarationSource);
-        observedPaths.add(toolsDeclaration);
-      }
-    } else {
+    if (toolsDeclarationSource === null) {
       complete = false;
-      observedPaths.add(toolsDeclaration);
+    } else {
+      files.set(toolsDeclarationAdmission.path, toolsDeclarationSource);
+      observedPaths.add(toolsDeclarationAdmission.path);
     }
   }
   return {

--- a/packages/harness/src/core/system-graph-relationships.ts
+++ b/packages/harness/src/core/system-graph-relationships.ts
@@ -1066,104 +1066,151 @@ function collectInvocationMethodAliases(
   }
 
   interface AliasResolution {
-    resolutions: SystemGraphInvocationMethodResolution[];
+    modeMask: number;
+    methodMultiplicity: 0 | 1 | 2;
     nonMethod: boolean;
     unresolved: boolean;
   }
-  const resolved = new Map<string, AliasResolution>();
-  const visiting = new Set<string>();
-  const resolvedState = new Set<string>();
-  let work = 0;
+  const BLOCKING_MODE = 1;
+  const ASYNC_MODE = 2;
   const dynamicAliasResolution = (): AliasResolution => ({
-    resolutions: [dynamicMethod],
+    modeMask: BLOCKING_MODE | ASYNC_MODE,
+    methodMultiplicity: 2,
     nonMethod: false,
     unresolved: true,
   });
-
-  const resolveAlias = (start: string): AliasResolution => {
-    const cached = resolved.get(start);
-    if (cached) return cached;
-    const stack: Array<{ key: string; expanded: boolean }> = [
-      { key: start, expanded: false },
-    ];
-    while (stack.length > 0) {
-      work += 1;
-      if (work > INVOCATION_ALIAS_MAX_WORK) {
-        for (const key of writes.keys()) {
-          resolved.set(key, dynamicAliasResolution());
-          resolvedState.add(key);
-          visiting.delete(key);
-        }
-        return resolved.get(start)!;
-      }
-      const frame = stack.pop()!;
-      if (resolved.has(frame.key)) continue;
-      const symbolWrites = writes.get(frame.key);
-      if (!symbolWrites || symbolWrites.length === 0) {
-        resolved.set(frame.key, {
-          resolutions: [],
-          nonMethod: false,
-          unresolved: true,
-        });
-        resolvedState.add(frame.key);
-        visiting.delete(frame.key);
-        continue;
-      }
-      if (!frame.expanded) {
-        if (visiting.has(frame.key)) {
-          resolved.set(frame.key, dynamicAliasResolution());
-          resolvedState.add(frame.key);
-          visiting.delete(frame.key);
-          continue;
-        }
-        if (resolvedState.has(frame.key)) continue;
-        visiting.add(frame.key);
-        stack.push({ key: frame.key, expanded: true });
-        for (const write of symbolWrites) {
-          if (write.kind !== "alias") continue;
-          if (visiting.has(write.key)) {
-            resolved.set(write.key, dynamicAliasResolution());
-            resolvedState.add(write.key);
-            visiting.delete(write.key);
-          } else if (!resolved.has(write.key)) {
-            stack.push({ key: write.key, expanded: false });
-          }
-        }
-        continue;
-      }
-      const resolutions: SystemGraphInvocationMethodResolution[] = [];
-      let nonMethod = false;
-      let unresolved = false;
-      for (const write of symbolWrites) {
-        if (write.kind === "method") {
-          resolutions.push(write.resolution);
-        } else if (write.kind === "non-method") {
-          nonMethod = true;
-        } else {
-          const alias = resolved.get(write.key) ?? dynamicAliasResolution();
-          resolutions.push(...alias.resolutions);
-          nonMethod ||= alias.nonMethod;
-          unresolved ||= alias.unresolved;
-        }
-      }
-      resolved.set(frame.key, { resolutions, nonMethod, unresolved });
-      resolvedState.add(frame.key);
-      visiting.delete(frame.key);
-    }
-    return resolved.get(start) ?? dynamicAliasResolution();
+  const methodResolutionState = (
+    resolution: SystemGraphInvocationMethodResolution,
+  ): AliasResolution => ({
+    modeMask:
+      resolution.kind === "resolved"
+        ? resolution.mode === "blocking"
+          ? BLOCKING_MODE
+          : ASYNC_MODE
+        : resolution.modes.reduce(
+            (mask, mode) =>
+              mask | (mode === "blocking" ? BLOCKING_MODE : ASYNC_MODE),
+            0,
+          ),
+    methodMultiplicity: 1,
+    nonMethod: false,
+    unresolved: resolution.kind === "dynamic",
+  });
+  const saturatedAdd = (left: 0 | 1 | 2, right: 0 | 1 | 2): 0 | 1 | 2 =>
+    left === 0 ? right : right === 0 ? left : 2;
+  const mergeState = (
+    left: AliasResolution,
+    right: AliasResolution,
+  ): boolean => {
+    const next: AliasResolution = {
+      modeMask: left.modeMask | right.modeMask,
+      methodMultiplicity: saturatedAdd(
+        left.methodMultiplicity,
+        right.methodMultiplicity,
+      ),
+      nonMethod: left.nonMethod || right.nonMethod,
+      unresolved: left.unresolved || right.unresolved,
+    };
+    const changed =
+      next.modeMask !== left.modeMask ||
+      next.methodMultiplicity !== left.methodMultiplicity ||
+      next.nonMethod !== left.nonMethod ||
+      next.unresolved !== left.unresolved;
+    if (changed) Object.assign(left, next);
+    return changed;
   };
 
+  const states = new Map<string, AliasResolution>();
+  const aliasEdges: Array<{ source: string; target: string }> = [];
   for (const [key, symbolWrites] of writes) {
-    const alias = resolveAlias(key);
-    if (alias.resolutions.length === 0) continue;
+    const state: AliasResolution = {
+      modeMask: 0,
+      methodMultiplicity: 0,
+      nonMethod: false,
+      unresolved: false,
+    };
+    states.set(key, state);
+    for (const write of symbolWrites) {
+      if (write.kind === "method") {
+        mergeState(state, methodResolutionState(write.resolution));
+      } else if (write.kind === "non-method") {
+        state.nonMethod = true;
+      } else {
+        aliasEdges.push({ source: key, target: write.key });
+      }
+    }
+  }
+  for (const edge of aliasEdges) {
+    if (states.has(edge.target)) continue;
+    const state = states.get(edge.source);
+    if (state) state.unresolved = true;
+  }
+  const cycleIndegree = new Map<string, number>();
+  const cycleOutgoing = new Map<string, string[]>();
+  for (const key of writes.keys()) {
+    cycleIndegree.set(key, 0);
+    cycleOutgoing.set(key, []);
+  }
+  for (const edge of aliasEdges) {
+    if (!writes.has(edge.target)) continue;
+    cycleIndegree.set(edge.target, (cycleIndegree.get(edge.target) ?? 0) + 1);
+    cycleOutgoing.get(edge.source)?.push(edge.target);
+  }
+  const acyclic = [...cycleIndegree]
+    .filter(([, count]) => count === 0)
+    .map(([key]) => key)
+    .sort();
+  for (let index = 0; index < acyclic.length; index += 1) {
+    const key = acyclic[index]!;
+    for (const target of cycleOutgoing.get(key) ?? []) {
+      const next = (cycleIndegree.get(target) ?? 0) - 1;
+      cycleIndegree.set(target, next);
+      if (next === 0) acyclic.push(target);
+    }
+  }
+  for (const [key, count] of cycleIndegree) {
+    if (count > 0) mergeState(states.get(key)!, dynamicAliasResolution());
+  }
+
+  let work = 0;
+  const aliasTargets = new Map<string, string[]>();
+  for (const edge of aliasEdges) {
+    const targets = aliasTargets.get(edge.source) ?? [];
+    targets.push(edge.target);
+    aliasTargets.set(edge.source, targets);
+  }
+  for (const key of [...acyclic].reverse()) {
+    const source = states.get(key);
+    if (!source) continue;
+    for (const targetKey of (aliasTargets.get(key) ?? []).sort()) {
+      const target = states.get(targetKey);
+      if (!target) continue;
+      work += 1;
+      if (work > INVOCATION_ALIAS_MAX_WORK) {
+        return new Map(
+          [...writes.keys()].map((key) => [key, dynamicMethod]),
+        );
+      }
+      mergeState(source, target);
+    }
+  }
+
+  for (const [key, symbolWrites] of writes) {
+    const alias = states.get(key);
+    if (!alias || alias.modeMask === 0) continue;
+    const cleanBlocking = alias.modeMask === BLOCKING_MODE;
+    const cleanAsync = alias.modeMask === ASYNC_MODE;
     methodAliases.set(
       key,
       symbolWrites.length === 1 &&
-        alias.resolutions.length === 1 &&
+        alias.methodMultiplicity === 1 &&
         !alias.nonMethod &&
         !alias.unresolved &&
-        alias.resolutions[0]!.kind === "resolved"
-        ? alias.resolutions[0]!
+        (cleanBlocking || cleanAsync)
+        ? {
+            kind: "resolved",
+            mode: cleanBlocking ? "blocking" : "async",
+          }
         : { kind: "dynamic", modes: ["blocking", "async"] },
     );
   }

--- a/packages/harness/src/core/system-graph-relationships.ts
+++ b/packages/harness/src/core/system-graph-relationships.ts
@@ -1,10 +1,12 @@
 import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import ts from "typescript";
 
 import {
   listSourceFilesWithObservations,
   readWorkflowSourceFile,
+  workflowSourceFileMetadata,
   type AgentInvocationDetectionWarning,
   type AgentInvocationMode,
   type SourceEvidence,
@@ -578,6 +580,7 @@ type InvocationMethodAliasMap = ReadonlyMap<
 >;
 type InvocationMethodWrite =
   | { kind: "method"; resolution: SystemGraphInvocationMethodResolution }
+  | { kind: "alias"; key: string }
   | { kind: "non-method" };
 
 interface PackageInvocation {
@@ -931,7 +934,6 @@ function symbolWriteKey(
 function methodWriteFromExpression(
   expression: ts.Expression,
   checker: ts.TypeChecker,
-  resolvedAliases: InvocationMethodAliasMap,
 ): InvocationMethodWrite {
   const direct = directInvocationMethodResolution(expression, checker);
   if (direct) return { kind: "method", resolution: direct };
@@ -940,14 +942,12 @@ function methodWriteFromExpression(
     const whenTrue = methodWriteFromExpression(
       current.whenTrue,
       checker,
-      resolvedAliases,
     );
     const whenFalse = methodWriteFromExpression(
       current.whenFalse,
       checker,
-      resolvedAliases,
     );
-    return whenTrue.kind === "method" || whenFalse.kind === "method"
+    return whenTrue.kind !== "non-method" || whenFalse.kind !== "non-method"
       ? { kind: "method", resolution: { kind: "dynamic", modes: ["blocking", "async"] } }
       : { kind: "non-method" };
   }
@@ -955,10 +955,7 @@ function methodWriteFromExpression(
     return { kind: "non-method" };
   }
   const key = symbolWriteKey(checker, current);
-  const aliased = key ? resolvedAliases.get(key) ?? null : null;
-  return aliased
-    ? { kind: "method", resolution: aliased }
-    : { kind: "non-method" };
+  return key ? { kind: "alias", key } : { kind: "non-method" };
 }
 
 function addMethodAliasWrite(
@@ -1020,7 +1017,7 @@ function collectInvocationMethodAliases(
           writes,
           checker,
           node.name,
-          methodWriteFromExpression(node.initializer, checker, methodAliases),
+          methodWriteFromExpression(node.initializer, checker),
         );
       }
     } else if (
@@ -1033,26 +1030,60 @@ function collectInvocationMethodAliases(
           writes,
           checker,
           left,
-          methodWriteFromExpression(node.right, checker, methodAliases),
+          methodWriteFromExpression(node.right, checker),
         );
       }
     }
     ts.forEachChild(node, visit);
   };
   for (const sourceFile of sourceFiles) visit(sourceFile);
+
+  const resolveWrites = (
+    key: string,
+    seen = new Set<string>(),
+  ): {
+    resolutions: SystemGraphInvocationMethodResolution[];
+    nonMethod: boolean;
+    unresolved: boolean;
+  } => {
+    const symbolWrites = writes.get(key);
+    if (!symbolWrites || symbolWrites.length === 0) {
+      return { resolutions: [], nonMethod: false, unresolved: true };
+    }
+    if (seen.has(key)) {
+      return { resolutions: [], nonMethod: false, unresolved: true };
+    }
+    const nextSeen = new Set(seen);
+    nextSeen.add(key);
+    const resolutions: SystemGraphInvocationMethodResolution[] = [];
+    let nonMethod = false;
+    let unresolved = false;
+    for (const write of symbolWrites) {
+      if (write.kind === "method") {
+        resolutions.push(write.resolution);
+      } else if (write.kind === "non-method") {
+        nonMethod = true;
+      } else {
+        const resolved = resolveWrites(write.key, nextSeen);
+        resolutions.push(...resolved.resolutions);
+        nonMethod ||= resolved.nonMethod;
+        unresolved ||= resolved.unresolved;
+      }
+    }
+    return { resolutions, nonMethod, unresolved };
+  };
+
   for (const [key, symbolWrites] of writes) {
-    const methodWrites = symbolWrites.filter(
-      (write): write is Extract<InvocationMethodWrite, { kind: "method" }> =>
-        write.kind === "method",
-    );
-    if (methodWrites.length === 0) continue;
-    const hasNonMethodWrite = symbolWrites.some((write) => write.kind === "non-method");
+    const resolved = resolveWrites(key);
+    if (resolved.resolutions.length === 0) continue;
     methodAliases.set(
       key,
-      methodWrites.length === 1 &&
-        !hasNonMethodWrite &&
-        methodWrites[0]!.resolution.kind === "resolved"
-        ? methodWrites[0]!.resolution
+      symbolWrites.length === 1 &&
+        resolved.resolutions.length === 1 &&
+        !resolved.nonMethod &&
+        !resolved.unresolved &&
+        resolved.resolutions[0]!.kind === "resolved"
+        ? resolved.resolutions[0]!
         : { kind: "dynamic", modes: ["blocking", "async"] },
     );
   }
@@ -1281,7 +1312,7 @@ async function snapshotPackageSources(
     }
     files.set(canonicalFile, content);
   }
-  const toolsDeclaration = canonicalGraphPath(
+  const toolsDeclaration = lexicalAbsolutePath(
     path.join(
       canonicalPackageRoot,
       "node_modules",
@@ -1289,15 +1320,41 @@ async function snapshotPackageSources(
       "tools",
       "index.d.ts",
     ),
-  );
-  const toolsDeclarationSource = await readWorkflowSourceFile(
     canonicalPackageRoot,
-    toolsDeclaration,
-    readHooks,
   );
-  if (toolsDeclarationSource !== null) {
-    files.set(toolsDeclaration, toolsDeclarationSource);
-    observedPaths.add(toolsDeclaration);
+  let toolsDeclarationExists = true;
+  try {
+    await fs.lstat(toolsDeclaration);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") {
+      toolsDeclarationExists = false;
+    } else {
+      complete = false;
+      observedPaths.add(toolsDeclaration);
+    }
+  }
+  if (toolsDeclarationExists) {
+    const toolsDeclarationMetadata = await workflowSourceFileMetadata(
+      canonicalPackageRoot,
+      toolsDeclaration,
+    );
+    if (toolsDeclarationMetadata.status === "regular") {
+      const toolsDeclarationSource = await readWorkflowSourceFile(
+        canonicalPackageRoot,
+        toolsDeclaration,
+        readHooks,
+      );
+      if (toolsDeclarationSource === null) {
+        complete = false;
+      } else {
+        files.set(toolsDeclaration, toolsDeclarationSource);
+        observedPaths.add(toolsDeclaration);
+      }
+    } else {
+      complete = false;
+      observedPaths.add(toolsDeclaration);
+    }
   }
   return {
     packageRoot: canonicalPackageRoot,

--- a/packages/harness/src/core/system-graph-relationships.ts
+++ b/packages/harness/src/core/system-graph-relationships.ts
@@ -79,6 +79,7 @@ interface CachedInvocationEntry {
 }
 
 interface InvocationTask {
+  cacheKey: string;
   sourceRoot: string;
   caller: AgentInventoryItem;
   generation: number;
@@ -88,6 +89,7 @@ interface InvocationTask {
 interface BackgroundInvocationEntry {
   generation: number;
   scopeEpoch: number;
+  caller?: AgentInventoryItem;
   snapshot?: AgentInvocationSnapshot;
 }
 
@@ -110,6 +112,7 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
   private readonly active = new Map<string, InvocationTask>();
   private readonly pendingChanges = new Set<string>();
   private readonly invalidatedScopes = new Map<string, number>();
+  private retainedCallers: readonly AgentInventoryItem[] = [];
   private nextGeneration = 1;
   private nextScopeEpoch = 1;
   private activeCount = 0;
@@ -127,10 +130,10 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
   async listInvocations(
     caller: AgentInventoryItem,
   ): Promise<AgentInvocationProviderResult> {
-    const key = canonicalGraphPath(caller.sourceRoot);
+    const key = callerInvocationCacheKey(caller);
     let fingerprint: string;
     try {
-      fingerprint = await this.fingerprint(key);
+      fingerprint = await this.fingerprint(packageRootForCaller(caller));
     } catch (error) {
       this.entries.delete(key);
       throw error;
@@ -154,14 +157,45 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
   }
 
   invalidateSource(sourceRoot: string): void {
-    const key = canonicalGraphPath(sourceRoot);
-    this.entries.delete(key);
-    this.background.set(key, {
-      generation: this.nextGeneration++,
-      scopeEpoch: this.scopeEpochForSource(key),
+    const changed = canonicalGraphPath(sourceRoot);
+    const candidateCallers = new Map<string, AgentInventoryItem>();
+    for (const caller of this.retainedCallers) {
+      candidateCallers.set(callerInvocationCacheKey(caller), caller);
+    }
+    for (const [key, entry] of this.background) {
+      if (entry.caller) candidateCallers.set(key, entry.caller);
+    }
+    const affected = [...candidateCallers.values()].filter((caller) => {
+      const callerRoot = canonicalGraphPath(caller.sourceRoot);
+      const packageRoot = packageRootForCaller(caller);
+      return (
+        callerRoot === changed ||
+        packageRoot === changed ||
+        this.scopeContainsSource(packageRoot, changed) ||
+        this.scopeContainsSource(changed, callerRoot)
+      );
     });
-    this.dropQueued(key);
-    this.pendingChanges.delete(key);
+    if (affected.length === 0) {
+      this.entries.delete(changed);
+      this.background.set(changed, {
+        generation: this.nextGeneration++,
+        scopeEpoch: this.scopeEpochForSource(changed),
+      });
+      this.dropQueued(changed);
+      this.pendingChanges.delete(changed);
+      return;
+    }
+    for (const caller of affected) {
+      const key = callerInvocationCacheKey(caller);
+      this.entries.delete(key);
+      this.background.set(key, {
+        generation: this.nextGeneration++,
+        scopeEpoch: this.scopeEpochForSource(caller.sourceRoot),
+        caller,
+      });
+      this.dropQueued(key);
+      this.pendingChanges.delete(caller.sourceRoot);
+    }
   }
 
   /** O(1) conservative invalidation for an ambiguous workspace event. */
@@ -175,7 +209,8 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
   /** Explicit graph Retry re-arms terminal failures without read-loop churn. */
   retryFailed(scopeRoot: string): void {
     const root = canonicalGraphPath(scopeRoot);
-    for (const [sourceRoot, entry] of this.background) {
+    for (const [cacheKey, entry] of this.background) {
+      const sourceRoot = canonicalGraphPath(entry.caller?.sourceRoot ?? cacheKey);
       const relative = path.relative(root, sourceRoot);
       if (
         (entry.snapshot?.status !== "failed" &&
@@ -189,22 +224,27 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
       ) {
         continue;
       }
-      this.background.set(sourceRoot, {
+      this.background.set(cacheKey, {
         generation: this.nextGeneration++,
         scopeEpoch: this.scopeEpochForSource(sourceRoot),
+        ...(entry.caller ? { caller: entry.caller } : {}),
       });
-      this.dropQueued(sourceRoot);
+      this.dropQueued(cacheKey);
     }
   }
 
   retainCallers(callers: readonly AgentInventoryItem[]): void {
+    this.retainedCallers = [...callers].sort(
+      (left, right) =>
+        callerInvocationCacheKey(left).localeCompare(callerInvocationCacheKey(right)),
+    );
     try {
-      this.inner.retainCallers?.(callers);
+      this.inner.retainCallers?.(this.retainedCallers);
     } catch {
       // Inner cache pruning is an optimization and cannot affect projection.
     }
     const retained = new Set(
-      callers.map((caller) => canonicalGraphPath(caller.sourceRoot)),
+      this.retainedCallers.map(callerInvocationCacheKey),
     );
     for (const sourceRoot of this.entries.keys()) {
       if (!retained.has(sourceRoot)) this.entries.delete(sourceRoot);
@@ -217,8 +257,8 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
     }
     for (const scopeRoot of this.invalidatedScopes.keys()) {
       if (
-        [...retained].some((sourceRoot) =>
-          this.scopeContainsSource(scopeRoot, sourceRoot),
+        this.retainedCallers.some((caller) =>
+          this.scopeContainsSource(scopeRoot, caller.sourceRoot),
         )
       ) {
         continue;
@@ -244,9 +284,9 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
   peekInvocations(
     caller: AgentInventoryItem,
   ): AgentInvocationSnapshot | undefined {
-    const sourceRoot = canonicalGraphPath(caller.sourceRoot);
-    const entry = this.background.get(sourceRoot);
-    if (entry?.scopeEpoch !== this.scopeEpochForSource(sourceRoot)) {
+    const key = callerInvocationCacheKey(caller);
+    const entry = this.background.get(key);
+    if (entry?.scopeEpoch !== this.scopeEpochForSource(caller.sourceRoot)) {
       return undefined;
     }
     if (
@@ -264,27 +304,29 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
 
   startInvocations(callers: readonly AgentInventoryItem[]): void {
     for (const caller of callers) {
+      const key = callerInvocationCacheKey(caller);
       const sourceRoot = canonicalGraphPath(caller.sourceRoot);
-      let entry = this.background.get(sourceRoot);
+      let entry = this.background.get(key);
       const scopeEpoch = this.scopeEpochForSource(sourceRoot);
       if (!entry || entry.scopeEpoch !== scopeEpoch) {
-        entry = { generation: this.nextGeneration++, scopeEpoch };
-        this.background.set(sourceRoot, entry);
-        this.dropQueued(sourceRoot);
+        entry = { generation: this.nextGeneration++, scopeEpoch, caller };
+        this.background.set(key, entry);
+        this.dropQueued(key);
       }
       if (entry.snapshot) continue;
       if (
-        this.active.get(sourceRoot)?.generation === entry.generation ||
+        this.active.get(key)?.generation === entry.generation ||
         this.queued.some(
           (task) =>
-            task.sourceRoot === sourceRoot &&
+            task.cacheKey === key &&
             task.generation === entry!.generation,
         )
       ) {
         continue;
       }
-      this.dropQueued(sourceRoot);
+      this.dropQueued(key);
       this.queued.push({
+        cacheKey: key,
         sourceRoot,
         caller,
         generation: entry.generation,
@@ -297,8 +339,9 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
   invocationObservations(): readonly AgentInvocationObservation[] {
     const entries = [...this.background.entries()]
       .filter(
-        ([sourceRoot, entry]) =>
-          entry.scopeEpoch === this.scopeEpochForSource(sourceRoot) &&
+        ([, entry]) =>
+          entry.caller &&
+          entry.scopeEpoch === this.scopeEpochForSource(entry.caller.sourceRoot) &&
           (entry.snapshot?.result.observedPaths?.length ?? 0) > 0,
       )
       .sort(([left], [right]) => left.localeCompare(right));
@@ -320,15 +363,16 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
       if (!added) break;
       round += 1;
     }
-    return [...selected.entries()].map(([sourceRoot, paths]) => ({
-      candidateRoot: sourceRoot,
-      workspaceRoot: sourceRoot,
-      paths,
-    }));
+    return [...selected.entries()].flatMap(([key, paths]) => {
+      const caller = this.background.get(key)?.caller;
+      if (!caller) return [];
+      const packageRoot = packageRootForCaller(caller);
+      return [{ candidateRoot: packageRoot, workspaceRoot: packageRoot, paths }];
+    });
   }
 
   private current(task: InvocationTask): boolean {
-    const entry = this.background.get(task.sourceRoot);
+    const entry = this.background.get(task.cacheKey);
     return (
       entry?.generation === task.generation &&
       entry.scopeEpoch === task.scopeEpoch &&
@@ -358,7 +402,9 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
   private refreshObservationCoverage(): void {
     let count = 0;
     let truncated = false;
-    for (const [sourceRoot, entry] of this.background) {
+    for (const [, entry] of this.background) {
+      const sourceRoot = entry.caller?.sourceRoot;
+      if (!sourceRoot) continue;
       if (entry.scopeEpoch !== this.scopeEpochForSource(sourceRoot)) continue;
       count += entry.snapshot?.result.observedPaths?.length ?? 0;
       if (count > INVOCATION_OBSERVATION_MAX_PATHS) {
@@ -371,8 +417,10 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
     // Coverage is part of every retained ready snapshot's effective
     // completeness. Crossing the global observation cap (in either direction)
     // therefore changes more than the task that happened to settle/retire.
-    for (const [sourceRoot, entry] of this.background) {
+    for (const [, entry] of this.background) {
+      const sourceRoot = entry.caller?.sourceRoot;
       if (
+        sourceRoot &&
         entry.snapshot &&
         entry.scopeEpoch === this.scopeEpochForSource(sourceRoot)
       ) {
@@ -382,9 +430,9 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
     this.scheduleChanges();
   }
 
-  private dropQueued(sourceRoot: string): void {
+  private dropQueued(cacheKey: string): void {
     for (let index = this.queued.length - 1; index >= 0; index -= 1) {
-      if (this.queued[index]!.sourceRoot === sourceRoot) {
+      if (this.queued[index]!.cacheKey === cacheKey) {
         this.queued.splice(index, 1);
       }
     }
@@ -397,16 +445,16 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
     const concurrency = Math.max(1, this.options.concurrency ?? 4);
     while (this.activeCount < concurrency) {
       const index = this.queued.findIndex(
-        (task) => !this.active.has(task.sourceRoot),
+        (task) => !this.active.has(task.cacheKey),
       );
       if (index === -1) break;
       const [task] = this.queued.splice(index, 1);
       if (!task || !this.current(task)) continue;
-      this.active.set(task.sourceRoot, task);
+      this.active.set(task.cacheKey, task);
       this.activeCount += 1;
       void this.run(task).finally(() => {
-        if (this.active.get(task.sourceRoot) === task) {
-          this.active.delete(task.sourceRoot);
+        if (this.active.get(task.cacheKey) === task) {
+          this.active.delete(task.cacheKey);
           this.activeCount -= 1;
         }
         this.drain();
@@ -428,9 +476,10 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
       };
     }
     if (!this.current(task)) return;
-    this.background.set(task.sourceRoot, {
+    this.background.set(task.cacheKey, {
       generation: task.generation,
       scopeEpoch: task.scopeEpoch,
+      caller: task.caller,
       snapshot,
     });
     this.refreshObservationCoverage();
@@ -450,7 +499,9 @@ export class CachedAgentInvocationProvider implements AgentInvocationProvider {
     if (this.pendingChanges.size === 0) return;
     const changed = [...this.pendingChanges]
       .filter((sourceRoot) => {
-        const entry = this.background.get(sourceRoot);
+        const entry = [...this.background.values()].find(
+          (candidate) => candidate.caller?.sourceRoot === sourceRoot,
+        );
         return (
           entry?.snapshot !== undefined &&
           entry.scopeEpoch === this.scopeEpochForSource(sourceRoot)
@@ -486,6 +537,46 @@ type TargetResult = { kind: "literal"; slug: string } | { kind: "dynamic" };
 type WrapperTargetResult =
   | TargetResult
   | { kind: "parameter"; index: number };
+export type SystemGraphInvocationMethodResolution =
+  | { kind: "resolved"; mode: AgentInvocationMode }
+  | { kind: "dynamic"; modes: readonly AgentInvocationMode[] };
+
+export type SystemGraphInvocationTargetResolution =
+  | { kind: "resolved"; mode: AgentInvocationMode; target: string }
+  | { kind: "dynamic-target"; mode: AgentInvocationMode }
+  | { kind: "dynamic-method"; modes: readonly AgentInvocationMode[] };
+
+export interface SystemGraphPackageSource {
+  path: string;
+  source: string;
+  sourceFile: ts.SourceFile;
+}
+
+export interface SystemGraphPackageCompilerResult {
+  packageKey: string;
+  packageRoot: string;
+  generation: number;
+  program: ts.Program;
+  checker: ts.TypeChecker;
+  sources: ReadonlyMap<string, SystemGraphPackageSource>;
+  observedPaths: readonly string[];
+  complete: boolean;
+  sourceFingerprint: `sha256:${string}`;
+  resolveInvocationTarget(
+    call: ts.CallExpression,
+  ): SystemGraphInvocationTargetResolution | null;
+}
+
+export interface SystemGraphPackageCompilerInput {
+  packageRoot: string;
+  generation?: number;
+  readHooks?: WorkflowSourceReadHooks;
+}
+
+type InvocationMethodAliasMap = ReadonlyMap<
+  string,
+  SystemGraphInvocationMethodResolution
+>;
 
 interface PackageInvocation {
   target: string;
@@ -502,30 +593,30 @@ interface PackageInvocationScan {
   sourceFingerprint: `sha256:${string}`;
 }
 
+interface PackageSourceSnapshot {
+  packageRoot: string;
+  files: ReadonlyMap<string, string>;
+  observedPaths: readonly string[];
+  complete: boolean;
+}
+
 function packageRootForCaller(caller: AgentInventoryItem): string {
   if (caller.path === ".") return canonicalGraphPath(caller.sourceRoot);
   const depth = caller.path.split("/").filter(Boolean).length;
   return canonicalGraphPath(
-    path.resolve(caller.sourceRoot, ...Array.from({ length: depth }, () => "..")),
+    path.resolve(
+      caller.sourceRoot,
+      ...Array.from({ length: depth }, () => ".."),
+    ),
   );
 }
 
-function commonSourceRoot(callers: readonly AgentInventoryItem[]): string {
-  const roots = callers
-    .map(packageRootForCaller)
-    .sort();
-  const [first] = roots;
-  if (!first) return process.cwd();
-  const segments = first.split(path.sep);
-  for (const root of roots.slice(1)) {
-    const candidate = root.split(path.sep);
-    let index = 0;
-    while (index < segments.length && segments[index] === candidate[index]) {
-      index += 1;
-    }
-    segments.length = index;
-  }
-  return segments.length === 0 ? path.parse(first).root : segments.join(path.sep);
+function callerInvocationCacheKey(caller: AgentInventoryItem): string {
+  return [
+    packageRootForCaller(caller),
+    caller.agentKey,
+    canonicalGraphPath(caller.sourceRoot),
+  ].join("\0");
 }
 
 function unwrapTsExpression(expression: ts.Expression): ts.Expression {
@@ -544,6 +635,17 @@ function unwrapTsExpression(expression: ts.Expression): ts.Expression {
 function propertyAccessName(expression: ts.Expression): string | null {
   const current = unwrapTsExpression(expression);
   return ts.isIdentifier(current) ? current.text : null;
+}
+
+function expressionPropertyName(
+  checker: ts.TypeChecker,
+  expression: ts.Expression,
+): string | null {
+  const current = unwrapTsExpression(expression);
+  if (ts.isStringLiteral(current) || ts.isNoSubstitutionTemplateLiteral(current)) {
+    return current.text;
+  }
+  return symbolStringLiteral(checker, current);
 }
 
 function objectPropertyName(name: ts.PropertyName): string | null {
@@ -609,6 +711,20 @@ function aliasedSymbol(
     : symbol;
 }
 
+function expressionValueSymbol(
+  checker: ts.TypeChecker,
+  expression: ts.Identifier | ts.PropertyAccessExpression,
+): ts.Symbol | undefined {
+  if (
+    ts.isIdentifier(expression) &&
+    ts.isShorthandPropertyAssignment(expression.parent) &&
+    expression.parent.name === expression
+  ) {
+    return checker.getShorthandAssignmentValueSymbol(expression.parent);
+  }
+  return checker.getSymbolAtLocation(expression);
+}
+
 function resolvesSapiomNamespace(
   expression: ts.Expression,
   checker: ts.TypeChecker,
@@ -667,18 +783,29 @@ function resolvesSapiomNamespace(
   return false;
 }
 
-function packageInvocationMode(
-  call: ts.CallExpression,
+function directInvocationMethodResolution(
+  expression: ts.Expression,
   checker: ts.TypeChecker,
-): AgentInvocationMode | null {
-  const expression = unwrapTsExpression(call.expression);
-  if (!ts.isPropertyAccessExpression(expression) || expression.questionDotToken) {
+): SystemGraphInvocationMethodResolution | null {
+  const current = unwrapTsExpression(expression);
+  let receiver: ts.Expression;
+  let method: string | null;
+  let dynamicMethod = false;
+
+  if (ts.isPropertyAccessExpression(current)) {
+    if (current.questionDotToken) return null;
+    receiver = unwrapTsExpression(current.expression);
+    method = current.name.text;
+  } else if (ts.isElementAccessExpression(current)) {
+    if (current.questionDotToken) return null;
+    receiver = unwrapTsExpression(current.expression);
+    method = expressionPropertyName(checker, current.argumentExpression);
+    dynamicMethod = method === null;
+  } else {
     return null;
   }
 
-  const method = expression.name.text;
-  if (method !== "run" && method !== "launch") return null;
-  const receiver = unwrapTsExpression(expression.expression);
+  if (method !== null && method !== "run" && method !== "launch") return null;
   if (ts.isPropertyAccessExpression(receiver) && receiver.name.text === "agents") {
     const context = unwrapTsExpression(receiver.expression);
     if (
@@ -686,16 +813,62 @@ function packageInvocationMode(
       context.name.text === "sapiom" &&
       propertyAccessName(context.expression) === "ctx"
     ) {
-      return method === "run" ? "blocking" : "async";
+      return dynamicMethod
+        ? { kind: "dynamic", modes: ["blocking", "async"] }
+        : { kind: "resolved", mode: method === "run" ? "blocking" : "async" };
     }
   }
   if (resolvesSapiomNamespace(receiver, checker, "agents")) {
-    return method === "run" ? "blocking" : "async";
+    return dynamicMethod
+      ? { kind: "dynamic", modes: ["blocking", "async"] }
+      : { kind: "resolved", mode: method === "run" ? "blocking" : "async" };
   }
-  if (method === "launch" && resolvesSapiomNamespace(receiver, checker, "orchestrations")) {
-    return "async";
+  if (resolvesSapiomNamespace(receiver, checker, "orchestrations")) {
+    if (dynamicMethod) return { kind: "dynamic", modes: ["async"] };
+    if (method === "launch") return { kind: "resolved", mode: "async" };
   }
   return null;
+}
+
+function packageInvocationMethodResolution(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+  methodAliases: InvocationMethodAliasMap = new Map(),
+): SystemGraphInvocationMethodResolution | null {
+  const direct = directInvocationMethodResolution(call.expression, checker);
+  if (direct) return direct;
+  const expression = unwrapTsExpression(call.expression);
+  if (!ts.isIdentifier(expression) && !ts.isPropertyAccessExpression(expression)) {
+    return null;
+  }
+  const symbol = aliasedSymbol(checker, checker.getSymbolAtLocation(expression));
+  const key = symbolKey(symbol);
+  return key ? methodAliases.get(key) ?? null : null;
+}
+
+function packageInvocationMode(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+  methodAliases: InvocationMethodAliasMap = new Map(),
+): AgentInvocationMode | null {
+  const resolution = packageInvocationMethodResolution(call, checker, methodAliases);
+  return resolution?.kind === "resolved" ? resolution.mode : null;
+}
+
+function resolvePackageInvocationTarget(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+  methodAliases: InvocationMethodAliasMap,
+): SystemGraphInvocationTargetResolution | null {
+  const method = packageInvocationMethodResolution(call, checker, methodAliases);
+  if (!method) return null;
+  if (method.kind === "dynamic") {
+    return { kind: "dynamic-method", modes: [...method.modes].sort((left, right) => MODE_ORDER[left] - MODE_ORDER[right]) };
+  }
+  const target = staticDefinitionTarget(call, checker);
+  return target.kind === "literal"
+    ? { kind: "resolved", mode: method.mode, target: target.slug }
+    : { kind: "dynamic-target", mode: method.mode };
 }
 
 function symbolStringLiteral(
@@ -708,24 +881,141 @@ function symbolStringLiteral(
     return current.text;
   }
   if (!ts.isIdentifier(current)) return null;
-  const symbol = aliasedSymbol(checker, checker.getSymbolAtLocation(current));
+  const symbol = aliasedSymbol(checker, expressionValueSymbol(checker, current));
   if (!symbol || seen.has(symbol)) return null;
   seen.add(symbol);
   for (const declaration of symbol.declarations ?? []) {
     if (
       ts.isVariableDeclaration(declaration) &&
       declaration.initializer &&
-      (ts.getCombinedNodeFlags(declaration) & ts.NodeFlags.Const) !== 0
+      ts.isVariableDeclarationList(declaration.parent) &&
+      (declaration.parent.flags & ts.NodeFlags.Const) !== 0
     ) {
-          const resolved = symbolStringLiteral(
-            checker,
-            declaration.initializer,
-            seen,
-          );
+      const resolved = symbolStringLiteral(
+        checker,
+        declaration.initializer,
+        seen,
+      );
       if (resolved !== null) return resolved;
     }
   }
   return null;
+}
+
+function invocationMethodFromName(
+  namespace: "agents" | "orchestrations",
+  method: string,
+): SystemGraphInvocationMethodResolution | null {
+  if (namespace === "agents") {
+    if (method === "run") return { kind: "resolved", mode: "blocking" };
+    if (method === "launch") return { kind: "resolved", mode: "async" };
+  }
+  if (namespace === "orchestrations" && method === "launch") {
+    return { kind: "resolved", mode: "async" };
+  }
+  return null;
+}
+
+function methodAliasFromExpression(
+  expression: ts.Expression,
+  checker: ts.TypeChecker,
+  methodAliases: InvocationMethodAliasMap,
+): SystemGraphInvocationMethodResolution | null {
+  const direct = directInvocationMethodResolution(expression, checker);
+  if (direct?.kind === "resolved") return direct;
+  const current = unwrapTsExpression(expression);
+  if (!ts.isIdentifier(current) && !ts.isPropertyAccessExpression(current)) {
+    return null;
+  }
+  const symbol = aliasedSymbol(checker, checker.getSymbolAtLocation(current));
+  const key = symbolKey(symbol);
+  const aliased = key ? methodAliases.get(key) ?? null : null;
+  return aliased?.kind === "resolved" ? aliased : null;
+}
+
+function addMethodAlias(
+  methodAliases: Map<string, SystemGraphInvocationMethodResolution>,
+  checker: ts.TypeChecker,
+  name: ts.Node,
+  resolution: SystemGraphInvocationMethodResolution | null,
+): void {
+  if (
+    !resolution ||
+    resolution.kind !== "resolved" ||
+    (!ts.isIdentifier(name) && !ts.isPropertyAccessExpression(name))
+  ) {
+    return;
+  }
+  const key = symbolKey(
+    aliasedSymbol(checker, checker.getSymbolAtLocation(name)),
+  );
+  if (key) methodAliases.set(key, resolution);
+}
+
+function collectDestructuredMethodAliases(
+  declaration: ts.VariableDeclaration,
+  checker: ts.TypeChecker,
+  methodAliases: Map<string, SystemGraphInvocationMethodResolution>,
+): void {
+  if (!declaration.initializer || !ts.isObjectBindingPattern(declaration.name)) {
+    return;
+  }
+  const initializer = unwrapTsExpression(declaration.initializer);
+  const namespace = resolvesSapiomNamespace(initializer, checker, "agents")
+    ? "agents"
+    : resolvesSapiomNamespace(initializer, checker, "orchestrations")
+      ? "orchestrations"
+      : null;
+  if (!namespace) return;
+  for (const element of declaration.name.elements) {
+    if (element.dotDotDotToken || !ts.isIdentifier(element.name)) continue;
+    const method = element.propertyName
+      ? objectPropertyName(element.propertyName)
+      : element.name.text;
+    if (!method) continue;
+    addMethodAlias(
+      methodAliases,
+      checker,
+      element.name,
+      invocationMethodFromName(namespace, method),
+    );
+  }
+}
+
+function collectInvocationMethodAliases(
+  sourceFiles: readonly ts.SourceFile[],
+  checker: ts.TypeChecker,
+): InvocationMethodAliasMap {
+  const methodAliases = new Map<string, SystemGraphInvocationMethodResolution>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isVariableDeclaration(node)) {
+      collectDestructuredMethodAliases(node, checker, methodAliases);
+      if (node.initializer) {
+        addMethodAlias(
+          methodAliases,
+          checker,
+          node.name,
+          methodAliasFromExpression(node.initializer, checker, methodAliases),
+        );
+      }
+    } else if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken
+    ) {
+      const left = unwrapTsExpression(node.left);
+      if (ts.isIdentifier(left) || ts.isPropertyAccessExpression(left)) {
+        addMethodAlias(
+          methodAliases,
+          checker,
+          left,
+          methodAliasFromExpression(node.right, checker, methodAliases),
+        );
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  for (const sourceFile of sourceFiles) visit(sourceFile);
+  return methodAliases;
 }
 
 function resolvedObjectLiteral(
@@ -743,7 +1033,8 @@ function resolvedObjectLiteral(
     if (
       ts.isVariableDeclaration(declaration) &&
       declaration.initializer &&
-      (ts.getCombinedNodeFlags(declaration) & ts.NodeFlags.Const) !== 0
+      ts.isVariableDeclarationList(declaration.parent) &&
+      (declaration.parent.flags & ts.NodeFlags.Const) !== 0
     ) {
       const resolved = resolvedObjectLiteral(
         checker,
@@ -798,13 +1089,21 @@ function staticDefinitionTarget(
 function parameterTarget(
   expression: ts.Expression,
   parameters: readonly ts.ParameterDeclaration[],
+  checker: ts.TypeChecker,
 ): WrapperTargetResult | null {
   const current = unwrapTsExpression(expression);
   if (!ts.isIdentifier(current)) return null;
-  const index = parameters.findIndex(
-    (parameter) =>
-      ts.isIdentifier(parameter.name) && parameter.name.text === current.text,
+  const expressionKey = symbolKey(
+    aliasedSymbol(checker, expressionValueSymbol(checker, current)),
   );
+  if (!expressionKey) return null;
+  const index = parameters.findIndex((parameter) => {
+    if (!ts.isIdentifier(parameter.name)) return false;
+    const parameterKey = symbolKey(
+      aliasedSymbol(checker, checker.getSymbolAtLocation(parameter.name)),
+    );
+    return parameterKey === expressionKey;
+  });
   return index === -1 ? null : { kind: "parameter", index };
 }
 
@@ -828,7 +1127,7 @@ function wrapperDefinitionTarget(
       continue;
     }
     if (ts.isShorthandPropertyAssignment(property)) {
-      const parameter = parameterTarget(property.name, parameters);
+      const parameter = parameterTarget(property.name, parameters, checker);
       if (parameter) {
         result = parameter;
         continue;
@@ -844,7 +1143,7 @@ function wrapperDefinitionTarget(
       result = { kind: "dynamic" };
       continue;
     }
-    const parameter = parameterTarget(property.initializer, parameters);
+    const parameter = parameterTarget(property.initializer, parameters, checker);
     if (parameter) {
       result = parameter;
       continue;
@@ -910,17 +1209,184 @@ function stableScanFingerprint(
     .digest("hex")}`;
 }
 
-function createPackageProgram(rootNames: readonly string[]): ts.Program {
-  return ts.createProgram([...rootNames], {
+async function snapshotPackageSources(
+  packageRoot: string,
+  readHooks: WorkflowSourceReadHooks,
+): Promise<PackageSourceSnapshot> {
+  const canonicalPackageRoot = canonicalGraphPath(packageRoot);
+  const sourceSet = await listSourceFilesWithObservations(canonicalPackageRoot);
+  const files = new Map<string, string>();
+  const observedPaths = new Set(sourceSet.observedPaths.map(canonicalGraphPath));
+  let complete = sourceSet.complete;
+  for (const file of sourceSet.files) {
+    const canonicalFile = canonicalGraphPath(file);
+    const content = await readWorkflowSourceFile(
+      canonicalPackageRoot,
+      canonicalFile,
+      readHooks,
+    );
+    if (content === null) {
+      complete = false;
+      continue;
+    }
+    files.set(canonicalFile, content);
+  }
+  const toolsDeclaration = canonicalGraphPath(
+    path.join(
+      canonicalPackageRoot,
+      "node_modules",
+      "@sapiom",
+      "tools",
+      "index.d.ts",
+    ),
+  );
+  const toolsDeclarationSource = await readWorkflowSourceFile(
+    canonicalPackageRoot,
+    toolsDeclaration,
+    readHooks,
+  );
+  if (toolsDeclarationSource !== null) {
+    files.set(toolsDeclaration, toolsDeclarationSource);
+    observedPaths.add(toolsDeclaration);
+  }
+  return {
+    packageRoot: canonicalPackageRoot,
+    files,
+    observedPaths: [...observedPaths].sort(),
+    complete,
+  };
+}
+
+function createPackageProgram(snapshot: PackageSourceSnapshot): ts.Program {
+  const compilerOptions: ts.CompilerOptions = {
     allowJs: false,
     esModuleInterop: true,
     jsx: ts.JsxEmit.ReactJSX,
     module: ts.ModuleKind.ESNext,
     moduleResolution: ts.ModuleResolutionKind.Bundler,
+    noLib: true,
     noEmit: true,
     skipLibCheck: true,
     target: ts.ScriptTarget.ES2022,
+  };
+  const host = ts.createCompilerHost(compilerOptions, true);
+  const sourceFiles = snapshot.files;
+  const hostPath = (fileName: string): string =>
+    canonicalGraphPath(
+      path.isAbsolute(fileName)
+        ? fileName
+        : path.resolve(snapshot.packageRoot, fileName),
+    );
+  const hasFile = (fileName: string): boolean =>
+    sourceFiles.has(hostPath(fileName));
+  return ts.createProgram([...sourceFiles.keys()].sort(), compilerOptions, {
+    ...host,
+    getCurrentDirectory: () => snapshot.packageRoot,
+    getCanonicalFileName: hostPath,
+    fileExists: hasFile,
+    readFile: (fileName) => sourceFiles.get(hostPath(fileName)),
+    realpath: hostPath,
+    directoryExists: (directoryName) => {
+      const canonicalDirectory = hostPath(directoryName);
+      return [...sourceFiles.keys()].some((fileName) => {
+        const relative = path.relative(canonicalDirectory, fileName);
+        return (
+          relative !== "" &&
+          relative !== ".." &&
+          !relative.startsWith(`..${path.sep}`) &&
+          !path.isAbsolute(relative)
+        );
+      });
+    },
+    getDirectories: (directoryName) => {
+      const canonicalDirectory = hostPath(directoryName);
+      const directories = new Set<string>();
+      for (const fileName of sourceFiles.keys()) {
+        const relative = path.relative(canonicalDirectory, fileName);
+        if (
+          relative === "" ||
+          relative === ".." ||
+          relative.startsWith(`..${path.sep}`) ||
+          path.isAbsolute(relative)
+        ) {
+          continue;
+        }
+        const [first] = relative.split(path.sep);
+        if (first) directories.add(first);
+      }
+      return [...directories].sort();
+    },
+    getSourceFile: (fileName, languageVersion) => {
+      const canonicalFile = hostPath(fileName);
+      const content = sourceFiles.get(canonicalFile);
+      return content === undefined
+        ? undefined
+        : ts.createSourceFile(
+            canonicalFile,
+            content,
+            languageVersion,
+            true,
+            path.extname(canonicalFile) === ".tsx"
+              ? ts.ScriptKind.TSX
+              : ts.ScriptKind.TS,
+          );
+    },
   });
+}
+
+function packageSourceFingerprint(
+  snapshot: PackageSourceSnapshot,
+): `sha256:${string}` {
+  return stableScanFingerprint(
+    [...snapshot.files].map(([file, content]) => ({
+      file: path
+        .relative(snapshot.packageRoot, file)
+        .split(path.sep)
+        .join(path.posix.sep),
+      content,
+    })),
+    snapshot.complete,
+  );
+}
+
+export async function createSystemGraphPackageCompilerResult({
+  packageRoot,
+  generation = 1,
+  readHooks = {},
+}: SystemGraphPackageCompilerInput): Promise<SystemGraphPackageCompilerResult> {
+  const snapshot = await snapshotPackageSources(packageRoot, readHooks);
+  const program = createPackageProgram(snapshot);
+  const checker = program.getTypeChecker();
+  const sourceFilesByPath = new Map(
+    program.getSourceFiles().map((sourceFile) => [
+      canonicalGraphPath(sourceFile.fileName),
+      sourceFile,
+    ]),
+  );
+  const sources = new Map<string, SystemGraphPackageSource>();
+  for (const [file, source] of snapshot.files) {
+    const sourceFile = sourceFilesByPath.get(file);
+    if (!sourceFile) continue;
+    sources.set(file, { path: file, source, sourceFile });
+  }
+  const methodAliases = collectInvocationMethodAliases(
+    [...sources.values()].map((entry) => entry.sourceFile),
+    checker,
+  );
+  const sourceFingerprint = packageSourceFingerprint(snapshot);
+  return {
+    packageKey: snapshot.packageRoot,
+    packageRoot: snapshot.packageRoot,
+    generation,
+    program,
+    checker,
+    sources,
+    observedPaths: snapshot.observedPaths,
+    complete: snapshot.complete,
+    sourceFingerprint,
+    resolveInvocationTarget: (call) =>
+      resolvePackageInvocationTarget(call, checker, methodAliases),
+  };
 }
 
 function symbolKey(symbol: ts.Symbol | undefined): string | null {
@@ -934,6 +1400,7 @@ function symbolKey(symbol: ts.Symbol | undefined): string | null {
 function directInvocationsInFunction(
   node: ts.Node,
   checker: ts.TypeChecker,
+  methodAliases: InvocationMethodAliasMap,
 ): Array<{ target: WrapperTargetResult; mode: AgentInvocationMode }> {
   const invocations: Array<{ target: WrapperTargetResult; mode: AgentInvocationMode }> = [];
   const body =
@@ -955,7 +1422,7 @@ function directInvocationsInFunction(
   const visit = (child: ts.Node): void => {
     if (child !== body && ts.isFunctionLike(child)) return;
     if (ts.isCallExpression(child)) {
-      const mode = packageInvocationMode(child, checker);
+      const mode = packageInvocationMode(child, checker, methodAliases);
       if (mode) {
         const target = wrapperDefinitionTarget(child, checker, parameters);
         invocations.push({ target, mode });
@@ -1029,227 +1496,235 @@ function resolveWrapperInvocationTarget(
 async function scanPackageInvocations(
   callers: readonly AgentInventoryItem[],
   readHooks: WorkflowSourceReadHooks,
+  generation = 1,
 ): Promise<Map<string, AgentInvocationProviderResult>> {
   const orderedCallers = [...callers].sort((left, right) =>
-    left.agentKey.localeCompare(right.agentKey),
+    callerInvocationCacheKey(left).localeCompare(callerInvocationCacheKey(right)),
   );
-  const byAgentKey = new Map<string, PackageInvocationScan>();
-  const rootNames: string[] = [];
-  const observed = new Set<string>();
-  let complete = true;
+  const groupedCallers = new Map<string, AgentInventoryItem[]>();
   for (const caller of orderedCallers) {
-    const sourceSet = await listSourceFilesWithObservations(caller.sourceRoot);
-    if (!sourceSet.complete) complete = false;
-    sourceSet.files.forEach((file) => rootNames.push(file));
-    sourceSet.observedPaths.forEach((path) => observed.add(path));
-    byAgentKey.set(caller.agentKey, {
-      invocations: [],
-      groupedInvocations: [],
-      warnings: [],
-      observedPaths: [...sourceSet.observedPaths],
-      complete: sourceSet.complete,
-      sourceFingerprint: `sha256:${"0".repeat(64)}`,
+    const packageRoot = packageRootForCaller(caller);
+    const group = groupedCallers.get(packageRoot) ?? [];
+    group.push(caller);
+    groupedCallers.set(packageRoot, group);
+  }
+
+  const results = new Map<string, AgentInvocationProviderResult>();
+  for (const [packageRoot, packageCallers] of [...groupedCallers].sort(
+    ([left], [right]) => left.localeCompare(right),
+  )) {
+    const analysis = await createSystemGraphPackageCompilerResult({
+      packageRoot,
+      generation,
+      readHooks,
     });
-  }
-  const program = createPackageProgram([...new Set(rootNames)].sort());
-  const checker = program.getTypeChecker();
-  const workspaceRoot = commonSourceRoot(orderedCallers);
-  const sourceFiles = program
-    .getSourceFiles()
-    .filter(
-      (sourceFile) =>
-        !sourceFile.isDeclarationFile &&
-        PROGRAM_SOURCE_EXTENSIONS.has(path.extname(sourceFile.fileName)) &&
-        !sourceFile.fileName.includes(`${path.sep}node_modules${path.sep}`) &&
-        path.relative(workspaceRoot, sourceFile.fileName) !== ".." &&
-        !path
-          .relative(workspaceRoot, sourceFile.fileName)
-          .startsWith(`..${path.sep}`),
-    )
-    .sort((left, right) => left.fileName.localeCompare(right.fileName));
-  const contents = new Map<string, string | null>();
-  for (const sourceFile of sourceFiles) {
-    observed.add(sourceFile.fileName);
-    const owner = owningCaller(sourceFile.fileName, orderedCallers);
-    const content = owner
-      ? await readWorkflowSourceFile(
-          owner.sourceRoot,
-          sourceFile.fileName,
-          readHooks,
-        )
-      : sourceFile.text;
-    if (content === null) complete = false;
-    contents.set(sourceFile.fileName, content);
-  }
-
-  const wrappers = new Map<
-    string,
-    Array<{ target: WrapperTargetResult; mode: AgentInvocationMode }>
-  >();
-  for (const sourceFile of sourceFiles) {
-    if (contents.get(sourceFile.fileName) === null) continue;
-    const visit = (node: ts.Node): void => {
-      const callable = functionLikeFromDeclaration(node as ts.Declaration);
-      if (callable) {
-        const symbol =
-          ts.isFunctionDeclaration(node) && node.name
-            ? checker.getSymbolAtLocation(node.name)
-            : ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)
-              ? checker.getSymbolAtLocation(node.name)
-              : undefined;
-        const key = symbolKey(aliasedSymbol(checker, symbol));
-        const invocations = directInvocationsInFunction(callable, checker);
-        if (key && invocations.length > 0) wrappers.set(key, invocations);
-      }
-      ts.forEachChild(node, visit);
-    };
-    visit(sourceFile);
-  }
-
-  const invokedWrapperKeys = new Set<string>();
-  for (const sourceFile of sourceFiles) {
-    if (contents.get(sourceFile.fileName) === null) continue;
-    if (!owningCaller(sourceFile.fileName, orderedCallers)) continue;
-    const visit = (node: ts.Node): void => {
-      if (ts.isCallExpression(node) && !packageInvocationMode(node, checker)) {
-        const expression = unwrapTsExpression(node.expression);
-        const symbol =
-          ts.isIdentifier(expression) || ts.isPropertyAccessExpression(expression)
-            ? aliasedSymbol(checker, checker.getSymbolAtLocation(expression))
-            : undefined;
-        const key = symbolKey(symbol);
-        if (key && wrappers.has(key)) invokedWrapperKeys.add(key);
-      }
-      ts.forEachChild(node, visit);
-    };
-    visit(sourceFile);
-  }
-
-  for (const sourceFile of sourceFiles) {
-    if (contents.get(sourceFile.fileName) === null) continue;
-    const caller = owningCaller(sourceFile.fileName, orderedCallers);
-    if (!caller) continue;
-    const scan = byAgentKey.get(caller.agentKey)!;
-    const visit = (node: ts.Node): void => {
-      if (ts.isCallExpression(node)) {
-        const mode = packageInvocationMode(node, checker);
-        const position = node.expression.getStart(sourceFile);
-        if (mode) {
-          if (containingWrapperKey(node, checker, invokedWrapperKeys, sourceFile)) {
-            ts.forEachChild(node, visit);
-            return;
-          }
-          const evidence = relativeProgramEvidence(
-            caller.sourceRoot,
-            sourceFile.fileName,
-            sourceFile,
-            position,
+    const byCallerKey = new Map<string, PackageInvocationScan>();
+    for (const caller of packageCallers) {
+      byCallerKey.set(callerInvocationCacheKey(caller), {
+        invocations: [],
+        groupedInvocations: [],
+        warnings: [],
+        observedPaths: [...analysis.observedPaths],
+        complete: analysis.complete,
+        sourceFingerprint: analysis.sourceFingerprint,
+      });
+    }
+    const sourceFiles = [...analysis.sources.values()]
+      .map((entry) => entry.sourceFile)
+      .filter(
+        (sourceFile) =>
+          !sourceFile.isDeclarationFile &&
+          PROGRAM_SOURCE_EXTENSIONS.has(path.extname(sourceFile.fileName)) &&
+          !sourceFile.fileName.includes(`${path.sep}node_modules${path.sep}`),
+      )
+      .sort((left, right) => left.fileName.localeCompare(right.fileName));
+    const methodAliases = collectInvocationMethodAliases(
+      sourceFiles,
+      analysis.checker,
+    );
+    const wrappers = new Map<
+      string,
+      Array<{ target: WrapperTargetResult; mode: AgentInvocationMode }>
+    >();
+    for (const sourceFile of sourceFiles) {
+      const visit = (node: ts.Node): void => {
+        const callable = functionLikeFromDeclaration(node as ts.Declaration);
+        if (callable) {
+          const symbol =
+            ts.isFunctionDeclaration(node) && node.name
+              ? analysis.checker.getSymbolAtLocation(node.name)
+              : ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)
+                ? analysis.checker.getSymbolAtLocation(node.name)
+                : undefined;
+          const key = symbolKey(aliasedSymbol(analysis.checker, symbol));
+          const invocations = directInvocationsInFunction(
+            callable,
+            analysis.checker,
+            methodAliases,
           );
-          const target = staticDefinitionTarget(node, checker);
-          if (target.kind === "literal") {
-            scan.invocations.push({ target: target.slug, mode, evidence });
-          } else {
-            scan.warnings.push({ code: "dynamic-target", mode, evidence });
-          }
-        } else {
+          if (key && invocations.length > 0) wrappers.set(key, invocations);
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(sourceFile);
+    }
+
+    const invokedWrapperKeys = new Set<string>();
+    for (const sourceFile of sourceFiles) {
+      if (!owningCaller(sourceFile.fileName, packageCallers)) continue;
+      const visit = (node: ts.Node): void => {
+        if (
+          ts.isCallExpression(node) &&
+          !analysis.resolveInvocationTarget(node)
+        ) {
           const expression = unwrapTsExpression(node.expression);
           const symbol =
             ts.isIdentifier(expression) || ts.isPropertyAccessExpression(expression)
-              ? aliasedSymbol(checker, checker.getSymbolAtLocation(expression))
+              ? aliasedSymbol(
+                  analysis.checker,
+                  analysis.checker.getSymbolAtLocation(expression),
+                )
               : undefined;
-          const wrapper = wrappers.get(symbolKey(symbol) ?? "");
-          if (wrapper) {
+          const key = symbolKey(symbol);
+          if (key && wrappers.has(key)) invokedWrapperKeys.add(key);
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(sourceFile);
+    }
+
+    for (const sourceFile of sourceFiles) {
+      const caller = owningCaller(sourceFile.fileName, packageCallers);
+      if (!caller) continue;
+      const scan = byCallerKey.get(callerInvocationCacheKey(caller))!;
+      const visit = (node: ts.Node): void => {
+        if (ts.isCallExpression(node)) {
+          const resolution = analysis.resolveInvocationTarget(node);
+          const position = node.expression.getStart(sourceFile);
+          if (resolution) {
+            if (
+              containingWrapperKey(
+                node,
+                analysis.checker,
+                invokedWrapperKeys,
+                sourceFile,
+              )
+            ) {
+              ts.forEachChild(node, visit);
+              return;
+            }
             const evidence = relativeProgramEvidence(
               caller.sourceRoot,
               sourceFile.fileName,
               sourceFile,
               position,
             );
-            for (const invocation of wrapper) {
-              const target = resolveWrapperInvocationTarget(
-                invocation.target,
-                node,
-                checker,
+            if (resolution.kind === "resolved") {
+              scan.invocations.push({
+                target: resolution.target,
+                mode: resolution.mode,
+                evidence,
+              });
+            } else if (resolution.kind === "dynamic-target") {
+              scan.warnings.push({
+                code: "dynamic-target",
+                mode: resolution.mode,
+                evidence,
+              });
+            } else {
+              for (const mode of resolution.modes) {
+                scan.warnings.push({ code: "dynamic-target", mode, evidence });
+              }
+            }
+          } else {
+            const expression = unwrapTsExpression(node.expression);
+            const symbol =
+              ts.isIdentifier(expression) || ts.isPropertyAccessExpression(expression)
+                ? aliasedSymbol(
+                    analysis.checker,
+                    analysis.checker.getSymbolAtLocation(expression),
+                  )
+                : undefined;
+            const wrapper = wrappers.get(symbolKey(symbol) ?? "");
+            if (wrapper) {
+              const evidence = relativeProgramEvidence(
+                caller.sourceRoot,
+                sourceFile.fileName,
+                sourceFile,
+                position,
               );
-              if (target === null) {
-                scan.warnings.push({
-                  code: "dynamic-target",
-                  mode: invocation.mode,
-                  evidence,
-                });
-              } else {
-                scan.invocations.push({
-                  target,
-                  mode: invocation.mode,
-                  evidence,
-                });
+              for (const invocation of wrapper) {
+                const target = resolveWrapperInvocationTarget(
+                  invocation.target,
+                  node,
+                  analysis.checker,
+                );
+                if (target === null) {
+                  scan.warnings.push({
+                    code: "dynamic-target",
+                    mode: invocation.mode,
+                    evidence,
+                  });
+                } else {
+                  scan.invocations.push({
+                    target,
+                    mode: invocation.mode,
+                    evidence,
+                  });
+                }
               }
             }
           }
         }
-      }
-      ts.forEachChild(node, visit);
-    };
-    visit(sourceFile);
-  }
+        ts.forEachChild(node, visit);
+      };
+      visit(sourceFile);
+    }
 
-  const fingerprint = stableScanFingerprint(
-    sourceFiles.map((sourceFile) => ({
-      file: path.relative(workspaceRoot, sourceFile.fileName).split(path.sep).join(path.posix.sep),
-      content: contents.get(sourceFile.fileName) ?? sourceFile.text,
-    })),
-    complete,
-  );
-  for (const scan of byAgentKey.values()) {
-    scan.observedPaths = [
-      ...new Set([...scan.observedPaths, ...observed]),
-    ].sort();
-    scan.complete = scan.complete && complete;
-    scan.sourceFingerprint = fingerprint;
-    const grouped = new Map<string, AgentInvocationCandidate>();
-    for (const invocation of scan.invocations.sort((left, right) =>
-      evidenceOrder(left.evidence, right.evidence),
-    )) {
-      const key = `${invocation.target}\0${invocation.mode}`;
-      const existing = grouped.get(key);
-      if (existing) {
-        existing.evidence.push(invocation.evidence);
-      } else {
-        grouped.set(key, {
-          target: invocation.target,
-          mode: invocation.mode,
-          evidence: [invocation.evidence],
-        });
+    for (const [callerKey, scan] of byCallerKey) {
+      const grouped = new Map<string, AgentInvocationCandidate>();
+      for (const invocation of scan.invocations.sort((left, right) =>
+        evidenceOrder(left.evidence, right.evidence),
+      )) {
+        const key = `${invocation.target}\0${invocation.mode}`;
+        const existing = grouped.get(key);
+        if (existing) {
+          existing.evidence.push(invocation.evidence);
+        } else {
+          grouped.set(key, {
+            target: invocation.target,
+            mode: invocation.mode,
+            evidence: [invocation.evidence],
+          });
+        }
       }
-    }
-    scan.groupedInvocations = [...grouped.values()];
-    for (const candidate of scan.groupedInvocations) {
-      candidate.evidence.sort(evidenceOrder);
-    }
-    scan.groupedInvocations.sort(
-      (left, right) =>
-        left.evidence[0]!.file.localeCompare(right.evidence[0]!.file) ||
-        left.evidence[0]!.line - right.evidence[0]!.line ||
-        left.evidence[0]!.column - right.evidence[0]!.column ||
-        MODE_ORDER[left.mode] - MODE_ORDER[right.mode] ||
-        left.target.localeCompare(right.target),
-    );
-    scan.warnings.sort((left, right) =>
-      evidenceOrder(left.evidence, right.evidence),
-    );
-  }
-  return new Map(
-    [...byAgentKey].map(([agentKey, scan]) => [
-      agentKey,
-      {
+      scan.groupedInvocations = [...grouped.values()];
+      for (const candidate of scan.groupedInvocations) {
+        candidate.evidence.sort(evidenceOrder);
+      }
+      scan.groupedInvocations.sort(
+        (left, right) =>
+          left.evidence[0]!.file.localeCompare(right.evidence[0]!.file) ||
+          left.evidence[0]!.line - right.evidence[0]!.line ||
+          left.evidence[0]!.column - right.evidence[0]!.column ||
+          MODE_ORDER[left.mode] - MODE_ORDER[right.mode] ||
+          left.target.localeCompare(right.target),
+      );
+      scan.warnings.sort(
+        (left, right) =>
+          evidenceOrder(left.evidence, right.evidence) ||
+          MODE_ORDER[left.mode] - MODE_ORDER[right.mode],
+      );
+      results.set(callerKey, {
         invocations: scan.groupedInvocations,
         warnings: scan.warnings,
         observedPaths: scan.observedPaths,
         complete: scan.complete,
         sourceFingerprint: scan.sourceFingerprint,
-      },
-    ]),
-  );
+      });
+    }
+  }
+  return results;
 }
 /**
  * V0 per-agent filesystem adapter for literal direct invocations.
@@ -1262,6 +1737,7 @@ async function scanPackageInvocations(
  */
 export class SourceAgentInvocationProvider implements AgentInvocationProvider {
   private retainedCallers: readonly AgentInventoryItem[] = [];
+  private nextGeneration = 1;
   private inFlight:
     | {
         key: string;
@@ -1273,31 +1749,41 @@ export class SourceAgentInvocationProvider implements AgentInvocationProvider {
 
   retainCallers(callers: readonly AgentInventoryItem[]): void {
     this.retainedCallers = [...callers].sort((left, right) =>
-      left.agentKey.localeCompare(right.agentKey),
+      callerInvocationCacheKey(left).localeCompare(callerInvocationCacheKey(right)),
     );
   }
 
   async listInvocations(
     caller: AgentInventoryItem,
   ): Promise<AgentInvocationProviderResult> {
-    const callers = this.retainedCallers.some(
-      (candidate) => candidate.agentKey === caller.agentKey,
+    const callerKey = callerInvocationCacheKey(caller);
+    const packageRoot = packageRootForCaller(caller);
+    const retainedPackageCallers = this.retainedCallers.filter(
+      (candidate) => packageRootForCaller(candidate) === packageRoot,
+    );
+    const callers = retainedPackageCallers.some(
+      (candidate) => callerInvocationCacheKey(candidate) === callerKey,
     )
-      ? this.retainedCallers
+      ? retainedPackageCallers
       : [caller];
     const key = callers
-      .map((candidate) => `${candidate.agentKey}\0${candidate.sourceRoot}`)
+      .map(callerInvocationCacheKey)
       .sort()
       .join("\0");
     if (!this.inFlight || this.inFlight.key !== key) {
-      const result = scanPackageInvocations(callers, this.readHooks).finally(() => {
+      const generation = this.nextGeneration++;
+      const result = scanPackageInvocations(
+        callers,
+        this.readHooks,
+        generation,
+      ).finally(() => {
         if (this.inFlight?.key === key) this.inFlight = null;
       });
       this.inFlight = { key, result };
     }
     const packageResult = await this.inFlight.result;
     return (
-      packageResult.get(caller.agentKey) ?? {
+      packageResult.get(callerKey) ?? {
         invocations: [],
         warnings: [],
         observedPaths: [],

--- a/packages/harness/src/core/system-graph-relationships.ts
+++ b/packages/harness/src/core/system-graph-relationships.ts
@@ -985,26 +985,31 @@ function functionLikeFromDeclaration(
 function containingWrapperKey(
   node: ts.Node,
   checker: ts.TypeChecker,
-  wrappers: ReadonlyMap<string, readonly { target: WrapperTargetResult; mode: AgentInvocationMode }[]>,
+  invokedWrapperKeys: ReadonlySet<string>,
   sourceFile: ts.SourceFile,
 ): string | null {
-  for (let ancestor = node.parent; ancestor && ancestor !== sourceFile; ancestor = ancestor.parent) {
+  for (
+    let ancestor = node.parent;
+    ancestor && ancestor !== sourceFile;
+    ancestor = ancestor.parent
+  ) {
     if (
       ts.isFunctionDeclaration(ancestor) ||
       ts.isFunctionExpression(ancestor) ||
       ts.isArrowFunction(ancestor)
     ) {
-      const declaration = ts.isArrowFunction(ancestor) || ts.isFunctionExpression(ancestor)
-        ? ancestor.parent
-        : ancestor;
+      const declaration =
+        ts.isArrowFunction(ancestor) || ts.isFunctionExpression(ancestor)
+          ? ancestor.parent
+          : ancestor;
       const symbol =
         ts.isFunctionDeclaration(declaration) && declaration.name
           ? checker.getSymbolAtLocation(declaration.name)
           : ts.isVariableDeclaration(declaration) && ts.isIdentifier(declaration.name)
-            ? checker.getSymbolAtLocation(declaration.name)
-            : undefined;
+              ? checker.getSymbolAtLocation(declaration.name)
+              : undefined;
       const key = symbolKey(aliasedSymbol(checker, symbol));
-      if (key && wrappers.has(key)) return key;
+      if (key && invokedWrapperKeys.has(key)) return key;
     }
   }
   return null;
@@ -1101,6 +1106,25 @@ async function scanPackageInvocations(
     visit(sourceFile);
   }
 
+  const invokedWrapperKeys = new Set<string>();
+  for (const sourceFile of sourceFiles) {
+    if (contents.get(sourceFile.fileName) === null) continue;
+    if (!owningCaller(sourceFile.fileName, orderedCallers)) continue;
+    const visit = (node: ts.Node): void => {
+      if (ts.isCallExpression(node) && !packageInvocationMode(node, checker)) {
+        const expression = unwrapTsExpression(node.expression);
+        const symbol =
+          ts.isIdentifier(expression) || ts.isPropertyAccessExpression(expression)
+            ? aliasedSymbol(checker, checker.getSymbolAtLocation(expression))
+            : undefined;
+        const key = symbolKey(symbol);
+        if (key && wrappers.has(key)) invokedWrapperKeys.add(key);
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+  }
+
   for (const sourceFile of sourceFiles) {
     if (contents.get(sourceFile.fileName) === null) continue;
     const caller = owningCaller(sourceFile.fileName, orderedCallers);
@@ -1111,7 +1135,7 @@ async function scanPackageInvocations(
         const mode = packageInvocationMode(node, checker);
         const position = node.expression.getStart(sourceFile);
         if (mode) {
-          if (containingWrapperKey(node, checker, wrappers, sourceFile)) {
+          if (containingWrapperKey(node, checker, invokedWrapperKeys, sourceFile)) {
             ts.forEachChild(node, visit);
             return;
           }

--- a/packages/harness/src/core/system-graph.test.ts
+++ b/packages/harness/src/core/system-graph.test.ts
@@ -251,10 +251,13 @@ describe("StaticSystemGraphBuilder", () => {
     first.afterCommit?.();
 
     let graph = first.graph;
-    await vi.waitFor(async () => {
-      graph = (await builder.build(scope)).graph;
-      expect(graph.edges).toHaveLength(2);
-    });
+    await vi.waitFor(
+      async () => {
+        graph = (await builder.build(scope)).graph;
+        expect(graph.edges).toHaveLength(2);
+      },
+      { timeout: 3_000 },
+    );
 
     expect(graph).toEqual({
       kind: "system",

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -2150,6 +2150,9 @@ export const startServer = async (
           systemGraphInventory.invalidateScope(scope.root);
           systemGraphInvocations.invalidateScope(scope.root);
         } else {
+          sourcePaths.forEach((sourcePath) =>
+            systemGraphInvocations.invalidateSource(sourcePath),
+          );
           for (const root of dirtyGraphSourceRoots(
             scope.root,
             workflowsCache.map((workflow) => workflow.path),
@@ -2178,6 +2181,9 @@ export const startServer = async (
           systemGraphInventory.invalidateScope(canonicalScope.root);
           systemGraphInvocations.invalidateScope(canonicalScope.root);
         } else {
+          sourcePaths.forEach((sourcePath) =>
+            systemGraphInvocations.invalidateSource(sourcePath),
+          );
           for (const workflowRoot of dirtyRoots) {
             systemGraphInventory.invalidateSource(workflowRoot);
             systemGraphInvocations.invalidateSource(workflowRoot);


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [x] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

SAP-3015 upgrades direct invocation extraction from the SAP-2986 syntax-only per-agent scan to a bounded package-wide TypeScript Program/TypeChecker. Static System Graph invocation evidence follows resolvable imports, re-exports, aliases, and simple wrappers without broadening into runtime dispatch, semantic candidates, or dataflow.

## Summary and scope

- build one reusable bounded package-wide TypeScript Program/TypeChecker for retained graph callers
- isolate callers and caches by package/workspace identity plus agent identity
- resolve direct `ctx.sapiom.agents.run/launch`, `@sapiom/tools` aliases/re-exports, namespace imports, const object/target aliases, and simple wrapper functions
- fingerprint admitted package sources and expose the shared compiler seam consumed by SAP-3016
- enforce lexical no-follow source admission and bounded constant-size alias resolution
- preserve SAP-3014 AgentFacts contracts and SAP-2986 evidence lifecycle semantics

Out of scope: `feeds/static-dataflow`, runtime dispatch/handoffs, semantic candidates, persistence, deployment transport, UI, and System Graph DTO changes.

## Wave 2 terminal status

This PR remains draft and is **TIMEBOXED**, not review-ready. Two bounded Wave 2 review/fix passes are exhausted with one independently reproduced High:

1. Cycle detection classifies clean method dependencies reachable from an alias cycle as cyclic. A separate immutable `run = agents.run; run(...)` call can therefore lose its required blocking edge and receive dynamic-method diagnostics because another alias component cycles.

Bounded next correction: compute actual strongly connected components (or equivalent dependency-first sink elimination), mark only true cycle members and aliases depending on those cycles dynamic, then propagate the constant-size lattice in dependency order.

## Validation at frozen head

```text
head: 634b03bbfae1016bf8096adf436ff933aac48e1f
coordinator graph slice: 4 files, 105 tests passed
pnpm --filter @sapiom/harness typecheck: passed
targeted ESLint: passed
pnpm --filter @sapiom/harness build:server: passed
git diff --check: passed
independent terminal review: 86 focused tests passed; REVIEW_FAIL_HIGH (1 finding above)
GitHub automated review: passed; PR CLEAN/MERGEABLE
```

## Confirmed closed in Wave 2

- transitive alias chains resolve deterministically; ambiguous/dynamic chains degrade explicitly
- explicit tools declarations and symlinked ancestors are rejected before descendant traversal
- long and multi-file alias graphs are bounded by deterministic vertex/edge/work caps
- duplicate-edge diamonds use a constant-size saturated lattice and no longer expand paths or crash
- package isolation, cache/fingerprint behavior, re-exports, source confinement, and deterministic output remain covered

## Related work

- Closes: SAP-3015
- Base: SAP-3014 / `conductor/sap-3014-agent-facts`
- Frozen head: `634b03bbfae1016bf8096adf436ff933aac48e1f`
- Builds on SAP-2986 direct-invocation graph evidence

## Security

- [x] No secrets, credentials, private data, or unsanitized logs are included.

## AI assistance

- [x] AI assistance implemented and independently reviewed this change; terminal findings and exact verification are recorded above.
