### PR TITLE
feat(harness): initialize durable Agent Map project state

### DIFF
--- a/.changeset/calm-maps-arrive.md
+++ b/.changeset/calm-maps-arrive.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": minor
+---
+
+Add durable, path-free Studio project identities and lazy Agent Map workspace state. The authenticated local server now exposes project workspace and root-binding association endpoints, and stores the new catalog at `studio-projects.json` with per-project records beneath `agent-map/` in the configured harness state root. The legacy System Graph and per-agent Canvas remain unchanged.

--- a/packages/harness-desktop/src/main/boot.ts
+++ b/packages/harness-desktop/src/main/boot.ts
@@ -55,7 +55,9 @@ import {
 export interface BootResult {
   server: HarnessServer;
   mainWindow: BrowserWindow;
-  /** The tokened local URL the main window loaded (useful for dev smoke tests). */
+  /** Trusted-main-process copy used only by packaged smoke checks. */
+  bootToken: string;
+  /** The UI-credentialed local URL the main window loaded. */
   url: string;
 }
 
@@ -551,14 +553,17 @@ export async function boot(setupWin: BrowserWindow, mode: BootMode): Promise<Boo
   });
 
   // 9. Load the SPA in the main window; close setup once it renders.
-  const url = withDeepLinkParams(`http://127.0.0.1:${server.port}/?token=${bootToken}`, mode.deepLink);
+  const url = withDeepLinkParams(
+    `http://127.0.0.1:${server.port}/?uiToken=${server.uiToken}`,
+    mode.deepLink,
+  );
   const mainWindow = createMainWindow(url);
   mainWindow.webContents.once("did-finish-load", () => {
     if (!setupWin.isDestroyed()) setupWin.close();
   });
   progress(setupWin, { phase: "ready", message: "Ready.", status: "done" });
 
-  return { server, mainWindow, url };
+  return { server, mainWindow, bootToken, url };
 }
 
 /**

--- a/packages/harness-desktop/src/main/index.ts
+++ b/packages/harness-desktop/src/main/index.ts
@@ -179,8 +179,8 @@ if (lock.action === "fail") {
       const coldTarget = coldLink ? parseDeepLink(coldLink) : null;
       bootResult = await boot(setupWin, { devMode, smoke: smokeMode, deepLink: coldTarget ?? undefined });
       if (devMode || smokeMode) {
-        // Dev/smoke hook: print the tokened URL so a harness can verify the
-        // server booted without driving the GUI.
+        // Dev/smoke hook: print the UI-authorized launch URL so a harness can
+        // verify the server booted without driving the GUI.
         console.log(`[harness-desktop] ready: ${bootResult.url}`);
       }
       // BEFORE the smoke branch, deliberately. initUpdater gates itself on

--- a/packages/harness-desktop/src/main/smoke.ts
+++ b/packages/harness-desktop/src/main/smoke.ts
@@ -881,7 +881,7 @@ async function checkUpdateConfig(): Promise<string> {
  */
 export async function runSmokeChecks(boot: BootResult): Promise<SmokeCheck[]> {
   const base = `http://127.0.0.1:${boot.server.port}`;
-  const token = new URL(boot.url).searchParams.get("token");
+  const token = boot.bootToken;
 
   return [
     await check("http-spa", async () => {

--- a/packages/harness/scripts/e2e-live.ts
+++ b/packages/harness/scripts/e2e-live.ts
@@ -389,8 +389,9 @@ async function testCoreFlow(): Promise<void> {
 
     assert(capture.env.SAPIOM_HARNESS_INGEST_URL?.endsWith("/ingest"), "pty env carries SAPIOM_HARNESS_INGEST_URL");
     assert(
-      capture.env.SAPIOM_HARNESS_INGEST_TOKEN === bootToken,
-      "pty env carries the boot token as SAPIOM_HARNESS_INGEST_TOKEN",
+      capture.env.SAPIOM_HARNESS_INGEST_TOKEN !== bootToken &&
+        Boolean(capture.env.SAPIOM_HARNESS_INGEST_TOKEN),
+      "pty env carries a distinct ingest-only SAPIOM_HARNESS_INGEST_TOKEN",
     );
     assert(capture.env.SAPIOM_HARNESS_SESSION_ID === sessionId, "pty env carries SAPIOM_HARNESS_SESSION_ID");
 
@@ -410,7 +411,10 @@ async function testCoreFlow(): Promise<void> {
     // wouldn't be interactive before its own hooks fire. Simulating that
     // event before injecting input mirrors real production ordering, not
     // just satisfying the script.
-    const ingestHeaders = { "Content-Type": "application/json", Authorization: `Bearer ${bootToken}` };
+    const ingestHeaders = {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${capture.env.SAPIOM_HARNESS_INGEST_TOKEN}`,
+    };
     const agentSessionId = "e2e-agent-session-1";
 
     const sessionStartRes = await fetch(`${baseUrl}/ingest`, {

--- a/packages/harness/src/cli/banner.ts
+++ b/packages/harness/src/cli/banner.ts
@@ -4,7 +4,7 @@ import { AGENT_STUDIO_PRODUCT_NAME } from "../shared/branding.js";
 export interface PrintBannerOptions {
   dir: string;
   port: number;
-  bootToken: string;
+  uiToken: string;
   identity: Pick<
     HarnessIdentity,
     "organizationName" | "userId" | "source"
@@ -27,13 +27,13 @@ export function printBanner(opts: PrintBannerOptions): void {
   console.log(`  directory   ${opts.dir}`);
   console.log(`  auth        ${authLine}`);
   console.log(`  telemetry   ${opts.telemetryOptIn ? "on" : "off"}`);
-  // Always the full tokened URL — with --no-open (or a browser that failed
+  // Always the full UI-authorized URL — with --no-open (or a browser that failed
   // to launch) this is the only way to reach the app; a bare host:port
-  // 401s on every /api call and can't open the WS connections.
+  // cannot receive the privileged browser bootstrap.
   console.log(
     `  url         ${
       opts.serverStarted
-        ? `http://localhost:${opts.port}/?token=${opts.bootToken}`
+        ? `http://localhost:${opts.port}/?uiToken=${opts.uiToken}`
         : "(server not started)"
     }`,
   );

--- a/packages/harness/src/cli/bin-boot.test.ts
+++ b/packages/harness/src/cli/bin-boot.test.ts
@@ -75,7 +75,7 @@ describe("printBanner — 'Agent Studio' name", () => {
     printBanner({
       dir: "/some/dir",
       port: 4000,
-      bootToken: "tok",
+      uiToken: "tok",
       identity: null,
       telemetryOptIn: false,
       serverStarted: false,
@@ -91,7 +91,7 @@ describe("printBanner — 'Agent Studio' name", () => {
     printBanner({
       dir: "/some/dir",
       port: 4000,
-      bootToken: "tok",
+      uiToken: "tok",
       identity: null,
       telemetryOptIn: false,
       serverStarted: true,
@@ -105,7 +105,7 @@ describe("printBanner — 'Agent Studio' name", () => {
     printBanner({
       dir: "/some/dir",
       port: 4000,
-      bootToken: "tok",
+      uiToken: "tok",
       identity: { organizationName: "Acme", userId: "u-1", source: "cached" },
       telemetryOptIn: true,
       serverStarted: true,
@@ -117,25 +117,25 @@ describe("printBanner — 'Agent Studio' name", () => {
     );
   });
 
-  it("banner shows the tokened URL when server started", () => {
+  it("banner shows the UI-authorized launch URL when server started", () => {
     printBanner({
       dir: "/some/dir",
       port: 4000,
-      bootToken: "abc123",
+      uiToken: "abc123",
       identity: null,
       telemetryOptIn: false,
       serverStarted: true,
     });
 
     const lines = logSpy.mock.calls.map((c) => String(c[0]));
-    expect(lines.some((l) => l.includes("http://localhost:4000/?token=abc123"))).toBe(true);
+    expect(lines.some((l) => l.includes("http://localhost:4000/?uiToken=abc123"))).toBe(true);
   });
 
   it("banner shows '(server not started)' when server failed to start", () => {
     printBanner({
       dir: "/some/dir",
       port: 4000,
-      bootToken: "abc123",
+      uiToken: "abc123",
       identity: null,
       telemetryOptIn: false,
       serverStarted: false,

--- a/packages/harness/src/cli/bin.test.ts
+++ b/packages/harness/src/cli/bin.test.ts
@@ -40,6 +40,7 @@ function makeServer(): {
   const closeCalls: number[] = [];
   const server: HarnessServer = {
     port: 9999,
+    uiToken: "ui-token",
     sessionManager: {} as HarnessServer["sessionManager"],
     close: vi.fn().mockImplementation(async () => {
       closeCalls.push(Date.now());

--- a/packages/harness/src/cli/bin.ts
+++ b/packages/harness/src/cli/bin.ts
@@ -116,14 +116,14 @@ const main = async (): Promise<void> => {
   printBanner({
     dir: options.dir,
     port: server?.port ?? options.port,
-    bootToken,
+    uiToken: server?.uiToken ?? "",
     identity,
     telemetryOptIn: consentResult.telemetryOptIn,
     serverStarted: server !== null,
   });
 
   if (server && !options.noOpen) {
-    await open(`http://localhost:${server.port}/?token=${bootToken}`);
+    await open(`http://localhost:${server.port}/?uiToken=${server.uiToken}`);
   }
 
   if (server) {

--- a/packages/harness/src/core/agent-map-workspace-store.test.ts
+++ b/packages/harness/src/core/agent-map-workspace-store.test.ts
@@ -60,6 +60,34 @@ describe("AgentMapWorkspaceStore", () => {
     });
   });
 
+  it("selects one winner across independent store instances", async () => {
+    const root = await fixture();
+    const firstEvent = vi.fn();
+    const secondEvent = vi.fn();
+    const first = new AgentMapWorkspaceStore(root, {
+      now: () => new Date("2026-09-01T12:00:00.000Z"),
+      onEvent: firstEvent,
+    });
+    const second = new AgentMapWorkspaceStore(root, {
+      now: () => new Date("2026-09-01T12:00:01.000Z"),
+      onEvent: secondEvent,
+    });
+
+    const [left, right] = await Promise.all([
+      first.readOrCreate(projectId),
+      second.readOrCreate(projectId),
+    ]);
+    const restarted = await new AgentMapWorkspaceStore(root).readOrCreate(
+      projectId,
+    );
+
+    expect(left).toEqual(right);
+    expect(restarted).toEqual(left);
+    expect(firstEvent.mock.calls.length + secondEvent.mock.calls.length).toBe(
+      1,
+    );
+  });
+
   it("does not treat a leftover temporary file as workspace state", async () => {
     const root = await fixture();
     const directory = path.join(root, "projects", projectId);

--- a/packages/harness/src/core/agent-map-workspace-store.test.ts
+++ b/packages/harness/src/core/agent-map-workspace-store.test.ts
@@ -1,0 +1,154 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AgentMapWorkspaceStore } from "./agent-map-workspace-store.js";
+
+const projectId = "project_00000000-0000-4000-8000-000000000001";
+
+describe("AgentMapWorkspaceStore", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      roots
+        .splice(0)
+        .map((root) => fs.rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  async function fixture() {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "agent-map-store-"));
+    roots.push(root);
+    return root;
+  }
+
+  it("lazily creates exactly one empty record under concurrent reads and survives restart", async () => {
+    const root = await fixture();
+    const onEvent = vi.fn();
+    const store = new AgentMapWorkspaceStore(root, {
+      now: () => new Date("2026-09-01T12:00:00.000Z"),
+      onEvent,
+    });
+
+    const records = await Promise.all(
+      Array.from({ length: 20 }, () => store.readOrCreate(projectId)),
+    );
+    const restarted = await new AgentMapWorkspaceStore(root).readOrCreate(
+      projectId,
+    );
+
+    expect(new Set(records.map((record) => JSON.stringify(record))).size).toBe(
+      1,
+    );
+    expect(restarted).toEqual(records[0]);
+    expect(restarted).toEqual({
+      projectId,
+      schemaVersion: 1,
+      recordVersion: 1,
+      confirmedRevisionId: null,
+      activeProposalId: null,
+      projectBuildPlanId: null,
+      createdAt: "2026-09-01T12:00:00.000Z",
+      updatedAt: "2026-09-01T12:00:00.000Z",
+    });
+    expect(onEvent).toHaveBeenCalledTimes(1);
+    expect(onEvent).toHaveBeenCalledWith({
+      name: "agent_map.workspace_initialized",
+      projectId,
+    });
+  });
+
+  it("does not treat a leftover temporary file as workspace state", async () => {
+    const root = await fixture();
+    const directory = path.join(root, "projects", projectId);
+    await fs.mkdir(directory, { recursive: true });
+    await fs.writeFile(
+      path.join(directory, "workspace.json.tmp-stale"),
+      "partial",
+    );
+    await expect(
+      new AgentMapWorkspaceStore(root).readOrCreate(projectId),
+    ).resolves.toMatchObject({
+      projectId,
+      schemaVersion: 1,
+      recordVersion: 1,
+    });
+  });
+
+  it.each([
+    ["malformed JSON", "{", "malformed_state"],
+    [
+      "future schema",
+      JSON.stringify({
+        projectId,
+        schemaVersion: 99,
+        recordVersion: 1,
+        confirmedRevisionId: null,
+        activeProposalId: null,
+        projectBuildPlanId: null,
+        createdAt: "2026-09-01T12:00:00.000Z",
+        updatedAt: "2026-09-01T12:00:00.000Z",
+        futureField: "allowed only because this schema is unsupported",
+      }),
+      "unsupported_schema",
+    ],
+    [
+      "project mismatch",
+      JSON.stringify({
+        projectId: "project_00000000-0000-4000-8000-000000000002",
+        schemaVersion: 1,
+        recordVersion: 1,
+        confirmedRevisionId: null,
+        activeProposalId: null,
+        projectBuildPlanId: null,
+        createdAt: "2026-09-01T12:00:00.000Z",
+        updatedAt: "2026-09-01T12:00:00.000Z",
+      }),
+      "malformed_state",
+    ],
+  ])(
+    "bounds %s failures without repairing the file",
+    async (_name, raw, code) => {
+      const root = await fixture();
+      const workspacePath = path.join(
+        root,
+        "projects",
+        projectId,
+        "workspace.json",
+      );
+      await fs.mkdir(path.dirname(workspacePath), { recursive: true });
+      await fs.writeFile(workspacePath, raw);
+      const onEvent = vi.fn();
+
+      await expect(
+        new AgentMapWorkspaceStore(root, { onEvent }).readOrCreate(projectId),
+      ).rejects.toMatchObject({ code });
+      expect(await fs.readFile(workspacePath, "utf8")).toBe(raw);
+      expect(onEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "agent_map.workspace_read_failed",
+          projectId,
+          errorCode: code,
+        }),
+      );
+    },
+  );
+
+  it("reports storage unavailability without leaking an underlying path", async () => {
+    const root = await fixture();
+    const blocker = path.join(root, "not-a-directory");
+    await fs.writeFile(blocker, "file");
+    let error: (Error & { code?: string }) | undefined;
+    try {
+      await new AgentMapWorkspaceStore(blocker).readOrCreate(projectId);
+    } catch (failure) {
+      error = failure as Error & { code?: string };
+    }
+    expect(error).toBeDefined();
+    expect(error!.code).toBe("storage_unavailable");
+    expect(error!.message).toBe("Agent Map storage is unavailable");
+    expect(error!.message).not.toContain(root);
+  });
+});

--- a/packages/harness/src/core/agent-map-workspace-store.ts
+++ b/packages/harness/src/core/agent-map-workspace-store.ts
@@ -1,0 +1,281 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import {
+  AGENT_MAP_INITIAL_RECORD_VERSION,
+  AGENT_MAP_WORKSPACE_SCHEMA_VERSION,
+  type AgentMapErrorCode,
+  type AgentMapWorkspaceState,
+  type StudioProjectId,
+} from "../shared/agent-map.js";
+import { isStudioProjectId } from "./studio-project-catalog.js";
+
+export type AgentMapWorkspaceStoreEvent =
+  | {
+      name: "agent_map.workspace_initialized";
+      projectId: StudioProjectId;
+    }
+  | {
+      name: "agent_map.workspace_read_failed";
+      projectId: StudioProjectId;
+      schemaVersion?: number;
+      errorCode: Exclude<AgentMapErrorCode, "project_not_found">;
+    };
+
+export class AgentMapWorkspaceStoreError extends Error {
+  constructor(
+    readonly code: Exclude<AgentMapErrorCode, "project_not_found">,
+    readonly schemaVersion?: number,
+  ) {
+    super(
+      code === "unsupported_schema"
+        ? "Agent Map state uses an unsupported schema"
+        : code === "malformed_state"
+          ? "Agent Map state is malformed"
+          : "Agent Map storage is unavailable",
+    );
+    this.name = "AgentMapWorkspaceStoreError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index])
+  );
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.codePointAt(0)!;
+    return code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+  });
+}
+
+function isOpaqueId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value !== "" &&
+    value === value.trim() &&
+    !hasControlCharacter(value) &&
+    !value.includes("/") &&
+    !value.includes("\\") &&
+    !value.includes(":")
+  );
+}
+
+function isNullableOpaqueId(value: unknown): value is string | null {
+  return value === null || isOpaqueId(value);
+}
+
+function isTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    return new Date(value).toISOString() === value;
+  } catch {
+    return false;
+  }
+}
+
+export function parseAgentMapWorkspaceState(
+  value: unknown,
+  expectedProjectId: StudioProjectId,
+): AgentMapWorkspaceState {
+  const readableSchemaVersion =
+    isRecord(value) &&
+    Number.isSafeInteger(value.schemaVersion) &&
+    (value.schemaVersion as number) >= 0
+      ? (value.schemaVersion as number)
+      : undefined;
+  if (
+    readableSchemaVersion !== undefined &&
+    readableSchemaVersion > AGENT_MAP_WORKSPACE_SCHEMA_VERSION
+  ) {
+    throw new AgentMapWorkspaceStoreError(
+      "unsupported_schema",
+      readableSchemaVersion,
+    );
+  }
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "projectId",
+      "schemaVersion",
+      "recordVersion",
+      "confirmedRevisionId",
+      "activeProposalId",
+      "projectBuildPlanId",
+      "createdAt",
+      "updatedAt",
+    ]) ||
+    value.projectId !== expectedProjectId ||
+    !isStudioProjectId(value.projectId) ||
+    !Number.isSafeInteger(value.schemaVersion) ||
+    !Number.isSafeInteger(value.recordVersion) ||
+    (value.recordVersion as number) < 1 ||
+    !isNullableOpaqueId(value.confirmedRevisionId) ||
+    !isNullableOpaqueId(value.activeProposalId) ||
+    !isNullableOpaqueId(value.projectBuildPlanId) ||
+    !isTimestamp(value.createdAt) ||
+    !isTimestamp(value.updatedAt)
+  ) {
+    throw new AgentMapWorkspaceStoreError(
+      "malformed_state",
+      readableSchemaVersion,
+    );
+  }
+  if (value.schemaVersion !== AGENT_MAP_WORKSPACE_SCHEMA_VERSION) {
+    throw new AgentMapWorkspaceStoreError(
+      (value.schemaVersion as number) > AGENT_MAP_WORKSPACE_SCHEMA_VERSION
+        ? "unsupported_schema"
+        : "malformed_state",
+      value.schemaVersion as number,
+    );
+  }
+  return {
+    projectId: value.projectId,
+    schemaVersion: value.schemaVersion as number,
+    recordVersion: value.recordVersion as number,
+    confirmedRevisionId: value.confirmedRevisionId,
+    activeProposalId: value.activeProposalId,
+    projectBuildPlanId: value.projectBuildPlanId,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+  };
+}
+
+function storageError(): AgentMapWorkspaceStoreError {
+  return new AgentMapWorkspaceStoreError("storage_unavailable");
+}
+
+/** Lazy, restart-safe owner of each project's empty Agent Map workspace. */
+export class AgentMapWorkspaceStore {
+  private readonly reads = new Map<
+    StudioProjectId,
+    Promise<AgentMapWorkspaceState>
+  >();
+
+  constructor(
+    private readonly agentMapRoot: string,
+    private readonly options: {
+      now?: () => Date;
+      onEvent?: (event: AgentMapWorkspaceStoreEvent) => void | Promise<void>;
+    } = {},
+  ) {}
+
+  private workspacePath(projectId: StudioProjectId): string {
+    return path.join(
+      this.agentMapRoot,
+      "projects",
+      projectId,
+      "workspace.json",
+    );
+  }
+
+  private emit(event: AgentMapWorkspaceStoreEvent): void {
+    try {
+      void Promise.resolve(this.options.onEvent?.(event)).catch(() => {});
+    } catch {
+      // Observability is best-effort and cannot change durable state semantics.
+    }
+  }
+
+  private async read(
+    projectId: StudioProjectId,
+  ): Promise<AgentMapWorkspaceState> {
+    const workspacePath = this.workspacePath(projectId);
+    let raw: string;
+    try {
+      raw = await fs.readFile(workspacePath, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return this.create(projectId, workspacePath);
+      }
+      throw storageError();
+    }
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(raw) as unknown;
+    } catch {
+      throw new AgentMapWorkspaceStoreError("malformed_state");
+    }
+    return parseAgentMapWorkspaceState(decoded, projectId);
+  }
+
+  private async create(
+    projectId: StudioProjectId,
+    workspacePath: string,
+  ): Promise<AgentMapWorkspaceState> {
+    const timestamp = (this.options.now?.() ?? new Date()).toISOString();
+    const workspace: AgentMapWorkspaceState = {
+      projectId,
+      schemaVersion: AGENT_MAP_WORKSPACE_SCHEMA_VERSION,
+      recordVersion: AGENT_MAP_INITIAL_RECORD_VERSION,
+      confirmedRevisionId: null,
+      activeProposalId: null,
+      projectBuildPlanId: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    const directory = path.dirname(workspacePath);
+    const temporary = `${workspacePath}.tmp-${process.pid}-${randomUUID()}`;
+    try {
+      await fs.mkdir(directory, { recursive: true });
+      await fs.writeFile(
+        temporary,
+        `${JSON.stringify(workspace, null, 2)}\n`,
+        "utf8",
+      );
+      await fs.rename(temporary, workspacePath);
+    } catch {
+      throw storageError();
+    } finally {
+      await fs.rm(temporary, { force: true }).catch(() => {});
+    }
+    this.emit({ name: "agent_map.workspace_initialized", projectId });
+    return workspace;
+  }
+
+  /**
+   * The only E1 initializer. Concurrent calls share one per-project promise;
+   * no inventory, scanner, graph builder, or model dependency is reachable.
+   */
+  readOrCreate(projectId: StudioProjectId): Promise<AgentMapWorkspaceState> {
+    if (!isStudioProjectId(projectId)) {
+      return Promise.reject(new AgentMapWorkspaceStoreError("malformed_state"));
+    }
+    const active = this.reads.get(projectId);
+    if (active) return active;
+    const operation = this.read(projectId)
+      .catch((error: unknown) => {
+        const bounded =
+          error instanceof AgentMapWorkspaceStoreError ? error : storageError();
+        this.emit({
+          name: "agent_map.workspace_read_failed",
+          projectId,
+          ...(bounded.schemaVersion !== undefined
+            ? { schemaVersion: bounded.schemaVersion }
+            : {}),
+          errorCode: bounded.code,
+        });
+        throw bounded;
+      })
+      .finally(() => {
+        if (this.reads.get(projectId) === operation) {
+          this.reads.delete(projectId);
+        }
+      });
+    this.reads.set(projectId, operation);
+    return operation;
+  }
+}

--- a/packages/harness/src/core/agent-map-workspace-store.ts
+++ b/packages/harness/src/core/agent-map-workspace-store.ts
@@ -236,14 +236,41 @@ export class AgentMapWorkspaceStore {
         `${JSON.stringify(workspace, null, 2)}\n`,
         "utf8",
       );
-      await fs.rename(temporary, workspacePath);
-    } catch {
+      // `rename()` replaces an existing target on POSIX, so it cannot select
+      // one winner across two Studio processes (or even two store instances).
+      // The temporary file is already complete; linking it into the final name
+      // is an atomic, no-clobber commit. An EEXIST loser reads and returns the
+      // winner instead of publishing its divergent timestamp or event.
+      await fs.link(temporary, workspacePath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        return this.readExisting(projectId, workspacePath);
+      }
       throw storageError();
     } finally {
       await fs.rm(temporary, { force: true }).catch(() => {});
     }
     this.emit({ name: "agent_map.workspace_initialized", projectId });
     return workspace;
+  }
+
+  private async readExisting(
+    projectId: StudioProjectId,
+    workspacePath: string,
+  ): Promise<AgentMapWorkspaceState> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(workspacePath, "utf8");
+    } catch {
+      throw storageError();
+    }
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(raw) as unknown;
+    } catch {
+      throw new AgentMapWorkspaceStoreError("malformed_state");
+    }
+    return parseAgentMapWorkspaceState(decoded, projectId);
   }
 
   /**

--- a/packages/harness/src/core/paths.test.ts
+++ b/packages/harness/src/core/paths.test.ts
@@ -29,6 +29,8 @@ describe("resolveStatePaths", () => {
     expect(paths.workflows).toBe(path.join(root, "workflows.json"));
     expect(paths.events).toBe(path.join(root, "events.ndjson"));
     expect(paths.settings).toBe(path.join(root, "settings.json"));
+    expect(paths.studioProjects).toBe(path.join(root, "studio-projects.json"));
+    expect(paths.agentMap).toBe(path.join(root, "agent-map"));
     expect(paths.generated).toBe(path.join(root, "generated"));
     expect(paths.sampleProject).toBe(path.join(root, "sample-project"));
   });
@@ -41,6 +43,8 @@ describe("resolveStatePaths", () => {
     expect(paths.workflows).toBe("/scratch/state/workflows.json");
     expect(paths.events).toBe("/scratch/state/events.ndjson");
     expect(paths.settings).toBe("/scratch/state/settings.json");
+    expect(paths.studioProjects).toBe("/scratch/state/studio-projects.json");
+    expect(paths.agentMap).toBe("/scratch/state/agent-map");
     expect(paths.generated).toBe("/scratch/state/generated");
     expect(paths.sampleProject).toBe("/scratch/state/sample-project");
   });

--- a/packages/harness/src/core/paths.ts
+++ b/packages/harness/src/core/paths.ts
@@ -25,6 +25,8 @@ export interface HarnessStatePaths {
   workflows: string;
   events: string;
   settings: string;
+  studioProjects: string;
+  agentMap: string;
   generated: string;
   records: string;
   sampleProject: string;
@@ -53,6 +55,8 @@ export function resolveStatePaths(stateRoot?: string): HarnessStatePaths {
     workflows: join(root, relativeToHome(HARNESS_PATHS.workflows)),
     events: join(root, relativeToHome(HARNESS_PATHS.events)),
     settings: join(root, relativeToHome(HARNESS_PATHS.settings)),
+    studioProjects: join(root, relativeToHome(HARNESS_PATHS.studioProjects)),
+    agentMap: join(root, relativeToHome(HARNESS_PATHS.agentMap)),
     generated: join(root, relativeToHome(HARNESS_PATHS.generated)),
     records: join(root, relativeToHome(HARNESS_PATHS.records)),
     sampleProject: join(root, relativeToHome(HARNESS_PATHS.sampleProject)),

--- a/packages/harness/src/core/studio-project-catalog.test.ts
+++ b/packages/harness/src/core/studio-project-catalog.test.ts
@@ -8,6 +8,16 @@ import {
   StudioProjectCatalogError,
 } from "./studio-project-catalog.js";
 
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  return {
+    promise: new Promise<void>((done) => {
+      resolve = done;
+    }),
+    resolve,
+  };
+}
+
 describe("StudioProjectCatalog", () => {
   const roots: string[] = [];
 
@@ -139,7 +149,65 @@ describe("StudioProjectCatalog", () => {
     );
   });
 
-  it("skips unsafe live scopes without rejecting legal path whitespace", async () => {
+  it("does not let a delayed stale-lock waiter remove a newly acquired lock", async () => {
+    const { catalogPath } = await fixture();
+    const lockPath = `${catalogPath}.lock`;
+    await fs.mkdir(lockPath, { recursive: true });
+    await fs.writeFile(path.join(lockPath, "owner"), "abandoned-owner");
+    const staleAt = new Date(Date.now() - 60_000);
+    await fs.utimes(lockPath, staleAt, staleAt);
+
+    const delayedObserved = deferred();
+    const resumeDelayed = deferred();
+    const replacementAcquired = deferred();
+    const releaseReplacement = deferred();
+    const replacementRestored = deferred();
+
+    const delayed = new StudioProjectCatalog(
+      catalogPath,
+      () => new Date(),
+      {
+        afterStaleLockObserved: async () => {
+          delayedObserved.resolve();
+          await resumeDelayed.promise;
+        },
+        afterUnexpectedReclaimRestored: () => {
+          replacementRestored.resolve();
+        },
+      },
+    );
+    const replacement = new StudioProjectCatalog(
+      catalogPath,
+      () => new Date(),
+      {
+        afterLockAcquired: async () => {
+          replacementAcquired.resolve();
+          await releaseReplacement.promise;
+        },
+      },
+    );
+
+    const delayedWrite = delayed.create("Delayed writer");
+    await delayedObserved.promise;
+    const replacementWrite = replacement.create("Replacement writer");
+    await replacementAcquired.promise;
+
+    // The delayed waiter now acts on its stale observation. It atomically
+    // moves the replacement lock, notices the owner changed, and restores it.
+    resumeDelayed.resolve();
+    await replacementRestored.promise;
+    releaseReplacement.resolve();
+
+    await Promise.all([delayedWrite, replacementWrite]);
+    const restarted = await new StudioProjectCatalog(catalogPath).list();
+    expect(restarted.map((project) => project.displayName).sort()).toEqual([
+      "Delayed writer",
+      "Replacement writer",
+    ]);
+    await expect(fs.stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves unsafe live scopes without Agent Map assignment and accepts legal path whitespace", async () => {
     const { root, catalogPath } = await fixture();
     const spaced = path.join(root, "project ");
     await fs.mkdir(spaced);
@@ -151,9 +219,20 @@ describe("StudioProjectCatalog", () => {
 
     expect(reconciled.projects).toHaveLength(1);
     expect(reconciled.projects[0]?.displayName).toBe("project");
-    expect(reconciled.workspaceScopes).toEqual([
-      expect.objectContaining({ cwd: spaced }),
-    ]);
+    expect(reconciled.workspaceScopes).toEqual(
+      expect.arrayContaining([
+        {
+          workspaceKey: "workspace-unsafe",
+          cwd: `${root}/bad\npath`,
+        },
+        expect.objectContaining({ cwd: spaced }),
+      ]),
+    );
+    expect(
+      reconciled.workspaceScopes.find(
+        (scope) => scope.workspaceKey === "workspace-unsafe",
+      ),
+    ).not.toHaveProperty("projectId");
   });
 
   it("rejects a move onto another binding in the same project and remains restart-readable", async () => {

--- a/packages/harness/src/core/studio-project-catalog.test.ts
+++ b/packages/harness/src/core/studio-project-catalog.test.ts
@@ -84,9 +84,105 @@ describe("StudioProjectCatalog", () => {
     expect(moved.projectId).toBe(project.projectId);
     expect(expanded.projectId).toBe(project.projectId);
     expect(expanded.bindings).toHaveLength(2);
-    expect(expanded.bindings.map((entry) => entry.repositoryId)).toContain(
-      "repo_publisher",
+    expect(JSON.stringify(expanded)).not.toContain("repo_publisher");
+    expect(
+      (
+        JSON.parse(await fs.readFile(catalogPath, "utf8")) as {
+          projects: Array<{
+            rootBindings: Array<{ repositoryId: string | null }>;
+          }>;
+        }
+      ).projects[0]?.rootBindings.map((entry) => entry.repositoryId),
+    ).toContain("repo_publisher");
+
+    const restarted = await new StudioProjectCatalog(catalogPath).reconcile([
+      { workspaceKey: "workspace-new", cwd: movedRoot },
+      { workspaceKey: "workspace-publisher", cwd: secondRoot },
+    ]);
+    expect(restarted.projects).toHaveLength(1);
+    expect(restarted.projects[0]?.projectId).toBe(project.projectId);
+    expect(restarted.workspaceScopes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ projectId: project.projectId }),
+        expect.objectContaining({ projectId: project.projectId }),
+      ]),
     );
+  });
+
+  it("serializes concurrent writers from independent catalog instances", async () => {
+    const { root, catalogPath } = await fixture();
+    const alpha = path.join(root, "alpha");
+    const beta = path.join(root, "beta");
+    await Promise.all([fs.mkdir(alpha), fs.mkdir(beta)]);
+
+    const [first, second] = await Promise.all([
+      new StudioProjectCatalog(catalogPath).reconcile([
+        { workspaceKey: "workspace-alpha", cwd: alpha },
+      ]),
+      new StudioProjectCatalog(catalogPath).reconcile([
+        { workspaceKey: "workspace-beta", cwd: beta },
+      ]),
+    ]);
+    const reconciled = await new StudioProjectCatalog(catalogPath).reconcile([
+      { workspaceKey: "workspace-alpha", cwd: alpha },
+      { workspaceKey: "workspace-beta", cwd: beta },
+    ]);
+
+    expect(reconciled.projects).toHaveLength(2);
+    expect(
+      new Set(reconciled.workspaceScopes.map((scope) => scope.projectId)),
+    ).toEqual(
+      new Set([
+        first.workspaceScopes[0]?.projectId,
+        second.workspaceScopes[0]?.projectId,
+      ]),
+    );
+  });
+
+  it("skips unsafe live scopes without rejecting legal path whitespace", async () => {
+    const { root, catalogPath } = await fixture();
+    const spaced = path.join(root, "project ");
+    await fs.mkdir(spaced);
+
+    const reconciled = await new StudioProjectCatalog(catalogPath).reconcile([
+      { workspaceKey: "workspace-unsafe", cwd: `${root}/bad\npath` },
+      { workspaceKey: "workspace-spaced", cwd: spaced },
+    ]);
+
+    expect(reconciled.projects).toHaveLength(1);
+    expect(reconciled.projects[0]?.displayName).toBe("project");
+    expect(reconciled.workspaceScopes).toEqual([
+      expect.objectContaining({ cwd: spaced }),
+    ]);
+  });
+
+  it("rejects a move onto another binding in the same project and remains restart-readable", async () => {
+    const { root, catalogPath } = await fixture();
+    const firstRoot = path.join(root, "first");
+    const secondRoot = path.join(root, "second");
+    await Promise.all([fs.mkdir(firstRoot), fs.mkdir(secondRoot)]);
+    const catalog = new StudioProjectCatalog(catalogPath);
+    const project = (
+      await catalog.reconcile([
+        { workspaceKey: "workspace-first", cwd: firstRoot },
+      ])
+    ).projects[0]!;
+    await catalog.addRootBinding(project.projectId, secondRoot, {
+      legacyWorkspaceKey: "workspace-second",
+    });
+
+    await expect(
+      catalog.moveRootBinding(
+        project.projectId,
+        project.bindings[0]!.id,
+        secondRoot,
+      ),
+    ).rejects.toMatchObject({ code: "malformed_state" });
+
+    const restarted = await new StudioProjectCatalog(catalogPath).resolve(
+      project.projectId,
+    );
+    expect(restarted?.bindings).toHaveLength(2);
   });
 
   it("supports a project with no repository binding", async () => {

--- a/packages/harness/src/core/studio-project-catalog.test.ts
+++ b/packages/harness/src/core/studio-project-catalog.test.ts
@@ -149,62 +149,121 @@ describe("StudioProjectCatalog", () => {
     );
   });
 
-  it("does not let a delayed stale-lock waiter remove a newly acquired lock", async () => {
+  it("fences three writers while reclaiming a dead owner without leaking lock artifacts", async () => {
     const { catalogPath } = await fixture();
     const lockPath = `${catalogPath}.lock`;
-    await fs.mkdir(lockPath, { recursive: true });
-    await fs.writeFile(path.join(lockPath, "owner"), "abandoned-owner");
-    const staleAt = new Date(Date.now() - 60_000);
-    await fs.utimes(lockPath, staleAt, staleAt);
+    const deadPid = process.pid + 100_000;
+    await fs.writeFile(
+      lockPath,
+      JSON.stringify({ ownerId: "abandoned-owner", pid: deadPid }),
+    );
 
-    const delayedObserved = deferred();
+    const bothDelayedObserved = deferred();
     const resumeDelayed = deferred();
-    const replacementAcquired = deferred();
-    const releaseReplacement = deferred();
-    const replacementRestored = deferred();
-
-    const delayed = new StudioProjectCatalog(
-      catalogPath,
-      () => new Date(),
-      {
-        afterStaleLockObserved: async () => {
-          delayedObserved.resolve();
-          await resumeDelayed.promise;
-        },
-        afterUnexpectedReclaimRestored: () => {
-          replacementRestored.resolve();
-        },
+    const winnerAcquired = deferred();
+    const releaseWinner = deferred();
+    const delayedObservedReplacement = deferred();
+    let deadObservations = 0;
+    const delayedHooks = {
+      isPidAlive: (pid: number) => pid === process.pid,
+      afterDeadOwnerObserved: async () => {
+        deadObservations += 1;
+        if (deadObservations === 2) bothDelayedObserved.resolve();
+        await resumeDelayed.promise;
       },
+      afterObservedOwnerChanged: () => {
+        delayedObservedReplacement.resolve();
+      },
+      afterLiveOwnerObserved: () => {
+        delayedObservedReplacement.resolve();
+      },
+    };
+    const delayedB = new StudioProjectCatalog(
+      catalogPath,
+      () => new Date(),
+      delayedHooks,
     );
-    const replacement = new StudioProjectCatalog(
+    const delayedC = new StudioProjectCatalog(
+      catalogPath,
+      () => new Date(),
+      delayedHooks,
+    );
+    const winner = new StudioProjectCatalog(
       catalogPath,
       () => new Date(),
       {
+        isPidAlive: (pid) => pid === process.pid,
         afterLockAcquired: async () => {
-          replacementAcquired.resolve();
-          await releaseReplacement.promise;
+          winnerAcquired.resolve();
+          await releaseWinner.promise;
         },
       },
     );
 
-    const delayedWrite = delayed.create("Delayed writer");
-    await delayedObserved.promise;
-    const replacementWrite = replacement.create("Replacement writer");
-    await replacementAcquired.promise;
-
-    // The delayed waiter now acts on its stale observation. It atomically
-    // moves the replacement lock, notices the owner changed, and restores it.
+    const writeB = delayedB.create("Writer B");
+    const writeC = delayedC.create("Writer C");
+    await bothDelayedObserved.promise;
+    const writeA = winner.create("Writer A");
+    await winnerAcquired.promise;
     resumeDelayed.resolve();
-    await replacementRestored.promise;
-    releaseReplacement.resolve();
+    await delayedObservedReplacement.promise;
+    releaseWinner.resolve();
 
-    await Promise.all([delayedWrite, replacementWrite]);
+    await Promise.all([writeA, writeB, writeC]);
     const restarted = await new StudioProjectCatalog(catalogPath).list();
     expect(restarted.map((project) => project.displayName).sort()).toEqual([
-      "Delayed writer",
-      "Replacement writer",
+      "Writer A",
+      "Writer B",
+      "Writer C",
     ]);
-    await expect(fs.stat(lockPath)).rejects.toMatchObject({ code: "ENOENT" });
+    expect(
+      (await fs.readdir(path.dirname(catalogPath))).filter((entry) =>
+        entry.startsWith(`${path.basename(catalogPath)}.lock`),
+      ),
+    ).toEqual([]);
+  });
+
+  it("never evicts a slow live PID even when its lock mtime is old", async () => {
+    const { catalogPath } = await fixture();
+    const lockPath = `${catalogPath}.lock`;
+    const liveAcquired = deferred();
+    const releaseLive = deferred();
+    const waiterObservedLive = deferred();
+    let waiterSettled = false;
+    const live = new StudioProjectCatalog(catalogPath, () => new Date(), {
+      afterLockAcquired: async () => {
+        liveAcquired.resolve();
+        await releaseLive.promise;
+      },
+    });
+    const waiter = new StudioProjectCatalog(catalogPath, () => new Date(), {
+      afterLiveOwnerObserved: () => {
+        waiterObservedLive.resolve();
+      },
+    });
+
+    const liveWrite = live.create("Slow live writer");
+    await liveAcquired.promise;
+    const old = new Date(Date.now() - 60_000);
+    await fs.utimes(lockPath, old, old);
+    const waiterWrite = waiter.create("Patient writer").finally(() => {
+      waiterSettled = true;
+    });
+    await waiterObservedLive.promise;
+    expect(waiterSettled).toBe(false);
+    releaseLive.resolve();
+
+    await Promise.all([liveWrite, waiterWrite]);
+    expect(
+      (await new StudioProjectCatalog(catalogPath).list()).map(
+        (project) => project.displayName,
+      ).sort(),
+    ).toEqual(["Patient writer", "Slow live writer"]);
+    expect(
+      (await fs.readdir(path.dirname(catalogPath))).filter((entry) =>
+        entry.startsWith(`${path.basename(catalogPath)}.lock`),
+      ),
+    ).toEqual([]);
   });
 
   it("preserves unsafe live scopes without Agent Map assignment and accepts legal path whitespace", async () => {
@@ -233,6 +292,38 @@ describe("StudioProjectCatalog", () => {
         (scope) => scope.workspaceKey === "workspace-unsafe",
       ),
     ).not.toHaveProperty("projectId");
+  });
+
+  it("keeps every conflicting legacy-key root unassigned in both orders and after restart", async () => {
+    const { root, catalogPath } = await fixture();
+    const alpha = path.join(root, "alpha");
+    const beta = path.join(root, "beta");
+    await Promise.all([fs.mkdir(alpha), fs.mkdir(beta)]);
+    const forwardScopes = [
+      { workspaceKey: "shared-legacy-key", cwd: alpha },
+      { workspaceKey: "shared-legacy-key", cwd: beta },
+    ];
+
+    const forward = await new StudioProjectCatalog(catalogPath).reconcile(
+      forwardScopes,
+    );
+    const reversed = await new StudioProjectCatalog(catalogPath).reconcile(
+      [...forwardScopes].reverse(),
+    );
+
+    for (const result of [forward, reversed]) {
+      expect(result.projects).toEqual([]);
+      expect(result.workspaceScopes).toEqual(
+        expect.arrayContaining(forwardScopes),
+      );
+      expect(result.workspaceScopes).toHaveLength(2);
+      expect(
+        result.workspaceScopes.every(
+          (scope) => !Object.prototype.hasOwnProperty.call(scope, "projectId"),
+        ),
+      ).toBe(true);
+    }
+    expect(await new StudioProjectCatalog(catalogPath).list()).toEqual([]);
   });
 
   it("rejects a move onto another binding in the same project and remains restart-readable", async () => {

--- a/packages/harness/src/core/studio-project-catalog.test.ts
+++ b/packages/harness/src/core/studio-project-catalog.test.ts
@@ -1,0 +1,134 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  StudioProjectCatalog,
+  StudioProjectCatalogError,
+} from "./studio-project-catalog.js";
+
+describe("StudioProjectCatalog", () => {
+  const roots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      roots
+        .splice(0)
+        .map((root) => fs.rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  async function fixture() {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "studio-project-catalog-"),
+    );
+    roots.push(root);
+    return { root, catalogPath: path.join(root, "studio-projects.json") };
+  }
+
+  it("allocates one durable identity and publishes only path-free summaries", async () => {
+    const { root, catalogPath } = await fixture();
+    const projectRoot = path.join(root, "market-research");
+    await fs.mkdir(projectRoot);
+    const catalog = new StudioProjectCatalog(catalogPath);
+
+    const first = await catalog.reconcile([
+      { workspaceKey: "workspace-legacy-one", cwd: projectRoot },
+      { workspaceKey: "workspace-duplicate", cwd: `${projectRoot}/.` },
+    ]);
+    const restarted = new StudioProjectCatalog(catalogPath);
+    const second = await restarted.reconcile([
+      { workspaceKey: "workspace-legacy-one", cwd: projectRoot },
+    ]);
+
+    expect(first.projects).toHaveLength(1);
+    expect(second.projects[0]?.projectId).toBe(first.projects[0]?.projectId);
+    expect(second.workspaceScopes[0]?.projectId).toBe(
+      first.projects[0]?.projectId,
+    );
+    expect(JSON.stringify(second.projects)).not.toContain(projectRoot);
+    expect(JSON.stringify(second.projects)).not.toContain("workspace-legacy");
+  });
+
+  it("keeps project identity across a root move and an additional repository binding", async () => {
+    const { root, catalogPath } = await fixture();
+    const originalRoot = path.join(root, "old-name");
+    const movedRoot = path.join(root, "new-name");
+    const secondRoot = path.join(root, "publisher");
+    await Promise.all(
+      [originalRoot, movedRoot, secondRoot].map((dir) => fs.mkdir(dir)),
+    );
+    const catalog = new StudioProjectCatalog(catalogPath);
+    const initial = await catalog.reconcile([
+      { workspaceKey: "workspace-old", cwd: originalRoot },
+    ]);
+    const project = initial.projects[0]!;
+    const binding = project.bindings[0]!;
+
+    const moved = await catalog.moveRootBinding(
+      project.projectId,
+      binding.id,
+      movedRoot,
+      "workspace-new",
+    );
+    const expanded = await catalog.addRootBinding(
+      project.projectId,
+      secondRoot,
+      {
+        repositoryId: "repo_publisher",
+        legacyWorkspaceKey: "workspace-publisher",
+      },
+    );
+
+    expect(moved.projectId).toBe(project.projectId);
+    expect(expanded.projectId).toBe(project.projectId);
+    expect(expanded.bindings).toHaveLength(2);
+    expect(expanded.bindings.map((entry) => entry.repositoryId)).toContain(
+      "repo_publisher",
+    );
+  });
+
+  it("supports a project with no repository binding", async () => {
+    const { catalogPath } = await fixture();
+    const project = await new StudioProjectCatalog(catalogPath).create(
+      "Empty project",
+    );
+    expect(project.bindings).toEqual([]);
+    expect(
+      (await new StudioProjectCatalog(catalogPath).resolve(project.projectId))
+        ?.projectId,
+    ).toBe(project.projectId);
+  });
+
+  it("distinguishes malformed, unsupported, and unavailable catalog storage", async () => {
+    const malformed = await fixture();
+    await fs.writeFile(malformed.catalogPath, "{not-json");
+    await expect(
+      new StudioProjectCatalog(malformed.catalogPath).list(),
+    ).rejects.toMatchObject({
+      code: "malformed_state",
+    } satisfies Partial<StudioProjectCatalogError>);
+
+    const future = await fixture();
+    await fs.writeFile(
+      future.catalogPath,
+      JSON.stringify({ schemaVersion: 99, projects: [], futureField: true }),
+    );
+    await expect(
+      new StudioProjectCatalog(future.catalogPath).list(),
+    ).rejects.toMatchObject({
+      code: "unsupported_schema",
+    } satisfies Partial<StudioProjectCatalogError>);
+
+    const unavailable = await fixture();
+    await fs.writeFile(unavailable.root + "/not-a-directory", "file");
+    await expect(
+      new StudioProjectCatalog(
+        unavailable.root + "/not-a-directory/catalog.json",
+      ).create("Project"),
+    ).rejects.toMatchObject({
+      code: "storage_unavailable",
+    } satisfies Partial<StudioProjectCatalogError>);
+  });
+});

--- a/packages/harness/src/core/studio-project-catalog.ts
+++ b/packages/harness/src/core/studio-project-catalog.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
 
 import {
   STUDIO_PROJECT_CATALOG_SCHEMA_VERSION,
@@ -86,6 +87,13 @@ function isSafeText(value: unknown): value is string {
   );
 }
 
+/** Filesystem names may legally begin or end with spaces on macOS/POSIX. */
+function isSafePathText(value: unknown): value is string {
+  return (
+    typeof value === "string" && value !== "" && !hasControlCharacter(value)
+  );
+}
+
 function isOpaqueId(value: unknown): value is string {
   return (
     isSafeText(value) &&
@@ -132,7 +140,7 @@ function parseBinding(value: unknown): ProjectRootBinding | null {
     !hasExactKeys(value, ["id", "repositoryId", "localRootRef", "status"]) ||
     !isBindingId(value.id) ||
     (value.repositoryId !== null && !isOpaqueId(value.repositoryId)) ||
-    !isSafeText(value.localRootRef) ||
+    !isSafePathText(value.localRootRef) ||
     (!path.posix.isAbsolute(value.localRootRef) &&
       !path.win32.isAbsolute(value.localRootRef)) ||
     (value.status !== "active" && value.status !== "missing")
@@ -254,7 +262,7 @@ function publicSummary(project: StudioProjectIdentity): StudioProjectSummary {
     identityVersion: project.identityVersion,
     displayName: project.displayName,
     bindings: project.rootBindings
-      .map(({ id, repositoryId, status }) => ({ id, repositoryId, status }))
+      .map(({ id, status }) => ({ id, status }))
       .sort((left, right) => left.id.localeCompare(right.id)),
     createdAt: project.createdAt,
     updatedAt: project.updatedAt,
@@ -285,6 +293,10 @@ function storageError(): StudioProjectCatalogError {
   return new StudioProjectCatalogError("storage_unavailable");
 }
 
+const CATALOG_LOCK_TIMEOUT_MS = 5_000;
+const CATALOG_STALE_LOCK_MS = 30_000;
+const CATALOG_LOCK_RETRY_MS = 10;
+
 /**
  * Durable, serialized owner of Studio project identity. Catalog reads never
  * run package inventory or source discovery; callers provide the already
@@ -301,7 +313,19 @@ export class StudioProjectCatalog {
   ) {}
 
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
-    const result = this.mutationQueue.then(operation, operation);
+    const lockedOperation = async (): Promise<T> => {
+      const release = await this.acquireFileLock();
+      try {
+        // CLI and Electron share one state root. Always re-read after taking
+        // the cross-instance lock so a whole-catalog atomic rewrite includes
+        // identities committed by another live host.
+        await this.load(true);
+        return await operation();
+      } finally {
+        await release();
+      }
+    };
+    const result = this.mutationQueue.then(lockedOperation, lockedOperation);
     this.mutationQueue = result.then(
       () => undefined,
       () => undefined,
@@ -309,31 +333,71 @@ export class StudioProjectCatalog {
     return result;
   }
 
-  private async load(): Promise<void> {
-    if (this.projects !== null) return;
-    if (!this.loadPromise) {
-      this.loadPromise = (async () => {
-        let raw: string;
-        try {
-          raw = await fs.readFile(this.catalogPath, "utf8");
-        } catch (error) {
-          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-            this.projects = [];
-            return;
-          }
+  private async acquireFileLock(): Promise<() => Promise<void>> {
+    const lockPath = `${this.catalogPath}.lock`;
+    const deadline = Date.now() + CATALOG_LOCK_TIMEOUT_MS;
+    try {
+      await fs.mkdir(path.dirname(this.catalogPath), { recursive: true });
+    } catch {
+      throw storageError();
+    }
+    for (;;) {
+      try {
+        await fs.mkdir(lockPath);
+        return async () => {
+          await fs.rmdir(lockPath).catch(() => {});
+        };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
           throw storageError();
         }
-        let decoded: unknown;
-        try {
-          decoded = JSON.parse(raw) as unknown;
-        } catch {
-          throw new StudioProjectCatalogError("malformed_state");
+      }
+
+      try {
+        const lock = await fs.stat(lockPath);
+        if (Date.now() - lock.mtimeMs > CATALOG_STALE_LOCK_MS) {
+          await fs.rmdir(lockPath).catch(() => {});
+          continue;
         }
-        this.projects = parseCatalog(decoded).projects;
-      })().finally(() => {
-        this.loadPromise = null;
-      });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw storageError();
+      }
+      if (Date.now() >= deadline) throw storageError();
+      await delay(CATALOG_LOCK_RETRY_MS);
     }
+  }
+
+  private async load(force = false): Promise<void> {
+    if (this.loadPromise) {
+      await this.loadPromise;
+      // A forced mutation read may have joined a read that began before this
+      // instance acquired the file lock. Read once more while holding the lock
+      // so the mutation cannot commit from that potentially stale snapshot.
+      if (!force) return;
+    }
+    if (!force && this.projects !== null) return;
+    this.loadPromise = (async () => {
+      let raw: string;
+      try {
+        raw = await fs.readFile(this.catalogPath, "utf8");
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          this.projects = [];
+          return;
+        }
+        throw storageError();
+      }
+      let decoded: unknown;
+      try {
+        decoded = JSON.parse(raw) as unknown;
+      } catch {
+        throw new StudioProjectCatalogError("malformed_state");
+      }
+      this.projects = parseCatalog(decoded).projects;
+    })().finally(() => {
+      this.loadPromise = null;
+    });
     await this.loadPromise;
   }
 
@@ -369,7 +433,7 @@ export class StudioProjectCatalog {
 
   async list(): Promise<StudioProjectSummary[]> {
     await this.mutationQueue;
-    await this.load();
+    await this.load(true);
     return this.projects!.map(publicSummary);
   }
 
@@ -409,13 +473,21 @@ export class StudioProjectCatalog {
       const dedupedScopes = new Map<string, WorkspaceScopeSummary>();
       const rootsByLegacyKey = new Map<string, string>();
       for (const scope of scopes) {
-        if (!isSafeText(scope.workspaceKey) || !isSafeText(scope.cwd)) {
-          throw new StudioProjectCatalogError("malformed_state");
+        // Workspace scopes are live operational input, not persisted catalog
+        // state. One unsafe/unrepresentable path must not poison every valid
+        // project read. Spaces at either end remain valid path characters.
+        if (!isSafeText(scope.workspaceKey) || !isSafePathText(scope.cwd)) {
+          continue;
         }
-        const canonical = canonicalGraphPath(scope.cwd);
+        let canonical: string;
+        try {
+          canonical = canonicalGraphPath(scope.cwd);
+        } catch {
+          continue;
+        }
         const aliasedRoot = rootsByLegacyKey.get(scope.workspaceKey);
         if (aliasedRoot !== undefined && aliasedRoot !== canonical) {
-          throw new StudioProjectCatalogError("malformed_state");
+          continue;
         }
         rootsByLegacyKey.set(scope.workspaceKey, canonical);
         if (!dedupedScopes.has(canonical)) {
@@ -464,7 +536,7 @@ export class StudioProjectCatalog {
           project = {
             projectId: `project_${randomUUID()}`,
             identityVersion: 1,
-            displayName: path.basename(canonical) || "Project",
+            displayName: path.basename(canonical).trim() || "Project",
             rootBindings: [
               {
                 id: `root_${randomUUID()}`,
@@ -529,7 +601,7 @@ export class StudioProjectCatalog {
   ): Promise<StudioProjectSummary | null> {
     if (!isStudioProjectId(projectId)) return null;
     await this.mutationQueue;
-    await this.load();
+    await this.load(true);
     const project = this.projects!.find(
       (candidate) => candidate.projectId === projectId,
     );
@@ -552,13 +624,23 @@ export class StudioProjectCatalog {
       const binding = project?.rootBindings.find(
         (candidate) => candidate.id === bindingId,
       );
-      if (!project || !binding || !isSafeText(root)) {
+      if (!project || !binding || !isSafePathText(root)) {
         throw new StudioProjectCatalogError("malformed_state");
       }
       if (legacyWorkspaceKey !== undefined && !isSafeText(legacyWorkspaceKey)) {
         throw new StudioProjectCatalogError("malformed_state");
       }
       const canonical = canonicalGraphPath(root);
+      if (
+        project.rootBindings.some(
+          (candidate) =>
+            candidate.id !== binding.id && candidate.localRootRef === canonical,
+        )
+      ) {
+        // Reject instead of persisting two private bindings for the same root;
+        // the strict restart parser enforces this same invariant.
+        throw new StudioProjectCatalogError("malformed_state");
+      }
       if (
         next.some(
           (candidate) =>
@@ -601,7 +683,7 @@ export class StudioProjectCatalog {
       );
       if (
         !project ||
-        !isSafeText(root) ||
+        !isSafePathText(root) ||
         (options.repositoryId !== undefined &&
           options.repositoryId !== null &&
           !isOpaqueId(options.repositoryId)) ||

--- a/packages/harness/src/core/studio-project-catalog.ts
+++ b/packages/harness/src/core/studio-project-catalog.ts
@@ -296,6 +296,14 @@ function storageError(): StudioProjectCatalogError {
 const CATALOG_LOCK_TIMEOUT_MS = 5_000;
 const CATALOG_STALE_LOCK_MS = 30_000;
 const CATALOG_LOCK_RETRY_MS = 10;
+const CATALOG_LOCK_OWNER_FILE = "owner";
+
+/** Internal deterministic seams used only by file-lock race regressions. */
+export interface StudioProjectCatalogLockTestHooks {
+  afterStaleLockObserved?: (ownerId: string | null) => void | Promise<void>;
+  afterUnexpectedReclaimRestored?: () => void | Promise<void>;
+  afterLockAcquired?: (ownerId: string) => void | Promise<void>;
+}
 
 /**
  * Durable, serialized owner of Studio project identity. Catalog reads never
@@ -310,6 +318,7 @@ export class StudioProjectCatalog {
   constructor(
     private readonly catalogPath: string,
     private readonly now: () => Date = () => new Date(),
+    private readonly lockTestHooks: StudioProjectCatalogLockTestHooks = {},
   ) {}
 
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
@@ -335,6 +344,7 @@ export class StudioProjectCatalog {
 
   private async acquireFileLock(): Promise<() => Promise<void>> {
     const lockPath = `${this.catalogPath}.lock`;
+    const ownerId = randomUUID();
     const deadline = Date.now() + CATALOG_LOCK_TIMEOUT_MS;
     try {
       await fs.mkdir(path.dirname(this.catalogPath), { recursive: true });
@@ -344,19 +354,36 @@ export class StudioProjectCatalog {
     for (;;) {
       try {
         await fs.mkdir(lockPath);
-        return async () => {
-          await fs.rmdir(lockPath).catch(() => {});
-        };
+        try {
+          await fs.writeFile(
+            path.join(lockPath, CATALOG_LOCK_OWNER_FILE),
+            ownerId,
+            { encoding: "utf8", flag: "wx" },
+          );
+          await this.lockTestHooks.afterLockAcquired?.(ownerId);
+        } catch (error) {
+          await this.releaseFileLock(lockPath, ownerId);
+          throw error;
+        }
+        return () => this.releaseFileLock(lockPath, ownerId);
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
+          if (error instanceof StudioProjectCatalogError) throw error;
           throw storageError();
         }
       }
 
       try {
+        // Read identity before freshness. If another waiter replaces the lock
+        // between these observations, either the following stat sees the new
+        // (fresh) directory or the post-rename owner check restores it. Doing
+        // this in the opposite order could pair an old mtime with a new owner
+        // and mistakenly bless deletion of that new live lock.
+        const observedOwner = await this.readLockOwner(lockPath);
         const lock = await fs.stat(lockPath);
         if (Date.now() - lock.mtimeMs > CATALOG_STALE_LOCK_MS) {
-          await fs.rmdir(lockPath).catch(() => {});
+          await this.lockTestHooks.afterStaleLockObserved?.(observedOwner);
+          await this.reclaimStaleLock(lockPath, observedOwner);
           continue;
         }
       } catch (error) {
@@ -365,6 +392,84 @@ export class StudioProjectCatalog {
       }
       if (Date.now() >= deadline) throw storageError();
       await delay(CATALOG_LOCK_RETRY_MS);
+    }
+  }
+
+  private async readLockOwner(lockPath: string): Promise<string | null> {
+    try {
+      const owner = await fs.readFile(
+        path.join(lockPath, CATALOG_LOCK_OWNER_FILE),
+        "utf8",
+      );
+      return owner === "" ? null : owner;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+      throw storageError();
+    }
+  }
+
+  /**
+   * Atomically moves the exact stale directory we observed out of the lock
+   * path. A delayed waiter can otherwise `rmdir` a newer owner's lock after
+   * another process has already reclaimed and reacquired it. Revalidating the
+   * owner marker after rename lets that waiter restore the newer lock intact.
+   */
+  private async reclaimStaleLock(
+    lockPath: string,
+    observedOwner: string | null,
+  ): Promise<void> {
+    const tombstone = `${lockPath}.reclaim-${randomUUID()}`;
+    try {
+      await fs.rename(lockPath, tombstone);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw storageError();
+    }
+
+    const reclaimedOwner = await this.readLockOwner(tombstone);
+    if (reclaimedOwner !== observedOwner) {
+      try {
+        await fs.rename(tombstone, lockPath);
+      } catch {
+        // Losing the fixed path here would strand a live writer. Keep the
+        // tombstone for diagnosis and fail closed instead of deleting it.
+        throw storageError();
+      }
+      await this.lockTestHooks.afterUnexpectedReclaimRestored?.();
+      return;
+    }
+    try {
+      await fs.rm(tombstone, { recursive: true });
+    } catch {
+      throw storageError();
+    }
+  }
+
+  /** Release only the directory carrying this acquisition's owner marker. */
+  private async releaseFileLock(
+    lockPath: string,
+    ownerId: string,
+  ): Promise<void> {
+    if ((await this.readLockOwner(lockPath)) !== ownerId) return;
+    const tombstone = `${lockPath}.release-${ownerId}-${randomUUID()}`;
+    try {
+      await fs.rename(lockPath, tombstone);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw storageError();
+    }
+    if ((await this.readLockOwner(tombstone)) !== ownerId) {
+      try {
+        await fs.rename(tombstone, lockPath);
+      } catch {
+        throw storageError();
+      }
+      return;
+    }
+    try {
+      await fs.rm(tombstone, { recursive: true });
+    } catch {
+      throw storageError();
     }
   }
 
@@ -471,22 +576,35 @@ export class StudioProjectCatalog {
       await this.load();
       const next = cloneProjects(this.projects!);
       const dedupedScopes = new Map<string, WorkspaceScopeSummary>();
+      const unassignedScopes: WorkspaceScopeSummary[] = [];
       const rootsByLegacyKey = new Map<string, string>();
       for (const scope of scopes) {
         // Workspace scopes are live operational input, not persisted catalog
         // state. One unsafe/unrepresentable path must not poison every valid
         // project read. Spaces at either end remain valid path characters.
         if (!isSafeText(scope.workspaceKey) || !isSafePathText(scope.cwd)) {
+          unassignedScopes.push({
+            workspaceKey: scope.workspaceKey,
+            cwd: scope.cwd,
+          });
           continue;
         }
         let canonical: string;
         try {
           canonical = canonicalGraphPath(scope.cwd);
         } catch {
+          unassignedScopes.push({
+            workspaceKey: scope.workspaceKey,
+            cwd: scope.cwd,
+          });
           continue;
         }
         const aliasedRoot = rootsByLegacyKey.get(scope.workspaceKey);
         if (aliasedRoot !== undefined && aliasedRoot !== canonical) {
+          unassignedScopes.push({
+            workspaceKey: scope.workspaceKey,
+            cwd: scope.cwd,
+          });
           continue;
         }
         rootsByLegacyKey.set(scope.workspaceKey, canonical);
@@ -588,8 +706,8 @@ export class StudioProjectCatalog {
       }
       return {
         projects: (changed ? next : this.projects!).map(publicSummary),
-        workspaceScopes: reconciledScopes.sort((left, right) =>
-          left.cwd.localeCompare(right.cwd),
+        workspaceScopes: [...unassignedScopes, ...reconciledScopes].sort(
+          (left, right) => left.cwd.localeCompare(right.cwd),
         ),
       };
     });

--- a/packages/harness/src/core/studio-project-catalog.ts
+++ b/packages/harness/src/core/studio-project-catalog.ts
@@ -294,15 +294,31 @@ function storageError(): StudioProjectCatalogError {
 }
 
 const CATALOG_LOCK_TIMEOUT_MS = 5_000;
-const CATALOG_STALE_LOCK_MS = 30_000;
 const CATALOG_LOCK_RETRY_MS = 10;
-const CATALOG_LOCK_OWNER_FILE = "owner";
+
+interface CatalogLockOwner {
+  ownerId: string;
+  pid: number;
+}
+
+function sameLockOwner(
+  left: CatalogLockOwner | null,
+  right: CatalogLockOwner,
+): left is CatalogLockOwner {
+  return (
+    left !== null &&
+    left.ownerId === right.ownerId &&
+    left.pid === right.pid
+  );
+}
 
 /** Internal deterministic seams used only by file-lock race regressions. */
 export interface StudioProjectCatalogLockTestHooks {
-  afterStaleLockObserved?: (ownerId: string | null) => void | Promise<void>;
-  afterUnexpectedReclaimRestored?: () => void | Promise<void>;
+  afterDeadOwnerObserved?: (owner: CatalogLockOwner) => void | Promise<void>;
+  afterObservedOwnerChanged?: () => void | Promise<void>;
+  afterLiveOwnerObserved?: (owner: CatalogLockOwner) => void | Promise<void>;
   afterLockAcquired?: (ownerId: string) => void | Promise<void>;
+  isPidAlive?: (pid: number) => boolean;
 }
 
 /**
@@ -344,132 +360,191 @@ export class StudioProjectCatalog {
 
   private async acquireFileLock(): Promise<() => Promise<void>> {
     const lockPath = `${this.catalogPath}.lock`;
-    const ownerId = randomUUID();
+    const owner: CatalogLockOwner = {
+      ownerId: randomUUID(),
+      pid: process.pid,
+    };
     const deadline = Date.now() + CATALOG_LOCK_TIMEOUT_MS;
     try {
       await fs.mkdir(path.dirname(this.catalogPath), { recursive: true });
     } catch {
       throw storageError();
     }
+    await this.cleanupDeadLockArtifacts(lockPath);
     for (;;) {
-      try {
-        await fs.mkdir(lockPath);
+      if (await this.tryCreateLockFile(lockPath, owner)) {
         try {
-          await fs.writeFile(
-            path.join(lockPath, CATALOG_LOCK_OWNER_FILE),
-            ownerId,
-            { encoding: "utf8", flag: "wx" },
-          );
-          await this.lockTestHooks.afterLockAcquired?.(ownerId);
+          await this.lockTestHooks.afterLockAcquired?.(owner.ownerId);
         } catch (error) {
-          await this.releaseFileLock(lockPath, ownerId);
+          await this.releaseFileLock(lockPath, owner);
           throw error;
         }
-        return () => this.releaseFileLock(lockPath, ownerId);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code !== "EEXIST") {
-          if (error instanceof StudioProjectCatalogError) throw error;
-          throw storageError();
-        }
+        return () => this.releaseFileLock(lockPath, owner);
+      }
+
+      const observedOwner = await this.readLockOwner(lockPath);
+      if (observedOwner === null) {
+        // Another process may be between exclusive create and owner write.
+        // Never evict an owner whose PID cannot be proven dead.
+        if (Date.now() >= deadline) throw storageError();
+        await delay(CATALOG_LOCK_RETRY_MS);
+        continue;
+      }
+      if (this.isPidAlive(observedOwner.pid)) {
+        await this.lockTestHooks.afterLiveOwnerObserved?.(observedOwner);
+        if (Date.now() >= deadline) throw storageError();
+        await delay(CATALOG_LOCK_RETRY_MS);
+        continue;
+      }
+
+      await this.lockTestHooks.afterDeadOwnerObserved?.(observedOwner);
+      const claimPath = `${lockPath}.claim-${observedOwner.ownerId}`;
+      if (!(await this.tryCreateLockFile(claimPath, owner))) {
+        if (Date.now() >= deadline) throw storageError();
+        await delay(CATALOG_LOCK_RETRY_MS);
+        continue;
       }
 
       try {
-        // Read identity before freshness. If another waiter replaces the lock
-        // between these observations, either the following stat sees the new
-        // (fresh) directory or the post-rename owner check restores it. Doing
-        // this in the opposite order could pair an old mtime with a new owner
-        // and mistakenly bless deletion of that new live lock.
-        const observedOwner = await this.readLockOwner(lockPath);
-        const lock = await fs.stat(lockPath);
-        if (Date.now() - lock.mtimeMs > CATALOG_STALE_LOCK_MS) {
-          await this.lockTestHooks.afterStaleLockObserved?.(observedOwner);
-          await this.reclaimStaleLock(lockPath, observedOwner);
+        // Every waiter that observed this dead owner competes for the same
+        // claim. Re-read under that claim: a delayed waiter must not rename a
+        // newer live owner's fixed lock.
+        const currentOwner = await this.readLockOwner(lockPath);
+        if (
+          !sameLockOwner(currentOwner, observedOwner) ||
+          this.isPidAlive(currentOwner.pid)
+        ) {
+          await this.lockTestHooks.afterObservedOwnerChanged?.();
           continue;
         }
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
-        throw storageError();
+
+        const tombstone = `${lockPath}.reclaim-${owner.ownerId}`;
+        try {
+          await fs.rename(lockPath, tombstone);
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+          throw storageError();
+        }
+
+        // The fixed name is the fence. A normal contender may win this gap;
+        // this reclaimer proceeds only if its own exclusive create wins.
+        if (!(await this.tryCreateLockFile(lockPath, owner))) {
+          await fs.rm(tombstone, { force: true }).catch(() => {});
+          continue;
+        }
+
+        await fs.rm(tombstone, { force: true });
+        try {
+          await this.lockTestHooks.afterLockAcquired?.(owner.ownerId);
+        } catch (error) {
+          await this.releaseFileLock(lockPath, owner);
+          throw error;
+        }
+        return () => this.releaseFileLock(lockPath, owner);
+      } finally {
+        await this.releaseFileLock(claimPath, owner);
       }
-      if (Date.now() >= deadline) throw storageError();
-      await delay(CATALOG_LOCK_RETRY_MS);
     }
   }
 
-  private async readLockOwner(lockPath: string): Promise<string | null> {
+  private async tryCreateLockFile(
+    lockPath: string,
+    owner: CatalogLockOwner,
+  ): Promise<boolean> {
     try {
-      const owner = await fs.readFile(
-        path.join(lockPath, CATALOG_LOCK_OWNER_FILE),
-        "utf8",
-      );
-      return owner === "" ? null : owner;
+      await fs.writeFile(lockPath, `${JSON.stringify(owner)}\n`, {
+        encoding: "utf8",
+        flag: "wx",
+      });
+      return true;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+      throw storageError();
+    }
+  }
+
+  private async readLockOwner(lockPath: string): Promise<CatalogLockOwner | null> {
+    let raw: string;
+    try {
+      raw = await fs.readFile(lockPath, "utf8");
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
       throw storageError();
     }
+    try {
+      const decoded = JSON.parse(raw) as unknown;
+      if (
+        !isRecord(decoded) ||
+        !hasExactKeys(decoded, ["ownerId", "pid"]) ||
+        !isOpaqueId(decoded.ownerId) ||
+        !Number.isSafeInteger(decoded.pid) ||
+        (decoded.pid as number) <= 0
+      ) {
+        return null;
+      }
+      return {
+        ownerId: decoded.ownerId,
+        pid: decoded.pid as number,
+      };
+    } catch {
+      // An exclusive creator may still be writing its owner record. Unknown
+      // ownership waits and fails closed; it is never reclaimed by age.
+      return null;
+    }
   }
 
-  /**
-   * Atomically moves the exact stale directory we observed out of the lock
-   * path. A delayed waiter can otherwise `rmdir` a newer owner's lock after
-   * another process has already reclaimed and reacquired it. Revalidating the
-   * owner marker after rename lets that waiter restore the newer lock intact.
-   */
-  private async reclaimStaleLock(
-    lockPath: string,
-    observedOwner: string | null,
-  ): Promise<void> {
-    const tombstone = `${lockPath}.reclaim-${randomUUID()}`;
+  private isPidAlive(pid: number): boolean {
+    if (this.lockTestHooks.isPidAlive) {
+      return this.lockTestHooks.isPidAlive(pid);
+    }
     try {
-      await fs.rename(lockPath, tombstone);
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      return (error as NodeJS.ErrnoException).code !== "ESRCH";
+    }
+  }
+
+  private async cleanupDeadLockArtifacts(lockPath: string): Promise<void> {
+    const directory = path.dirname(lockPath);
+    const base = path.basename(lockPath);
+    let entries: string[];
+    try {
+      entries = await fs.readdir(directory);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
       throw storageError();
     }
-
-    const reclaimedOwner = await this.readLockOwner(tombstone);
-    if (reclaimedOwner !== observedOwner) {
-      try {
-        await fs.rename(tombstone, lockPath);
-      } catch {
-        // Losing the fixed path here would strand a live writer. Keep the
-        // tombstone for diagnosis and fail closed instead of deleting it.
-        throw storageError();
-      }
-      await this.lockTestHooks.afterUnexpectedReclaimRestored?.();
-      return;
-    }
-    try {
-      await fs.rm(tombstone, { recursive: true });
-    } catch {
-      throw storageError();
-    }
+    await Promise.all(
+      entries
+        .filter(
+          (entry) =>
+            entry.startsWith(`${base}.reclaim-`) ||
+            entry.startsWith(`${base}.claim-`),
+        )
+        .map(async (entry) => {
+          const artifact = path.join(directory, entry);
+          const artifactOwner = await this.readLockOwner(artifact);
+          if (artifactOwner && !this.isPidAlive(artifactOwner.pid)) {
+            await fs.rm(artifact, { force: true });
+          }
+        }),
+    );
   }
 
-  /** Release only the directory carrying this acquisition's owner marker. */
+  /** A live PID cannot be reclaimed, so this read-then-unlink is owner-safe. */
   private async releaseFileLock(
     lockPath: string,
-    ownerId: string,
+    owner: CatalogLockOwner,
   ): Promise<void> {
-    if ((await this.readLockOwner(lockPath)) !== ownerId) return;
-    const tombstone = `${lockPath}.release-${ownerId}-${randomUUID()}`;
+    const currentOwner = await this.readLockOwner(lockPath);
+    if (!sameLockOwner(currentOwner, owner)) return;
     try {
-      await fs.rename(lockPath, tombstone);
+      await fs.unlink(lockPath);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-      throw storageError();
-    }
-    if ((await this.readLockOwner(tombstone)) !== ownerId) {
-      try {
-        await fs.rename(tombstone, lockPath);
-      } catch {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
         throw storageError();
       }
-      return;
-    }
-    try {
-      await fs.rm(tombstone, { recursive: true });
-    } catch {
-      throw storageError();
     }
   }
 
@@ -577,7 +652,11 @@ export class StudioProjectCatalog {
       const next = cloneProjects(this.projects!);
       const dedupedScopes = new Map<string, WorkspaceScopeSummary>();
       const unassignedScopes: WorkspaceScopeSummary[] = [];
-      const rootsByLegacyKey = new Map<string, string>();
+      const canonicalScopes: Array<{
+        scope: WorkspaceScopeSummary;
+        canonical: string;
+      }> = [];
+      const rootsByLegacyKey = new Map<string, Set<string>>();
       for (const scope of scopes) {
         // Workspace scopes are live operational input, not persisted catalog
         // state. One unsafe/unrepresentable path must not poison every valid
@@ -599,15 +678,28 @@ export class StudioProjectCatalog {
           });
           continue;
         }
-        const aliasedRoot = rootsByLegacyKey.get(scope.workspaceKey);
-        if (aliasedRoot !== undefined && aliasedRoot !== canonical) {
+        canonicalScopes.push({ scope, canonical });
+        const roots = rootsByLegacyKey.get(scope.workspaceKey) ?? new Set();
+        roots.add(canonical);
+        rootsByLegacyKey.set(scope.workspaceKey, roots);
+      }
+
+      const conflictingLegacyKeys = new Set(
+        [...rootsByLegacyKey]
+          .filter(([, roots]) => roots.size > 1)
+          .map(([workspaceKey]) => workspaceKey),
+      );
+      for (const { scope, canonical } of canonicalScopes) {
+        // Decide alias conflicts as a group before assigning anything. Input
+        // order must not let the first member mint a durable identity while
+        // later members with the same legacy key remain ambiguous.
+        if (conflictingLegacyKeys.has(scope.workspaceKey)) {
           unassignedScopes.push({
             workspaceKey: scope.workspaceKey,
             cwd: scope.cwd,
           });
           continue;
         }
-        rootsByLegacyKey.set(scope.workspaceKey, canonical);
         if (!dedupedScopes.has(canonical)) {
           // Canonical form is private matching evidence only. Preserve the
           // existing lexical cwd in AppState so this additive join cannot

--- a/packages/harness/src/core/studio-project-catalog.ts
+++ b/packages/harness/src/core/studio-project-catalog.ts
@@ -1,0 +1,658 @@
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import {
+  STUDIO_PROJECT_CATALOG_SCHEMA_VERSION,
+  type AgentMapErrorCode,
+  type ProjectRootBindingStatus,
+  type StudioProjectId,
+  type StudioProjectSummary,
+} from "../shared/agent-map.js";
+import type { WorkspaceScopeSummary } from "../shared/system-graph.js";
+import { canonicalGraphPath } from "./canonical-graph-path.js";
+
+export interface ProjectRootBinding {
+  id: string;
+  repositoryId: string | null;
+  /** Server-private canonical path reference. Never included in public JSON. */
+  localRootRef: string;
+  status: ProjectRootBindingStatus;
+}
+
+export interface StudioProjectIdentity {
+  projectId: StudioProjectId;
+  identityVersion: number;
+  displayName: string;
+  rootBindings: ProjectRootBinding[];
+  /** Migration lookup only; never canonical identity or public map data. */
+  legacyWorkspaceKeys: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface PersistedStudioProjectCatalog {
+  schemaVersion: number;
+  projects: StudioProjectIdentity[];
+}
+
+export interface ReconciledStudioProjects {
+  projects: StudioProjectSummary[];
+  workspaceScopes: WorkspaceScopeSummary[];
+}
+
+export class StudioProjectCatalogError extends Error {
+  constructor(readonly code: Exclude<AgentMapErrorCode, "project_not_found">) {
+    super(
+      code === "unsupported_schema"
+        ? "Studio project state uses an unsupported schema"
+        : code === "malformed_state"
+          ? "Studio project state is malformed"
+          : "Studio project storage is unavailable",
+    );
+    this.name = "StudioProjectCatalogError";
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index])
+  );
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.codePointAt(0)!;
+    return code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+  });
+}
+
+function isSafeText(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value !== "" &&
+    value === value.trim() &&
+    !hasControlCharacter(value)
+  );
+}
+
+function isOpaqueId(value: unknown): value is string {
+  return (
+    isSafeText(value) &&
+    !value.includes("/") &&
+    !value.includes("\\") &&
+    !value.includes(":")
+  );
+}
+
+function isSafeDisplayName(value: unknown): value is string {
+  return isSafeText(value) && !value.includes("/") && !value.includes("\\");
+}
+
+export function isStudioProjectId(value: unknown): value is StudioProjectId {
+  return (
+    typeof value === "string" &&
+    /^project_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(
+      value,
+    )
+  );
+}
+
+function isBindingId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^root_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(
+      value,
+    )
+  );
+}
+
+function isTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    return new Date(value).toISOString() === value;
+  } catch {
+    return false;
+  }
+}
+
+function parseBinding(value: unknown): ProjectRootBinding | null {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["id", "repositoryId", "localRootRef", "status"]) ||
+    !isBindingId(value.id) ||
+    (value.repositoryId !== null && !isOpaqueId(value.repositoryId)) ||
+    !isSafeText(value.localRootRef) ||
+    (!path.posix.isAbsolute(value.localRootRef) &&
+      !path.win32.isAbsolute(value.localRootRef)) ||
+    (value.status !== "active" && value.status !== "missing")
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    repositoryId: value.repositoryId,
+    localRootRef: value.localRootRef,
+    status: value.status,
+  };
+}
+
+function parseProject(value: unknown): StudioProjectIdentity | null {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "projectId",
+      "identityVersion",
+      "displayName",
+      "rootBindings",
+      "legacyWorkspaceKeys",
+      "createdAt",
+      "updatedAt",
+    ]) ||
+    !isStudioProjectId(value.projectId) ||
+    !Number.isSafeInteger(value.identityVersion) ||
+    (value.identityVersion as number) < 1 ||
+    !isSafeDisplayName(value.displayName) ||
+    !Array.isArray(value.rootBindings) ||
+    !Array.isArray(value.legacyWorkspaceKeys) ||
+    !isTimestamp(value.createdAt) ||
+    !isTimestamp(value.updatedAt)
+  ) {
+    return null;
+  }
+  const rootBindings = value.rootBindings.map(parseBinding);
+  if (
+    rootBindings.some((binding) => binding === null) ||
+    value.legacyWorkspaceKeys.some((key) => !isSafeText(key))
+  ) {
+    return null;
+  }
+  const bindings = rootBindings as ProjectRootBinding[];
+  const keys = value.legacyWorkspaceKeys as string[];
+  if (
+    new Set(bindings.map((binding) => binding.id)).size !== bindings.length ||
+    new Set(bindings.map((binding) => binding.localRootRef)).size !==
+      bindings.length ||
+    new Set(keys).size !== keys.length
+  ) {
+    return null;
+  }
+  return {
+    projectId: value.projectId,
+    identityVersion: value.identityVersion as number,
+    displayName: value.displayName,
+    rootBindings: bindings,
+    legacyWorkspaceKeys: keys,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+  };
+}
+
+function parseCatalog(value: unknown): PersistedStudioProjectCatalog {
+  if (
+    isRecord(value) &&
+    Number.isSafeInteger(value.schemaVersion) &&
+    (value.schemaVersion as number) > STUDIO_PROJECT_CATALOG_SCHEMA_VERSION
+  ) {
+    throw new StudioProjectCatalogError("unsupported_schema");
+  }
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["schemaVersion", "projects"]) ||
+    !Number.isSafeInteger(value.schemaVersion) ||
+    !Array.isArray(value.projects)
+  ) {
+    throw new StudioProjectCatalogError("malformed_state");
+  }
+  if (value.schemaVersion !== STUDIO_PROJECT_CATALOG_SCHEMA_VERSION) {
+    throw new StudioProjectCatalogError(
+      (value.schemaVersion as number) > STUDIO_PROJECT_CATALOG_SCHEMA_VERSION
+        ? "unsupported_schema"
+        : "malformed_state",
+    );
+  }
+  const projects = value.projects.map(parseProject);
+  if (projects.some((project) => project === null)) {
+    throw new StudioProjectCatalogError("malformed_state");
+  }
+  const parsed = projects as StudioProjectIdentity[];
+  const bindingIds = parsed.flatMap((project) =>
+    project.rootBindings.map((binding) => binding.id),
+  );
+  const roots = parsed.flatMap((project) =>
+    project.rootBindings.map((binding) => binding.localRootRef),
+  );
+  const legacyKeys = parsed.flatMap((project) => project.legacyWorkspaceKeys);
+  if (
+    new Set(parsed.map((project) => project.projectId)).size !==
+      parsed.length ||
+    new Set(bindingIds).size !== bindingIds.length ||
+    new Set(roots).size !== roots.length ||
+    new Set(legacyKeys).size !== legacyKeys.length
+  ) {
+    throw new StudioProjectCatalogError("malformed_state");
+  }
+  return {
+    schemaVersion: STUDIO_PROJECT_CATALOG_SCHEMA_VERSION,
+    projects: parsed,
+  };
+}
+
+function publicSummary(project: StudioProjectIdentity): StudioProjectSummary {
+  return {
+    projectId: project.projectId,
+    identityVersion: project.identityVersion,
+    displayName: project.displayName,
+    bindings: project.rootBindings
+      .map(({ id, repositoryId, status }) => ({ id, repositoryId, status }))
+      .sort((left, right) => left.id.localeCompare(right.id)),
+    createdAt: project.createdAt,
+    updatedAt: project.updatedAt,
+  };
+}
+
+function cloneProjects(
+  projects: readonly StudioProjectIdentity[],
+): StudioProjectIdentity[] {
+  return projects.map((project) => ({
+    ...project,
+    rootBindings: project.rootBindings.map((binding) => ({ ...binding })),
+    legacyWorkspaceKeys: [...project.legacyWorkspaceKeys],
+  }));
+}
+
+function sortProjects(projects: StudioProjectIdentity[]): void {
+  projects.sort((left, right) => left.projectId.localeCompare(right.projectId));
+  for (const project of projects) {
+    project.rootBindings.sort((left, right) => left.id.localeCompare(right.id));
+    project.legacyWorkspaceKeys.sort((left, right) =>
+      left.localeCompare(right),
+    );
+  }
+}
+
+function storageError(): StudioProjectCatalogError {
+  return new StudioProjectCatalogError("storage_unavailable");
+}
+
+/**
+ * Durable, serialized owner of Studio project identity. Catalog reads never
+ * run package inventory or source discovery; callers provide the already
+ * allow-listed workspace scopes they want reconciled.
+ */
+export class StudioProjectCatalog {
+  private projects: StudioProjectIdentity[] | null = null;
+  private loadPromise: Promise<void> | null = null;
+  private mutationQueue: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly catalogPath: string,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.mutationQueue.then(operation, operation);
+    this.mutationQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private async load(): Promise<void> {
+    if (this.projects !== null) return;
+    if (!this.loadPromise) {
+      this.loadPromise = (async () => {
+        let raw: string;
+        try {
+          raw = await fs.readFile(this.catalogPath, "utf8");
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            this.projects = [];
+            return;
+          }
+          throw storageError();
+        }
+        let decoded: unknown;
+        try {
+          decoded = JSON.parse(raw) as unknown;
+        } catch {
+          throw new StudioProjectCatalogError("malformed_state");
+        }
+        this.projects = parseCatalog(decoded).projects;
+      })().finally(() => {
+        this.loadPromise = null;
+      });
+    }
+    await this.loadPromise;
+  }
+
+  private async persist(projects: StudioProjectIdentity[]): Promise<void> {
+    sortProjects(projects);
+    const directory = path.dirname(this.catalogPath);
+    const temporary = `${this.catalogPath}.tmp-${process.pid}-${randomUUID()}`;
+    try {
+      await fs.mkdir(directory, { recursive: true });
+      await fs.writeFile(
+        temporary,
+        `${JSON.stringify(
+          {
+            schemaVersion: STUDIO_PROJECT_CATALOG_SCHEMA_VERSION,
+            projects,
+          } satisfies PersistedStudioProjectCatalog,
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      await fs.rename(temporary, this.catalogPath);
+    } catch {
+      throw storageError();
+    } finally {
+      await fs.rm(temporary, { force: true }).catch(() => {});
+    }
+  }
+
+  private timestamp(): string {
+    return this.now().toISOString();
+  }
+
+  async list(): Promise<StudioProjectSummary[]> {
+    await this.mutationQueue;
+    await this.load();
+    return this.projects!.map(publicSummary);
+  }
+
+  async create(displayName: string): Promise<StudioProjectSummary> {
+    if (!isSafeDisplayName(displayName)) {
+      throw new StudioProjectCatalogError("malformed_state");
+    }
+    return this.enqueue(async () => {
+      await this.load();
+      const timestamp = this.timestamp();
+      const project: StudioProjectIdentity = {
+        projectId: `project_${randomUUID()}`,
+        identityVersion: 1,
+        displayName,
+        rootBindings: [],
+        legacyWorkspaceKeys: [],
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+      const next = [...cloneProjects(this.projects!), project];
+      await this.persist(next);
+      this.projects = next;
+      return publicSummary(project);
+    });
+  }
+
+  /**
+   * Reconciles existing allow-listed roots and allocates an identity only for
+   * roots not already known by private binding or migration alias.
+   */
+  async reconcile(
+    scopes: readonly WorkspaceScopeSummary[],
+  ): Promise<ReconciledStudioProjects> {
+    return this.enqueue(async () => {
+      await this.load();
+      const next = cloneProjects(this.projects!);
+      const dedupedScopes = new Map<string, WorkspaceScopeSummary>();
+      const rootsByLegacyKey = new Map<string, string>();
+      for (const scope of scopes) {
+        if (!isSafeText(scope.workspaceKey) || !isSafeText(scope.cwd)) {
+          throw new StudioProjectCatalogError("malformed_state");
+        }
+        const canonical = canonicalGraphPath(scope.cwd);
+        const aliasedRoot = rootsByLegacyKey.get(scope.workspaceKey);
+        if (aliasedRoot !== undefined && aliasedRoot !== canonical) {
+          throw new StudioProjectCatalogError("malformed_state");
+        }
+        rootsByLegacyKey.set(scope.workspaceKey, canonical);
+        if (!dedupedScopes.has(canonical)) {
+          // Canonical form is private matching evidence only. Preserve the
+          // existing lexical cwd in AppState so this additive join cannot
+          // perturb legacy rail/session path equality.
+          dedupedScopes.set(canonical, { ...scope });
+        }
+      }
+
+      const activeRoots = new Set(dedupedScopes.keys());
+      let changed = false;
+      for (const project of next) {
+        let projectChanged = false;
+        for (const binding of project.rootBindings) {
+          const status = activeRoots.has(binding.localRootRef)
+            ? "active"
+            : "missing";
+          if (binding.status !== status) {
+            binding.status = status;
+            projectChanged = true;
+          }
+        }
+        if (projectChanged) {
+          project.identityVersion += 1;
+          project.updatedAt = this.timestamp();
+          changed = true;
+        }
+      }
+
+      const reconciledScopes: WorkspaceScopeSummary[] = [];
+      for (const [canonical, scope] of dedupedScopes) {
+        const matchingProjects = next.filter(
+          (candidate) =>
+            candidate.legacyWorkspaceKeys.includes(scope.workspaceKey) ||
+            candidate.rootBindings.some(
+              (binding) => binding.localRootRef === canonical,
+            ),
+        );
+        if (matchingProjects.length > 1) {
+          throw new StudioProjectCatalogError("malformed_state");
+        }
+        let project = matchingProjects[0];
+        if (!project) {
+          const timestamp = this.timestamp();
+          project = {
+            projectId: `project_${randomUUID()}`,
+            identityVersion: 1,
+            displayName: path.basename(canonical) || "Project",
+            rootBindings: [
+              {
+                id: `root_${randomUUID()}`,
+                repositoryId: null,
+                localRootRef: canonical,
+                status: "active",
+              },
+            ],
+            legacyWorkspaceKeys: [scope.workspaceKey],
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          };
+          next.push(project);
+          changed = true;
+        } else {
+          let projectChanged = false;
+          if (!project.legacyWorkspaceKeys.includes(scope.workspaceKey)) {
+            project.legacyWorkspaceKeys.push(scope.workspaceKey);
+            projectChanged = true;
+          }
+          let binding = project.rootBindings.find(
+            (candidate) => candidate.localRootRef === canonical,
+          );
+          if (!binding) {
+            binding = {
+              id: `root_${randomUUID()}`,
+              repositoryId: null,
+              localRootRef: canonical,
+              status: "active",
+            };
+            project.rootBindings.push(binding);
+            projectChanged = true;
+          } else if (binding.status !== "active") {
+            binding.status = "active";
+            projectChanged = true;
+          }
+          if (projectChanged) {
+            project.identityVersion += 1;
+            project.updatedAt = this.timestamp();
+            changed = true;
+          }
+        }
+        reconciledScopes.push({ ...scope, projectId: project.projectId });
+      }
+
+      if (changed) {
+        await this.persist(next);
+        this.projects = next;
+      }
+      return {
+        projects: (changed ? next : this.projects!).map(publicSummary),
+        workspaceScopes: reconciledScopes.sort((left, right) =>
+          left.cwd.localeCompare(right.cwd),
+        ),
+      };
+    });
+  }
+
+  /** Resolve only identities owned by this durable local catalog. */
+  async resolve(
+    projectId: StudioProjectId,
+  ): Promise<StudioProjectSummary | null> {
+    if (!isStudioProjectId(projectId)) return null;
+    await this.mutationQueue;
+    await this.load();
+    const project = this.projects!.find(
+      (candidate) => candidate.projectId === projectId,
+    );
+    return project ? publicSummary(project) : null;
+  }
+
+  /** Explicit move/rebind seam: identity survives path and WorkspaceKey churn. */
+  async moveRootBinding(
+    projectId: StudioProjectId,
+    bindingId: string,
+    root: string,
+    legacyWorkspaceKey?: string,
+  ): Promise<StudioProjectSummary> {
+    return this.enqueue(async () => {
+      await this.load();
+      const next = cloneProjects(this.projects!);
+      const project = next.find(
+        (candidate) => candidate.projectId === projectId,
+      );
+      const binding = project?.rootBindings.find(
+        (candidate) => candidate.id === bindingId,
+      );
+      if (!project || !binding || !isSafeText(root)) {
+        throw new StudioProjectCatalogError("malformed_state");
+      }
+      if (legacyWorkspaceKey !== undefined && !isSafeText(legacyWorkspaceKey)) {
+        throw new StudioProjectCatalogError("malformed_state");
+      }
+      const canonical = canonicalGraphPath(root);
+      if (
+        next.some(
+          (candidate) =>
+            candidate.projectId !== projectId &&
+            (candidate.rootBindings.some(
+              (candidateBinding) => candidateBinding.localRootRef === canonical,
+            ) ||
+              (legacyWorkspaceKey !== undefined &&
+                candidate.legacyWorkspaceKeys.includes(legacyWorkspaceKey))),
+        )
+      ) {
+        throw new StudioProjectCatalogError("malformed_state");
+      }
+      binding.localRootRef = canonical;
+      binding.status = "active";
+      if (
+        legacyWorkspaceKey &&
+        !project.legacyWorkspaceKeys.includes(legacyWorkspaceKey)
+      ) {
+        project.legacyWorkspaceKeys.push(legacyWorkspaceKey);
+      }
+      project.identityVersion += 1;
+      project.updatedAt = this.timestamp();
+      await this.persist(next);
+      this.projects = next;
+      return publicSummary(project);
+    });
+  }
+
+  async addRootBinding(
+    projectId: StudioProjectId,
+    root: string,
+    options: { repositoryId?: string | null; legacyWorkspaceKey?: string } = {},
+  ): Promise<StudioProjectSummary> {
+    return this.enqueue(async () => {
+      await this.load();
+      const next = cloneProjects(this.projects!);
+      const project = next.find(
+        (candidate) => candidate.projectId === projectId,
+      );
+      if (
+        !project ||
+        !isSafeText(root) ||
+        (options.repositoryId !== undefined &&
+          options.repositoryId !== null &&
+          !isOpaqueId(options.repositoryId)) ||
+        (options.legacyWorkspaceKey !== undefined &&
+          !isSafeText(options.legacyWorkspaceKey))
+      ) {
+        throw new StudioProjectCatalogError("malformed_state");
+      }
+      const canonical = canonicalGraphPath(root);
+      if (
+        next.some(
+          (candidate) =>
+            candidate.projectId !== projectId &&
+            (candidate.rootBindings.some(
+              (binding) => binding.localRootRef === canonical,
+            ) ||
+              (options.legacyWorkspaceKey !== undefined &&
+                candidate.legacyWorkspaceKeys.includes(
+                  options.legacyWorkspaceKey,
+                ))),
+        )
+      ) {
+        throw new StudioProjectCatalogError("malformed_state");
+      }
+      const existing = project.rootBindings.find(
+        (binding) => binding.localRootRef === canonical,
+      );
+      if (existing) {
+        existing.status = "active";
+        if (options.repositoryId !== undefined) {
+          existing.repositoryId = options.repositoryId;
+        }
+      } else {
+        project.rootBindings.push({
+          id: `root_${randomUUID()}`,
+          repositoryId: options.repositoryId ?? null,
+          localRootRef: canonical,
+          status: "active",
+        });
+      }
+      if (
+        options.legacyWorkspaceKey &&
+        !project.legacyWorkspaceKeys.includes(options.legacyWorkspaceKey)
+      ) {
+        project.legacyWorkspaceKeys.push(options.legacyWorkspaceKey);
+      }
+      project.identityVersion += 1;
+      project.updatedAt = this.timestamp();
+      await this.persist(next);
+      this.projects = next;
+      return publicSummary(project);
+    });
+  }
+}

--- a/packages/harness/src/server/agent-map-auth-wiring.test.ts
+++ b/packages/harness/src/server/agent-map-auth-wiring.test.ts
@@ -1,0 +1,130 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  HarnessAdapter,
+  LaunchOpts,
+  SpawnSpec,
+} from "../shared/types.js";
+import { startServer, type HarnessServer } from "./index.js";
+
+const BOOT_TOKEN = "trusted-host-token";
+
+function tokenCapturingAdapter(tokenPath: string): HarnessAdapter {
+  const launch = (opts: LaunchOpts): SpawnSpec => ({
+    command: "bash",
+    args: [
+      "-c",
+      'printf "%s" "$SAPIOM_HARNESS_INGEST_TOKEN" > "$SAPIOM_TEST_INGEST_TOKEN_PATH"; exec bash',
+    ],
+    env: { SAPIOM_TEST_INGEST_TOKEN_PATH: tokenPath },
+    cwd: opts.cwd,
+  });
+  return {
+    id: "claude-code",
+    eventSource: "hooks",
+    doctor: async () => [],
+    launch,
+    resume: (_agentSessionId, opts) => launch(opts),
+    listPastSessions: async () => [],
+    canResume: async () => true,
+  };
+}
+
+describe("coding-agent authorization boundary", () => {
+  let root: string;
+  let projectRoot: string;
+  let tokenPath: string;
+  let server: HarnessServer | undefined;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "agent-map-auth-wiring-"));
+    projectRoot = path.join(root, "project");
+    tokenPath = path.join(root, "ingest-token");
+    await fs.mkdir(projectRoot);
+  });
+
+  afterEach(async () => {
+    await server?.sessionManager.flush();
+    await server?.close();
+    await server?.sessionManager.flush();
+    server = undefined;
+    // Session exit schedules generated-dir cleanup. Retry if that bounded
+    // removal overlaps this fixture's own recursive cleanup.
+    await fs.rm(root, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 50,
+    });
+  });
+
+  it("allows the PTY token to ingest hooks but rejects it on project mutations", async () => {
+    server = await startServer({
+      port: 0,
+      bootToken: BOOT_TOKEN,
+      telemetryOptIn: false,
+      adapters: { "claude-code": tokenCapturingAdapter(tokenPath) },
+      stateRoot: root,
+      launchDir: projectRoot,
+      autoCreateSession: false,
+      loadSystemPrompt: async () => "",
+    });
+    const session = await server.sessionManager.create({
+      cwd: projectRoot,
+      harness: "claude-code",
+    });
+    let ingestToken = "";
+    await vi.waitFor(async () => {
+      ingestToken = await fs.readFile(tokenPath, "utf8");
+      expect(ingestToken).not.toBe("");
+    });
+
+    expect(ingestToken).not.toBe(BOOT_TOKEN);
+    const baseUrl = `http://127.0.0.1:${server.port}`;
+    const mutation = await fetch(`${baseUrl}/api/projects`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Harness-Token": ingestToken,
+      },
+      body: JSON.stringify({ displayName: "Model-controlled project" }),
+    });
+    expect(mutation.status).toBe(401);
+
+    const bootTokenIngest = await fetch(`${baseUrl}/ingest`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${BOOT_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        hookEvent: "SessionStart",
+        harnessSessionId: session.id,
+        payload: { session_id: "agent-wrong-token" },
+      }),
+    });
+    expect(bootTokenIngest.status).toBe(401);
+
+    const ingest = await fetch(`${baseUrl}/ingest`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${ingestToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        hookEvent: "SessionStart",
+        harnessSessionId: session.id,
+        payload: { session_id: "agent-ingest-only", source: "startup" },
+      }),
+    });
+    expect(ingest.status).toBe(200);
+    await vi.waitFor(() => {
+      expect(server?.sessionManager.get(session.id)?.agentSessionId).toBe(
+        "agent-ingest-only",
+      );
+    });
+  });
+});

--- a/packages/harness/src/server/agent-map-auth-wiring.test.ts
+++ b/packages/harness/src/server/agent-map-auth-wiring.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { createServer as createNetServer, type AddressInfo } from "node:net";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {
@@ -17,7 +18,7 @@ function tokenCapturingAdapter(tokenPath: string): HarnessAdapter {
     command: "bash",
     args: [
       "-c",
-      'printf "%s" "$SAPIOM_HARNESS_INGEST_TOKEN" > "$SAPIOM_TEST_INGEST_TOKEN_PATH"; exec bash',
+      'printf \'{"ingestUrl":"%s","ingestToken":"%s"}\' "$SAPIOM_HARNESS_INGEST_URL" "$SAPIOM_HARNESS_INGEST_TOKEN" > "$SAPIOM_TEST_INGEST_TOKEN_PATH"; exec bash',
     ],
     env: { SAPIOM_TEST_INGEST_TOKEN_PATH: tokenPath },
     cwd: opts.cwd,
@@ -33,17 +34,34 @@ function tokenCapturingAdapter(tokenPath: string): HarnessAdapter {
   };
 }
 
+async function unusedPort(): Promise<number> {
+  const probe = createNetServer();
+  await new Promise<void>((resolve) => probe.listen(0, "127.0.0.1", resolve));
+  const port = (probe.address() as AddressInfo).port;
+  await new Promise<void>((resolve, reject) =>
+    probe.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
+
 describe("coding-agent authorization boundary", () => {
   let root: string;
   let projectRoot: string;
   let tokenPath: string;
+  let webDir: string;
   let server: HarnessServer | undefined;
 
   beforeEach(async () => {
     root = await fs.mkdtemp(path.join(os.tmpdir(), "agent-map-auth-wiring-"));
     projectRoot = path.join(root, "project");
     tokenPath = path.join(root, "ingest-token");
+    webDir = path.join(root, "web");
     await fs.mkdir(projectRoot);
+    await fs.mkdir(webDir);
+    await fs.writeFile(
+      path.join(webDir, "index.html"),
+      '<!doctype html><html><head></head><body><div id="root"></div></body></html>',
+    );
   });
 
   afterEach(async () => {
@@ -62,13 +80,15 @@ describe("coding-agent authorization boundary", () => {
   });
 
   it("allows the PTY token to ingest hooks but rejects it on project mutations", async () => {
+    const port = await unusedPort();
     server = await startServer({
-      port: 0,
+      port,
       bootToken: BOOT_TOKEN,
       telemetryOptIn: false,
       adapters: { "claude-code": tokenCapturingAdapter(tokenPath) },
       stateRoot: root,
       launchDir: projectRoot,
+      webDir,
       autoCreateSession: false,
       loadSystemPrompt: async () => "",
     });
@@ -76,14 +96,26 @@ describe("coding-agent authorization boundary", () => {
       cwd: projectRoot,
       harness: "claude-code",
     });
-    let ingestToken = "";
+    let ptyEnvironment: { ingestUrl: string; ingestToken: string } | undefined;
     await vi.waitFor(async () => {
-      ingestToken = await fs.readFile(tokenPath, "utf8");
-      expect(ingestToken).not.toBe("");
+      ptyEnvironment = JSON.parse(await fs.readFile(tokenPath, "utf8")) as {
+        ingestUrl: string;
+        ingestToken: string;
+      };
+      expect(ptyEnvironment.ingestToken).not.toBe("");
     });
 
+    const { ingestToken, ingestUrl } = ptyEnvironment!;
     expect(ingestToken).not.toBe(BOOT_TOKEN);
-    const baseUrl = `http://127.0.0.1:${server.port}`;
+    expect(JSON.stringify(ptyEnvironment)).not.toContain(server.uiToken);
+    const baseUrl = new URL(ingestUrl).origin;
+    expect(baseUrl).toBe(`http://127.0.0.1:${server.port}`);
+
+    // The model can fetch the origin it receives for hooks, but without the
+    // host-only UI launch capability the HTML contains no privileged token.
+    const bareHtml = await (await fetch(`${baseUrl}/`)).text();
+    expect(bareHtml).not.toContain(BOOT_TOKEN);
+    expect(bareHtml).not.toContain(server.uiToken);
     const mutation = await fetch(`${baseUrl}/api/projects`, {
       method: "POST",
       headers: {
@@ -93,6 +125,22 @@ describe("coding-agent authorization boundary", () => {
       body: JSON.stringify({ displayName: "Model-controlled project" }),
     });
     expect(mutation.status).toBe(401);
+
+    const legitimateLaunch = await fetch(
+      `${baseUrl}/?uiToken=${encodeURIComponent(server.uiToken)}`,
+      { redirect: "manual" },
+    );
+    expect(legitimateLaunch.status).toBe(303);
+    expect(legitimateLaunch.headers.get("location")).not.toContain("uiToken");
+    const uiCookie = legitimateLaunch.headers
+      .get("set-cookie")
+      ?.split(";", 1)[0];
+    const legitimateHtml = await (
+      await fetch(`${baseUrl}${legitimateLaunch.headers.get("location")!}`, {
+        headers: { cookie: uiCookie! },
+      })
+    ).text();
+    expect(legitimateHtml).toContain(JSON.stringify(BOOT_TOKEN));
 
     const bootTokenIngest = await fetch(`${baseUrl}/ingest`, {
       method: "POST",

--- a/packages/harness/src/server/agent-map.test.ts
+++ b/packages/harness/src/server/agent-map.test.ts
@@ -1,0 +1,149 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AddressInfo } from "node:net";
+import express from "express";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AgentMapWorkspaceStore } from "../core/agent-map-workspace-store.js";
+import { StudioProjectCatalog } from "../core/studio-project-catalog.js";
+import type { AgentMapWorkspaceResponse } from "../shared/agent-map.js";
+import { createBootTokenMiddleware } from "./auth.js";
+import { createAgentMapRouter } from "./agent-map.js";
+
+describe("createAgentMapRouter", () => {
+  const roots: string[] = [];
+  let server: ReturnType<express.Express["listen"]> | undefined;
+
+  afterEach(async () => {
+    if (server)
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+    server = undefined;
+    await Promise.all(
+      roots
+        .splice(0)
+        .map((root) => fs.rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  async function start() {
+    const stateRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "agent-map-router-"),
+    );
+    roots.push(stateRoot);
+    const privateRoot = path.join(stateRoot, "private-market-research");
+    await fs.mkdir(privateRoot);
+    const scope = { workspaceKey: "workspace-private-alias", cwd: privateRoot };
+    const catalog = new StudioProjectCatalog(
+      path.join(stateRoot, "studio-projects.json"),
+    );
+    const project = (await catalog.reconcile([scope])).projects[0]!;
+    const listWorkspaceScopes = vi.fn(async () => [scope]);
+    const onEvent = vi.fn();
+    const store = new AgentMapWorkspaceStore(
+      path.join(stateRoot, "agent-map"),
+      { onEvent },
+    );
+    const app = express();
+    app.use("/api", createBootTokenMiddleware("test-token"));
+    app.use(
+      "/api",
+      createAgentMapRouter({ catalog, store, listWorkspaceScopes }),
+    );
+    server = app.listen(0);
+    const address = server.address() as AddressInfo;
+    return {
+      baseUrl: `http://127.0.0.1:${address.port}`,
+      stateRoot,
+      privateRoot,
+      project,
+      listWorkspaceScopes,
+      onEvent,
+    };
+  }
+
+  it("is boot-token protected, lazy, idempotent, and path-free", async () => {
+    const fixture = await start();
+    const route = `${fixture.baseUrl}/api/projects/${fixture.project.projectId}/agent-map/workspace`;
+    const workspacePath = path.join(
+      fixture.stateRoot,
+      "agent-map",
+      "projects",
+      fixture.project.projectId,
+      "workspace.json",
+    );
+
+    expect((await fetch(route)).status).toBe(401);
+    await expect(fs.stat(workspacePath)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    const first = await fetch(route, {
+      headers: { "X-Harness-Token": "test-token" },
+    });
+    const second = await fetch(route, {
+      headers: { "X-Harness-Token": "test-token" },
+    });
+    const firstBody = (await first.json()) as AgentMapWorkspaceResponse;
+    const secondBody = (await second.json()) as AgentMapWorkspaceResponse;
+
+    expect(first.status).toBe(200);
+    expect(first.headers.get("Cache-Control")).toBe("no-store");
+    expect(secondBody).toEqual(firstBody);
+    expect(firstBody.workspace).toMatchObject({
+      projectId: fixture.project.projectId,
+      schemaVersion: 1,
+      recordVersion: 1,
+      confirmedRevisionId: null,
+      activeProposalId: null,
+      projectBuildPlanId: null,
+    });
+    const publicJson = JSON.stringify(firstBody);
+    expect(publicJson).not.toContain(fixture.privateRoot);
+    expect(publicJson).not.toContain("workspace-private-alias");
+    expect(fixture.onEvent).toHaveBeenCalledTimes(1);
+    expect(fixture.listWorkspaceScopes).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns a bounded 404 before touching workspace storage", async () => {
+    const fixture = await start();
+    const unknown = "project_00000000-0000-4000-8000-000000000099";
+    const response = await fetch(
+      `${fixture.baseUrl}/api/projects/${unknown}/agent-map/workspace`,
+      { headers: { "X-Harness-Token": "test-token" } },
+    );
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({
+      code: "project_not_found",
+      error: "Studio project not found",
+    });
+    await expect(
+      fs.stat(path.join(fixture.stateRoot, "agent-map", "projects", unknown)),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+    expect(fixture.onEvent).not.toHaveBeenCalled();
+  });
+
+  it("bounds malformed persisted state and never repairs it", async () => {
+    const fixture = await start();
+    const workspacePath = path.join(
+      fixture.stateRoot,
+      "agent-map",
+      "projects",
+      fixture.project.projectId,
+      "workspace.json",
+    );
+    await fs.mkdir(path.dirname(workspacePath), { recursive: true });
+    await fs.writeFile(workspacePath, "{bad-json");
+    const response = await fetch(
+      `${fixture.baseUrl}/api/projects/${fixture.project.projectId}/agent-map/workspace`,
+      { headers: { "X-Harness-Token": "test-token" } },
+    );
+
+    expect(response.status).toBe(500);
+    expect(await response.json()).toEqual({
+      code: "malformed_state",
+      error: "Agent Map state is malformed",
+    });
+    expect(await fs.readFile(workspacePath, "utf8")).toBe("{bad-json");
+  });
+});

--- a/packages/harness/src/server/agent-map.test.ts
+++ b/packages/harness/src/server/agent-map.test.ts
@@ -34,11 +34,12 @@ describe("createAgentMapRouter", () => {
     const privateRoot = path.join(stateRoot, "private-market-research");
     await fs.mkdir(privateRoot);
     const scope = { workspaceKey: "workspace-private-alias", cwd: privateRoot };
+    const scopes = [scope];
     const catalog = new StudioProjectCatalog(
       path.join(stateRoot, "studio-projects.json"),
     );
     const project = (await catalog.reconcile([scope])).projects[0]!;
-    const listWorkspaceScopes = vi.fn(async () => [scope]);
+    const listWorkspaceScopes = vi.fn(async () => [...scopes]);
     const onEvent = vi.fn();
     const store = new AgentMapWorkspaceStore(
       path.join(stateRoot, "agent-map"),
@@ -46,6 +47,7 @@ describe("createAgentMapRouter", () => {
     );
     const app = express();
     app.use("/api", createBootTokenMiddleware("test-token"));
+    app.use("/api", express.json());
     app.use(
       "/api",
       createAgentMapRouter({ catalog, store, listWorkspaceScopes }),
@@ -57,6 +59,8 @@ describe("createAgentMapRouter", () => {
       stateRoot,
       privateRoot,
       project,
+      catalog,
+      scopes,
       listWorkspaceScopes,
       onEvent,
     };
@@ -102,6 +106,130 @@ describe("createAgentMapRouter", () => {
     expect(publicJson).not.toContain("workspace-private-alias");
     expect(fixture.onEvent).toHaveBeenCalledTimes(1);
     expect(fixture.listWorkspaceScopes).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates a zero-binding project without eagerly creating map state", async () => {
+    const fixture = await start();
+    const response = await fetch(`${fixture.baseUrl}/api/projects`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Harness-Token": "test-token",
+      },
+      body: JSON.stringify({ displayName: "Empty plan" }),
+    });
+    const project = (await response.json()) as {
+      projectId: string;
+      bindings: unknown[];
+    };
+
+    expect(response.status).toBe(201);
+    expect(project.bindings).toEqual([]);
+    await expect(
+      fs.stat(
+        path.join(
+          fixture.stateRoot,
+          "agent-map",
+          "projects",
+          project.projectId,
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves identity when the authenticated boundary moves and adds root bindings", async () => {
+    const fixture = await start();
+    const movedRoot = path.join(fixture.stateRoot, "moved-market-research");
+    const secondRoot = path.join(fixture.stateRoot, "publisher-repository");
+    await Promise.all([fs.mkdir(movedRoot), fs.mkdir(secondRoot)]);
+    fixture.scopes.splice(
+      0,
+      fixture.scopes.length,
+      { workspaceKey: "workspace-moved", cwd: movedRoot },
+      { workspaceKey: "workspace-publisher", cwd: secondRoot },
+    );
+    const headers = {
+      "Content-Type": "application/json",
+      "X-Harness-Token": "test-token",
+    };
+
+    const moved = await fetch(
+      `${fixture.baseUrl}/api/projects/${fixture.project.projectId}/root-bindings/${fixture.project.bindings[0]!.id}`,
+      {
+        method: "PUT",
+        headers,
+        body: JSON.stringify({ root: movedRoot }),
+      },
+    );
+    const added = await fetch(
+      `${fixture.baseUrl}/api/projects/${fixture.project.projectId}/root-bindings`,
+      {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ root: secondRoot }),
+      },
+    );
+    const opened = await fetch(
+      `${fixture.baseUrl}/api/projects/${fixture.project.projectId}/agent-map/workspace`,
+      { headers },
+    );
+    const movedBody = (await moved.json()) as Record<string, unknown>;
+    const addedBody = (await added.json()) as Record<string, unknown>;
+    const openedBody = (await opened.json()) as AgentMapWorkspaceResponse;
+
+    expect(moved.status).toBe(200);
+    expect(added.status).toBe(201);
+    expect(opened.status).toBe(200);
+    expect(movedBody.projectId).toBe(fixture.project.projectId);
+    expect(addedBody.projectId).toBe(fixture.project.projectId);
+    expect(openedBody.project.projectId).toBe(fixture.project.projectId);
+    expect(openedBody.project.bindings).toHaveLength(2);
+    for (const body of [movedBody, addedBody, openedBody]) {
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain(movedRoot);
+      expect(serialized).not.toContain(secondRoot);
+      expect(serialized).not.toContain("workspace-moved");
+      expect(serialized).not.toContain("repositoryId");
+    }
+
+    const restarted = await new StudioProjectCatalog(
+      path.join(fixture.stateRoot, "studio-projects.json"),
+    ).reconcile(fixture.scopes);
+    expect(restarted.projects).toHaveLength(1);
+    expect(restarted.projects[0]?.projectId).toBe(fixture.project.projectId);
+    expect(restarted.projects[0]?.bindings).toHaveLength(2);
+  });
+
+  it("does not expose root association without the boot token or allow list", async () => {
+    const fixture = await start();
+    const unknownRoot = path.join(fixture.stateRoot, "not-opened");
+    await fs.mkdir(unknownRoot);
+    const route = `${fixture.baseUrl}/api/projects/${fixture.project.projectId}/root-bindings`;
+
+    expect(
+      (
+        await fetch(route, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ root: unknownRoot }),
+        })
+      ).status,
+    ).toBe(401);
+    expect(
+      (
+        await fetch(route, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "X-Harness-Token": "test-token",
+          },
+          body: JSON.stringify({ root: unknownRoot }),
+        })
+      ).status,
+    ).toBe(404);
+    expect(
+      (await fixture.catalog.resolve(fixture.project.projectId))?.bindings,
+    ).toHaveLength(1);
   });
 
   it("returns a bounded 404 before touching workspace storage", async () => {

--- a/packages/harness/src/server/agent-map.ts
+++ b/packages/harness/src/server/agent-map.ts
@@ -1,0 +1,69 @@
+import { Router } from "express";
+
+import {
+  type AgentMapErrorCode,
+  type AgentMapErrorResponse,
+  type AgentMapWorkspaceResponse,
+} from "../shared/agent-map.js";
+import type { WorkspaceScopeSummary } from "../shared/system-graph.js";
+import {
+  AgentMapWorkspaceStore,
+  AgentMapWorkspaceStoreError,
+} from "../core/agent-map-workspace-store.js";
+import {
+  StudioProjectCatalog,
+  StudioProjectCatalogError,
+} from "../core/studio-project-catalog.js";
+
+export interface AgentMapRouterOptions {
+  catalog: StudioProjectCatalog;
+  store: AgentMapWorkspaceStore;
+  /** Existing allow-listed roots only; this callback must not scan source. */
+  listWorkspaceScopes: () =>
+    | readonly WorkspaceScopeSummary[]
+    | Promise<readonly WorkspaceScopeSummary[]>;
+}
+
+const ERROR_MESSAGES: Record<AgentMapErrorCode, string> = {
+  project_not_found: "Studio project not found",
+  malformed_state: "Agent Map state is malformed",
+  unsupported_schema: "Agent Map state uses an unsupported schema",
+  storage_unavailable: "Agent Map storage is unavailable",
+};
+
+function errorBody(code: AgentMapErrorCode): AgentMapErrorResponse {
+  return { code, error: ERROR_MESSAGES[code] };
+}
+
+/** Mounted beneath the boot-token-protected `/api` boundary. */
+export function createAgentMapRouter(options: AgentMapRouterOptions): Router {
+  const router = Router();
+  router.get("/projects/:projectId/agent-map/workspace", async (req, res) => {
+    try {
+      await options.catalog.reconcile(await options.listWorkspaceScopes());
+      const project = await options.catalog.resolve(req.params.projectId);
+      if (!project) {
+        res.status(404).json(errorBody("project_not_found"));
+        return;
+      }
+
+      // Project resolution intentionally happens before the lazy initializer:
+      // an arbitrary/cross-instance ID can never create a state directory.
+      const workspace = await options.store.readOrCreate(project.projectId);
+      res
+        .status(200)
+        .setHeader("Cache-Control", "no-store")
+        .json({ project, workspace } satisfies AgentMapWorkspaceResponse);
+    } catch (error) {
+      const bounded =
+        error instanceof AgentMapWorkspaceStoreError ||
+        error instanceof StudioProjectCatalogError
+          ? error.code
+          : "storage_unavailable";
+      res
+        .status(bounded === "storage_unavailable" ? 503 : 500)
+        .json(errorBody(bounded));
+    }
+  });
+  return router;
+}

--- a/packages/harness/src/server/agent-map.ts
+++ b/packages/harness/src/server/agent-map.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { z } from "zod";
 
 import {
   type AgentMapErrorCode,
@@ -14,6 +15,7 @@ import {
   StudioProjectCatalog,
   StudioProjectCatalogError,
 } from "../core/studio-project-catalog.js";
+import { canonicalGraphPath } from "../core/canonical-graph-path.js";
 
 export interface AgentMapRouterOptions {
   catalog: StudioProjectCatalog;
@@ -35,9 +37,131 @@ function errorBody(code: AgentMapErrorCode): AgentMapErrorResponse {
   return { code, error: ERROR_MESSAGES[code] };
 }
 
+const rootAssociationSchema = z.object({ root: z.string().min(1) }).strict();
+const createProjectSchema = z
+  .object({ displayName: z.string().min(1) })
+  .strict();
+
+async function allowlistedScope(
+  options: AgentMapRouterOptions,
+  requestedRoot: string,
+): Promise<WorkspaceScopeSummary | null> {
+  let requested: string;
+  try {
+    requested = canonicalGraphPath(requestedRoot);
+  } catch {
+    return null;
+  }
+  for (const scope of await options.listWorkspaceScopes()) {
+    try {
+      if (canonicalGraphPath(scope.cwd) === requested) return scope;
+    } catch {
+      // One malformed live scope cannot authorize or poison another root.
+    }
+  }
+  return null;
+}
+
 /** Mounted beneath the boot-token-protected `/api` boundary. */
 export function createAgentMapRouter(options: AgentMapRouterOptions): Router {
   const router = Router();
+
+  router.post("/projects", async (req, res) => {
+    const parsed = createProjectSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json(errorBody("malformed_state"));
+      return;
+    }
+    try {
+      const project = await options.catalog.create(parsed.data.displayName);
+      res.status(201).setHeader("Cache-Control", "no-store").json(project);
+    } catch (error) {
+      const bounded =
+        error instanceof StudioProjectCatalogError
+          ? error.code
+          : "storage_unavailable";
+      res
+        .status(bounded === "storage_unavailable" ? 503 : 400)
+        .json(errorBody(bounded));
+    }
+  });
+
+  // These two mutations are the trusted project-open association boundary.
+  // The boot-token-authenticated client names an existing durable project and
+  // a root already allow-listed by Studio. The catalog, not a path/hash/model,
+  // owns whether that root moves an existing binding or adds another one.
+  router.post("/projects/:projectId/root-bindings", async (req, res) => {
+    const parsed = rootAssociationSchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json(errorBody("malformed_state"));
+      return;
+    }
+    try {
+      const project = await options.catalog.resolve(req.params.projectId);
+      if (!project) {
+        res.status(404).json(errorBody("project_not_found"));
+        return;
+      }
+      const scope = await allowlistedScope(options, parsed.data.root);
+      if (!scope) {
+        res.status(404).json(errorBody("project_not_found"));
+        return;
+      }
+      const updated = await options.catalog.addRootBinding(
+        project.projectId,
+        scope.cwd,
+        { legacyWorkspaceKey: scope.workspaceKey },
+      );
+      res.status(201).setHeader("Cache-Control", "no-store").json(updated);
+    } catch (error) {
+      const bounded =
+        error instanceof StudioProjectCatalogError
+          ? error.code
+          : "storage_unavailable";
+      res
+        .status(bounded === "storage_unavailable" ? 503 : 400)
+        .json(errorBody(bounded));
+    }
+  });
+
+  router.put(
+    "/projects/:projectId/root-bindings/:bindingId",
+    async (req, res) => {
+      const parsed = rootAssociationSchema.safeParse(req.body);
+      if (!parsed.success) {
+        res.status(400).json(errorBody("malformed_state"));
+        return;
+      }
+      try {
+        const project = await options.catalog.resolve(req.params.projectId);
+        if (!project) {
+          res.status(404).json(errorBody("project_not_found"));
+          return;
+        }
+        const scope = await allowlistedScope(options, parsed.data.root);
+        if (!scope) {
+          res.status(404).json(errorBody("project_not_found"));
+          return;
+        }
+        const updated = await options.catalog.moveRootBinding(
+          project.projectId,
+          req.params.bindingId,
+          scope.cwd,
+          scope.workspaceKey,
+        );
+        res.status(200).setHeader("Cache-Control", "no-store").json(updated);
+      } catch (error) {
+        const bounded =
+          error instanceof StudioProjectCatalogError
+            ? error.code
+            : "storage_unavailable";
+        res
+          .status(bounded === "storage_unavailable" ? 503 : 400)
+          .json(errorBody(bounded));
+      }
+    },
+  );
+
   router.get("/projects/:projectId/agent-map/workspace", async (req, res) => {
     try {
       await options.catalog.reconcile(await options.listWorkspaceScopes());

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -11,6 +11,7 @@ import {
   createServer as createHttpServer,
   type Server as HttpServer,
 } from "node:http";
+import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -149,6 +150,9 @@ import { createBootTokenMiddleware } from "./auth.js";
 import { createApiKeyProvider } from "../core/api-key-provider.js";
 import { createRestRouter } from "./rest.js";
 import { createSystemGraphRouter } from "./system-graph.js";
+import { createAgentMapRouter } from "./agent-map.js";
+import { AgentMapWorkspaceStore } from "../core/agent-map-workspace-store.js";
+import { StudioProjectCatalog } from "../core/studio-project-catalog.js";
 import { createStaticRouter } from "./static.js";
 import { createTerminalWebSocketHandler } from "./terminal-ws.js";
 import { createEventsWebSocketHandler } from "./events-ws.js";
@@ -1074,6 +1078,9 @@ export const startServer = async (
     ...(await loadSettings(statePaths.settings)).recentDirs,
     ...sessionManager.list().map((session) => session.cwd),
   ]);
+  const studioProjectCatalog = new StudioProjectCatalog(
+    statePaths.studioProjects,
+  );
   const activeSystemGraphScopes = new Map<string, WorkspaceScope>();
   const systemGraphInvocations = new CachedAgentInvocationProvider(
     new SourceAgentInvocationProvider(),
@@ -2246,7 +2253,14 @@ export const startServer = async (
         activeSystemGraphScopes.delete(workspaceKey);
       }
     }
-    return scopes;
+    try {
+      return (await studioProjectCatalog.reconcile(scopes)).workspaceScopes;
+    } catch {
+      // Agent Map is additive in E1. A bad/unavailable new catalog cannot
+      // strand the legacy rail or System Graph during coexistence.
+      console.error("[harness] Studio project catalog is unavailable");
+      return scopes;
+    }
   };
 
   /** Enrich only the bound workflow before a Canvas render. Canvas extraction
@@ -2467,6 +2481,40 @@ export const startServer = async (
   // and createIngestRouter) so the uiTrack closure can reference it lazily.
   const seqCounter = createSeqCounter();
 
+  const agentMapWorkspaceStore = new AgentMapWorkspaceStore(
+    statePaths.agentMap,
+    {
+      onEvent: (event) => {
+        const sessionId = `agent-map-${event.projectId}`;
+        const analyticsEvent: AnalyticsEvent = {
+          eventId: randomUUID(),
+          seq: seqCounter.next(sessionId),
+          ts: new Date().toISOString(),
+          userId: identity?.userId ?? null,
+          tenantId: identity?.tenantId ?? null,
+          machineId,
+          harnessSessionId: sessionId,
+          agentSessionId: null,
+          harness: "claude-code",
+          type: event.name,
+          payload: {
+            project_id: event.projectId,
+            ...(event.name === "agent_map.workspace_read_failed"
+              ? {
+                  error_code: event.errorCode,
+                  ...(event.schemaVersion !== undefined
+                    ? { schema_version: event.schemaVersion }
+                    : {}),
+                }
+              : {}),
+          },
+        };
+        void eventStore.append(analyticsEvent).catch(() => {});
+        batcher.enqueue(analyticsEvent);
+      },
+    },
+  );
+
   const app: Express = express();
   app.disable("x-powered-by");
 
@@ -2498,6 +2546,14 @@ export const startServer = async (
       listWorkflows: async () =>
         publicWorkflowInfos(await enrichWorkflows(workflowsCache)),
       listWorkspaceScopes: listWorkspaceScopesAndRetain,
+      listStudioProjects: async () => {
+        try {
+          return await studioProjectCatalog.list();
+        } catch {
+          console.error("[harness] Studio project catalog is unavailable");
+          return [];
+        }
+      },
       listMacros: () => DEFAULT_MACROS,
       findWorkflow: (workflowPath) =>
         workflowsCache.find((w) => w.path === workflowPath) ?? null,
@@ -2540,6 +2596,14 @@ export const startServer = async (
         tenantId: identity?.tenantId ?? null,
       },
       settingsPath: statePaths.settings,
+    }),
+  );
+  app.use(
+    "/api",
+    createAgentMapRouter({
+      catalog: studioProjectCatalog,
+      store: agentMapWorkspaceStore,
+      listWorkspaceScopes: () => workspaceScopeCatalog.list(),
     }),
   );
   app.use(

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -339,6 +339,8 @@ export interface HarnessServerOptions {
 export interface HarnessServer {
   close(): Promise<void>;
   port: number;
+  /** Host-only credential used to authorize the initial browser HTML bootstrap. */
+  uiToken: string;
   sessionManager: SessionManager;
 }
 
@@ -586,6 +588,9 @@ export const startServer = async (
   // its own PTY environment, so injecting the boot token would also grant it
   // every mutation beneath /api (including durable project rebinding).
   const ingestToken = randomUUID();
+  // The browser launch capability is separate again: it authorizes delivery
+  // of the boot token in initial HTML, but cannot call /api by itself.
+  const uiToken = randomUUID();
   const identity = options.identity ?? null;
   // The single source of truth for the Sapiom API key (`sk_…`) that Studio
   // actions authenticate with — distinct from the per-boot boot token that only
@@ -3152,7 +3157,9 @@ export const startServer = async (
   // NOTE: mount additional routers above this line — the static/SPA fallback
   // below is a catch-all and must stay last.
   const webDir = options.webDir ?? join(packageRoot(), "dist", "web");
-  app.use(createStaticRouter(webDir, options.bootToken));
+  app.use(
+    createStaticRouter(webDir, { bootToken: options.bootToken, uiToken }),
+  );
 
   app.use(unhandledRequestErrorHandler);
 
@@ -3214,6 +3221,7 @@ export const startServer = async (
 
   return {
     port: actualPort,
+    uiToken,
     sessionManager,
     close: async () => {
       coordinatorActive = false;

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -210,7 +210,10 @@ export interface HarnessServerOptions {
   port: number;
   /** Bind address. Defaults to 127.0.0.1 — the server must never listen on 0.0.0.0. */
   host?: string;
-  /** Per-boot secret; required on WS upgrades, /api (header) and hook scripts (bearer). */
+  /**
+   * Per-boot host/browser secret; required on WS upgrades and `/api` headers.
+   * This credential is deliberately never injected into coding-agent PTYs.
+   */
   bootToken: string;
   telemetryOptIn: boolean;
   /** Sapiom identity from CLI auth; omit/null when unauthenticated or --no-auth. */
@@ -578,6 +581,11 @@ export const startServer = async (
   options: HarnessServerOptions,
 ): Promise<HarnessServer> => {
   const host = options.host ?? "127.0.0.1";
+  // Coding-agent hooks need to authenticate only to /ingest. Keep that
+  // capability distinct from the host/browser boot token: a model can read
+  // its own PTY environment, so injecting the boot token would also grant it
+  // every mutation beneath /api (including durable project rebinding).
+  const ingestToken = randomUUID();
   const identity = options.identity ?? null;
   // The single source of truth for the Sapiom API key (`sk_…`) that Studio
   // actions authenticate with — distinct from the per-boot boot token that only
@@ -1062,7 +1070,7 @@ export const startServer = async (
   const sessionManager = new SessionManager({
     adapters,
     ingestUrl: `http://${host}:${options.port}`,
-    ingestToken: options.bootToken,
+    ingestToken,
     collectorUrl: options.collectorUrl,
     sessionsPath: options.sessionsPath ?? statePaths.sessions,
     buildLaunchOpts,
@@ -1215,7 +1223,7 @@ export const startServer = async (
   const taskManager = new TaskManager({
     adapters,
     ingestUrl: `http://${host}:${options.port}`,
-    ingestToken: options.bootToken,
+    ingestToken,
     collectorUrl: options.collectorUrl,
     buildLaunchOpts,
     onCleanup: (taskId) => {
@@ -2968,7 +2976,7 @@ export const startServer = async (
   // Feeds the same seqCounter declared above — both hook POSTs and the Codex
   // transcript tailer run through processIngest(), which shares the counter.
   const ingestDeps: IngestDeps = {
-    ingestToken: options.bootToken,
+    ingestToken,
     normalize: normalizeHookEvent,
     resolveSession: resolveIngestSession,
     onAgentSessionResolved: (harnessSessionId, agentSessionId) => {

--- a/packages/harness/src/server/record-archive-wiring.test.ts
+++ b/packages/harness/src/server/record-archive-wiring.test.ts
@@ -31,12 +31,20 @@ import type {
 const TOKEN = "test-token";
 
 /** A claude-code-shaped adapter that spawns bash — a real pty we can kill. */
-function fakeClaudeAdapter(): HarnessAdapter {
+function fakeClaudeAdapter(ingestTokenPath: string): HarnessAdapter {
   return {
     id: "claude-code",
     eventSource: "hooks",
     doctor: async () => [],
-    launch: (opts: LaunchOpts): SpawnSpec => ({ command: "bash", args: [], env: {}, cwd: opts.cwd }),
+    launch: (opts: LaunchOpts): SpawnSpec => ({
+      command: "bash",
+      args: [
+        "-c",
+        'printf "%s" "$SAPIOM_HARNESS_INGEST_TOKEN" > "$SAPIOM_TEST_INGEST_TOKEN_PATH"; exec bash',
+      ],
+      env: { SAPIOM_TEST_INGEST_TOKEN_PATH: ingestTokenPath },
+      cwd: opts.cwd,
+    }),
     resume: (_agentSessionId: string, opts: LaunchOpts): SpawnSpec => ({
       command: "bash",
       args: [],
@@ -53,6 +61,7 @@ describe("session record archive wiring", () => {
   let cwd: string;
   let eventStorePath: string;
   let recordsRoot: string;
+  let ingestTokenPath: string;
   let server: HarnessServer | undefined;
   let baseUrl: string;
 
@@ -61,6 +70,7 @@ describe("session record archive wiring", () => {
     cwd = join(dir, "project");
     eventStorePath = join(dir, "events.ndjson");
     recordsRoot = join(dir, "records");
+    ingestTokenPath = join(dir, "ingest-token");
     await mkdir(cwd, { recursive: true });
   });
 
@@ -78,7 +88,7 @@ describe("session record archive wiring", () => {
       bootToken: TOKEN,
       telemetryOptIn: false,
       autoCreateSession: false,
-      adapters: { "claude-code": fakeClaudeAdapter() },
+      adapters: { "claude-code": fakeClaudeAdapter(ingestTokenPath) },
       stateRoot: dir,
     });
     baseUrl = `http://127.0.0.1:${booted.port}`;
@@ -91,9 +101,17 @@ describe("session record archive wiring", () => {
     hookEvent: string,
     payload: Record<string, unknown> = {},
   ): Promise<void> {
+    let ingestToken = "";
+    await vi.waitFor(async () => {
+      ingestToken = await readFile(ingestTokenPath, "utf8");
+      expect(ingestToken).not.toBe("");
+    });
     const res = await fetch(`${baseUrl}/ingest`, {
       method: "POST",
-      headers: { authorization: `Bearer ${TOKEN}`, "content-type": "application/json" },
+      headers: {
+        authorization: `Bearer ${ingestToken}`,
+        "content-type": "application/json",
+      },
       body: JSON.stringify({ hookEvent, harnessSessionId, payload }),
     });
     expect(res.status).toBe(200);

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -33,6 +33,7 @@ import type {
   WorkflowInfo,
 } from "../shared/types.js";
 import type { WorkspaceScopeSummary } from "../shared/system-graph.js";
+import type { StudioProjectSummary } from "../shared/agent-map.js";
 import {
   HARNESS_UPLOADS_DIR,
   JSON_BODY_LIMIT_BYTES,
@@ -188,6 +189,10 @@ export interface RestRouterOptions {
   listWorkspaceScopes?: () =>
     | WorkspaceScopeSummary[]
     | Promise<WorkspaceScopeSummary[]>;
+  /** Path-free durable Agent Map project identities. */
+  listStudioProjects?: () =>
+    | StudioProjectSummary[]
+    | Promise<StudioProjectSummary[]>;
   listMacros: () => MacroDef[];
   /** Look up a registered workflow by its path; null when not found. Backs
    *  PATCH /sessions/:id/workflow's validation (a bind target must already
@@ -319,6 +324,9 @@ export function createRestRouter(options: RestRouterOptions): Router {
         workflows: await listWorkflows(),
         ...(options.listWorkspaceScopes
           ? { workspaceScopes: await options.listWorkspaceScopes() }
+          : {}),
+        ...(options.listStudioProjects
+          ? { studioProjects: await options.listStudioProjects() }
           : {}),
         macros: listMacros(),
         launchDir: options.launchDir,

--- a/packages/harness/src/server/static.test.ts
+++ b/packages/harness/src/server/static.test.ts
@@ -16,21 +16,25 @@ import { createStaticRouter } from "./static.js";
 // than 404ing — so the launch-critical `build → serve → npx` path can't
 // silently regress.
 //
-// SAP-1898: the router also bakes `window.__HARNESS__ = { token }` into every
-// HTML response so the SPA can always read the boot token without depending on
-// the `?token=` query param (which is lost on navigation/reload).
+// The router bakes `window.__HARNESS__.token` only into a UI-authorized HTML
+// response. A session cookie preserves SAP-1898 reload/deep-route behavior.
 // ---------------------------------------------------------------------------
 
 const TEST_BOOT_TOKEN = "test-boot-token-abc123";
+const TEST_UI_TOKEN = "test-ui-token-def456";
 
 describe("createStaticRouter", () => {
   let server: ReturnType<express.Express["listen"]>;
   let baseUrl: string;
   const tmpDirs: string[] = [];
 
-  function start(webDir: string, bootToken = TEST_BOOT_TOKEN): void {
+  function start(
+    webDir: string,
+    bootToken = TEST_BOOT_TOKEN,
+    uiToken = TEST_UI_TOKEN,
+  ): void {
     const app = express();
-    app.use(createStaticRouter(webDir, bootToken));
+    app.use(createStaticRouter(webDir, { bootToken, uiToken }));
     server = app.listen(0);
     const address = server.address() as AddressInfo;
     baseUrl = `http://127.0.0.1:${address.port}`;
@@ -91,18 +95,36 @@ describe("createStaticRouter", () => {
       expect(html).toContain("<title>Agent Studio</title>");
     });
 
-    // SAP-1898: boot-token injection
-    it("injects window.__HARNESS__ script with the boot token before </head>", async () => {
+    it("does not expose the boot token to an unauthenticated root request", async () => {
       start(makeBuiltWebDir(), TEST_BOOT_TOKEN);
 
       const res = await fetch(`${baseUrl}/`);
       expect(res.status).toBe(200);
       const html = await res.text();
+      expect(html).toContain("window.__HARNESS__");
+      expect(html).not.toContain(JSON.stringify(TEST_BOOT_TOKEN));
+      expect(html).not.toContain(TEST_UI_TOKEN);
+    });
 
-      // The script must be present and contain the token JSON-encoded.
+    it("injects the boot token before </head> for a UI-credentialed launch", async () => {
+      start(makeBuiltWebDir(), TEST_BOOT_TOKEN);
+
+      const launch = await fetch(
+        `${baseUrl}/?uiToken=${encodeURIComponent(TEST_UI_TOKEN)}&agent=42&frame=macos`,
+        { redirect: "manual" },
+      );
+      expect(launch.status).toBe(303);
+      expect(launch.headers.get("location")).toBe("/?agent=42&frame=macos");
+      expect(launch.headers.get("location")).not.toContain("uiToken");
+      const cookie = launch.headers.get("set-cookie")?.split(";", 1)[0];
+      const res = await fetch(`${baseUrl}${launch.headers.get("location")!}`, {
+        headers: { cookie: cookie! },
+      });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+
       expect(html).toContain("window.__HARNESS__");
       expect(html).toContain(JSON.stringify(TEST_BOOT_TOKEN));
-      // The script must appear before </head> so it runs before SPA modules load.
       const scriptPos = html.indexOf("window.__HARNESS__");
       const headClosePos = html.indexOf("</head>");
       expect(scriptPos).toBeGreaterThan(-1);
@@ -110,10 +132,21 @@ describe("createStaticRouter", () => {
       expect(scriptPos).toBeLessThan(headClosePos);
     });
 
-    it("injects window.__HARNESS__ on deep SPA routes too (navigation/reload safety)", async () => {
+    it("uses the HttpOnly UI cookie on deep SPA routes and reloads", async () => {
       start(makeBuiltWebDir(), TEST_BOOT_TOKEN);
 
-      const res = await fetch(`${baseUrl}/some/client/route`);
+      const launch = await fetch(
+        `${baseUrl}/?uiToken=${encodeURIComponent(TEST_UI_TOKEN)}`,
+        { redirect: "manual" },
+      );
+      const cookie = launch.headers.get("set-cookie")?.split(";", 1)[0];
+      expect(cookie).toContain("sapiom_studio_ui=");
+      expect(launch.headers.get("set-cookie")).toContain("HttpOnly");
+      expect(launch.headers.get("set-cookie")).toContain("SameSite=Strict");
+
+      const res = await fetch(`${baseUrl}/some/client/route`, {
+        headers: { cookie: cookie! },
+      });
       expect(res.status).toBe(200);
       const html = await res.text();
       expect(html).toContain("window.__HARNESS__");
@@ -125,7 +158,14 @@ describe("createStaticRouter", () => {
       const weirdToken = 'tok"en</script><script>evil';
       start(makeBuiltWebDir(), weirdToken);
 
-      const res = await fetch(`${baseUrl}/`);
+      const launch = await fetch(
+        `${baseUrl}/?uiToken=${encodeURIComponent(TEST_UI_TOKEN)}`,
+        { redirect: "manual" },
+      );
+      const cookie = launch.headers.get("set-cookie")?.split(";", 1)[0];
+      const res = await fetch(`${baseUrl}${launch.headers.get("location")!}`, {
+        headers: { cookie: cookie! },
+      });
       const html = await res.text();
       // The raw string must NOT appear verbatim — it must be JSON-escaped.
       expect(html).not.toContain(weirdToken);

--- a/packages/harness/src/server/static.ts
+++ b/packages/harness/src/server/static.ts
@@ -3,11 +3,14 @@
  * when the web bundle hasn't been built yet (e.g. `pnpm dev` without a prior
  * `pnpm build:web`), so the server is still useful for API/WS-only testing.
  *
- * Boot-token injection: every HTML response has a `<script>` block baked in
- * before `</head>` that sets `window.__HARNESS__ = { token, posthog }`.
- * This lets `getBootToken()` (web/src/lib/api.ts) resolve the token without
- * relying on the `?token=` query param — which is lost on navigation/reload
- * and caused every /api POST to 401 after the first page load (SAP-1898).
+ * Privileged bootstrap: only a browser request carrying the separate UI
+ * launch credential receives `window.__HARNESS__.token`. A coding-agent PTY
+ * knows this server's origin for `/ingest`, so an unconditional token-bearing
+ * index page would let the model upgrade its ingest-only capability into full
+ * `/api` mutation authority. A valid launch query establishes an HttpOnly,
+ * same-site session cookie, then redirects to remove the UI credential before
+ * any app/analytics code runs. Reloads and deep SPA routes stay authorized
+ * without ever placing that UI credential in browser JavaScript.
  *
  * PostHog config injection (SAP-1988): the same `<script>` also carries the
  * client PostHog project key + hosts, resolved server-side from env so ONE
@@ -29,6 +32,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import express, { Router, type Request, type Response } from "express";
+import { timingSafeEqualString } from "./auth.js";
 
 const PLACEHOLDER_HTML = `<!doctype html>
 <html>
@@ -58,6 +62,8 @@ interface PosthogClientConfig {
 
 /** Documented default client key — the Sapiom product project (291192). */
 const DEFAULT_POSTHOG_KEY = "phc_QmzsBloYUZJw7orDRBsEeV9Oz4lQ548cputd7RZ8pAq";
+const UI_BOOTSTRAP_QUERY = "uiToken";
+const UI_BOOTSTRAP_COOKIE = "sapiom_studio_ui";
 
 function resolvePosthogConfig(): PosthogClientConfig | null {
   // Explicit empty string disables; unset falls back to the default key.
@@ -76,8 +82,9 @@ function resolvePosthogConfig(): PosthogClientConfig | null {
  * values are safely escaped even if they contain characters that could break a
  * bare string interpolation.
  */
-function buildTokenScript(bootToken: string): string {
-  const payload: { token: string; posthog?: PosthogClientConfig } = { token: bootToken };
+function buildBootstrapScript(bootToken?: string): string {
+  const payload: { token?: string; posthog?: PosthogClientConfig } = {};
+  if (bootToken) payload.token = bootToken;
   const posthog = resolvePosthogConfig();
   if (posthog) payload.posthog = posthog;
   const safeJson = JSON.stringify(payload).replace(/</g, "\\u003c");
@@ -90,8 +97,8 @@ function buildTokenScript(bootToken: string): string {
  * load. Falls back to prepending to `<body>` if `</head>` is absent (shouldn't
  * happen with our Vite output, but keeps the injection unconditional).
  */
-function injectTokenScript(html: string, bootToken: string): string {
-  const script = buildTokenScript(bootToken);
+function injectBootstrapScript(html: string, bootToken?: string): string {
+  const script = buildBootstrapScript(bootToken);
   if (html.includes("</head>")) {
     return html.replace("</head>", `${script}</head>`);
   }
@@ -103,7 +110,29 @@ function injectTokenScript(html: string, bootToken: string): string {
   return script + html;
 }
 
-export function createStaticRouter(webDir: string, bootToken: string): Router {
+function cookieValue(req: Request, name: string): string {
+  const header = req.header("cookie") ?? "";
+  for (const entry of header.split(";")) {
+    const separator = entry.indexOf("=");
+    if (separator === -1 || entry.slice(0, separator).trim() !== name) continue;
+    try {
+      return decodeURIComponent(entry.slice(separator + 1).trim());
+    } catch {
+      return "";
+    }
+  }
+  return "";
+}
+
+function queryValue(req: Request, name: string): string {
+  const value = req.query[name];
+  return typeof value === "string" ? value : "";
+}
+
+export function createStaticRouter(
+  webDir: string,
+  credentials: { bootToken: string; uiToken: string },
+): Router {
   const router = Router();
   const indexPath = join(webDir, "index.html");
 
@@ -112,7 +141,11 @@ export function createStaticRouter(webDir: string, bootToken: string): Router {
     // (it's a Vite build output), so a single read is fine and avoids
     // repeated disk I/O for every page navigation request.
     const rawHtml = readFileSync(indexPath, "utf-8");
-    const injectedHtml = injectTokenScript(rawHtml, bootToken);
+    const publicHtml = injectBootstrapScript(rawHtml);
+    const privilegedHtml = injectBootstrapScript(
+      rawHtml,
+      credentials.bootToken,
+    );
 
     // Serve hashed assets (JS, CSS, images) via express.static.
     // `index: false` prevents express.static from auto-serving index.html
@@ -120,8 +153,36 @@ export function createStaticRouter(webDir: string, bootToken: string): Router {
     // below so every HTML response always carries the injected token script.
     router.use(express.static(webDir, { index: false }));
 
-    router.get("*", (_req: Request, res: Response) => {
-      res.status(200).set("Content-Type", "text/html").send(injectedHtml);
+    router.get("*", (req: Request, res: Response) => {
+      const queryAuthorized = timingSafeEqualString(
+        queryValue(req, UI_BOOTSTRAP_QUERY),
+        credentials.uiToken,
+      );
+      const cookieAuthorized = timingSafeEqualString(
+        cookieValue(req, UI_BOOTSTRAP_COOKIE),
+        credentials.uiToken,
+      );
+      if (queryAuthorized) {
+        res.cookie(UI_BOOTSTRAP_COOKIE, credentials.uiToken, {
+          httpOnly: true,
+          sameSite: "strict",
+          path: "/",
+        });
+        const cleanUrl = new URL(req.originalUrl, "http://localhost");
+        cleanUrl.searchParams.delete(UI_BOOTSTRAP_QUERY);
+        res
+          .status(303)
+          .set("Cache-Control", "no-store")
+          .set("Location", `${cleanUrl.pathname}${cleanUrl.search}`)
+          .send();
+        return;
+      }
+      res
+        .status(200)
+        .set("Content-Type", "text/html")
+        .set("Cache-Control", "no-store")
+        .set("Vary", "Cookie")
+        .send(cookieAuthorized ? privilegedHtml : publicHtml);
     });
   } else {
     router.get("*", (_req: Request, res: Response) => {

--- a/packages/harness/src/shared/agent-map.ts
+++ b/packages/harness/src/shared/agent-map.ts
@@ -1,0 +1,65 @@
+/**
+ * Public, path-free contracts for the plan-first Agent Map.
+ *
+ * Durable filesystem bindings live in core/studio-project-catalog.ts. This
+ * module is safe to import in the browser: it deliberately has no local root,
+ * repository URL, legacy WorkspaceKey, prompt, or source-inventory fields.
+ */
+
+export type StudioProjectId = string;
+
+export const STUDIO_PROJECT_CATALOG_SCHEMA_VERSION = 1;
+export const AGENT_MAP_WORKSPACE_SCHEMA_VERSION = 1;
+export const AGENT_MAP_INITIAL_RECORD_VERSION = 1;
+
+export type ProjectRootBindingStatus = "active" | "missing";
+
+/** The public projection of a server-private root binding. */
+export interface StudioProjectBindingSummary {
+  id: string;
+  repositoryId: string | null;
+  status: ProjectRootBindingStatus;
+}
+
+/** Stable project identity published to AppState and Agent Map consumers. */
+export interface StudioProjectSummary {
+  projectId: StudioProjectId;
+  identityVersion: number;
+  displayName: string;
+  bindings: StudioProjectBindingSummary[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * The deliberately empty E1 workspace record. Schema and record versions are
+ * independent: schemaVersion controls persistence migration while
+ * recordVersion is reserved for optimistic application mutations.
+ */
+export interface AgentMapWorkspaceState {
+  projectId: StudioProjectId;
+  schemaVersion: number;
+  recordVersion: number;
+  confirmedRevisionId: string | null;
+  activeProposalId: string | null;
+  projectBuildPlanId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface AgentMapWorkspaceResponse {
+  project: StudioProjectSummary;
+  workspace: AgentMapWorkspaceState;
+}
+
+export type AgentMapErrorCode =
+  | "project_not_found"
+  | "malformed_state"
+  | "unsupported_schema"
+  | "storage_unavailable";
+
+/** Stable error shape; `error` is intentionally bounded and path-free. */
+export interface AgentMapErrorResponse {
+  code: AgentMapErrorCode;
+  error: string;
+}

--- a/packages/harness/src/shared/agent-map.ts
+++ b/packages/harness/src/shared/agent-map.ts
@@ -17,7 +17,6 @@ export type ProjectRootBindingStatus = "active" | "missing";
 /** The public projection of a server-private root binding. */
 export interface StudioProjectBindingSummary {
   id: string;
-  repositoryId: string | null;
   status: ProjectRootBindingStatus;
 }
 

--- a/packages/harness/src/shared/system-graph.ts
+++ b/packages/harness/src/shared/system-graph.ts
@@ -102,6 +102,8 @@ export interface WorkspaceScopeSummary {
   workspaceKey: WorkspaceKey;
   /** Used only to join the existing workspace-folder projection in AppState. */
   cwd: string;
+  /** Durable Agent Map identity joined server-side; WorkspaceKey stays legacy. */
+  projectId?: import("./agent-map.js").StudioProjectId;
 }
 
 export interface SystemGraphNode {

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -31,6 +31,10 @@ export const HARNESS_PATHS = {
   events: `${HARNESS_HOME}/events.ndjson`,
   /** User settings (opt-in state, macros overrides). */
   settings: `${HARNESS_HOME}/settings.json`,
+  /** Durable Studio project identities and private repository/root bindings. */
+  studioProjects: `${HARNESS_HOME}/studio-projects.json`,
+  /** Durable plan-first Agent Map records, partitioned beneath projects/. */
+  agentMap: `${HARNESS_HOME}/agent-map`,
   /** Generated per-session agent config (claude settings/mcp-config files). */
   generated: `${HARNESS_HOME}/generated`,
   /**
@@ -785,7 +789,9 @@ export type AnalyticsEventType =
   | "consent.changed"
   | "session.created"
   | "mcp.install"
-  | "plan.upgrade_clicked";
+  | "plan.upgrade_clicked"
+  | "agent_map.workspace_initialized"
+  | "agent_map.workspace_read_failed";
 
 /**
  * The normalized event — the shape that (with opt-in) is batched to the
@@ -1184,6 +1190,8 @@ export interface AppState {
   /** Opaque identities for the workspace folders currently known to Studio.
    * Optional for compatibility with older servers and test fixtures. */
   workspaceScopes?: import("./system-graph.js").WorkspaceScopeSummary[];
+  /** Path-free durable project identities for the plan-first Agent Map. */
+  studioProjects?: import("./agent-map.js").StudioProjectSummary[];
   macros: MacroDef[];
   /** The directory the CLI was launched against — the SPA prefills the
    *  new-session modal with this instead of recentDirs[0]. */

--- a/packages/harness/vitest.config.ts
+++ b/packages/harness/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       // truth. Mirrors the alias in web/vite.config.ts.
       "@shared/types": fileURLToPath(new URL("src/shared/types.ts", import.meta.url)),
       "@shared/system-graph": fileURLToPath(new URL("src/shared/system-graph.ts", import.meta.url)),
+      "@shared/agent-map": fileURLToPath(new URL("src/shared/agent-map.ts", import.meta.url)),
       "@shared/agent-name": fileURLToPath(new URL("src/shared/agent-name.ts", import.meta.url)),
     },
   },

--- a/packages/harness/web/src/lib/agent-map.test.ts
+++ b/packages/harness/web/src/lib/agent-map.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAgentMapWorkspaceResponse } from "./agent-map";
+import { MockApi } from "./api";
+
+const projectId = "project_00000000-0000-4000-8000-000000000001";
+const timestamp = "2026-09-01T12:00:00.000Z";
+
+function validResponse(): unknown {
+  return {
+    project: {
+      projectId,
+      identityVersion: 1,
+      displayName: "Market Research",
+      bindings: [
+        {
+          id: "root_00000000-0000-4000-8000-000000000001",
+          repositoryId: "repo_market_research",
+          status: "active",
+        },
+      ],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+    workspace: {
+      projectId,
+      schemaVersion: 1,
+      recordVersion: 1,
+      confirmedRevisionId: null,
+      activeProposalId: null,
+      projectBuildPlanId: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+  };
+}
+
+describe("parseAgentMapWorkspaceResponse", () => {
+  it("accepts the strict path-free public shape", () => {
+    expect(parseAgentMapWorkspaceResponse(validResponse(), projectId)).toEqual(
+      validResponse(),
+    );
+  });
+
+  it("uses the same public shape in mock mode", async () => {
+    const api = new MockApi();
+    const state = await api.getState();
+    const project = state.studioProjects?.[0];
+    expect(project).toBeDefined();
+    expect(
+      parseAgentMapWorkspaceResponse(
+        await api.getAgentMapWorkspace(project!.projectId),
+        project!.projectId,
+      ).workspace,
+    ).toMatchObject({
+      projectId: project!.projectId,
+      schemaVersion: 1,
+      recordVersion: 1,
+    });
+  });
+
+  it.each([
+    ["extra field", (value: any) => (value.workspace.privateRoot = "/secret")],
+    [
+      "path display name",
+      (value: any) => (value.project.displayName = "/secret/project"),
+    ],
+    [
+      "repository URL",
+      (value: any) =>
+        (value.project.bindings[0].repositoryId = "https://example.com/repo"),
+    ],
+    [
+      "project mismatch",
+      (value: any) =>
+        (value.workspace.projectId =
+          "project_00000000-0000-4000-8000-000000000002"),
+    ],
+    ["future schema", (value: any) => (value.workspace.schemaVersion = 2)],
+    [
+      "negative record version",
+      (value: any) => (value.workspace.recordVersion = -1),
+    ],
+    [
+      "invalid timestamp",
+      (value: any) => (value.workspace.updatedAt = "yesterday"),
+    ],
+  ])("rejects %s", (_name, mutate) => {
+    const value = validResponse();
+    mutate(value);
+    expect(() => parseAgentMapWorkspaceResponse(value, projectId)).toThrow(
+      "Invalid Agent Map workspace response",
+    );
+  });
+});

--- a/packages/harness/web/src/lib/agent-map.test.ts
+++ b/packages/harness/web/src/lib/agent-map.test.ts
@@ -15,7 +15,6 @@ function validResponse(): unknown {
       bindings: [
         {
           id: "root_00000000-0000-4000-8000-000000000001",
-          repositoryId: "repo_market_research",
           status: "active",
         },
       ],
@@ -66,9 +65,8 @@ describe("parseAgentMapWorkspaceResponse", () => {
       (value: any) => (value.project.displayName = "/secret/project"),
     ],
     [
-      "repository URL",
-      (value: any) =>
-        (value.project.bindings[0].repositoryId = "https://example.com/repo"),
+      "private repository field",
+      (value: any) => (value.project.bindings[0].repositoryId = "repo-private"),
     ],
     [
       "project mismatch",

--- a/packages/harness/web/src/lib/agent-map.ts
+++ b/packages/harness/web/src/lib/agent-map.ts
@@ -1,0 +1,172 @@
+import type {
+  AgentMapWorkspaceResponse,
+  AgentMapWorkspaceState,
+  StudioProjectBindingSummary,
+  StudioProjectSummary,
+} from "@shared/agent-map";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): boolean {
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return (
+    actual.length === expected.length &&
+    actual.every((key, index) => key === expected[index])
+  );
+}
+
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => {
+    const code = character.codePointAt(0)!;
+    return code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+  });
+}
+
+function isOpaqueId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value !== "" &&
+    value === value.trim() &&
+    !hasControlCharacter(value) &&
+    !value.includes("/") &&
+    !value.includes("\\") &&
+    !value.includes(":")
+  );
+}
+
+function isProjectId(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    /^project_[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(
+      value,
+    )
+  );
+}
+
+function isTimestamp(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  try {
+    return new Date(value).toISOString() === value;
+  } catch {
+    return false;
+  }
+}
+
+function parseBinding(value: unknown): StudioProjectBindingSummary | null {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, ["id", "repositoryId", "status"]) ||
+    !isOpaqueId(value.id) ||
+    (value.repositoryId !== null && !isOpaqueId(value.repositoryId)) ||
+    (value.status !== "active" && value.status !== "missing")
+  ) {
+    return null;
+  }
+  return {
+    id: value.id,
+    repositoryId: value.repositoryId,
+    status: value.status,
+  };
+}
+
+function parseProject(value: unknown): StudioProjectSummary | null {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "projectId",
+      "identityVersion",
+      "displayName",
+      "bindings",
+      "createdAt",
+      "updatedAt",
+    ]) ||
+    !isProjectId(value.projectId) ||
+    !Number.isSafeInteger(value.identityVersion) ||
+    (value.identityVersion as number) < 1 ||
+    typeof value.displayName !== "string" ||
+    value.displayName === "" ||
+    value.displayName !== value.displayName.trim() ||
+    hasControlCharacter(value.displayName) ||
+    value.displayName.includes("/") ||
+    value.displayName.includes("\\") ||
+    !Array.isArray(value.bindings) ||
+    !isTimestamp(value.createdAt) ||
+    !isTimestamp(value.updatedAt)
+  ) {
+    return null;
+  }
+  const bindings = value.bindings.map(parseBinding);
+  if (bindings.some((binding) => binding === null)) return null;
+  const parsed = bindings as StudioProjectBindingSummary[];
+  if (new Set(parsed.map((binding) => binding.id)).size !== parsed.length) {
+    return null;
+  }
+  return {
+    projectId: value.projectId,
+    identityVersion: value.identityVersion as number,
+    displayName: value.displayName,
+    bindings: parsed,
+    createdAt: value.createdAt,
+    updatedAt: value.updatedAt,
+  };
+}
+
+function parseWorkspace(
+  value: unknown,
+  expectedProjectId: string,
+): AgentMapWorkspaceState | null {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, [
+      "projectId",
+      "schemaVersion",
+      "recordVersion",
+      "confirmedRevisionId",
+      "activeProposalId",
+      "projectBuildPlanId",
+      "createdAt",
+      "updatedAt",
+    ]) ||
+    value.projectId !== expectedProjectId ||
+    !Number.isSafeInteger(value.schemaVersion) ||
+    value.schemaVersion !== 1 ||
+    !Number.isSafeInteger(value.recordVersion) ||
+    (value.recordVersion as number) < 1 ||
+    ![
+      value.confirmedRevisionId,
+      value.activeProposalId,
+      value.projectBuildPlanId,
+    ].every((candidate) => candidate === null || isOpaqueId(candidate)) ||
+    !isTimestamp(value.createdAt) ||
+    !isTimestamp(value.updatedAt)
+  ) {
+    return null;
+  }
+  return value as unknown as AgentMapWorkspaceState;
+}
+
+/** Strictly validates the path-free Agent Map HTTP boundary. */
+export function parseAgentMapWorkspaceResponse(
+  value: unknown,
+  expectedProjectId?: string,
+): AgentMapWorkspaceResponse {
+  if (!isRecord(value) || !hasExactKeys(value, ["project", "workspace"])) {
+    throw new Error("Invalid Agent Map workspace response");
+  }
+  const project = parseProject(value.project);
+  if (
+    !project ||
+    (expectedProjectId && project.projectId !== expectedProjectId)
+  ) {
+    throw new Error("Invalid Agent Map workspace response");
+  }
+  const workspace = parseWorkspace(value.workspace, project.projectId);
+  if (!workspace) throw new Error("Invalid Agent Map workspace response");
+  return { project, workspace };
+}

--- a/packages/harness/web/src/lib/agent-map.ts
+++ b/packages/harness/web/src/lib/agent-map.ts
@@ -61,16 +61,14 @@ function isTimestamp(value: unknown): value is string {
 function parseBinding(value: unknown): StudioProjectBindingSummary | null {
   if (
     !isRecord(value) ||
-    !hasExactKeys(value, ["id", "repositoryId", "status"]) ||
+    !hasExactKeys(value, ["id", "status"]) ||
     !isOpaqueId(value.id) ||
-    (value.repositoryId !== null && !isOpaqueId(value.repositoryId)) ||
     (value.status !== "active" && value.status !== "missing")
   ) {
     return null;
   }
   return {
     id: value.id,
-    repositoryId: value.repositoryId,
     status: value.status,
   };
 }

--- a/packages/harness/web/src/lib/analytics/before-send.test.ts
+++ b/packages/harness/web/src/lib/analytics/before-send.test.ts
@@ -8,9 +8,9 @@ function capture(event: string, properties: Record<string, unknown>, extra?: Par
 }
 
 describe("sanitizeUrl", () => {
-  it("strips the query string (which carries the boot token) and the fragment", () => {
-    expect(sanitizeUrl("http://localhost:4100/?token=super-secret")).toBe("http://localhost/");
-    expect(sanitizeUrl("http://localhost:4100/workbench?token=x#frag")).toBe("http://localhost/workbench");
+  it("strips the query string (including a UI launch credential) and the fragment", () => {
+    expect(sanitizeUrl("http://localhost:4100/?uiToken=super-secret")).toBe("http://localhost/");
+    expect(sanitizeUrl("http://localhost:4100/workbench?uiToken=x#frag")).toBe("http://localhost/workbench");
   });
 
   it("collapses the ephemeral port so every boot reports one origin", () => {
@@ -49,11 +49,11 @@ describe("beforeSend", () => {
     expect(beforeSend(null)).toBeNull();
   });
 
-  it("redacts the boot token from $current_url and person-property URLs", () => {
+  it("redacts the UI launch credential from $current_url and person-property URLs", () => {
     const result = capture(
       "$pageview",
-      { $current_url: "http://localhost:4100/?token=secret" },
-      { $set_once: { $initial_current_url: "http://localhost:4100/?token=secret" } },
+      { $current_url: "http://localhost:4100/?uiToken=secret" },
+      { $set_once: { $initial_current_url: "http://localhost:4100/?uiToken=secret" } },
     );
     const out = beforeSend(result)!;
     expect((out.properties as Record<string, unknown>).$current_url).toBe("http://localhost/");

--- a/packages/harness/web/src/lib/analytics/before-send.ts
+++ b/packages/harness/web/src/lib/analytics/before-send.ts
@@ -11,10 +11,11 @@ import type { CaptureResult } from "posthog-js";
  * drops replay snapshots here; the harness sets journey as a super-property and
  * never records, so both are gone):
  *
- * 1. **Strip URL secrets.** The harness serves itself at
- *    `http://localhost:<port>/?token=<bootToken>` — the boot token is a live
- *    credential sitting in `$current_url` on every event. Drop ALL query params
- *    and fragments (the harness has no attribution params worth keeping).
+ * 1. **Strip URL secrets.** The host launches the harness once with a short-lived
+ *    `?uiToken=<launchCredential>` URL. The server redirects it away before the
+ *    SPA or PostHog loads, and this redaction remains a defense in depth. Drop
+ *    ALL query params and fragments (the harness has no attribution params
+ *    worth keeping).
  * 2. **Redact click text.** Truncate autocaptured `$el_text` everywhere, and
  *    drop it entirely on a secrets/vault surface, where a copy-button's label or
  *    a field value can be the secret itself.

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -263,12 +263,12 @@ export function errorMessage(err: unknown, fallback: string): string {
   return fallback;
 }
 
-/** Read once at module load: `window.__HARNESS__ = {token}` (baked in by the server), falling back to `?token=`. */
+/** Read the boot token injected only into a UI-credential-authorized HTML response. */
 export function getBootToken(): string {
   const injected = (window as unknown as { __HARNESS__?: { token?: string } })
     .__HARNESS__;
   if (injected?.token) return injected.token;
-  return new URLSearchParams(window.location.search).get("token") ?? "";
+  return "";
 }
 
 /** Response from GET /api/auth/status — live auth state from the server. */

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -41,6 +41,11 @@ import {
   type WorkspaceKey,
   type WorkspaceScopeSummary,
 } from "@shared/system-graph";
+import type {
+  AgentMapWorkspaceResponse,
+  StudioProjectId,
+  StudioProjectSummary,
+} from "@shared/agent-map";
 
 import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
 
@@ -50,6 +55,7 @@ import {
   parseSystemGraphNavigation,
   parseSystemGraphSnapshot,
 } from "./system-graph";
+import { parseAgentMapWorkspaceResponse } from "./agent-map";
 import { refuseMove, remapUnder } from "./agent-move";
 import { basenameOf, isWithinDir, parentOf, samePath } from "./paths";
 
@@ -347,6 +353,10 @@ export interface HarnessApi {
    */
   authStatus(): Promise<AuthStatusResponse>;
   getState(): Promise<AppState>;
+  /** Durable, path-free empty/proposal/revision pointers for one Studio project. */
+  getAgentMapWorkspace(
+    projectId: StudioProjectId,
+  ): Promise<AgentMapWorkspaceResponse>;
   /** Revisioned local dependency projection for one server-issued workspace key. */
   getSystemGraph(
     workspaceKey: WorkspaceKey,
@@ -574,6 +584,15 @@ class RealApi implements HarnessApi {
 
   getState(): Promise<AppState> {
     return this.request<AppState>("/api/state");
+  }
+
+  async getAgentMapWorkspace(
+    projectId: StudioProjectId,
+  ): Promise<AgentMapWorkspaceResponse> {
+    const value = await this.request<unknown>(
+      `/api/projects/${encodeURIComponent(projectId)}/agent-map/workspace`,
+    );
+    return parseAgentMapWorkspaceResponse(value, projectId);
   }
 
   async getSystemGraph(
@@ -1636,6 +1655,7 @@ export class MockApi implements HarnessApi {
   /** Stable for the lifetime of the mock process, mirroring server-issued
    * opaque keys without putting filesystem paths into graph payloads. */
   private workspaceKeys = new Map<string, WorkspaceKey>();
+  private studioProjectIds = new Map<string, StudioProjectId>();
   private systemGraphSnapshots = new Map<WorkspaceKey, SystemGraphSnapshot>();
   private systemGraphNavigation = new Map<
     WorkspaceKey,
@@ -1844,6 +1864,16 @@ export class MockApi implements HarnessApi {
     return key;
   }
 
+  private studioProjectId(cwd: string): StudioProjectId {
+    const existing = this.studioProjectIds.get(cwd);
+    if (existing) return existing;
+    // Valid UUID-shaped IDs keep mock and real strict parsing identical.
+    const ordinal = String(this.studioProjectIds.size + 1).padStart(12, "0");
+    const projectId = `project_00000000-0000-4000-8000-${ordinal}`;
+    this.studioProjectIds.set(cwd, projectId);
+    return projectId;
+  }
+
   private workspaceScopes(): WorkspaceScopeSummary[] {
     const roots = new Set([
       ...this.settings.recentDirs,
@@ -1851,7 +1881,29 @@ export class MockApi implements HarnessApi {
     ]);
     return [...roots]
       .sort((left, right) => left.localeCompare(right))
-      .map((cwd) => ({ cwd, workspaceKey: this.workspaceKey(cwd) }));
+      .map((cwd) => ({
+        cwd,
+        workspaceKey: this.workspaceKey(cwd),
+        projectId: this.studioProjectId(cwd),
+      }));
+  }
+
+  private studioProjects(): StudioProjectSummary[] {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    return this.workspaceScopes().map((scope, index) => ({
+      projectId: scope.projectId!,
+      identityVersion: 1,
+      displayName: basenameOf(scope.cwd) || "Project",
+      bindings: [
+        {
+          id: `root_00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`,
+          repositoryId: null,
+          status: "active",
+        },
+      ],
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }));
   }
 
   async getState(): Promise<AppState> {
@@ -1926,6 +1978,7 @@ export class MockApi implements HarnessApi {
       sessions: this.sessions,
       workflows: this.workflows,
       workspaceScopes: this.workspaceScopes(),
+      studioProjects: this.studioProjects(),
       macros: MOCK_MACROS,
       launchDir: MOCK_LAUNCH_DIR,
       // Mirrors the Electron host (`<launchDir>/projects`) rather than the CLI
@@ -1936,6 +1989,38 @@ export class MockApi implements HarnessApi {
       ...(mockEnvReason ? { consentEnvReason: mockEnvReason } : {}),
       ...(this.fresh ? { firstRun: true } : {}),
     };
+  }
+
+  async getAgentMapWorkspace(
+    projectId: StudioProjectId,
+  ): Promise<AgentMapWorkspaceResponse> {
+    await delay();
+    const project = this.studioProjects().find(
+      (candidate) => candidate.projectId === projectId,
+    );
+    if (!project) {
+      throw new ApiError(
+        404,
+        "Studio project not found",
+        "Studio project not found",
+      );
+    }
+    return parseAgentMapWorkspaceResponse(
+      {
+        project,
+        workspace: {
+          projectId,
+          schemaVersion: 1,
+          recordVersion: 1,
+          confirmedRevisionId: null,
+          activeProposalId: null,
+          projectBuildPlanId: null,
+          createdAt: project.createdAt,
+          updatedAt: project.updatedAt,
+        },
+      },
+      projectId,
+    );
   }
 
   async getSystemGraph(

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -1192,7 +1192,8 @@ function writeMockHelpSeen(seen: boolean): void {
  * dismiss survives a reload — for the fixture most likely to want it: dismiss
  * on a fresh install, reload as a returning user, stay dismissed.
  */
-if (typeof window !== "undefined" && isFreshMockState()) writeMockHelpSeen(false);
+if (typeof window !== "undefined" && isFreshMockState())
+  writeMockHelpSeen(false);
 
 /**
  * Every rail-state write the mock has served this page load, newest last, for
@@ -1897,7 +1898,6 @@ export class MockApi implements HarnessApi {
       bindings: [
         {
           id: `root_00000000-0000-4000-8000-${String(index + 1).padStart(12, "0")}`,
-          repositoryId: null,
           status: "active",
         },
       ],

--- a/packages/harness/web/tsconfig.json
+++ b/packages/harness/web/tsconfig.json
@@ -15,6 +15,7 @@
     "paths": {
       "@shared/types": ["../src/shared/types.ts"],
       "@shared/system-graph": ["../src/shared/system-graph.ts"],
+      "@shared/agent-map": ["../src/shared/agent-map.ts"],
       "@shared/agent-name": ["../src/shared/agent-name.ts"],
       "@shared/render-local-run": ["../src/core/render-local-run.ts"],
       "@shared/stub-feedback": ["../src/core/stub-feedback.ts"],

--- a/packages/harness/web/vite.config.ts
+++ b/packages/harness/web/vite.config.ts
@@ -90,6 +90,7 @@ export default defineConfig({
       // build against one source of truth — no vendored copy to drift.
       "@shared/types": fileURLToPath(new URL("../src/shared/types.ts", import.meta.url)),
       "@shared/system-graph": fileURLToPath(new URL("../src/shared/system-graph.ts", import.meta.url)),
+      "@shared/agent-map": fileURLToPath(new URL("../src/shared/agent-map.ts", import.meta.url)),
       // One agent-name rule for the dialog and the create route: a name the
       // field accepts and the server refuses reads as a broken app.
       "@shared/agent-name": fileURLToPath(new URL("../src/shared/agent-name.ts", import.meta.url)),


### PR DESCRIPTION
## Summary

Introduces the additive durable foundation for the plan-first Agent Map. Studio now assigns stable project IDs through a server-private catalog and lazily creates one empty, restart-safe Agent Map workspace record only when its protected read endpoint is opened.

## Changes

- Add strict, path-free Agent Map project/workspace/error contracts with independent schema and record versions.
- Persist `studio-projects.json` plus per-project `agent-map/projects/<projectId>/workspace.json` records using cross-host serialized catalog writes and atomic no-clobber workspace creation.
- Reconcile existing allow-listed workspace scopes to durable project IDs while keeping roots and legacy WorkspaceKeys private/migration-only.
- Mount boot-token-protected project create/root-association routes plus `GET /api/projects/:projectId/agent-map/workspace`, with allow-listed roots, bounded errors, and path-free `no-store` responses.
- Publish path-free project summaries through AppState and add strict real/mock browser parsing.
- Emit bounded initialization/read-failure telemetry without paths, repository material, record bodies, or raw errors.
- Preserve the legacy System Graph, per-agent Canvas, discovery, and watchers unchanged; catalog failures degrade back to the legacy AppState projection.
- Add a minor `@sapiom/harness` changeset covering the new published behavior and state-root files.

### Review refinements

- Use an atomic hard-link commit for first workspace creation so independent store instances return one winning timestamp and emit initialization once.
- Serialize catalog writers across CLI/Electron hosts, re-read after acquiring the file lock, and keep reads fresh across live instances.
- Route root moves and additional bindings through authenticated, allow-listed project association endpoints; a path/hash never selects durable identity.
- Remove private `repositoryId` from public summary types, serialization, browser parsing, mocks, and response tests.
- Reject same-project target-root collisions before persistence and prove the catalog remains restart-readable.
- Skip unsafe live input scopes without treating them as corrupt persistence, while accepting legal path names with surrounding spaces.

This is the main-based foundation PR. SAP-3057 and SAP-3055 can stack on this branch while it is under review.

## Testing

- [x] `pnpm --filter @sapiom/harness exec vitest run` — 179 files, 3,019 tests passed
- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `pnpm --filter @sapiom/harness lint`
- [x] `pnpm --filter @sapiom/harness build`
- [x] `git diff --check`

## Related

- Closes: SAP-3056
- Linear: https://linear.app/sapiom/issue/SAP-3056

## Checklist

- [x] Additive migration boundary; no legacy route/store/loader removed
- [x] No local paths or legacy WorkspaceKeys in Agent Map payloads
- [x] Cross-instance lazy initialization, concurrent catalog writers, and restart behavior covered
- [x] Malformed, future-schema, unknown-project, authorization, and storage failures covered
- [x] Self-reviewed; no hardcoded secrets
