### PR TITLE
feat(harness): add static dataflow evidence slice

### DIFF
--- a/.changeset/static-dataflow-provenance.md
+++ b/.changeset/static-dataflow-provenance.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/harness": patch
+---
+
+Add an internal static dataflow evidence producer that tracks resolved agent
+outputs into downstream invocation inputs and emits package graph
+`feeds/static-dataflow` evidence with deterministic diagnostics.

--- a/packages/harness/src/core/system-graph-static-dataflow-evidence.test.ts
+++ b/packages/harness/src/core/system-graph-static-dataflow-evidence.test.ts
@@ -1048,4 +1048,234 @@ export async function run(route) {
     });
     expect(cache.getOrAnalyze(partial)).not.toBe(cache.getOrAnalyze(partial));
   });
+
+  it("applies helper leaf mutations through parameter aliases without erasing siblings", async () => {
+    expect(
+      await edgePairs({
+        "shared/mutate.ts": `
+export function put(holder, value) {
+  const alias = holder;
+  alias.value = value;
+}
+
+export function putNested(holder, value) {
+  const child = holder.child;
+  child.value = value;
+}
+
+export function putBoth(left, right, first, second) {
+  const leftAlias = left;
+  leftAlias.value = first;
+  right.value = second;
+}
+`,
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+import { put, putBoth, putNested } from "../../shared/mutate";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const sales = await agents.run({ definition: "sales" });
+  const holder = { keep: sales, child: {} };
+  const other = {};
+  put(holder, research);
+  putNested(holder, research);
+  putBoth(holder, other, research, sales);
+  await agents.run({ definition: "growth", input: holder.value });
+  await agents.run({ definition: "coordinator", input: holder.keep });
+  await agents.run({ definition: "sales", input: holder.child.value });
+  await agents.run({ definition: "growth", input: other.value });
+}
+`,
+      }),
+    ).toEqual([
+      ["research", "growth"],
+      ["research", "sales"],
+      ["sales", "coordinator"],
+      ["sales", "growth"],
+    ]);
+  });
+
+  it("freshens cached summary allocation references for each helper invocation", async () => {
+    const files = {
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+function init(holder) {
+  holder.child = {};
+}
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const a = {};
+  const b = {};
+  init(a);
+  init(b);
+  a.child.value = research;
+  await agents.run({ definition: "growth", input: b.child.value });
+  await agents.run({ definition: "sales", input: a.child.value });
+}
+`,
+    };
+    expect(await edgePairs(files)).toEqual([["research", "sales"]]);
+
+    const fixture = await writeFixture(files);
+    const cache = new StaticDataflowSummaryCache();
+    const first = cache.getOrAnalyze(fixture);
+    const second = cache.getOrAnalyze(fixture);
+    expect(second).toBe(first);
+    expect(first.result.evidence).toEqual(second.result.evidence);
+  });
+
+  it("models logical assignments and invalidates deletes and compound provenance writes", async () => {
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const holder = {};
+  holder.value ||= research;
+  holder["other"] ??= research;
+  await agents.run({ definition: "growth", input: holder.value });
+  await agents.run({ definition: "sales", input: holder.other });
+  delete holder.value;
+  delete holder["other"];
+  await agents.run({ definition: "coordinator", input: holder.value });
+}
+`,
+      }),
+    ).toEqual([
+      ["research", "growth"],
+      ["research", "sales"],
+    ]);
+
+    for (const source of [
+      `
+import { agents } from "@sapiom/tools";
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const holder = {};
+  holder.value += research;
+  await agents.run({ definition: "growth", input: holder.value });
+}
+`,
+      `
+import { agents } from "@sapiom/tools";
+export async function run(key) {
+  const research = await agents.run({ definition: "research" });
+  const holder = {};
+  holder[key] ||= research;
+}
+`,
+    ]) {
+      const result = await analyze({ "agents/coordinator/index.ts": source });
+      expect(result.result.complete).toBe(false);
+      expect(result.result.cacheable).toBe(false);
+      expect(result.result.result.evidence).toEqual([]);
+    }
+  });
+
+  it("marks unsupported loops with declaration initializers and wrapper effects partial", async () => {
+    for (const source of [
+      `
+import { agents } from "@sapiom/tools";
+function produce() {
+  return agents.run({ definition: "research" });
+}
+export async function run() {
+  for (let output = produce(); output; output = null) {
+    break;
+  }
+}
+`,
+      `
+import { agents } from "@sapiom/tools";
+function inner(value) {
+  agents.run({ definition: "growth", input: value });
+}
+function outer(value) {
+  inner(value);
+}
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  while (true) {
+    outer(output);
+    break;
+  }
+}
+`,
+      `
+import { agents } from "@sapiom/tools";
+function mutate(holder, value) {
+  holder.value = value;
+}
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  const holder = {};
+  do {
+    mutate(holder, output);
+    break;
+  } while (true);
+  await agents.run({ definition: "growth", input: holder.value });
+}
+`,
+    ]) {
+      const result = await analyze({ "agents/coordinator/index.ts": source });
+      expect(result.result.complete).toBe(false);
+      expect(result.result.cacheable).toBe(false);
+      expect(result.result.result.evidence).toEqual([]);
+    }
+  });
+
+  it("does not publish candidates or diagnostics from disconnected uncalled functions", async () => {
+    const unused = await analyze({
+      "shared/unused.ts": `
+import { agents } from "@sapiom/tools";
+
+export function exportedButUncalled() {
+  const output = agents.run({ definition: "research" });
+  agents.run({ definition: "growth", input: output });
+}
+`,
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+function unused() {
+  const output = agents.run({ definition: "research" });
+  agents.run({ definition: "growth", input: output });
+}
+
+function unusedPartial(value) {
+  while (value) {
+    agents.run({ definition: "growth", input: value });
+  }
+}
+
+export async function run() {
+}
+`,
+    });
+    expect(unused.result.complete).toBe(true);
+    expect(unused.result.result.evidence).toEqual([]);
+    expect(unused.result.result.diagnostics).toEqual([]);
+
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+function used() {
+  const output = agents.run({ definition: "research" });
+  agents.run({ definition: "growth", input: output });
+}
+
+export async function run() {
+  used();
+}
+`,
+      }),
+    ).toEqual([["research", "growth"]]);
+  });
 });

--- a/packages/harness/src/core/system-graph-static-dataflow-evidence.test.ts
+++ b/packages/harness/src/core/system-graph-static-dataflow-evidence.test.ts
@@ -1,0 +1,720 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  projectPackageGraphEvidence,
+  type PackageInventory,
+  type PackageInventoryAgent,
+} from "@sapiom/agent";
+
+import type { AgentInventoryItem } from "./system-graph-inventory.js";
+import {
+  createSystemGraphPackageCompilerResult,
+  type SystemGraphPackageCompilerResult,
+} from "./system-graph-relationships.js";
+import {
+  analyzeStaticDataflow,
+  StaticDataflowSummaryCache,
+  STATIC_DATAFLOW_EVIDENCE_PRODUCER,
+} from "./system-graph-static-dataflow-evidence.js";
+
+const REVISION = `sha256:${"a".repeat(64)}` as const;
+const temporaryRoots: string[] = [];
+
+interface AgentFixture {
+  context: AgentInventoryItem;
+  public: PackageInventoryAgent;
+}
+
+function agent(
+  root: string,
+  agentKey: string,
+  aliases: readonly string[] = [agentKey],
+): AgentFixture {
+  return {
+    context: {
+      agentKey,
+      identityStatus: "canonical",
+      definitionId: null,
+      definitionSlug: null,
+      label: agentKey,
+      resolutionAliases: [...aliases],
+      sourceRoot: path.join(root, "agents", agentKey),
+      workflowPath: path.join(root, "agents", agentKey),
+      path: `agents/${agentKey}`,
+      entrypoint: "index.ts",
+    },
+    public: {
+      agentKey,
+      identityStatus: "canonical",
+      path: `agents/${agentKey}`,
+      entrypoint: "index.ts",
+    },
+  };
+}
+
+function inventory(fixtures: readonly AgentFixture[]): PackageInventory {
+  return {
+    protocol: 1,
+    version: {
+      kind: "working-tree",
+      workspaceKey: "workspace-dataflow",
+      revision: REVISION,
+    },
+    status: "complete",
+    agents: fixtures.map((fixture) => fixture.public),
+  };
+}
+
+async function writeFixture(
+  files: Record<string, string>,
+  agentKeys: readonly string[] = ["coordinator", "research", "growth", "sales"],
+): Promise<{
+  inventory: PackageInventory;
+  agents: AgentInventoryItem[];
+  compiler: SystemGraphPackageCompilerResult;
+}> {
+  const root = await fs.mkdtemp(
+    path.join(os.tmpdir(), "static-dataflow-evidence-"),
+  );
+  temporaryRoots.push(root);
+  const toolsRoot = path.join(root, "node_modules", "@sapiom", "tools");
+  await fs.mkdir(toolsRoot, { recursive: true });
+  await fs.writeFile(
+    path.join(toolsRoot, "package.json"),
+    JSON.stringify({ name: "@sapiom/tools", types: "index.d.ts" }),
+  );
+  await fs.writeFile(
+    path.join(toolsRoot, "index.d.ts"),
+    `
+export declare const agents: {
+  run(spec: { definition: string; input?: unknown }): Promise<unknown>;
+  launch(spec: { definition: string; input?: unknown }): Promise<unknown>;
+};
+`,
+  );
+  for (const [relative, content] of Object.entries(files)) {
+    const absolute = path.join(root, relative);
+    await fs.mkdir(path.dirname(absolute), { recursive: true });
+    await fs.writeFile(absolute, content);
+  }
+  const fixtures = agentKeys.map((key) => agent(root, key));
+  const compiler = await createSystemGraphPackageCompilerResult({
+    packageRoot: root,
+  });
+  return {
+    inventory: inventory(fixtures),
+    agents: fixtures.map((fixture) => fixture.context),
+    compiler,
+  };
+}
+
+async function analyze(
+  files: Record<string, string>,
+  agentKeys?: readonly string[],
+) {
+  const fixture = await writeFixture(files, agentKeys);
+  return {
+    ...fixture,
+    result: analyzeStaticDataflow(fixture),
+  };
+}
+
+async function connectors(files: Record<string, string>) {
+  const { inventory: packageInventory, result } = await analyze(files);
+  return projectPackageGraphEvidence(packageInventory, [
+    result.result,
+  ]).connectors;
+}
+
+async function edgePairs(files: Record<string, string>) {
+  return (await connectors(files)).map(({ fromAgentKey, toAgentKey }) => [
+    fromAgentKey,
+    toAgentKey,
+  ]);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("analyzeStaticDataflow", () => {
+  it("emits one canonical Research output to Growth input feeds edge through awaits and sync transforms", async () => {
+    const analysis = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+function formatReport(report) {
+  const { summary } = report;
+  return { body: summary, raw: report };
+}
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const formatted = formatReport(research);
+  await agents.run({ definition: "growth", input: formatted });
+}
+`,
+    });
+
+    expect(analysis.result.complete).toBe(true);
+    expect(analysis.result.result).toMatchObject({
+      protocol: 1,
+      kind: "static-result",
+      producer: STATIC_DATAFLOW_EVIDENCE_PRODUCER,
+      outcome: "success",
+      coverage: { status: "complete" },
+    });
+    expect(
+      analysis.result.result.evidence.map((evidence) => ({
+        fromAgentKey: evidence.fromAgentKey,
+        toAgentKey: evidence.toAgentKey,
+        relation: evidence.relation,
+        basis: evidence.basis,
+      })),
+    ).toEqual([
+      {
+        fromAgentKey: "research",
+        toAgentKey: "growth",
+        relation: "feeds",
+        basis: "static-dataflow",
+      },
+    ]);
+  });
+
+  it("keeps sibling properties independent and selects only the addressed property", async () => {
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const sales = await agents.run({ definition: "sales" });
+  const payload = { research, sales };
+  await agents.run({ definition: "growth", input: payload.sales });
+}
+`,
+      }),
+    ).toEqual([["sales", "growth"]]);
+  });
+
+  it("preserves root agent output through direct property/index access and destructuring", async () => {
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  const { summary } = output;
+  await agents.run({ definition: "growth", input: output.summary });
+  await agents.run({ definition: "sales", input: output[0] });
+  await agents.run({ definition: "coordinator", input: summary });
+}
+`,
+      }),
+    ).toEqual([
+      ["research", "coordinator"],
+      ["research", "growth"],
+      ["research", "sales"],
+    ]);
+  });
+
+  it("preserves structured provenance through object and array rest selections", async () => {
+    const analysis = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  const sales = await agents.run({ definition: "sales" });
+  const { ignored, ...objectRest } = output;
+  const [first, ...arrayRest] = output;
+  const values = [sales, output];
+  const [, ...reindexed] = values;
+  await agents.run({ definition: "growth", input: objectRest.summary });
+  await agents.run({ definition: "sales", input: arrayRest[0] });
+  await agents.run({ definition: "coordinator", input: reindexed[0] });
+}
+`,
+    });
+
+    expect(analysis.result.complete).toBe(true);
+    expect(analysis.result.cacheable).toBe(true);
+    expect(
+      projectPackageGraphEvidence(analysis.inventory, [
+        analysis.result.result,
+      ]).connectors.map(({ fromAgentKey, toAgentKey }) => [
+        fromAgentKey,
+        toAgentKey,
+      ]),
+    ).toEqual([
+      ["research", "coordinator"],
+      ["research", "growth"],
+      ["research", "sales"],
+    ]);
+  });
+
+  it("follows wrappers, re-exports, destructuring, construction, and literal routing keys", async () => {
+    expect(
+      (await connectors({
+        "shared/helpers.ts": `
+import { agents } from "@sapiom/tools";
+
+export function submitGrowth({ result }) {
+  return agents.launch({ definition: "growth", input: { payload: result } });
+}
+
+export function submitSales(report) {
+  return agents.run({ definition: "sales", input: [report] });
+}
+`,
+        "shared/router.ts": `
+export { submitGrowth as growthWriter, submitSales } from "./helpers";
+`,
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+import { growthWriter, submitSales } from "../../shared/router";
+
+const table = { growth: growthWriter, sales: submitSales };
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  const envelope = { result: output, copy: { ...output } };
+  table["growth"](envelope);
+  table["sales"](envelope);
+}
+`,
+      })).map(({ fromAgentKey, toAgentKey, relation, bases }) => ({
+        fromAgentKey,
+        toAgentKey,
+        relation,
+        bases,
+      })),
+    ).toEqual([
+      {
+        fromAgentKey: "research",
+        toAgentKey: "growth",
+        relation: "feeds",
+        bases: ["static-dataflow"],
+      },
+      {
+        fromAgentKey: "research",
+        toAgentKey: "sales",
+        relation: "feeds",
+        bases: ["static-dataflow"],
+      },
+    ]);
+  });
+
+  it("does not fan out dynamic routing keys", async () => {
+    const analysis = await analyze({
+      "shared/helpers.ts": `
+import { agents } from "@sapiom/tools";
+export function submitGrowth(value) {
+  return agents.run({ definition: "growth", input: value });
+}
+`,
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+import { submitGrowth } from "../../shared/helpers";
+const table = { growth: submitGrowth };
+export async function run(route) {
+  const output = await agents.run({ definition: "research" });
+  table[route](output);
+}
+`,
+    });
+
+    expect(analysis.result.result.evidence).toEqual([]);
+    expect(analysis.result.complete).toBe(false);
+  });
+
+  it("continues after fallthrough branches and merges returned branch values", async () => {
+    expect(
+      (await connectors({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+function choose(flag, value) {
+  if (flag) {
+    return { payload: value };
+  }
+  const wrapped = { payload: value };
+  return wrapped;
+}
+
+function fallthrough(flag, value) {
+  if (flag) {
+    const ignored = { other: value };
+  }
+  const wrapped = { payload: value };
+  return wrapped;
+}
+
+export async function run(flag) {
+  const output = await agents.run({ definition: "research" });
+  await agents.run({ definition: "growth", input: choose(flag, output).payload });
+  await agents.run({ definition: "sales", input: fallthrough(flag, output).payload });
+}
+`,
+      })).map(({ fromAgentKey, toAgentKey }) => [fromAgentKey, toAgentKey]),
+    ).toEqual([
+      ["research", "growth"],
+      ["research", "sales"],
+    ]);
+  });
+
+  it("resolves aliased and spread invocation option objects through the shared checker seam", async () => {
+    expect(
+      (await connectors({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  const base = { input: output };
+  const options = { ...base, definition: "growth" };
+  await agents.run(options);
+}
+`,
+      })).map(({ fromAgentKey, toAgentKey }) => [fromAgentKey, toAgentKey]),
+    ).toEqual([["research", "growth"]]);
+  });
+
+  it("uses last-write semantics for object spreads and invocation option input", async () => {
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const sales = await agents.run({ definition: "sales" });
+  const spread = { input: research, value: research };
+  const options = { ...spread, definition: "growth", input: sales };
+  const payload = { ...spread, value: sales };
+  await agents.run(options);
+  await agents.run({ definition: "growth", input: payload.value });
+}
+`,
+      }),
+    ).toEqual([["sales", "growth"]]);
+  });
+
+  it("marks provenance-bearing unresolved option spreads partial without guessing overwritten input", async () => {
+    const analysis = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run(extra) {
+  const output = await agents.run({ definition: "research" });
+  await agents.run({ definition: "growth", input: output, ...extra });
+}
+`,
+    });
+
+    expect(analysis.result.complete).toBe(false);
+    expect(analysis.result.cacheable).toBe(false);
+    expect(analysis.result.result.evidence).toEqual([]);
+  });
+
+  it("tracks statically addressed property and element assignments", async () => {
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  const holder = {};
+  holder.value = output;
+  await agents.run({ definition: "growth", input: holder.value });
+}
+`,
+      }),
+    ).toEqual([["research", "growth"]]);
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  const holder = {};
+  holder["value"] = output;
+  await agents.run({ definition: "growth", input: holder["value"] });
+}
+`,
+      }),
+    ).toEqual([["research", "growth"]]);
+  });
+
+  it("degrades unsupported provenance-bearing writes and destructuring assignment forms", async () => {
+    const supported = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  let value;
+  ({ summary: value } = output);
+  await agents.run({ definition: "growth", input: value });
+}
+`,
+    });
+    expect(supported.result.complete).toBe(true);
+    expect(
+      projectPackageGraphEvidence(supported.inventory, [
+        supported.result.result,
+      ]).connectors.map(({ fromAgentKey, toAgentKey }) => [
+        fromAgentKey,
+        toAgentKey,
+      ]),
+    ).toEqual([["research", "growth"]]);
+
+    const unsupported = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run(key) {
+  const output = await agents.run({ definition: "research" });
+  const holder = {};
+  holder[key] = output;
+}
+`,
+    });
+    expect(unsupported.result.complete).toBe(false);
+    expect(unsupported.result.cacheable).toBe(false);
+  });
+
+  it("marks provenance-bearing unsupported conditions and dynamic switches partial", async () => {
+    const condition = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  if (JSON.parse(JSON.stringify(output))) {
+    return;
+  }
+}
+`,
+    });
+    expect(condition.result.complete).toBe(false);
+    expect(condition.result.cacheable).toBe(false);
+
+    const dynamicSwitch = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  switch (output.kind) {
+    case "growth":
+      await agents.run({ definition: "growth", input: output });
+      break;
+  }
+}
+`,
+    });
+    expect(dynamicSwitch.result.complete).toBe(false);
+    expect(dynamicSwitch.result.cacheable).toBe(false);
+  });
+
+  it("models statically bounded switch branches with fallthrough environment merging", async () => {
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+function route(kind, value) {
+  let selected;
+  switch (kind) {
+    case "growth":
+      selected = { payload: value };
+      break;
+    default:
+      selected = { payload: value };
+  }
+  return selected;
+}
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  await agents.run({ definition: "growth", input: route("growth", output).payload });
+}
+`,
+      }),
+    ).toEqual([["research", "growth"]]);
+  });
+
+  it("prefers canonical agent keys before stale compatibility aliases", async () => {
+    const fixture = await writeFixture(
+      {
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  await agents.run({ definition: "growth", input: output });
+}
+`,
+      },
+      ["coordinator", "research", "growth", "sales"],
+    );
+    const withStaleAlias = {
+      ...fixture,
+      agents: fixture.agents.map((item) =>
+        item.agentKey === "sales"
+          ? { ...item, resolutionAliases: ["sales", "growth"] }
+          : item,
+      ),
+    };
+    const result = analyzeStaticDataflow(withStaleAlias);
+    expect(
+      projectPackageGraphEvidence(withStaleAlias.inventory, [
+        result.result,
+      ]).connectors.map(({ fromAgentKey, toAgentKey }) => [
+        fromAgentKey,
+        toAgentKey,
+      ]),
+    ).toEqual([["research", "growth"]]);
+  });
+
+  it("keys duplicate function names across files by checker-resolved declaration identity", async () => {
+    expect(
+      (await connectors({
+        "shared/a.ts": `
+export function format(value) {
+  return { picked: value };
+}
+`,
+        "shared/b.ts": `
+export function format(value) {
+  return { ignored: value };
+}
+`,
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+import { format as formatA } from "../../shared/a";
+import { format as formatB } from "../../shared/b";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const sales = await agents.run({ definition: "sales" });
+  await agents.run({ definition: "growth", input: formatA(research).picked });
+  await agents.run({ definition: "growth", input: formatB(sales).picked });
+}
+`,
+      })).map(({ fromAgentKey, toAgentKey }) => [fromAgentKey, toAgentKey]),
+    ).toEqual([["research", "growth"]]);
+  });
+
+  it("does not treat launch handles as returned agent output provenance", async () => {
+    expect(
+      (await connectors({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const handle = agents.launch({ definition: "research" });
+  await agents.run({ definition: "growth", input: handle });
+}
+`,
+      })).map(({ fromAgentKey, toAgentKey }) => [fromAgentKey, toAgentKey]),
+    ).toEqual([]);
+  });
+
+  it("marks opaque stores, constructors, unsupported transforms, dynamic targets, unresolved targets, and cycles partial without guessed edges", async () => {
+    const analysis = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+const queue = [];
+class Box { constructor(value) { this.value = value; } }
+function loop(value) {
+  return loop(value);
+}
+export async function run(name) {
+  const output = await agents.run({ definition: "research" });
+  queue.push(output);
+  new Box(output);
+  const transformed = JSON.parse(JSON.stringify(output));
+  await agents.run({ definition: "growth", input: transformed });
+  await agents.run({ definition: name, input: output });
+  await agents.run({ definition: "missing", input: output });
+  loop(output);
+}
+`,
+    });
+
+    expect(analysis.result.complete).toBe(false);
+    expect(analysis.result.result.coverage.status).toBe("partial");
+    expect(analysis.result.result.evidence).toEqual([]);
+    expect(
+      new Set(
+        analysis.result.result.diagnostics.map((diagnostic) => diagnostic.code),
+      ),
+    ).toEqual(new Set(["dynamic-target", "incomplete-analysis"]));
+  });
+
+  it("keeps target-resolution identity in cache keys and never retains partial results", async () => {
+    const first = await writeFixture({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  await agents.run({ definition: "writer", input: output });
+}
+`,
+    });
+    const cache = new StaticDataflowSummaryCache();
+    const firstWithAlias = {
+      ...first,
+      agents: first.agents.map((item) =>
+        item.agentKey === "growth"
+          ? { ...item, resolutionAliases: ["growth", "writer"] }
+          : item,
+      ),
+    };
+    const secondWithAlias = {
+      ...first,
+      agents: first.agents.map((item) =>
+        item.agentKey === "sales"
+          ? { ...item, resolutionAliases: ["sales", "writer"] }
+          : item,
+      ),
+    };
+
+    const growth = cache.getOrAnalyze(firstWithAlias);
+    const sales = cache.getOrAnalyze(secondWithAlias);
+    expect(
+      projectPackageGraphEvidence(first.inventory, [growth.result])
+        .connectors[0]?.toAgentKey,
+    ).toBe("growth");
+    expect(
+      projectPackageGraphEvidence(first.inventory, [sales.result])
+        .connectors[0]?.toAgentKey,
+    ).toBe("sales");
+    expect(sales).not.toBe(growth);
+
+    const partial = await writeFixture({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+export async function run(route) {
+  const output = await agents.run({ definition: "research" });
+  const table = { growth: (value) => agents.run({ definition: "growth", input: value }) };
+  table[route](output);
+}
+`,
+    });
+    expect(cache.getOrAnalyze(partial)).not.toBe(cache.getOrAnalyze(partial));
+  });
+});

--- a/packages/harness/src/core/system-graph-static-dataflow-evidence.test.ts
+++ b/packages/harness/src/core/system-graph-static-dataflow-evidence.test.ts
@@ -449,6 +449,48 @@ export async function run() {
     ).toEqual([["sales", "growth"]]);
   });
 
+  it("carries overwrite hazards through nested and multiple object spreads until restored", async () => {
+    const nested = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const sales = await agents.run({ definition: "sales" });
+  const inner = { value: sales, ...research };
+  const outer = { ...inner };
+  await agents.run({ definition: "growth", input: outer.value });
+}
+`,
+    });
+    expect(nested.result.complete).toBe(false);
+    expect(nested.result.cacheable).toBe(false);
+    expect(nested.result.result.evidence).toEqual([]);
+
+    const restored = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const sales = await agents.run({ definition: "sales" });
+  const inner = { value: sales, ...research };
+  const restored = { ...inner, value: sales };
+  await agents.run({ definition: "growth", input: restored.value });
+}
+`,
+    });
+    expect(restored.result.complete).toBe(true);
+    expect(
+      projectPackageGraphEvidence(restored.inventory, [
+        restored.result.result,
+      ]).connectors.map(({ fromAgentKey, toAgentKey }) => [
+        fromAgentKey,
+        toAgentKey,
+      ]),
+    ).toEqual([["sales", "growth"]]);
+  });
+
   it("marks provenance-bearing unresolved option spreads partial without guessing overwritten input", async () => {
     const analysis = await analyze({
       "agents/coordinator/index.ts": `
@@ -525,6 +567,76 @@ export async function run() {
   const assigned = (holder.value = research);
   await agents.run({ definition: "growth", input: holder.value });
   await agents.run({ definition: "sales", input: assigned });
+}
+`,
+      }),
+    ).toEqual([
+      ["research", "growth"],
+      ["research", "sales"],
+    ]);
+  });
+
+  it("keeps rest top-level containers independent while preserving nested child identity", async () => {
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const holder = { nested: {} };
+  const { ...rest } = holder;
+  rest.value = research;
+  rest.nested.value = research;
+  await agents.run({ definition: "growth", input: holder.value });
+  await agents.run({ definition: "sales", input: holder.nested.value });
+}
+`,
+      }),
+    ).toEqual([["research", "sales"]]);
+
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const holder = [{}];
+  const [...rest] = holder;
+  rest[0].value = research;
+  rest[1] = research;
+  await agents.run({ definition: "growth", input: holder[0].value });
+  await agents.run({ definition: "sales", input: holder[1] });
+}
+`,
+      }),
+    ).toEqual([["research", "growth"]]);
+  });
+
+  it("propagates chained assignments, nested invocation-input assignments, and helper mutations", async () => {
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+function put(holder, value) {
+  holder.value = value;
+}
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const a = {};
+  const b = {};
+  a.value = b.value = research;
+  const holder = {};
+  await agents.run({ definition: "sales", input: (holder.value = research) });
+  const target = {};
+  put(target, research);
+  await agents.run({ definition: "growth", input: a.value });
+  await agents.run({ definition: "growth", input: b.value });
+  await agents.run({ definition: "growth", input: holder.value });
+  await agents.run({ definition: "growth", input: target.value });
 }
 `,
       }),
@@ -641,17 +753,78 @@ export async function run() {
 
     const safe = await analyze({
       "agents/coordinator/index.ts": `
-import { agents } from "@sapiom/tools";
-
 export async function run() {
   for (const item of ["static"]) {
-    await agents.run({ definition: "growth", input: item });
+    const value = item;
   }
 }
 `,
     });
     expect(safe.result.complete).toBe(true);
     expect(safe.result.result.evidence).toEqual([]);
+  });
+
+  it("marks loop-local producers and parameter-root loop provenance partial", async () => {
+    for (const source of [
+      `
+import { agents } from "@sapiom/tools";
+export async function run() {
+  let r;
+  while (true) {
+    r = await agents.run({ definition: "research" });
+    await agents.run({ definition: "growth", input: r });
+    break;
+  }
+}
+`,
+      `
+import { agents } from "@sapiom/tools";
+export async function run() {
+  let r;
+  do {
+    r = await agents.run({ definition: "research" });
+    await agents.run({ definition: "growth", input: r });
+    break;
+  } while (true);
+}
+`,
+      `
+import { agents } from "@sapiom/tools";
+export async function run() {
+  for (let i = 0; i < 1; i++) {
+    const r = await agents.run({ definition: "research" });
+    await agents.run({ definition: "growth", input: r });
+  }
+}
+`,
+      `
+import { agents } from "@sapiom/tools";
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  const map = { value: output };
+  for (const key in map) {
+    await agents.run({ definition: "growth", input: map[key] });
+  }
+}
+`,
+      `
+import { agents } from "@sapiom/tools";
+function send(items) {
+  for (const item of items) {
+    agents.run({ definition: "growth", input: item });
+  }
+}
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  send([output]);
+}
+`,
+    ]) {
+      const result = await analyze({ "agents/coordinator/index.ts": source });
+      expect(result.result.complete).toBe(false);
+      expect(result.result.cacheable).toBe(false);
+      expect(result.result.result.evidence).toEqual([]);
+    }
   });
 
   it("preserves positional identity through known array spreads and degrades unknown-length spreads", async () => {

--- a/packages/harness/src/core/system-graph-static-dataflow-evidence.test.ts
+++ b/packages/harness/src/core/system-graph-static-dataflow-evidence.test.ts
@@ -409,6 +409,46 @@ export async function run() {
     ).toEqual([["sales", "growth"]]);
   });
 
+  it("does not guess complete evidence when a trailing unknown object spread may overwrite a key", async () => {
+    const unsafe = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const sales = await agents.run({ definition: "sales" });
+  const payload = { value: sales, ...research };
+  await agents.run({ definition: "growth", input: payload.value });
+}
+`,
+    });
+    expect(unsafe.result.complete).toBe(false);
+    expect(unsafe.result.cacheable).toBe(false);
+    expect(unsafe.result.result.evidence).toEqual([]);
+
+    const safe = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const sales = await agents.run({ definition: "sales" });
+  const payload = { ...research, value: sales };
+  await agents.run({ definition: "growth", input: payload.value });
+}
+`,
+    });
+    expect(safe.result.complete).toBe(true);
+    expect(
+      projectPackageGraphEvidence(safe.inventory, [
+        safe.result.result,
+      ]).connectors.map(({ fromAgentKey, toAgentKey }) => [
+        fromAgentKey,
+        toAgentKey,
+      ]),
+    ).toEqual([["sales", "growth"]]);
+  });
+
   it("marks provenance-bearing unresolved option spreads partial without guessing overwritten input", async () => {
     const analysis = await analyze({
       "agents/coordinator/index.ts": `
@@ -455,6 +495,43 @@ export async function run() {
 `,
       }),
     ).toEqual([["research", "growth"]]);
+  });
+
+  it("propagates property writes through aliases and nested assignment expressions", async () => {
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const holder = {};
+  const alias = holder;
+  alias.value = research;
+  await agents.run({ definition: "growth", input: holder.value });
+}
+`,
+      }),
+    ).toEqual([["research", "growth"]]);
+
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const holder = {};
+  const assigned = (holder.value = research);
+  await agents.run({ definition: "growth", input: holder.value });
+  await agents.run({ definition: "sales", input: assigned });
+}
+`,
+      }),
+    ).toEqual([
+      ["research", "growth"],
+      ["research", "sales"],
+    ]);
   });
 
   it("degrades unsupported provenance-bearing writes and destructuring assignment forms", async () => {
@@ -527,6 +604,87 @@ export async function run() {
     });
     expect(dynamicSwitch.result.complete).toBe(false);
     expect(dynamicSwitch.result.cacheable).toBe(false);
+  });
+
+  it("marks unsupported provenance-bearing loops partial without guessing loop body edges", async () => {
+    const whileLoop = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  while (output) {
+    await agents.run({ definition: "growth", input: output });
+  }
+}
+`,
+    });
+    expect(whileLoop.result.complete).toBe(false);
+    expect(whileLoop.result.cacheable).toBe(false);
+    expect(whileLoop.result.result.evidence).toEqual([]);
+
+    const forOf = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  for (const item of [output]) {
+    await agents.run({ definition: "growth", input: item });
+  }
+}
+`,
+    });
+    expect(forOf.result.complete).toBe(false);
+    expect(forOf.result.cacheable).toBe(false);
+    expect(forOf.result.result.evidence).toEqual([]);
+
+    const safe = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  for (const item of ["static"]) {
+    await agents.run({ definition: "growth", input: item });
+  }
+}
+`,
+    });
+    expect(safe.result.complete).toBe(true);
+    expect(safe.result.result.evidence).toEqual([]);
+  });
+
+  it("preserves positional identity through known array spreads and degrades unknown-length spreads", async () => {
+    expect(
+      await edgePairs({
+        "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const research = await agents.run({ definition: "research" });
+  const sales = await agents.run({ definition: "sales" });
+  const values = [research, sales];
+  const combined = [...values];
+  await agents.run({ definition: "growth", input: combined[1] });
+}
+`,
+      }),
+    ).toEqual([["sales", "growth"]]);
+
+    const unknown = await analyze({
+      "agents/coordinator/index.ts": `
+import { agents } from "@sapiom/tools";
+
+export async function run() {
+  const output = await agents.run({ definition: "research" });
+  const combined = [...output];
+  await agents.run({ definition: "growth", input: combined[0] });
+}
+`,
+    });
+    expect(unknown.result.complete).toBe(false);
+    expect(unknown.result.cacheable).toBe(false);
+    expect(unknown.result.result.evidence).toEqual([]);
   });
 
   it("models statically bounded switch branches with fallthrough environment merging", async () => {

--- a/packages/harness/src/core/system-graph-static-dataflow-evidence.ts
+++ b/packages/harness/src/core/system-graph-static-dataflow-evidence.ts
@@ -69,8 +69,12 @@ interface FlowValue {
   sources: SourceMap;
   properties: Map<string, FlowValue>;
   elements: Map<string, FlowValue>;
+  propertyHazards: Set<string>;
+  elementHazards: Set<string>;
   unknown: FlowValue | null;
   parameters: readonly ParameterReference[];
+  references: readonly string[];
+  opaque: boolean;
 }
 
 type Environment = Map<string, FlowValue>;
@@ -95,6 +99,7 @@ interface AnalysisContext {
   cycleStack: Set<string>;
   diagnostics: PackageGraphEvidenceDiagnostic[];
   coverageGaps: PackageGraphEvidenceCoverageGap[];
+  nextReferenceId: number;
   complete: boolean;
 }
 
@@ -376,8 +381,12 @@ function emptyValue(): FlowValue {
     sources: new Map(),
     properties: new Map(),
     elements: new Map(),
+    propertyHazards: new Set(),
+    elementHazards: new Set(),
     unknown: null,
     parameters: [],
+    references: [],
+    opaque: false,
   };
 }
 
@@ -412,11 +421,15 @@ function cloneValue(value: FlowValue): FlowValue {
         cloneValue(child),
       ]),
     ),
+    propertyHazards: new Set(value.propertyHazards),
+    elementHazards: new Set(value.elementHazards),
     unknown: value.unknown ? cloneValue(value.unknown) : null,
     parameters: value.parameters.map((param) => ({
       index: param.index,
       path: [...param.path],
     })),
+    references: [...value.references],
+    opaque: value.opaque,
   };
 }
 
@@ -460,6 +473,10 @@ function mergeValues(...values: readonly FlowValue[]): FlowValue {
       result.unknown = mergeValues(result.unknown ?? emptyValue(), value.unknown);
     }
     result.parameters = [...result.parameters, ...value.parameters];
+    result.references = [...result.references, ...value.references];
+    for (const key of value.propertyHazards) result.propertyHazards.add(key);
+    for (const key of value.elementHazards) result.elementHazards.add(key);
+    result.opaque ||= value.opaque;
   }
   const seen = new Set<string>();
   result.parameters = result.parameters.filter((param) => {
@@ -468,11 +485,13 @@ function mergeValues(...values: readonly FlowValue[]): FlowValue {
     seen.add(key);
     return true;
   });
+  result.references = [...new Set(result.references)].sort(compareText);
   return result;
 }
 
 function hasProvenance(value: FlowValue): boolean {
   return (
+    value.opaque ||
     value.sources.size > 0 ||
     value.parameters.length > 0 ||
     [...value.properties.values()].some(hasProvenance) ||
@@ -490,6 +509,16 @@ function hasParameterReferences(value: FlowValue): boolean {
   );
 }
 
+function hasConcreteProvenance(value: FlowValue): boolean {
+  return (
+    value.opaque ||
+    value.sources.size > 0 ||
+    [...value.properties.values()].some(hasConcreteProvenance) ||
+    [...value.elements.values()].some(hasConcreteProvenance) ||
+    (value.unknown ? hasConcreteProvenance(value.unknown) : false)
+  );
+}
+
 function allSources(value: FlowValue): SourceMap {
   return mergeSourceMaps(
     value.sources,
@@ -497,6 +526,10 @@ function allSources(value: FlowValue): SourceMap {
     ...[...value.elements.values()].map(allSources),
     ...(value.unknown ? [allSources(value.unknown)] : []),
   );
+}
+
+function hasOwnSources(value: FlowValue): boolean {
+  return value.sources.size > 0 || value.parameters.length > 0;
 }
 
 function selectPath(value: FlowValue, path: readonly string[]): FlowValue {
@@ -510,6 +543,9 @@ function selectPath(value: FlowValue, path: readonly string[]): FlowValue {
 }
 
 function selectProperty(value: FlowValue, key: string): FlowValue {
+  if (value.propertyHazards.has(key)) {
+    return { ...emptyValue(), opaque: true };
+  }
   const explicit = value.properties.get(key);
   return mergeValues(
     { ...emptyValue(), sources: new Map(value.sources) },
@@ -525,6 +561,9 @@ function selectProperty(value: FlowValue, key: string): FlowValue {
 }
 
 function selectElement(value: FlowValue, key: string): FlowValue {
+  if (value.elementHazards.has(key)) {
+    return { ...emptyValue(), opaque: true };
+  }
   const explicit = value.elements.get(key);
   return mergeValues(
     { ...emptyValue(), sources: new Map(value.sources) },
@@ -547,6 +586,9 @@ function objectRestWithout(value: FlowValue, keys: ReadonlySet<string>): FlowVal
         .filter(([key]) => !keys.has(key))
         .map(([key, child]) => [key, cloneValue(child)]),
     ),
+    propertyHazards: new Set(
+      [...value.propertyHazards].filter((key) => !keys.has(key)),
+    ),
   };
   return rest;
 }
@@ -555,13 +597,68 @@ function arrayRestFrom(value: FlowValue, start: number): FlowValue {
   const rest = {
     ...cloneValue(value),
     elements: new Map<string, FlowValue>(),
+    elementHazards: new Set<string>(),
   };
   for (const [key, child] of value.elements) {
     const index = Number(key);
     if (!Number.isInteger(index) || index < start) continue;
     rest.elements.set((index - start).toString(), cloneValue(child));
   }
+  for (const key of value.elementHazards) {
+    const index = Number(key);
+    if (!Number.isInteger(index) || index < start) continue;
+    rest.elementHazards.add((index - start).toString());
+  }
   return rest;
+}
+
+function withReference(value: FlowValue, context: AnalysisContext): FlowValue {
+  return {
+    ...value,
+    references: [`ref:${context.nextReferenceId++}`],
+  };
+}
+
+function referencesOverlap(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  if (left.length === 0 || right.length === 0) return false;
+  const rightSet = new Set(right);
+  return left.some((reference) => rightSet.has(reference));
+}
+
+function updateReferencedPath(
+  value: FlowValue,
+  references: readonly string[],
+  pathSegments: readonly AssignmentPathSegment[],
+  assigned: FlowValue,
+): FlowValue {
+  if (referencesOverlap(value.references, references)) {
+    return assignPath(value, pathSegments, assigned);
+  }
+  const next = cloneValue(value);
+  for (const [key, child] of value.properties) {
+    next.properties.set(
+      key,
+      updateReferencedPath(child, references, pathSegments, assigned),
+    );
+  }
+  for (const [key, child] of value.elements) {
+    next.elements.set(
+      key,
+      updateReferencedPath(child, references, pathSegments, assigned),
+    );
+  }
+  if (value.unknown) {
+    next.unknown = updateReferencedPath(
+      value.unknown,
+      references,
+      pathSegments,
+      assigned,
+    );
+  }
+  return next;
 }
 
 function symbolIdentity(
@@ -714,10 +811,22 @@ function assignExpression(
     return environment;
   }
   const next = new Map(environment);
-  next.set(
-    target.root,
-    assignPath(next.get(target.root) ?? emptyValue(), target.path, right),
-  );
+  const rootValue = next.get(target.root) ?? emptyValue();
+  if (target.path.length > 0 && rootValue.references.length > 0) {
+    for (const [key, value] of next) {
+      next.set(
+        key,
+        updateReferencedPath(
+          value,
+          rootValue.references,
+          target.path,
+          right,
+        ),
+      );
+    }
+  } else {
+    next.set(target.root, assignPath(rootValue, target.path, right));
+  }
   return next;
 }
 
@@ -774,6 +883,7 @@ function invocationInput(
   if (!options || seen.has(options)) return emptyValue();
   seen.add(options);
   let input = emptyValue();
+  let inputHazard: SourceEvidence | null = null;
   for (const property of options.properties) {
     if (ts.isSpreadAssignment(property)) {
       const object = resolvedObjectLiteral(
@@ -781,7 +891,7 @@ function invocationInput(
         property.expression,
       );
       if (object) {
-        input = invocationInput(
+        const spreadInput = invocationInput(
           {
             ...call,
             arguments: ts.factory.createNodeArray([object]),
@@ -791,6 +901,10 @@ function invocationInput(
           file,
           seen,
         );
+        if (hasProvenance(spreadInput)) {
+          input = spreadInput;
+          inputHazard = null;
+        }
         continue;
       }
       const spread = evaluateExpression(
@@ -800,10 +914,7 @@ function invocationInput(
         file,
       );
       if (hasProvenance(spread)) {
-        addPartialDiagnostic(context, "opaque-boundary", {
-          reason: "spread-options",
-          callsite: callsite(file, property),
-        });
+        inputHazard = callsite(file, property);
         input = emptyValue();
       }
       continue;
@@ -814,13 +925,22 @@ function invocationInput(
       objectPropertyName(property.name) === "input"
     ) {
       input = evaluateExpression(property.initializer, environment, context, file);
+      inputHazard = null;
     }
     if (
       ts.isShorthandPropertyAssignment(property) &&
       property.name.text === "input"
     ) {
       input = shorthandValue(context.compiler.checker, property, environment);
+      inputHazard = null;
     }
+  }
+  if (inputHazard) {
+    addPartialDiagnostic(context, "opaque-boundary", {
+      reason: "spread-options",
+      callsite: inputHazard,
+    });
+    return emptyValue();
   }
   return input;
 }
@@ -831,6 +951,13 @@ function emitSinkCandidates(
   input: FlowValue,
   destination: SourceEvidence,
 ): void {
+  if (input.opaque) {
+    addPartialDiagnostic(context, "opaque-boundary", {
+      reason: "opaque-selection",
+      destination,
+    });
+    return;
+  }
   if (hasParameterReferences(input)) {
     context.markerSinks.push({ targetAgentKey, destination, input });
   }
@@ -967,7 +1094,7 @@ function evaluateExpression(
       : selectProperty(owner, key);
   }
   if (ts.isObjectLiteralExpression(current)) {
-    const value = emptyValue();
+    const value = withReference(emptyValue(), context);
     for (const property of current.properties) {
       if (ts.isSpreadAssignment(property)) {
         const spread = evaluateExpression(
@@ -976,8 +1103,19 @@ function evaluateExpression(
           context,
           file,
         );
+        if (
+          value.properties.size > 0 &&
+          (hasOwnSources(spread) || spread.unknown || spread.opaque)
+        ) {
+          for (const key of value.properties.keys()) {
+            value.propertyHazards.add(key);
+          }
+        }
         for (const [key, child] of spread.properties) {
           value.properties.set(key, cloneValue(child));
+          if (!spread.unknown && !hasOwnSources(spread) && !spread.opaque) {
+            value.propertyHazards.delete(key);
+          }
         }
         value.unknown = mergeValues(
           value.unknown ?? emptyValue(),
@@ -1000,31 +1138,62 @@ function evaluateExpression(
             key,
             evaluateExpression(property.initializer, environment, context, file),
           );
+          value.propertyHazards.delete(key);
         }
       } else if (ts.isShorthandPropertyAssignment(property)) {
         value.properties.set(
           property.name.text,
           shorthandValue(context.compiler.checker, property, environment),
         );
+        value.propertyHazards.delete(property.name.text);
       }
     }
     return value;
   }
   if (ts.isArrayLiteralExpression(current)) {
-    const value = emptyValue();
-    current.elements.forEach((element, index) => {
+    const value = withReference(emptyValue(), context);
+    let nextIndex = 0;
+    for (const element of current.elements) {
       if (ts.isSpreadElement(element)) {
-        value.unknown = mergeValues(
-          value.unknown ?? emptyValue(),
-          evaluateExpression(element.expression, environment, context, file),
+        const spread = evaluateExpression(
+          element.expression,
+          environment,
+          context,
+          file,
         );
+        if (
+          spread.sources.size > 0 ||
+          spread.parameters.length > 0 ||
+          spread.unknown ||
+          spread.opaque
+        ) {
+          if (hasProvenance(spread)) {
+            addPartialDiagnostic(context, "opaque-boundary", {
+              reason: "unknown-array-spread",
+              callsite: callsite(file, element),
+            });
+          }
+          continue;
+        }
+        const indexes = [...spread.elements.keys()]
+          .map(Number)
+          .filter(Number.isInteger)
+          .sort((left, right) => left - right);
+        for (const index of indexes) {
+          const child = spread.elements.get(index.toString());
+          if (!child) continue;
+          value.elements.set((nextIndex + index).toString(), cloneValue(child));
+        }
+        if (indexes.length > 0) nextIndex += Math.max(...indexes) + 1;
       } else {
         value.elements.set(
-          index.toString(),
+          nextIndex.toString(),
           evaluateExpression(element, environment, context, file),
         );
+        value.elementHazards.delete(nextIndex.toString());
+        nextIndex += 1;
       }
-    });
+    }
     return value;
   }
   if (ts.isTemplateExpression(current)) {
@@ -1207,11 +1376,12 @@ function analyzeSwitchStatement(
     file,
   );
   const selectedCase = literalString(context.compiler.checker, statement.expression);
-  if (selectedCase === null && hasProvenance(expressionFlow)) {
+  if (selectedCase === null && hasConcreteProvenance(expressionFlow)) {
     addPartialDiagnostic(context, "opaque-boundary", {
       reason: "dynamic-switch",
       callsite: callsite(file, statement.expression),
     });
+    return { returns: [], fallthrough: true, breaks: false, environment };
   }
 
   const clauses = statement.caseBlock.clauses;
@@ -1258,6 +1428,60 @@ function analyzeSwitchStatement(
   };
 }
 
+function nodeReferencesProvenance(
+  node: ts.Node,
+  environment: Environment,
+  context: AnalysisContext,
+): boolean {
+  let found = false;
+  const visit = (child: ts.Node): void => {
+    if (found) return;
+    if (child !== node && ts.isFunctionLike(child)) return;
+    if (ts.isIdentifier(child)) {
+      const key = symbolIdentity(context.compiler.checker, child);
+      if (key && hasConcreteProvenance(environment.get(key) ?? emptyValue())) {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(child, visit);
+  };
+  visit(node);
+  return found;
+}
+
+function loopTouchesProvenance(
+  statement:
+    | ts.WhileStatement
+    | ts.DoStatement
+    | ts.ForStatement
+    | ts.ForOfStatement
+    | ts.ForInStatement,
+  environment: Environment,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+): boolean {
+  const expressions: ts.Expression[] = [];
+  if (ts.isWhileStatement(statement) || ts.isDoStatement(statement)) {
+    expressions.push(statement.expression);
+  } else if (ts.isForStatement(statement)) {
+    if (statement.initializer && ts.isExpression(statement.initializer)) {
+      expressions.push(statement.initializer);
+    }
+    if (statement.condition) expressions.push(statement.condition);
+    if (statement.incrementor) expressions.push(statement.incrementor);
+  } else {
+    expressions.push(statement.expression);
+  }
+  return (
+    expressions.some((expression) =>
+      hasConcreteProvenance(
+        evaluateExpression(expression, environment, context, file),
+      ),
+    ) || nodeReferencesProvenance(statement.statement, environment, context)
+  );
+}
+
 function analyzeStatement(
   statement: ts.Statement,
   environment: Environment,
@@ -1267,6 +1491,34 @@ function analyzeStatement(
   if (ts.isVariableStatement(statement)) {
     const next = new Map(environment);
     for (const declaration of statement.declarationList.declarations) {
+      const initializer = declaration.initializer
+        ? unwrapTsExpression(declaration.initializer)
+        : undefined;
+      if (
+        initializer &&
+        ts.isBinaryExpression(initializer) &&
+        initializer.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+        ts.isExpression(initializer.left)
+      ) {
+        const right = evaluateExpression(
+          initializer.right,
+          next,
+          context,
+          file,
+        );
+        const afterAssignment = assignExpression(
+          next,
+          context.compiler.checker,
+          unwrapTsExpression(initializer.left),
+          right,
+          context,
+          file,
+        );
+        next.clear();
+        for (const [key, value] of afterAssignment) next.set(key, value);
+        bindPattern(next, context.compiler.checker, declaration.name, right);
+        continue;
+      }
       bindPattern(
         next,
         context.compiler.checker,
@@ -1317,7 +1569,18 @@ function analyzeStatement(
     };
   }
   if (ts.isIfStatement(statement)) {
-    evaluateExpression(statement.expression, environment, context, file);
+    const condition = evaluateExpression(
+      statement.expression,
+      environment,
+      context,
+      file,
+    );
+    if (hasConcreteProvenance(condition)) {
+      addPartialDiagnostic(context, "opaque-boundary", {
+        reason: "provenance-condition",
+        callsite: callsite(file, statement.expression),
+      });
+    }
     const thenResult = analyzeStatements(
       ts.isBlock(statement.thenStatement)
         ? statement.thenStatement.statements
@@ -1355,6 +1618,21 @@ function analyzeStatement(
   }
   if (ts.isSwitchStatement(statement)) {
     return analyzeSwitchStatement(statement, environment, context, file);
+  }
+  if (
+    ts.isWhileStatement(statement) ||
+    ts.isDoStatement(statement) ||
+    ts.isForStatement(statement) ||
+    ts.isForOfStatement(statement) ||
+    ts.isForInStatement(statement)
+  ) {
+    if (loopTouchesProvenance(statement, environment, context, file)) {
+      addPartialDiagnostic(context, "opaque-boundary", {
+        reason: "unsupported-loop",
+        callsite: callsite(file, statement),
+      });
+    }
+    return { returns: [], fallthrough: true, breaks: false, environment };
   }
   if (ts.isBreakStatement(statement)) {
     return { returns: [], fallthrough: false, breaks: true, environment };
@@ -1559,6 +1837,7 @@ export function analyzeStaticDataflow(
     cycleStack: new Set(),
     diagnostics: [],
     coverageGaps: [],
+    nextReferenceId: 1,
     complete: true,
   };
   if (!input.compiler.complete) {

--- a/packages/harness/src/core/system-graph-static-dataflow-evidence.ts
+++ b/packages/harness/src/core/system-graph-static-dataflow-evidence.ts
@@ -99,6 +99,7 @@ interface AnalysisContext {
   sourceFiles: readonly StaticDataflowSourceFile[];
   targetAliases: ReadonlyMap<string, readonly AgentInventoryItem[]>;
   functions: Map<string, FunctionRecord>;
+  rootFunctions: Set<string>;
   routingTables: Map<string, Map<string, string>>;
   summaries: Map<string, FunctionSummary>;
   candidates: PackageGraphStaticEvidenceCandidate[];
@@ -408,6 +409,7 @@ function parameterValue(index: number): FlowValue {
   return {
     ...emptyValue(),
     parameters: [{ index, path: [] }],
+    references: [`param:${index}`],
   };
 }
 
@@ -633,6 +635,37 @@ function withFreshReference(value: FlowValue, context: AnalysisContext): FlowVal
   };
 }
 
+function instantiateSummaryReferences(
+  value: FlowValue,
+  context: AnalysisContext,
+  references = new Map<string, string>(),
+): FlowValue {
+  const next = cloneValue(value);
+  next.references = value.references.map((reference) => {
+    const existing = references.get(reference);
+    if (existing) return existing;
+    const replacement = `ref:${context.nextReferenceId++}`;
+    references.set(reference, replacement);
+    return replacement;
+  });
+  next.properties = new Map(
+    [...value.properties.entries()].map(([key, child]) => [
+      key,
+      instantiateSummaryReferences(child, context, references),
+    ]),
+  );
+  next.elements = new Map(
+    [...value.elements.entries()].map(([key, child]) => [
+      key,
+      instantiateSummaryReferences(child, context, references),
+    ]),
+  );
+  next.unknown = value.unknown
+    ? instantiateSummaryReferences(value.unknown, context, references)
+    : null;
+  return next;
+}
+
 function referencesOverlap(
   left: readonly string[],
   right: readonly string[],
@@ -675,6 +708,56 @@ function updateReferencedPath(
   return next;
 }
 
+function deletePath(
+  value: FlowValue,
+  pathSegments: readonly AssignmentPathSegment[],
+): FlowValue {
+  if (pathSegments.length === 0) return emptyValue();
+  const [head, ...tail] = pathSegments;
+  const next = cloneValue(value);
+  if (head.kind === "property") {
+    if (tail.length === 0) {
+      next.properties.delete(head.key);
+      next.propertyHazards.delete(head.key);
+    } else {
+      next.properties.set(
+        head.key,
+        deletePath(next.properties.get(head.key) ?? emptyValue(), tail),
+      );
+    }
+  } else if (tail.length === 0) {
+    next.elements.delete(head.key);
+    next.elementHazards.delete(head.key);
+  } else {
+    next.elements.set(
+      head.key,
+      deletePath(next.elements.get(head.key) ?? emptyValue(), tail),
+    );
+  }
+  return next;
+}
+
+function deleteReferencedPath(
+  value: FlowValue,
+  references: readonly string[],
+  pathSegments: readonly AssignmentPathSegment[],
+): FlowValue {
+  if (referencesOverlap(value.references, references)) {
+    return deletePath(value, pathSegments);
+  }
+  const next = cloneValue(value);
+  for (const [key, child] of value.properties) {
+    next.properties.set(key, deleteReferencedPath(child, references, pathSegments));
+  }
+  for (const [key, child] of value.elements) {
+    next.elements.set(key, deleteReferencedPath(child, references, pathSegments));
+  }
+  if (value.unknown) {
+    next.unknown = deleteReferencedPath(value.unknown, references, pathSegments);
+  }
+  return next;
+}
+
 function symbolIdentity(
   checker: ts.TypeChecker,
   node: ts.Node | undefined,
@@ -709,6 +792,10 @@ function functionIdentity(
     return symbolIdentity(checker, parent.name);
   }
   return null;
+}
+
+function isAgentSource(file: StaticDataflowSourceFile): boolean {
+  return file.path === "agents" || file.path.startsWith("agents/");
 }
 
 function literalString(
@@ -747,6 +834,24 @@ type AssignmentPathSegment =
 interface AssignmentTarget {
   root: string;
   path: readonly AssignmentPathSegment[];
+}
+
+function isLogicalAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return (
+    kind === ts.SyntaxKind.BarBarEqualsToken ||
+    kind === ts.SyntaxKind.AmpersandAmpersandEqualsToken ||
+    kind === ts.SyntaxKind.QuestionQuestionEqualsToken
+  );
+}
+
+function isCompoundAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return (
+    kind >= ts.SyntaxKind.FirstCompoundAssignment &&
+    kind <= ts.SyntaxKind.LastCompoundAssignment &&
+    kind !== ts.SyntaxKind.BarBarEqualsToken &&
+    kind !== ts.SyntaxKind.AmpersandAmpersandEqualsToken &&
+    kind !== ts.SyntaxKind.QuestionQuestionEqualsToken
+  );
 }
 
 function assignmentTarget(
@@ -859,6 +964,37 @@ function assignExpression(
     }
   } else {
     next.set(target.root, assignPath(rootValue, target.path, right));
+  }
+  return next;
+}
+
+function deleteExpression(
+  environment: Environment,
+  checker: ts.TypeChecker,
+  expression: ts.Expression,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+): Environment {
+  const target = assignmentTarget(checker, expression);
+  if (!target) {
+    const value = evaluateExpression(expression, environment, context, file);
+    if (hasProvenance(value)) {
+      addPartialDiagnostic(context, "opaque-boundary", {
+        reason: "unsupported-delete",
+        callsite: callsite(file, expression),
+      });
+    }
+    return environment;
+  }
+  const next = environment;
+  const rootValue = next.get(target.root) ?? emptyValue();
+  const base = selectedAssignmentBase(rootValue, target.path);
+  if (base.path.length > 0 && base.references.length > 0) {
+    for (const [key, value] of next) {
+      next.set(key, deleteReferencedPath(value, base.references, base.path));
+    }
+  } else {
+    next.set(target.root, deletePath(rootValue, target.path));
   }
   return next;
 }
@@ -1039,24 +1175,31 @@ function emitSinkCandidates(
   }
 }
 
-function substituteParameters(value: FlowValue, args: readonly FlowValue[]): FlowValue {
+function instantiateSummaryValue(
+  value: FlowValue,
+  args: readonly FlowValue[],
+  context: AnalysisContext,
+  references = new Map<string, string>(),
+): FlowValue {
   return mergeValues(
     {
-      ...cloneValue(value),
+      ...instantiateSummaryReferences(value, context, references),
       parameters: [],
       properties: new Map(
         [...value.properties.entries()].map(([key, child]) => [
           key,
-          substituteParameters(child, args),
+          instantiateSummaryValue(child, args, context, references),
         ]),
       ),
       elements: new Map(
         [...value.elements.entries()].map(([key, child]) => [
           key,
-          substituteParameters(child, args),
+          instantiateSummaryValue(child, args, context, references),
         ]),
       ),
-      unknown: value.unknown ? substituteParameters(value.unknown, args) : null,
+      unknown: value.unknown
+        ? instantiateSummaryValue(value.unknown, args, context, references)
+        : null,
     },
     ...value.parameters.map((param) =>
       selectPath(args[param.index] ?? emptyValue(), param.path),
@@ -1075,21 +1218,86 @@ function calledFunctionKey(
   return null;
 }
 
+function parameterPathSegments(
+  pathSegments: readonly string[],
+): AssignmentPathSegment[] | null {
+  const path: AssignmentPathSegment[] = [];
+  for (const segment of pathSegments) {
+    if (segment === "*") return null;
+    path.push(
+      segment.startsWith("#")
+        ? { kind: "element", key: segment.slice(1) }
+        : { kind: "property", key: segment },
+    );
+  }
+  return path;
+}
+
 function collectParameterMutations(
-  parameterIndex: number,
   value: FlowValue,
   pathSegments: readonly AssignmentPathSegment[] = [],
 ): SummaryMutation[] {
   const mutations: SummaryMutation[] = [];
+  for (const parameter of value.parameters) {
+    const parameterPath = parameterPathSegments(parameter.path);
+    if (!parameterPath) continue;
+    for (const [key, child] of value.properties) {
+      mutations.push({
+        parameterIndex: parameter.index,
+        path: [
+          ...parameterPath,
+          ...pathSegments,
+          { kind: "property" as const, key },
+        ],
+        value: cloneValue(child),
+      });
+    }
+    for (const [key, child] of value.elements) {
+      mutations.push({
+        parameterIndex: parameter.index,
+        path: [
+          ...parameterPath,
+          ...pathSegments,
+          { kind: "element" as const, key },
+        ],
+        value: cloneValue(child),
+      });
+    }
+  }
   for (const [key, child] of value.properties) {
-    const path = [...pathSegments, { kind: "property" as const, key }];
-    mutations.push({ parameterIndex, path, value: cloneValue(child) });
+    mutations.push(
+      ...collectParameterMutations(
+        child,
+        [...pathSegments, { kind: "property" as const, key }],
+      ),
+    );
   }
   for (const [key, child] of value.elements) {
-    const path = [...pathSegments, { kind: "element" as const, key }];
-    mutations.push({ parameterIndex, path, value: cloneValue(child) });
+    mutations.push(
+      ...collectParameterMutations(
+        child,
+        [...pathSegments, { kind: "element" as const, key }],
+      ),
+    );
   }
   return mutations;
+}
+
+function collectEnvironmentParameterMutations(
+  environment: Environment,
+): SummaryMutation[] {
+  const mutations = new Map<string, SummaryMutation>();
+  for (const [environmentKey, value] of [...environment].sort(([left], [right]) =>
+    compareText(left, right),
+  )) {
+    for (const mutation of collectParameterMutations(value)) {
+      const key = `${mutation.parameterIndex}:${mutation.path
+        .map((segment) => `${segment.kind}:${segment.key}`)
+        .join("/")}:${environmentKey}`;
+      mutations.set(key, mutation);
+    }
+  }
+  return [...mutations.values()];
 }
 
 function routedFunctionKey(
@@ -1284,6 +1492,16 @@ function evaluateExpression(
     }
     return value;
   }
+  if (ts.isDeleteExpression(current)) {
+    deleteExpression(
+      environment,
+      context.compiler.checker,
+      current.expression,
+      context,
+      file,
+    );
+    return emptyValue();
+  }
   if (ts.isTemplateExpression(current)) {
     return mergeValues(
       ...current.templateSpans.map((span) =>
@@ -1305,6 +1523,43 @@ function evaluateExpression(
         );
       }
       return right;
+    }
+    if (isLogicalAssignmentOperator(current.operatorToken.kind)) {
+      const left = evaluateExpression(current.left, environment, context, file);
+      const right = evaluateExpression(current.right, environment, context, file);
+      const assigned = mergeValues(left, right);
+      assignExpression(
+        environment,
+        context.compiler.checker,
+        unwrapTsExpression(current.left),
+        assigned,
+        context,
+        file,
+      );
+      return assigned;
+    }
+    if (isCompoundAssignmentOperator(current.operatorToken.kind)) {
+      const left = evaluateExpression(current.left, environment, context, file);
+      const right = evaluateExpression(current.right, environment, context, file);
+      const assigned =
+        hasProvenance(left) || hasProvenance(right)
+          ? { ...emptyValue(), opaque: true }
+          : emptyValue();
+      if (assigned.opaque) {
+        addPartialDiagnostic(context, "opaque-boundary", {
+          reason: "unsupported-assignment",
+          callsite: callsite(file, current.operatorToken),
+        });
+      }
+      assignExpression(
+        environment,
+        context.compiler.checker,
+        unwrapTsExpression(current.left),
+        assigned,
+        context,
+        file,
+      );
+      return assigned;
     }
     return mergeValues(
       evaluateExpression(current.left, environment, context, file),
@@ -1570,6 +1825,72 @@ function nodeContainsAgentInvocation(
   return found;
 }
 
+function isolatedProbeContext(context: AnalysisContext): AnalysisContext {
+  return {
+    ...context,
+    candidates: [],
+    markerSinks: [],
+    diagnostics: [],
+    coverageGaps: [],
+    nextReferenceId: context.nextReferenceId,
+    complete: true,
+  };
+}
+
+function expressionTouchesProvenanceOrEffects(
+  expression: ts.Expression,
+  environment: Environment,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+): boolean {
+  const probe = isolatedProbeContext(context);
+  const value = evaluateExpression(expression, new Map(environment), probe, file);
+  return (
+    hasProvenance(value) ||
+    !probe.complete ||
+    probe.candidates.length > 0 ||
+    probe.markerSinks.length > 0
+  );
+}
+
+function nodeContainsFunctionEffects(
+  node: ts.Node,
+  environment: Environment,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+): boolean {
+  let found = false;
+  const visit = (child: ts.Node): void => {
+    if (found) return;
+    if (child !== node && ts.isFunctionLike(child)) return;
+    if (ts.isCallExpression(child)) {
+      const probe = isolatedProbeContext(context);
+      const args = child.arguments.map((argument) =>
+        evaluateExpression(argument, new Map(environment), probe, file),
+      );
+      const key =
+        routedFunctionKey(child.expression, context) ??
+        calledFunctionKey(child.expression, context);
+      if (key && context.functions.has(key)) {
+        const summary = summarizeFunction(key, context);
+        found =
+          !summary.complete ||
+          !probe.complete ||
+          probe.candidates.length > 0 ||
+          probe.markerSinks.length > 0 ||
+          summary.candidates.length > 0 ||
+          summary.sinks.length > 0 ||
+          summary.mutations.length > 0 ||
+          hasProvenance(instantiateSummaryValue(summary.returns, args, probe));
+        return;
+      }
+    }
+    ts.forEachChild(child, visit);
+  };
+  visit(node);
+  return found;
+}
+
 function loopTouchesProvenance(
   statement:
     | ts.WhileStatement
@@ -1587,6 +1908,13 @@ function loopTouchesProvenance(
   } else if (ts.isForStatement(statement)) {
     if (statement.initializer && ts.isExpression(statement.initializer)) {
       expressions.push(statement.initializer);
+    } else if (
+      statement.initializer &&
+      ts.isVariableDeclarationList(statement.initializer)
+    ) {
+      for (const declaration of statement.initializer.declarations) {
+        if (declaration.initializer) expressions.push(declaration.initializer);
+      }
     }
     if (statement.condition) expressions.push(statement.condition);
     if (statement.incrementor) expressions.push(statement.incrementor);
@@ -1595,10 +1923,11 @@ function loopTouchesProvenance(
   }
   return (
     expressions.some((expression) =>
-      hasProvenance(evaluateExpression(expression, environment, context, file)),
+      expressionTouchesProvenanceOrEffects(expression, environment, context, file),
     ) ||
     nodeReferencesProvenance(statement.statement, environment, context) ||
-    nodeContainsAgentInvocation(statement.statement, context)
+    nodeContainsAgentInvocation(statement.statement, context) ||
+    nodeContainsFunctionEffects(statement.statement, environment, context, file)
   );
 }
 
@@ -1795,7 +2124,7 @@ function evaluateFunction(
   if (environment) {
     for (const mutation of summary.mutations) {
       const arg = args[mutation.parameterIndex] ?? emptyValue();
-      const value = substituteParameters(mutation.value, args);
+      const value = instantiateSummaryValue(mutation.value, args, context);
       if (arg.references.length > 0) {
         for (const [environmentKey, environmentValue] of environment) {
           environment.set(
@@ -1820,11 +2149,11 @@ function evaluateFunction(
     emitSinkCandidates(
       context,
       sink.targetAgentKey,
-      substituteParameters(sink.input, args),
+      instantiateSummaryValue(sink.input, args, context),
       sink.destination,
     );
   }
-  return substituteParameters(summary.returns, args);
+  return instantiateSummaryValue(summary.returns, args, context);
 }
 
 function summarizeFunction(
@@ -1865,11 +2194,7 @@ function summarizeFunction(
     cycleStack: context.cycleStack,
   };
   const environment: Environment = new Map();
-  const parameterKeys: Array<string | null> = [];
   record.node.parameters.forEach((parameter, index) => {
-    parameterKeys[index] = ts.isIdentifier(parameter.name)
-      ? symbolIdentity(context.compiler.checker, parameter.name)
-      : null;
     bindPattern(
       environment,
       context.compiler.checker,
@@ -1885,14 +2210,7 @@ function summarizeFunction(
   const summary: FunctionSummary = {
     returns: mergeValues(...result.returns),
     sinks: [...nested.markerSinks],
-    mutations: parameterKeys.flatMap((parameterKey, index) =>
-      parameterKey
-        ? collectParameterMutations(
-            index,
-            result.environment.get(parameterKey) ?? emptyValue(),
-          )
-        : [],
-    ),
+    mutations: collectEnvironmentParameterMutations(result.environment),
     candidates: normalizeCandidates(nested.candidates),
     complete: nested.complete,
   };
@@ -1908,9 +2226,20 @@ function collectTopLevel(context: AnalysisContext): void {
         const key = functionIdentity(context.compiler.checker, statement);
         if (key) {
           context.functions.set(key, { key, file, node: statement });
+          if (
+            isAgentSource(file) &&
+            statement.modifiers?.some(
+              (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+            )
+          ) {
+            context.rootFunctions.add(key);
+          }
         }
       }
       if (ts.isVariableStatement(statement)) {
+        const exported = statement.modifiers?.some(
+          (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword,
+        );
         for (const declaration of statement.declarationList.declarations) {
           if (!ts.isIdentifier(declaration.name) || !declaration.initializer) {
             continue;
@@ -1927,6 +2256,7 @@ function collectTopLevel(context: AnalysisContext): void {
             const key = functionIdentity(context.compiler.checker, initializer);
             if (key) {
               context.functions.set(key, { key, file, node: initializer });
+              if (exported && isAgentSource(file)) context.rootFunctions.add(key);
             }
           } else if (declarationKey && ts.isObjectLiteralExpression(initializer)) {
             const table = new Map<string, string>();
@@ -2004,6 +2334,7 @@ export function analyzeStaticDataflow(
     sourceFiles: files,
     targetAliases: targetAliases(input.agents),
     functions: new Map(),
+    rootFunctions: new Set(),
     routingTables: new Map(),
     summaries: new Map(),
     candidates: [],
@@ -2021,7 +2352,7 @@ export function analyzeStaticDataflow(
     });
   }
   collectTopLevel(context);
-  for (const key of [...context.functions.keys()].sort(compareText)) {
+  for (const key of [...context.rootFunctions].sort(compareText)) {
     evaluateFunction(key, [], context);
   }
   for (const file of files) {

--- a/packages/harness/src/core/system-graph-static-dataflow-evidence.ts
+++ b/packages/harness/src/core/system-graph-static-dataflow-evidence.ts
@@ -48,6 +48,7 @@ interface FunctionRecord {
 interface FunctionSummary {
   returns: FlowValue;
   sinks: readonly SummarySink[];
+  mutations: readonly SummaryMutation[];
   candidates: readonly PackageGraphStaticEvidenceCandidate[];
   complete: boolean;
 }
@@ -56,6 +57,12 @@ interface SummarySink {
   targetAgentKey: string;
   destination: SourceEvidence;
   input: FlowValue;
+}
+
+interface SummaryMutation {
+  parameterIndex: number;
+  path: readonly AssignmentPathSegment[];
+  value: FlowValue;
 }
 
 type SourceMap = Map<string, SourceEvidence[]>;
@@ -619,6 +626,13 @@ function withReference(value: FlowValue, context: AnalysisContext): FlowValue {
   };
 }
 
+function withFreshReference(value: FlowValue, context: AnalysisContext): FlowValue {
+  return {
+    ...cloneValue(value),
+    references: [`ref:${context.nextReferenceId++}`],
+  };
+}
+
 function referencesOverlap(
   left: readonly string[],
   right: readonly string[],
@@ -792,6 +806,24 @@ function assignPath(
   return next;
 }
 
+function selectedAssignmentBase(
+  value: FlowValue,
+  pathSegments: readonly AssignmentPathSegment[],
+): { references: readonly string[]; path: readonly AssignmentPathSegment[] } {
+  if (pathSegments.length === 0) return { references: value.references, path: [] };
+  let current = value;
+  for (const segment of pathSegments.slice(0, -1)) {
+    current =
+      segment.kind === "property"
+        ? selectProperty(current, segment.key)
+        : selectElement(current, segment.key);
+  }
+  return {
+    references: current.references,
+    path: pathSegments.slice(-1),
+  };
+}
+
 function assignExpression(
   environment: Environment,
   checker: ts.TypeChecker,
@@ -810,16 +842,17 @@ function assignExpression(
     }
     return environment;
   }
-  const next = new Map(environment);
+  const next = environment;
   const rootValue = next.get(target.root) ?? emptyValue();
-  if (target.path.length > 0 && rootValue.references.length > 0) {
+  const base = selectedAssignmentBase(rootValue, target.path);
+  if (base.path.length > 0 && base.references.length > 0) {
     for (const [key, value] of next) {
       next.set(
         key,
         updateReferencedPath(
           value,
-          rootValue.references,
-          target.path,
+          base.references,
+          base.path,
           right,
         ),
       );
@@ -835,6 +868,7 @@ function bindPattern(
   checker: ts.TypeChecker,
   name: ts.BindingName,
   value: FlowValue,
+  context?: AnalysisContext,
 ): void {
   if (ts.isIdentifier(name)) {
     const key = symbolIdentity(checker, name);
@@ -849,7 +883,15 @@ function bindPattern(
     }
     if (ts.isObjectBindingPattern(name)) {
       if (element.dotDotDotToken) {
-        bindPattern(environment, checker, element.name, objectRestWithout(value, consumed));
+        bindPattern(
+          environment,
+          checker,
+          element.name,
+          context
+            ? withFreshReference(objectRestWithout(value, consumed), context)
+            : objectRestWithout(value, consumed),
+          context,
+        );
         continue;
       }
       const key = element.propertyName
@@ -859,15 +901,35 @@ function bindPattern(
           : null;
       if (!key) continue;
       consumed.add(key);
-      bindPattern(environment, checker, element.name, selectProperty(value, key));
+      bindPattern(
+        environment,
+        checker,
+        element.name,
+        selectProperty(value, key),
+        context,
+      );
     } else {
       const index = consumed.size.toString();
       if (element.dotDotDotToken) {
-        bindPattern(environment, checker, element.name, arrayRestFrom(value, consumed.size));
+        bindPattern(
+          environment,
+          checker,
+          element.name,
+          context
+            ? withFreshReference(arrayRestFrom(value, consumed.size), context)
+            : arrayRestFrom(value, consumed.size),
+          context,
+        );
         continue;
       }
       consumed.add(index);
-      bindPattern(environment, checker, element.name, selectElement(value, index));
+      bindPattern(
+        environment,
+        checker,
+        element.name,
+        selectElement(value, index),
+        context,
+      );
     }
   }
 }
@@ -1013,6 +1075,23 @@ function calledFunctionKey(
   return null;
 }
 
+function collectParameterMutations(
+  parameterIndex: number,
+  value: FlowValue,
+  pathSegments: readonly AssignmentPathSegment[] = [],
+): SummaryMutation[] {
+  const mutations: SummaryMutation[] = [];
+  for (const [key, child] of value.properties) {
+    const path = [...pathSegments, { kind: "property" as const, key }];
+    mutations.push({ parameterIndex, path, value: cloneValue(child) });
+  }
+  for (const [key, child] of value.elements) {
+    const path = [...pathSegments, { kind: "element" as const, key }];
+    mutations.push({ parameterIndex, path, value: cloneValue(child) });
+  }
+  return mutations;
+}
+
 function routedFunctionKey(
   expression: ts.Expression,
   context: AnalysisContext,
@@ -1117,6 +1196,9 @@ function evaluateExpression(
             value.propertyHazards.delete(key);
           }
         }
+        for (const key of spread.propertyHazards) {
+          value.propertyHazards.add(key);
+        }
         value.unknown = mergeValues(
           value.unknown ?? emptyValue(),
           {
@@ -1184,6 +1266,12 @@ function evaluateExpression(
           if (!child) continue;
           value.elements.set((nextIndex + index).toString(), cloneValue(child));
         }
+        for (const key of spread.elementHazards) {
+          const index = Number(key);
+          if (Number.isInteger(index)) {
+            value.elementHazards.add((nextIndex + index).toString());
+          }
+        }
         if (indexes.length > 0) nextIndex += Math.max(...indexes) + 1;
       } else {
         value.elements.set(
@@ -1205,7 +1293,18 @@ function evaluateExpression(
   }
   if (ts.isBinaryExpression(current)) {
     if (current.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
-      return evaluateExpression(current.right, environment, context, file);
+      const right = evaluateExpression(current.right, environment, context, file);
+      if (ts.isExpression(current.left)) {
+        assignExpression(
+          environment,
+          context.compiler.checker,
+          unwrapTsExpression(current.left),
+          right,
+          context,
+          file,
+        );
+      }
+      return right;
     }
     return mergeValues(
       evaluateExpression(current.left, environment, context, file),
@@ -1243,7 +1342,7 @@ function evaluateExpression(
   const routed = routedFunctionKey(current.expression, context);
   const key = routed ?? calledFunctionKey(current.expression, context);
   if (key && context.functions.has(key)) {
-    return evaluateFunction(key, args, context);
+    return evaluateFunction(key, args, context, environment);
   }
   if (args.some(hasProvenance)) {
     addPartialDiagnostic(context, "opaque-boundary", {
@@ -1285,7 +1384,7 @@ function bindAssignmentPattern(
           next,
           checker,
           property.expression,
-          objectRestWithout(value, consumed),
+          withFreshReference(objectRestWithout(value, consumed), context),
           context,
           file,
         );
@@ -1345,7 +1444,7 @@ function bindAssignmentPattern(
         next,
         checker,
         element.expression,
-        arrayRestFrom(value, index),
+        withFreshReference(arrayRestFrom(value, index), context),
         context,
         file,
       );
@@ -1439,10 +1538,31 @@ function nodeReferencesProvenance(
     if (child !== node && ts.isFunctionLike(child)) return;
     if (ts.isIdentifier(child)) {
       const key = symbolIdentity(context.compiler.checker, child);
-      if (key && hasConcreteProvenance(environment.get(key) ?? emptyValue())) {
+      if (key && hasProvenance(environment.get(key) ?? emptyValue())) {
         found = true;
         return;
       }
+    }
+    ts.forEachChild(child, visit);
+  };
+  visit(node);
+  return found;
+}
+
+function nodeContainsAgentInvocation(
+  node: ts.Node,
+  context: AnalysisContext,
+): boolean {
+  let found = false;
+  const visit = (child: ts.Node): void => {
+    if (found) return;
+    if (child !== node && ts.isFunctionLike(child)) return;
+    if (
+      ts.isCallExpression(child) &&
+      context.compiler.resolveInvocationTarget(child)
+    ) {
+      found = true;
+      return;
     }
     ts.forEachChild(child, visit);
   };
@@ -1475,10 +1595,10 @@ function loopTouchesProvenance(
   }
   return (
     expressions.some((expression) =>
-      hasConcreteProvenance(
-        evaluateExpression(expression, environment, context, file),
-      ),
-    ) || nodeReferencesProvenance(statement.statement, environment, context)
+      hasProvenance(evaluateExpression(expression, environment, context, file)),
+    ) ||
+    nodeReferencesProvenance(statement.statement, environment, context) ||
+    nodeContainsAgentInvocation(statement.statement, context)
   );
 }
 
@@ -1506,7 +1626,7 @@ function analyzeStatement(
           context,
           file,
         );
-        const afterAssignment = assignExpression(
+        assignExpression(
           next,
           context.compiler.checker,
           unwrapTsExpression(initializer.left),
@@ -1514,9 +1634,7 @@ function analyzeStatement(
           context,
           file,
         );
-        next.clear();
-        for (const [key, value] of afterAssignment) next.set(key, value);
-        bindPattern(next, context.compiler.checker, declaration.name, right);
+        bindPattern(next, context.compiler.checker, declaration.name, right, context);
         continue;
       }
       bindPattern(
@@ -1524,6 +1642,7 @@ function analyzeStatement(
         context.compiler.checker,
         declaration.name,
         evaluateExpression(declaration.initializer, next, context, file),
+        context,
       );
     }
     return { returns: [], fallthrough: true, breaks: false, environment: next };
@@ -1668,10 +1787,35 @@ function evaluateFunction(
   key: string,
   args: readonly FlowValue[],
   context: AnalysisContext,
+  environment?: Environment,
 ): FlowValue {
   const summary = summarizeFunction(key, context);
   if (!summary.complete) context.complete = false;
   context.candidates.push(...summary.candidates);
+  if (environment) {
+    for (const mutation of summary.mutations) {
+      const arg = args[mutation.parameterIndex] ?? emptyValue();
+      const value = substituteParameters(mutation.value, args);
+      if (arg.references.length > 0) {
+        for (const [environmentKey, environmentValue] of environment) {
+          environment.set(
+            environmentKey,
+            updateReferencedPath(
+              environmentValue,
+              arg.references,
+              mutation.path,
+              value,
+            ),
+          );
+        }
+      } else if (hasProvenance(value)) {
+        addPartialDiagnostic(context, "opaque-boundary", {
+          reason: "unsupported-helper-mutation",
+          functionKey: digest(key),
+        });
+      }
+    }
+  }
   for (const sink of summary.sinks) {
     emitSinkCandidates(
       context,
@@ -1694,11 +1838,23 @@ function summarizeFunction(
       reason: "cycle",
       functionKey: digest(key),
     });
-    return { returns: emptyValue(), sinks: [], candidates: [], complete: false };
+    return {
+      returns: emptyValue(),
+      sinks: [],
+      mutations: [],
+      candidates: [],
+      complete: false,
+    };
   }
   const record = context.functions.get(key);
   if (!record?.node.body) {
-    return { returns: emptyValue(), sinks: [], candidates: [], complete: true };
+    return {
+      returns: emptyValue(),
+      sinks: [],
+      mutations: [],
+      candidates: [],
+      complete: true,
+    };
   }
   context.cycleStack.add(key);
   const nested: AnalysisContext = {
@@ -1709,8 +1865,18 @@ function summarizeFunction(
     cycleStack: context.cycleStack,
   };
   const environment: Environment = new Map();
+  const parameterKeys: Array<string | null> = [];
   record.node.parameters.forEach((parameter, index) => {
-    bindPattern(environment, context.compiler.checker, parameter.name, parameterValue(index));
+    parameterKeys[index] = ts.isIdentifier(parameter.name)
+      ? symbolIdentity(context.compiler.checker, parameter.name)
+      : null;
+    bindPattern(
+      environment,
+      context.compiler.checker,
+      parameter.name,
+      parameterValue(index),
+      context,
+    );
   });
   const body = ts.isBlock(record.node.body)
     ? record.node.body.statements
@@ -1719,6 +1885,14 @@ function summarizeFunction(
   const summary: FunctionSummary = {
     returns: mergeValues(...result.returns),
     sinks: [...nested.markerSinks],
+    mutations: parameterKeys.flatMap((parameterKey, index) =>
+      parameterKey
+        ? collectParameterMutations(
+            index,
+            result.environment.get(parameterKey) ?? emptyValue(),
+          )
+        : [],
+    ),
     candidates: normalizeCandidates(nested.candidates),
     complete: nested.complete,
   };

--- a/packages/harness/src/core/system-graph-static-dataflow-evidence.ts
+++ b/packages/harness/src/core/system-graph-static-dataflow-evidence.ts
@@ -1,0 +1,1614 @@
+import { createHash } from "node:crypto";
+import * as path from "node:path";
+import ts from "typescript";
+
+import {
+  createPackageGraphEvidenceStaticResult,
+  type PackageGraphEvidenceCoverageGap,
+  type PackageGraphEvidenceDiagnostic,
+  type PackageGraphEvidenceDigest,
+  type PackageGraphEvidenceProducer,
+  type PackageGraphEvidenceStaticResult,
+  type PackageGraphStaticEvidenceCandidate,
+  type PackageInventory,
+} from "@sapiom/agent";
+
+import type { SourceEvidence } from "./canvas-interconnections.js";
+import {
+  type SystemGraphPackageCompilerResult,
+} from "./system-graph-relationships.js";
+import type { AgentInventoryItem } from "./system-graph-inventory.js";
+
+export const STATIC_DATAFLOW_EVIDENCE_PRODUCER = {
+  id: "sapiom.harness.static-dataflow",
+  version: "0.2.0",
+} as const satisfies PackageGraphEvidenceProducer;
+
+const EXTRACTOR_VERSION = "sap-3016-static-dataflow-v2";
+const DIGEST = /^sha256:[0-9a-f]{64}$/;
+
+export interface StaticDataflowAnalysisInput {
+  inventory: PackageInventory;
+  agents: readonly AgentInventoryItem[];
+  compiler: SystemGraphPackageCompilerResult;
+}
+
+export interface StaticDataflowAnalysisResult {
+  result: PackageGraphEvidenceStaticResult;
+  cacheable: boolean;
+  complete: boolean;
+}
+
+interface FunctionRecord {
+  key: string;
+  file: StaticDataflowSourceFile;
+  node: ts.FunctionLikeDeclaration;
+}
+
+interface FunctionSummary {
+  returns: FlowValue;
+  sinks: readonly SummarySink[];
+  candidates: readonly PackageGraphStaticEvidenceCandidate[];
+  complete: boolean;
+}
+
+interface SummarySink {
+  targetAgentKey: string;
+  destination: SourceEvidence;
+  input: FlowValue;
+}
+
+type SourceMap = Map<string, SourceEvidence[]>;
+
+interface ParameterReference {
+  index: number;
+  path: readonly string[];
+}
+
+interface FlowValue {
+  sources: SourceMap;
+  properties: Map<string, FlowValue>;
+  elements: Map<string, FlowValue>;
+  unknown: FlowValue | null;
+  parameters: readonly ParameterReference[];
+}
+
+type Environment = Map<string, FlowValue>;
+
+interface StatementResult {
+  returns: FlowValue[];
+  fallthrough: boolean;
+  breaks: boolean;
+  environment: Environment;
+}
+
+interface AnalysisContext {
+  inventory: PackageInventory;
+  compiler: SystemGraphPackageCompilerResult;
+  sourceFiles: readonly StaticDataflowSourceFile[];
+  targetAliases: ReadonlyMap<string, readonly AgentInventoryItem[]>;
+  functions: Map<string, FunctionRecord>;
+  routingTables: Map<string, Map<string, string>>;
+  summaries: Map<string, FunctionSummary>;
+  candidates: PackageGraphStaticEvidenceCandidate[];
+  markerSinks: SummarySink[];
+  cycleStack: Set<string>;
+  diagnostics: PackageGraphEvidenceDiagnostic[];
+  coverageGaps: PackageGraphEvidenceCoverageGap[];
+  complete: boolean;
+}
+
+interface StaticDataflowSourceFile {
+  path: string;
+  sourceFile: ts.SourceFile;
+}
+
+function compareText(left: string, right: string): number {
+  return left === right ? 0 : left < right ? -1 : 1;
+}
+
+function stableJson(value: unknown): string {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "boolean" ||
+    typeof value === "number"
+  ) {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (typeof value !== "object") {
+    throw new TypeError("Static dataflow identity accepts JSON values only");
+  }
+  return `{${Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => compareText(left, right))
+    .map(([key, child]) => `${JSON.stringify(key)}:${stableJson(child)}`)
+    .join(",")}}`;
+}
+
+function digest(value: unknown): PackageGraphEvidenceDigest {
+  return `sha256:${createHash("sha256").update(stableJson(value)).digest("hex")}`;
+}
+
+function analysisFingerprint(
+  compiler: SystemGraphPackageCompilerResult,
+): PackageGraphEvidenceDigest {
+  if (DIGEST.test(compiler.sourceFingerprint)) {
+    return digest({
+      extractorVersion: EXTRACTOR_VERSION,
+      sourceFingerprint: compiler.sourceFingerprint,
+    });
+  }
+  return digest({
+    extractorVersion: EXTRACTOR_VERSION,
+    sources: [...compiler.sources.values()].map(({ path: sourcePath, source }) => ({
+      path: sourcePath,
+      contentDigest: digest(source),
+    })),
+  });
+}
+
+function canonicalSourcePath(
+  compiler: SystemGraphPackageCompilerResult,
+  sourcePath: string,
+): string {
+  const relative = path.relative(compiler.packageRoot, sourcePath);
+  if (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  ) {
+    return relative.split(path.sep).join(path.posix.sep);
+  }
+  return sourcePath.split(path.sep).join(path.posix.sep);
+}
+
+function sourceFiles(
+  compiler: SystemGraphPackageCompilerResult,
+): StaticDataflowSourceFile[] {
+  return [...compiler.sources.values()]
+    .filter((source) => !source.sourceFile.isDeclarationFile)
+    .map((source) => ({
+      path: canonicalSourcePath(compiler, source.path),
+      sourceFile: source.sourceFile,
+    }))
+    .sort((left, right) => compareText(left.path, right.path));
+}
+
+function targetAliases(
+  agents: readonly AgentInventoryItem[],
+): ReadonlyMap<string, readonly AgentInventoryItem[]> {
+  const aliases = new Map<string, AgentInventoryItem[]>();
+  const addAlias = (alias: string, agent: AgentInventoryItem): void => {
+    const matches = aliases.get(alias) ?? [];
+    if (!matches.some((match) => match.agentKey === agent.agentKey)) {
+      matches.push(agent);
+      aliases.set(alias, matches);
+    }
+  };
+  for (const agent of agents) {
+    addAlias(agent.agentKey, agent);
+    for (const alias of agent.resolutionAliases) addAlias(alias, agent);
+  }
+  return new Map(
+    [...aliases].map(([alias, matches]) => [
+      alias,
+      matches.sort((left, right) => compareText(left.agentKey, right.agentKey)),
+    ]),
+  );
+}
+
+function targetAliasIdentity(
+  agents: readonly AgentInventoryItem[],
+): readonly unknown[] {
+  return [...targetAliases(agents)]
+    .map(([target, matches]) => ({
+      target,
+      agentKeys: matches.map((agent) => agent.agentKey),
+    }))
+    .sort((left, right) => compareText(left.target, right.target));
+}
+
+function resolveAgentTarget(
+  context: AnalysisContext,
+  target: string,
+):
+  | { kind: "resolved"; target: AgentInventoryItem }
+  | { kind: "unknown" | "ambiguous" } {
+  const exact = context.inventory.agents.find(
+    (agent) => agent.agentKey === target,
+  );
+  if (exact) {
+    const agent = [...context.targetAliases.values()]
+      .flat()
+      .find((candidate) => candidate.agentKey === exact.agentKey);
+    if (agent) return { kind: "resolved", target: agent };
+  }
+  const matches = context.targetAliases.get(target) ?? [];
+  if (matches.length === 1) return { kind: "resolved", target: matches[0]! };
+  return { kind: matches.length === 0 ? "unknown" : "ambiguous" };
+}
+
+function unwrapTsExpression(expression: ts.Expression): ts.Expression {
+  if (
+    ts.isParenthesizedExpression(expression) ||
+    ts.isAsExpression(expression) ||
+    ts.isTypeAssertionExpression(expression) ||
+    ts.isSatisfiesExpression(expression) ||
+    ts.isNonNullExpression(expression) ||
+    ts.isAwaitExpression(expression)
+  ) {
+    return unwrapTsExpression(expression.expression);
+  }
+  return expression;
+}
+
+function objectPropertyName(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name)) return name.text;
+  return null;
+}
+
+function aliasedSymbol(
+  checker: ts.TypeChecker,
+  symbol: ts.Symbol | undefined,
+): ts.Symbol | undefined {
+  if (!symbol) return undefined;
+  return symbol.flags & ts.SymbolFlags.Alias
+    ? checker.getAliasedSymbol(symbol)
+    : symbol;
+}
+
+function symbolKey(symbol: ts.Symbol | undefined): string | null {
+  const declarations = symbol?.declarations;
+  if (!declarations || declarations.length === 0) return null;
+  const declaration = declarations[0]!;
+  const sourceFile = declaration.getSourceFile();
+  return `${sourceFile.fileName}:${declaration.pos}:${declaration.end}`;
+}
+
+function expressionValueSymbol(
+  checker: ts.TypeChecker,
+  expression: ts.Identifier | ts.PropertyAccessExpression,
+): ts.Symbol | undefined {
+  if (
+    ts.isIdentifier(expression) &&
+    ts.isShorthandPropertyAssignment(expression.parent) &&
+    expression.parent.name === expression
+  ) {
+    return checker.getShorthandAssignmentValueSymbol(expression.parent);
+  }
+  return checker.getSymbolAtLocation(expression);
+}
+
+function resolvedObjectLiteral(
+  checker: ts.TypeChecker,
+  expression: ts.Expression,
+  seen = new Set<ts.Symbol>(),
+): ts.ObjectLiteralExpression | null {
+  const current = unwrapTsExpression(expression);
+  if (ts.isObjectLiteralExpression(current)) return current;
+  if (!ts.isIdentifier(current)) return null;
+  const symbol = aliasedSymbol(checker, expressionValueSymbol(checker, current));
+  if (!symbol || seen.has(symbol)) return null;
+  seen.add(symbol);
+  for (const declaration of symbol.declarations ?? []) {
+    if (
+      ts.isVariableDeclaration(declaration) &&
+      declaration.initializer &&
+      ts.isVariableDeclarationList(declaration.parent) &&
+      (declaration.parent.flags & ts.NodeFlags.Const) !== 0
+    ) {
+      const resolved = resolvedObjectLiteral(
+        checker,
+        declaration.initializer,
+        seen,
+      );
+      if (resolved) return resolved;
+    }
+  }
+  return null;
+}
+
+function staticInvocationOptions(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): ts.ObjectLiteralExpression | null {
+  const argument = call.arguments[0];
+  return argument ? resolvedObjectLiteral(checker, argument) : null;
+}
+
+function evidenceReference(kind: "source-callsite" | "dataflow-path", input: unknown) {
+  return { kind, ref: `${kind}:${digest(input)}` };
+}
+
+function callsite(file: StaticDataflowSourceFile, node: ts.Node): SourceEvidence {
+  const location = file.sourceFile.getLineAndCharacterOfPosition(
+    node.getStart(file.sourceFile),
+  );
+  return {
+    file: file.path,
+    line: location.line + 1,
+    column: location.character + 1,
+  };
+}
+
+function sourceCallsiteReference(source: SourceEvidence) {
+  return evidenceReference("source-callsite", {
+    protocol: 1,
+    source,
+  }) as { kind: "source-callsite"; ref: string };
+}
+
+function dataflowPathReference(source: SourceEvidence, destination: SourceEvidence) {
+  return evidenceReference("dataflow-path", {
+    protocol: 1,
+    source,
+    destination,
+  }) as { kind: "dataflow-path"; ref: string };
+}
+
+function addPartialDiagnostic(
+  context: AnalysisContext,
+  code: PackageGraphEvidenceCoverageGap["code"],
+  input: unknown,
+): void {
+  context.complete = false;
+  const fingerprint = digest({
+    producer: STATIC_DATAFLOW_EVIDENCE_PRODUCER,
+    code,
+    input,
+  });
+  context.coverageGaps.push({
+    code,
+    reference: evidenceReference("dataflow-path", { code, fingerprint }),
+  });
+  context.diagnostics.push({
+    code:
+      code === "dynamic-source" ? "dynamic-target" : "incomplete-analysis",
+    severity: "warning",
+    candidateFingerprint: fingerprint,
+  });
+}
+
+function emptyValue(): FlowValue {
+  return {
+    sources: new Map(),
+    properties: new Map(),
+    elements: new Map(),
+    unknown: null,
+    parameters: [],
+  };
+}
+
+function valueFromSource(agentKey: string, source: SourceEvidence): FlowValue {
+  return {
+    ...emptyValue(),
+    sources: new Map([[agentKey, [source]]]),
+  };
+}
+
+function parameterValue(index: number): FlowValue {
+  return {
+    ...emptyValue(),
+    parameters: [{ index, path: [] }],
+  };
+}
+
+function cloneValue(value: FlowValue): FlowValue {
+  return {
+    sources: new Map(
+      [...value.sources.entries()].map(([key, refs]) => [key, [...refs]]),
+    ),
+    properties: new Map(
+      [...value.properties.entries()].map(([key, child]) => [
+        key,
+        cloneValue(child),
+      ]),
+    ),
+    elements: new Map(
+      [...value.elements.entries()].map(([key, child]) => [
+        key,
+        cloneValue(child),
+      ]),
+    ),
+    unknown: value.unknown ? cloneValue(value.unknown) : null,
+    parameters: value.parameters.map((param) => ({
+      index: param.index,
+      path: [...param.path],
+    })),
+  };
+}
+
+function mergeSourceMaps(...sources: SourceMap[]): SourceMap {
+  const merged: SourceMap = new Map();
+  for (const source of sources) {
+    for (const [key, refs] of source) {
+      const current = merged.get(key) ?? [];
+      current.push(...refs);
+      merged.set(
+        key,
+        [...new Map(current.map((ref) => [`${ref.file}:${ref.line}:${ref.column}`, ref])).values()].sort(
+          (left, right) =>
+            compareText(left.file, right.file) ||
+            left.line - right.line ||
+            left.column - right.column,
+        ),
+      );
+    }
+  }
+  return merged;
+}
+
+function mergeValues(...values: readonly FlowValue[]): FlowValue {
+  const result = emptyValue();
+  result.sources = mergeSourceMaps(...values.map((value) => value.sources));
+  for (const value of values) {
+    for (const [key, child] of value.properties) {
+      result.properties.set(
+        key,
+        mergeValues(result.properties.get(key) ?? emptyValue(), child),
+      );
+    }
+    for (const [key, child] of value.elements) {
+      result.elements.set(
+        key,
+        mergeValues(result.elements.get(key) ?? emptyValue(), child),
+      );
+    }
+    if (value.unknown) {
+      result.unknown = mergeValues(result.unknown ?? emptyValue(), value.unknown);
+    }
+    result.parameters = [...result.parameters, ...value.parameters];
+  }
+  const seen = new Set<string>();
+  result.parameters = result.parameters.filter((param) => {
+    const key = `${param.index}:${param.path.join(".")}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+  return result;
+}
+
+function hasProvenance(value: FlowValue): boolean {
+  return (
+    value.sources.size > 0 ||
+    value.parameters.length > 0 ||
+    [...value.properties.values()].some(hasProvenance) ||
+    [...value.elements.values()].some(hasProvenance) ||
+    (value.unknown ? hasProvenance(value.unknown) : false)
+  );
+}
+
+function hasParameterReferences(value: FlowValue): boolean {
+  return (
+    value.parameters.length > 0 ||
+    [...value.properties.values()].some(hasParameterReferences) ||
+    [...value.elements.values()].some(hasParameterReferences) ||
+    (value.unknown ? hasParameterReferences(value.unknown) : false)
+  );
+}
+
+function allSources(value: FlowValue): SourceMap {
+  return mergeSourceMaps(
+    value.sources,
+    ...[...value.properties.values()].map(allSources),
+    ...[...value.elements.values()].map(allSources),
+    ...(value.unknown ? [allSources(value.unknown)] : []),
+  );
+}
+
+function selectPath(value: FlowValue, path: readonly string[]): FlowValue {
+  let current = value;
+  for (const key of path) {
+    current = key.startsWith("#")
+      ? selectElement(current, key.slice(1))
+      : selectProperty(current, key);
+  }
+  return current;
+}
+
+function selectProperty(value: FlowValue, key: string): FlowValue {
+  const explicit = value.properties.get(key);
+  return mergeValues(
+    { ...emptyValue(), sources: new Map(value.sources) },
+    explicit ?? value.unknown ?? emptyValue(),
+    {
+      ...emptyValue(),
+      parameters: value.parameters.map((param) => ({
+        index: param.index,
+        path: [...param.path, key],
+      })),
+    },
+  );
+}
+
+function selectElement(value: FlowValue, key: string): FlowValue {
+  const explicit = value.elements.get(key);
+  return mergeValues(
+    { ...emptyValue(), sources: new Map(value.sources) },
+    explicit ?? value.unknown ?? emptyValue(),
+    {
+      ...emptyValue(),
+      parameters: value.parameters.map((param) => ({
+        index: param.index,
+        path: [...param.path, `#${key}`],
+      })),
+    },
+  );
+}
+
+function objectRestWithout(value: FlowValue, keys: ReadonlySet<string>): FlowValue {
+  const rest = {
+    ...cloneValue(value),
+    properties: new Map(
+      [...value.properties.entries()]
+        .filter(([key]) => !keys.has(key))
+        .map(([key, child]) => [key, cloneValue(child)]),
+    ),
+  };
+  return rest;
+}
+
+function arrayRestFrom(value: FlowValue, start: number): FlowValue {
+  const rest = {
+    ...cloneValue(value),
+    elements: new Map<string, FlowValue>(),
+  };
+  for (const [key, child] of value.elements) {
+    const index = Number(key);
+    if (!Number.isInteger(index) || index < start) continue;
+    rest.elements.set((index - start).toString(), cloneValue(child));
+  }
+  return rest;
+}
+
+function symbolIdentity(
+  checker: ts.TypeChecker,
+  node: ts.Node | undefined,
+): string | null {
+  if (!node) return null;
+  return symbolKey(aliasedSymbol(checker, checker.getSymbolAtLocation(node)));
+}
+
+function shorthandValue(
+  checker: ts.TypeChecker,
+  property: ts.ShorthandPropertyAssignment,
+  environment: Environment,
+): FlowValue {
+  const key = symbolKey(
+    aliasedSymbol(checker, checker.getShorthandAssignmentValueSymbol(property)),
+  );
+  return key ? cloneValue(environment.get(key) ?? emptyValue()) : emptyValue();
+}
+
+function functionIdentity(
+  checker: ts.TypeChecker,
+  node: ts.FunctionLikeDeclaration,
+): string | null {
+  if (ts.isFunctionDeclaration(node) && node.name) {
+    return symbolIdentity(checker, node.name);
+  }
+  const parent = node.parent;
+  if (
+    ts.isVariableDeclaration(parent) &&
+    ts.isIdentifier(parent.name)
+  ) {
+    return symbolIdentity(checker, parent.name);
+  }
+  return null;
+}
+
+function literalString(
+  checker: ts.TypeChecker,
+  expression: ts.Expression | undefined,
+  seen = new Set<string>(),
+): string | null {
+  if (!expression) return null;
+  const current = unwrapTsExpression(expression);
+  if (ts.isStringLiteral(current) || ts.isNoSubstitutionTemplateLiteral(current)) {
+    return current.text;
+  }
+  if (ts.isNumericLiteral(current)) return current.text;
+  if (!ts.isIdentifier(current)) return null;
+  const key = symbolIdentity(checker, current);
+  if (!key || seen.has(key)) return null;
+  seen.add(key);
+  const symbol = aliasedSymbol(checker, checker.getSymbolAtLocation(current));
+  for (const declaration of symbol?.declarations ?? []) {
+    if (
+      ts.isVariableDeclaration(declaration) &&
+      declaration.initializer &&
+      (ts.getCombinedNodeFlags(declaration) & ts.NodeFlags.Const) !== 0
+    ) {
+      const resolved = literalString(checker, declaration.initializer, seen);
+      if (resolved !== null) return resolved;
+    }
+  }
+  return null;
+}
+
+type AssignmentPathSegment =
+  | { kind: "property"; key: string }
+  | { kind: "element"; key: string };
+
+interface AssignmentTarget {
+  root: string;
+  path: readonly AssignmentPathSegment[];
+}
+
+function assignmentTarget(
+  checker: ts.TypeChecker,
+  expression: ts.Expression,
+): AssignmentTarget | null {
+  const current = unwrapTsExpression(expression);
+  if (ts.isIdentifier(current)) {
+    const root = symbolIdentity(checker, current);
+    return root ? { root, path: [] } : null;
+  }
+  if (ts.isPropertyAccessExpression(current)) {
+    const owner = assignmentTarget(checker, current.expression);
+    return owner
+      ? {
+          root: owner.root,
+          path: [...owner.path, { kind: "property", key: current.name.text }],
+        }
+      : null;
+  }
+  if (ts.isElementAccessExpression(current)) {
+    const owner = assignmentTarget(checker, current.expression);
+    const key = literalString(checker, current.argumentExpression);
+    if (!owner || key === null) return null;
+    return {
+      root: owner.root,
+      path: [
+        ...owner.path,
+        /^\d+$/.test(key)
+          ? { kind: "element", key }
+          : { kind: "property", key },
+      ],
+    };
+  }
+  return null;
+}
+
+function assignPath(
+  value: FlowValue,
+  pathSegments: readonly AssignmentPathSegment[],
+  assigned: FlowValue,
+): FlowValue {
+  if (pathSegments.length === 0) return cloneValue(assigned);
+  const [head, ...tail] = pathSegments;
+  const next = cloneValue(value);
+  if (head.kind === "property") {
+    next.properties.set(
+      head.key,
+      assignPath(next.properties.get(head.key) ?? emptyValue(), tail, assigned),
+    );
+  } else {
+    next.elements.set(
+      head.key,
+      assignPath(next.elements.get(head.key) ?? emptyValue(), tail, assigned),
+    );
+  }
+  return next;
+}
+
+function assignExpression(
+  environment: Environment,
+  checker: ts.TypeChecker,
+  left: ts.Expression,
+  right: FlowValue,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+): Environment {
+  const target = assignmentTarget(checker, left);
+  if (!target) {
+    if (hasProvenance(right)) {
+      addPartialDiagnostic(context, "opaque-boundary", {
+        reason: "unsupported-write",
+        callsite: callsite(file, left),
+      });
+    }
+    return environment;
+  }
+  const next = new Map(environment);
+  next.set(
+    target.root,
+    assignPath(next.get(target.root) ?? emptyValue(), target.path, right),
+  );
+  return next;
+}
+
+function bindPattern(
+  environment: Environment,
+  checker: ts.TypeChecker,
+  name: ts.BindingName,
+  value: FlowValue,
+): void {
+  if (ts.isIdentifier(name)) {
+    const key = symbolIdentity(checker, name);
+    if (key) environment.set(key, cloneValue(value));
+    return;
+  }
+  const consumed = new Set<string>();
+  for (const element of name.elements) {
+    if (ts.isOmittedExpression(element)) {
+      if (ts.isArrayBindingPattern(name)) consumed.add(consumed.size.toString());
+      continue;
+    }
+    if (ts.isObjectBindingPattern(name)) {
+      if (element.dotDotDotToken) {
+        bindPattern(environment, checker, element.name, objectRestWithout(value, consumed));
+        continue;
+      }
+      const key = element.propertyName
+        ? objectPropertyName(element.propertyName)
+        : ts.isIdentifier(element.name)
+          ? element.name.text
+          : null;
+      if (!key) continue;
+      consumed.add(key);
+      bindPattern(environment, checker, element.name, selectProperty(value, key));
+    } else {
+      const index = consumed.size.toString();
+      if (element.dotDotDotToken) {
+        bindPattern(environment, checker, element.name, arrayRestFrom(value, consumed.size));
+        continue;
+      }
+      consumed.add(index);
+      bindPattern(environment, checker, element.name, selectElement(value, index));
+    }
+  }
+}
+
+function invocationInput(
+  call: ts.CallExpression,
+  environment: Environment,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+  seen = new Set<ts.ObjectLiteralExpression>(),
+): FlowValue {
+  const options = staticInvocationOptions(call, context.compiler.checker);
+  if (!options || seen.has(options)) return emptyValue();
+  seen.add(options);
+  let input = emptyValue();
+  for (const property of options.properties) {
+    if (ts.isSpreadAssignment(property)) {
+      const object = resolvedObjectLiteral(
+        context.compiler.checker,
+        property.expression,
+      );
+      if (object) {
+        input = invocationInput(
+          {
+            ...call,
+            arguments: ts.factory.createNodeArray([object]),
+          } as ts.CallExpression,
+          environment,
+          context,
+          file,
+          seen,
+        );
+        continue;
+      }
+      const spread = evaluateExpression(
+        property.expression,
+        environment,
+        context,
+        file,
+      );
+      if (hasProvenance(spread)) {
+        addPartialDiagnostic(context, "opaque-boundary", {
+          reason: "spread-options",
+          callsite: callsite(file, property),
+        });
+        input = emptyValue();
+      }
+      continue;
+    }
+    if (
+      ts.isPropertyAssignment(property) &&
+      property.name &&
+      objectPropertyName(property.name) === "input"
+    ) {
+      input = evaluateExpression(property.initializer, environment, context, file);
+    }
+    if (
+      ts.isShorthandPropertyAssignment(property) &&
+      property.name.text === "input"
+    ) {
+      input = shorthandValue(context.compiler.checker, property, environment);
+    }
+  }
+  return input;
+}
+
+function emitSinkCandidates(
+  context: AnalysisContext,
+  targetAgentKey: string,
+  input: FlowValue,
+  destination: SourceEvidence,
+): void {
+  if (hasParameterReferences(input)) {
+    context.markerSinks.push({ targetAgentKey, destination, input });
+  }
+  for (const [sourceKey, sources] of allSources(input)) {
+    if (sourceKey === targetAgentKey) continue;
+    for (const source of sources) {
+      context.candidates.push({
+        fromAgentKey: sourceKey,
+        toAgentKey: targetAgentKey,
+        relation: "feeds",
+        basis: "static-dataflow",
+        source: sourceCallsiteReference(source),
+        destination: sourceCallsiteReference(destination),
+        path: [dataflowPathReference(source, destination)],
+      });
+    }
+  }
+}
+
+function substituteParameters(value: FlowValue, args: readonly FlowValue[]): FlowValue {
+  return mergeValues(
+    {
+      ...cloneValue(value),
+      parameters: [],
+      properties: new Map(
+        [...value.properties.entries()].map(([key, child]) => [
+          key,
+          substituteParameters(child, args),
+        ]),
+      ),
+      elements: new Map(
+        [...value.elements.entries()].map(([key, child]) => [
+          key,
+          substituteParameters(child, args),
+        ]),
+      ),
+      unknown: value.unknown ? substituteParameters(value.unknown, args) : null,
+    },
+    ...value.parameters.map((param) =>
+      selectPath(args[param.index] ?? emptyValue(), param.path),
+    ),
+  );
+}
+
+function calledFunctionKey(
+  expression: ts.Expression,
+  context: AnalysisContext,
+): string | null {
+  const current = unwrapTsExpression(expression);
+  if (ts.isIdentifier(current) || ts.isPropertyAccessExpression(current)) {
+    return symbolIdentity(context.compiler.checker, current);
+  }
+  return null;
+}
+
+function routedFunctionKey(
+  expression: ts.Expression,
+  context: AnalysisContext,
+): string | null {
+  const current = unwrapTsExpression(expression);
+  if (!ts.isElementAccessExpression(current)) return null;
+  const tableKey = symbolIdentity(context.compiler.checker, current.expression);
+  const routeKey = literalString(context.compiler.checker, current.argumentExpression);
+  if (!tableKey || !routeKey) return null;
+  return context.routingTables.get(tableKey)?.get(routeKey) ?? null;
+}
+
+function evaluateInvocation(
+  call: ts.CallExpression,
+  environment: Environment,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+): FlowValue {
+  const destination = callsite(file, call.expression);
+  const invocation = context.compiler.resolveInvocationTarget(call);
+  if (!invocation) return emptyValue();
+  if (invocation.kind === "dynamic-method" || invocation.kind === "dynamic-target") {
+    addPartialDiagnostic(context, "dynamic-source", { destination });
+    return emptyValue();
+  }
+  const resolution = resolveAgentTarget(context, invocation.target);
+  if (resolution.kind !== "resolved") {
+    addPartialDiagnostic(context, "opaque-boundary", {
+      reason: resolution.kind === "ambiguous" ? "ambiguous-target" : "unknown-target",
+      target: digest(invocation.target),
+      destination,
+    });
+    return emptyValue();
+  }
+  emitSinkCandidates(
+    context,
+    resolution.target.agentKey,
+    invocationInput(call, environment, context, file),
+    destination,
+  );
+  return invocation.mode === "blocking"
+    ? valueFromSource(resolution.target.agentKey, destination)
+    : emptyValue();
+}
+
+function evaluateExpression(
+  expression: ts.Expression | undefined,
+  environment: Environment,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+): FlowValue {
+  if (!expression) return emptyValue();
+  const current = unwrapTsExpression(expression);
+  if (ts.isIdentifier(current)) {
+    const key = symbolIdentity(context.compiler.checker, current);
+    return key ? cloneValue(environment.get(key) ?? emptyValue()) : emptyValue();
+  }
+  if (ts.isPropertyAccessExpression(current)) {
+    return selectProperty(
+      evaluateExpression(current.expression, environment, context, file),
+      current.name.text,
+    );
+  }
+  if (ts.isElementAccessExpression(current)) {
+    const key = literalString(context.compiler.checker, current.argumentExpression);
+    if (key === null) {
+      const owner = evaluateExpression(current.expression, environment, context, file);
+      if (hasProvenance(owner)) {
+        addPartialDiagnostic(context, "opaque-boundary", {
+          reason: "dynamic-property",
+          callsite: callsite(file, current.argumentExpression ?? current),
+        });
+      }
+      return emptyValue();
+    }
+    const owner = evaluateExpression(current.expression, environment, context, file);
+    return /^\d+$/.test(key)
+      ? selectElement(owner, key)
+      : selectProperty(owner, key);
+  }
+  if (ts.isObjectLiteralExpression(current)) {
+    const value = emptyValue();
+    for (const property of current.properties) {
+      if (ts.isSpreadAssignment(property)) {
+        const spread = evaluateExpression(
+          property.expression,
+          environment,
+          context,
+          file,
+        );
+        for (const [key, child] of spread.properties) {
+          value.properties.set(key, cloneValue(child));
+        }
+        value.unknown = mergeValues(
+          value.unknown ?? emptyValue(),
+          {
+            ...spread,
+            properties: new Map(),
+            elements: new Map(),
+          parameters: spread.parameters.map((param) => ({
+            index: param.index,
+            path: [...param.path, "*"],
+          })),
+          },
+        );
+        continue;
+      }
+      if (ts.isPropertyAssignment(property) && property.name) {
+        const key = objectPropertyName(property.name);
+        if (key) {
+          value.properties.set(
+            key,
+            evaluateExpression(property.initializer, environment, context, file),
+          );
+        }
+      } else if (ts.isShorthandPropertyAssignment(property)) {
+        value.properties.set(
+          property.name.text,
+          shorthandValue(context.compiler.checker, property, environment),
+        );
+      }
+    }
+    return value;
+  }
+  if (ts.isArrayLiteralExpression(current)) {
+    const value = emptyValue();
+    current.elements.forEach((element, index) => {
+      if (ts.isSpreadElement(element)) {
+        value.unknown = mergeValues(
+          value.unknown ?? emptyValue(),
+          evaluateExpression(element.expression, environment, context, file),
+        );
+      } else {
+        value.elements.set(
+          index.toString(),
+          evaluateExpression(element, environment, context, file),
+        );
+      }
+    });
+    return value;
+  }
+  if (ts.isTemplateExpression(current)) {
+    return mergeValues(
+      ...current.templateSpans.map((span) =>
+        evaluateExpression(span.expression, environment, context, file),
+      ),
+    );
+  }
+  if (ts.isBinaryExpression(current)) {
+    if (current.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      return evaluateExpression(current.right, environment, context, file);
+    }
+    return mergeValues(
+      evaluateExpression(current.left, environment, context, file),
+      evaluateExpression(current.right, environment, context, file),
+    );
+  }
+  if (ts.isConditionalExpression(current)) {
+    return mergeValues(
+      evaluateExpression(current.whenTrue, environment, context, file),
+      evaluateExpression(current.whenFalse, environment, context, file),
+    );
+  }
+  if (ts.isNewExpression(current)) {
+    const args = current.arguments?.map((arg) =>
+      evaluateExpression(arg, environment, context, file),
+    ) ?? [];
+    if (args.some(hasProvenance)) {
+      addPartialDiagnostic(context, "opaque-boundary", {
+        reason: "constructor",
+        callsite: callsite(file, current.expression),
+      });
+    }
+    return emptyValue();
+  }
+  if (!ts.isCallExpression(current)) return emptyValue();
+
+  const invocation = context.compiler.resolveInvocationTarget(current);
+  if (invocation) {
+    return evaluateInvocation(current, environment, context, file);
+  }
+
+  const args = current.arguments.map((argument) =>
+    evaluateExpression(argument, environment, context, file),
+  );
+  const routed = routedFunctionKey(current.expression, context);
+  const key = routed ?? calledFunctionKey(current.expression, context);
+  if (key && context.functions.has(key)) {
+    return evaluateFunction(key, args, context);
+  }
+  if (args.some(hasProvenance)) {
+    addPartialDiagnostic(context, "opaque-boundary", {
+      reason:
+        ts.isIdentifier(unwrapTsExpression(current.expression)) &&
+        unwrapTsExpression(current.expression).getText(file.sourceFile) === "eval"
+          ? "dynamic-reflection"
+          : "unsupported-transform",
+      callsite: callsite(file, current.expression),
+    });
+  }
+  return emptyValue();
+}
+
+function mergeEnvironments(...environments: readonly Environment[]): Environment {
+  const merged: Environment = new Map();
+  for (const environment of environments) {
+    for (const [key, value] of environment) {
+      merged.set(key, mergeValues(merged.get(key) ?? emptyValue(), value));
+    }
+  }
+  return merged;
+}
+
+function bindAssignmentPattern(
+  environment: Environment,
+  checker: ts.TypeChecker,
+  pattern: ts.ObjectLiteralExpression | ts.ArrayLiteralExpression,
+  value: FlowValue,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+): Environment {
+  let next = new Map(environment);
+  if (ts.isObjectLiteralExpression(pattern)) {
+    const consumed = new Set<string>();
+    for (const property of pattern.properties) {
+      if (ts.isSpreadAssignment(property)) {
+        next = assignExpression(
+          next,
+          checker,
+          property.expression,
+          objectRestWithout(value, consumed),
+          context,
+          file,
+        );
+        continue;
+      }
+      if (ts.isShorthandPropertyAssignment(property)) {
+        const key = property.name.text;
+        consumed.add(key);
+        next = assignExpression(
+          next,
+          checker,
+          property.name,
+          selectProperty(value, key),
+          context,
+          file,
+        );
+        continue;
+      }
+      if (!ts.isPropertyAssignment(property) || !property.name) {
+        if (hasProvenance(value)) {
+          addPartialDiagnostic(context, "opaque-boundary", {
+            reason: "unsupported-destructuring-assignment",
+            callsite: callsite(file, property),
+          });
+        }
+        continue;
+      }
+      const key = objectPropertyName(property.name);
+      if (!key || !ts.isExpression(property.initializer)) {
+        if (hasProvenance(value)) {
+          addPartialDiagnostic(context, "opaque-boundary", {
+            reason: "unsupported-destructuring-assignment",
+            callsite: callsite(file, property),
+          });
+        }
+        continue;
+      }
+      consumed.add(key);
+      const selected = selectProperty(value, key);
+      const target = unwrapTsExpression(property.initializer);
+      if (ts.isObjectLiteralExpression(target) || ts.isArrayLiteralExpression(target)) {
+        next = bindAssignmentPattern(next, checker, target, selected, context, file);
+      } else {
+        next = assignExpression(next, checker, target, selected, context, file);
+      }
+    }
+    return next;
+  }
+  let index = 0;
+  for (const element of pattern.elements) {
+    if (ts.isOmittedExpression(element)) {
+      index += 1;
+      continue;
+    }
+    if (ts.isSpreadElement(element)) {
+      next = assignExpression(
+        next,
+        checker,
+        element.expression,
+        arrayRestFrom(value, index),
+        context,
+        file,
+      );
+      continue;
+    }
+    const selected = selectElement(value, index.toString());
+    const target = unwrapTsExpression(element);
+    if (ts.isObjectLiteralExpression(target) || ts.isArrayLiteralExpression(target)) {
+      next = bindAssignmentPattern(next, checker, target, selected, context, file);
+    } else {
+      next = assignExpression(next, checker, target, selected, context, file);
+    }
+    index += 1;
+  }
+  return next;
+}
+
+function analyzeSwitchStatement(
+  statement: ts.SwitchStatement,
+  environment: Environment,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+): StatementResult {
+  const expressionFlow = evaluateExpression(
+    statement.expression,
+    environment,
+    context,
+    file,
+  );
+  const selectedCase = literalString(context.compiler.checker, statement.expression);
+  if (selectedCase === null && hasProvenance(expressionFlow)) {
+    addPartialDiagnostic(context, "opaque-boundary", {
+      reason: "dynamic-switch",
+      callsite: callsite(file, statement.expression),
+    });
+  }
+
+  const clauses = statement.caseBlock.clauses;
+  const startIndexes: number[] = [];
+  if (selectedCase === null) {
+    startIndexes.push(...clauses.map((_, index) => index));
+  } else {
+    const matched = clauses.findIndex(
+      (clause) =>
+        ts.isCaseClause(clause) &&
+        literalString(context.compiler.checker, clause.expression) === selectedCase,
+    );
+    if (matched >= 0) {
+      startIndexes.push(matched);
+    } else {
+      const defaultIndex = clauses.findIndex(ts.isDefaultClause);
+      if (defaultIndex >= 0) startIndexes.push(defaultIndex);
+    }
+  }
+
+  const results: StatementResult[] = [];
+  for (const start of startIndexes) {
+    const branchStatements: ts.Statement[] = [];
+    for (let index = start; index < clauses.length; index += 1) {
+      branchStatements.push(...clauses[index]!.statements);
+      if (clauses[index]!.statements.some(ts.isBreakStatement)) break;
+    }
+    results.push(analyzeStatements(branchStatements, new Map(environment), context, file));
+  }
+  if (results.length === 0) {
+    return { returns: [], fallthrough: true, breaks: false, environment };
+  }
+  const exitEnvironments = results
+    .filter((result) => result.fallthrough || result.breaks)
+    .map((result) => result.environment);
+  return {
+    returns: results.flatMap((result) => result.returns),
+    fallthrough: exitEnvironments.length > 0,
+    breaks: false,
+    environment:
+      exitEnvironments.length > 0
+        ? mergeEnvironments(...exitEnvironments)
+        : environment,
+  };
+}
+
+function analyzeStatement(
+  statement: ts.Statement,
+  environment: Environment,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+): StatementResult {
+  if (ts.isVariableStatement(statement)) {
+    const next = new Map(environment);
+    for (const declaration of statement.declarationList.declarations) {
+      bindPattern(
+        next,
+        context.compiler.checker,
+        declaration.name,
+        evaluateExpression(declaration.initializer, next, context, file),
+      );
+    }
+    return { returns: [], fallthrough: true, breaks: false, environment: next };
+  }
+  if (ts.isExpressionStatement(statement)) {
+    const expression = unwrapTsExpression(statement.expression);
+    if (
+      ts.isBinaryExpression(expression) &&
+      expression.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isExpression(expression.left)
+    ) {
+      const right = evaluateExpression(expression.right, environment, context, file);
+      const left = unwrapTsExpression(expression.left);
+      const next =
+        ts.isObjectLiteralExpression(left) || ts.isArrayLiteralExpression(left)
+          ? bindAssignmentPattern(
+              environment,
+              context.compiler.checker,
+              left,
+              right,
+              context,
+              file,
+            )
+          : assignExpression(
+              environment,
+              context.compiler.checker,
+              left,
+              right,
+              context,
+              file,
+            );
+      return { returns: [], fallthrough: true, breaks: false, environment: next };
+    }
+    evaluateExpression(expression, environment, context, file);
+    return { returns: [], fallthrough: true, breaks: false, environment };
+  }
+  if (ts.isReturnStatement(statement)) {
+    return {
+      returns: [evaluateExpression(statement.expression, environment, context, file)],
+      fallthrough: false,
+      breaks: false,
+      environment,
+    };
+  }
+  if (ts.isIfStatement(statement)) {
+    evaluateExpression(statement.expression, environment, context, file);
+    const thenResult = analyzeStatements(
+      ts.isBlock(statement.thenStatement)
+        ? statement.thenStatement.statements
+        : [statement.thenStatement],
+      new Map(environment),
+      context,
+      file,
+    );
+    const elseResult = statement.elseStatement
+      ? analyzeStatements(
+          ts.isBlock(statement.elseStatement)
+            ? statement.elseStatement.statements
+            : [statement.elseStatement],
+          new Map(environment),
+          context,
+          file,
+        )
+      : { returns: [], fallthrough: true, breaks: false, environment };
+    const fallthroughEnvs = [
+      ...(thenResult.fallthrough ? [thenResult.environment] : []),
+      ...(elseResult.fallthrough ? [elseResult.environment] : []),
+    ];
+    return {
+      returns: [...thenResult.returns, ...elseResult.returns],
+      fallthrough: fallthroughEnvs.length > 0,
+      breaks: thenResult.breaks || elseResult.breaks,
+      environment:
+        fallthroughEnvs.length > 0
+          ? mergeEnvironments(...fallthroughEnvs)
+          : environment,
+    };
+  }
+  if (ts.isBlock(statement)) {
+    return analyzeStatements(statement.statements, environment, context, file);
+  }
+  if (ts.isSwitchStatement(statement)) {
+    return analyzeSwitchStatement(statement, environment, context, file);
+  }
+  if (ts.isBreakStatement(statement)) {
+    return { returns: [], fallthrough: false, breaks: true, environment };
+  }
+  return { returns: [], fallthrough: true, breaks: false, environment };
+}
+
+function analyzeStatements(
+  statements: ts.NodeArray<ts.Statement> | readonly ts.Statement[],
+  environment: Environment,
+  context: AnalysisContext,
+  file: StaticDataflowSourceFile,
+): StatementResult {
+  const returns: FlowValue[] = [];
+  let current = environment;
+  for (const statement of statements) {
+    const result = analyzeStatement(statement, current, context, file);
+    returns.push(...result.returns);
+    if (!result.fallthrough || result.breaks) {
+      return {
+        returns,
+        fallthrough: false,
+        breaks: result.breaks,
+        environment: result.environment,
+      };
+    }
+    current = result.environment;
+  }
+  return { returns, fallthrough: true, breaks: false, environment: current };
+}
+
+function evaluateFunction(
+  key: string,
+  args: readonly FlowValue[],
+  context: AnalysisContext,
+): FlowValue {
+  const summary = summarizeFunction(key, context);
+  if (!summary.complete) context.complete = false;
+  context.candidates.push(...summary.candidates);
+  for (const sink of summary.sinks) {
+    emitSinkCandidates(
+      context,
+      sink.targetAgentKey,
+      substituteParameters(sink.input, args),
+      sink.destination,
+    );
+  }
+  return substituteParameters(summary.returns, args);
+}
+
+function summarizeFunction(
+  key: string,
+  context: AnalysisContext,
+): FunctionSummary {
+  const cached = context.summaries.get(key);
+  if (cached) return cached;
+  if (context.cycleStack.has(key)) {
+    addPartialDiagnostic(context, "opaque-boundary", {
+      reason: "cycle",
+      functionKey: digest(key),
+    });
+    return { returns: emptyValue(), sinks: [], candidates: [], complete: false };
+  }
+  const record = context.functions.get(key);
+  if (!record?.node.body) {
+    return { returns: emptyValue(), sinks: [], candidates: [], complete: true };
+  }
+  context.cycleStack.add(key);
+  const nested: AnalysisContext = {
+    ...context,
+    candidates: [],
+    markerSinks: [],
+    summaries: context.summaries,
+    cycleStack: context.cycleStack,
+  };
+  const environment: Environment = new Map();
+  record.node.parameters.forEach((parameter, index) => {
+    bindPattern(environment, context.compiler.checker, parameter.name, parameterValue(index));
+  });
+  const body = ts.isBlock(record.node.body)
+    ? record.node.body.statements
+    : [ts.factory.createReturnStatement(record.node.body)];
+  const result = analyzeStatements(body, environment, nested, record.file);
+  const summary: FunctionSummary = {
+    returns: mergeValues(...result.returns),
+    sinks: [...nested.markerSinks],
+    candidates: normalizeCandidates(nested.candidates),
+    complete: nested.complete,
+  };
+  context.cycleStack.delete(key);
+  context.summaries.set(key, summary);
+  return summary;
+}
+
+function collectTopLevel(context: AnalysisContext): void {
+  for (const file of context.sourceFiles) {
+    for (const statement of file.sourceFile.statements) {
+      if (ts.isFunctionDeclaration(statement) && statement.name) {
+        const key = functionIdentity(context.compiler.checker, statement);
+        if (key) {
+          context.functions.set(key, { key, file, node: statement });
+        }
+      }
+      if (ts.isVariableStatement(statement)) {
+        for (const declaration of statement.declarationList.declarations) {
+          if (!ts.isIdentifier(declaration.name) || !declaration.initializer) {
+            continue;
+          }
+          const declarationKey = symbolIdentity(
+            context.compiler.checker,
+            declaration.name,
+          );
+          const initializer = unwrapTsExpression(declaration.initializer);
+          if (
+            ts.isFunctionExpression(initializer) ||
+            ts.isArrowFunction(initializer)
+          ) {
+            const key = functionIdentity(context.compiler.checker, initializer);
+            if (key) {
+              context.functions.set(key, { key, file, node: initializer });
+            }
+          } else if (declarationKey && ts.isObjectLiteralExpression(initializer)) {
+            const table = new Map<string, string>();
+            for (const property of initializer.properties) {
+              if (!ts.isPropertyAssignment(property) || !property.name) continue;
+              const route = objectPropertyName(property.name);
+              const target = calledFunctionKey(property.initializer, context);
+              if (route && target) table.set(route, target);
+            }
+            if (table.size > 0) context.routingTables.set(declarationKey, table);
+          }
+        }
+      }
+    }
+  }
+}
+
+function normalizeCandidates(
+  candidates: readonly PackageGraphStaticEvidenceCandidate[],
+): PackageGraphStaticEvidenceCandidate[] {
+  return [
+    ...new Map(
+      [...candidates]
+        .sort((left, right) =>
+          compareText(left.fromAgentKey, right.fromAgentKey) ||
+          compareText(left.toAgentKey, right.toAgentKey) ||
+          compareText(left.basis, right.basis) ||
+          compareText(stableJson(left), stableJson(right)),
+        )
+        .map((candidate) => [stableJson(candidate), candidate]),
+    ).values(),
+  ];
+}
+
+function compilerCacheIdentity(
+  input: StaticDataflowAnalysisInput,
+): Record<string, unknown> {
+  return {
+    packageKey: input.compiler.packageKey,
+    packageRoot: input.compiler.packageRoot,
+    generation: input.compiler.generation,
+    sourceFingerprint: input.compiler.sourceFingerprint,
+    complete: input.compiler.complete,
+    observedPaths: [...input.compiler.observedPaths].sort(),
+    sources: sourceFiles(input.compiler).map((source) => source.path),
+    targets: targetAliasIdentity(input.agents),
+  };
+}
+
+export class StaticDataflowSummaryCache {
+  private readonly results = new Map<string, StaticDataflowAnalysisResult>();
+
+  getOrAnalyze(input: StaticDataflowAnalysisInput): StaticDataflowAnalysisResult {
+    const key = stableJson({
+      extractorVersion: EXTRACTOR_VERSION,
+      scope: input.inventory.version,
+      fingerprint: analysisFingerprint(input.compiler),
+      compiler: compilerCacheIdentity(input),
+    });
+    const cached = this.results.get(key);
+    if (cached) return cached;
+    const result = analyzeStaticDataflow(input);
+    if (result.cacheable) this.results.set(key, result);
+    return result;
+  }
+}
+
+export function analyzeStaticDataflow(
+  input: StaticDataflowAnalysisInput,
+): StaticDataflowAnalysisResult {
+  const files = sourceFiles(input.compiler);
+  const context: AnalysisContext = {
+    inventory: input.inventory,
+    compiler: input.compiler,
+    sourceFiles: files,
+    targetAliases: targetAliases(input.agents),
+    functions: new Map(),
+    routingTables: new Map(),
+    summaries: new Map(),
+    candidates: [],
+    markerSinks: [],
+    cycleStack: new Set(),
+    diagnostics: [],
+    coverageGaps: [],
+    complete: true,
+  };
+  if (!input.compiler.complete) {
+    addPartialDiagnostic(context, "opaque-boundary", {
+      reason: "incomplete-compiler-scan",
+      packageKey: input.compiler.packageKey,
+    });
+  }
+  collectTopLevel(context);
+  for (const key of [...context.functions.keys()].sort(compareText)) {
+    evaluateFunction(key, [], context);
+  }
+  for (const file of files) {
+    analyzeStatements(file.sourceFile.statements, new Map(), context, file);
+  }
+  if (
+    !context.complete &&
+    !context.diagnostics.some(
+      (diagnostic) => diagnostic.code === "incomplete-analysis",
+    )
+  ) {
+    context.diagnostics.push({
+      code: "incomplete-analysis",
+      severity: "warning",
+    });
+  }
+  const coverage = context.complete
+    ? { status: "complete" as const }
+    : {
+        status: "partial" as const,
+        gaps:
+          context.coverageGaps.length > 0
+            ? context.coverageGaps
+            : [{ code: "other" as const }],
+      };
+  const result = createPackageGraphEvidenceStaticResult(
+    {
+      scope: input.inventory.version,
+      producer: STATIC_DATAFLOW_EVIDENCE_PRODUCER,
+      analysisFingerprint: analysisFingerprint(input.compiler),
+      outcome: "success",
+      coverage,
+      candidates: normalizeCandidates(context.candidates),
+      diagnostics: context.diagnostics,
+    },
+    input.inventory,
+  );
+  return {
+    result,
+    cacheable: context.complete && input.compiler.complete,
+    complete: context.complete,
+  };
+}


### PR DESCRIPTION
## Summary

- add an internal static-dataflow PackageGraphEvidence producer for `feeds/static-dataflow`
- consume SAP-3015's shared Program/TypeChecker, source index, fingerprint, and invocation resolver without rereading package sources
- track provenance through aliases, structured properties/indices, construction/spread/rest, assignments, wrappers, awaits, branches, bounded routing, and conservative unsupported-loop boundaries
- emit deterministic partial diagnostics for dynamic/unresolved targets, unsupported transforms, opaque stores, cycles, and incomplete compiler scans
- cache only complete results using normalized source and endpoint-resolution identity

## Stack

Base: `conductor/sap-3015-static-invocations` @ `634b03bbfae1016bf8096adf436ff933aac48e1f`

Head: `conductor/sap-3016-static-dataflow` @ `15512747f877e9190880b9e776ac946d0cf7e0a5`

The base PR is independently TIMEBOXED with one unresolved SAP-3015 High.

## Wave 2 terminal status

This PR remains draft and is **TIMEBOXED**, not review-ready. Two bounded Wave 2 review/fix passes are exhausted with three independently reproduced Highs:

1. Symbolic allocations shared within one helper call are instantiated with separate maps across mutations and return values, breaking aliases that must refer to the same object.
2. Logical assignments (`||=`, `&&=`, `??=`) merge both outcomes even when a constructed value has a statically definite short-circuit result, producing impossible or stale provenance while claiming completeness.
3. Agent entrypoints re-exported from another module are not discovered as authored roots, so reachable static dataflow can be omitted with `complete: true`.

Bounded next corrections: use one allocation-instantiation map per helper invocation; model definite truthiness/nullishness and otherwise degrade uncertain logical writes; derive authored roots from TypeChecker module exports with cycle-safe alias/re-export resolution.

## Validation at frozen head

```text
head: 15512747f877e9190880b9e776ac946d0cf7e0a5
base ancestry and three-file issue scope: passed
coordinator focused Vitest: 2 files, 76 tests passed
coordinator graph slice: 5 files, 137 tests passed
pnpm --filter @sapiom/harness typecheck: passed
pnpm --filter @sapiom/harness lint: passed
pnpm --filter @sapiom/harness build:server: passed
git diff --check: passed
independent terminal review: 118 focused tests passed; REVIEW_FAIL_HIGH (3 findings above)
GitHub automated review: passed; PR CLEAN/MERGEABLE
```

## Confirmed closed in Wave 2

- ordered nested spread hazards and known/unknown positional array spreads
- fresh top-level identity for object/array rest while retaining shallow child identity
- plain nested/chained assignments and direct/aliased helper leaf mutations
- separate allocation identity across distinct helper calls
- deletion and conservative compound/dynamic write handling
- loop-local producers, declaration initializers, and wrapper effects degrade unsupported loops deterministically
- disconnected uncalled functions no longer publish evidence; reachable roots/wrappers do
- canonical endpoint precedence, shared-compiler/no-reread behavior, cache gating, summaries/cycles, opaque boundaries, and deterministic output

## Related work

- Closes: SAP-3016
- Stacked on SAP-3015 / PR #757

## AI assistance

- [x] AI assistance implemented and independently reviewed this change; terminal findings and exact verification are recorded above.
