### PR TITLE
refactor(harness): isolate discovery freshness

### DIFF
--- a/.changeset/calm-scans-separate.md
+++ b/.changeset/calm-scans-separate.md
@@ -2,4 +2,4 @@
 "@sapiom/harness": patch
 ---
 
-Separate permanent workspace discovery freshness from legacy System Graph invocation observations while preserving shared watcher ownership.
+Separate permanent workspace discovery freshness from legacy System Graph invocation observations while preserving shared watcher ownership. On polling fallback, files covered only by legacy invocation scanning stop triggering session and rail rescans after the legacy graph subscription retires; accepted discovery inputs continue to refresh normally.

--- a/.changeset/calm-scans-separate.md
+++ b/.changeset/calm-scans-separate.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Separate permanent workspace discovery freshness from legacy System Graph invocation observations while preserving shared watcher ownership.

--- a/packages/harness/src/core/system-graph-watcher.test.ts
+++ b/packages/harness/src/core/system-graph-watcher.test.ts
@@ -597,6 +597,20 @@ describe("SystemGraphWatcherManager", () => {
     expect(graphPotential).toHaveBeenCalledOnce();
 
     sessions.stopAll();
+    expect(broker.size).toBe(1);
+    expect(close).not.toHaveBeenCalled();
+    sessionChange.mockClear();
+    graphSourceChange.mockClear();
+    watchListener(
+      "change",
+      path.relative(root, path.join(agentRoot, "index.ts")),
+    );
+    await vi.waitFor(() => expect(graphSourceChange).toHaveBeenCalledOnce(), {
+      timeout: 2_000,
+      interval: 10,
+    });
+    expect(sessionChange).not.toHaveBeenCalled();
+
     manager.retain(new Set());
     expect(broker.size).toBe(0);
     expect(close).toHaveBeenCalledTimes(1);

--- a/packages/harness/src/core/workspace-watch-broker.test.ts
+++ b/packages/harness/src/core/workspace-watch-broker.test.ts
@@ -371,7 +371,7 @@ describe("SharedWorkspaceWatchBroker", () => {
     expect(onLastLeaseReleased).toHaveBeenCalledOnce();
   });
 
-  it("detects a real source edit racing an observation coverage rebase", async () => {
+  it("does not swallow a source edit between current and baseline coverage walks", async () => {
     const agentRoot = path.join(root, "agent");
     const discoveryPath = path.join(agentRoot, "discovery.ts");
     const invocationPath = path.join(agentRoot, "invocation.ts");
@@ -387,7 +387,9 @@ describe("SharedWorkspaceWatchBroker", () => {
     };
     let includeInvocation = false;
     let discoveryVersion = "discovery-v1";
-    let mutateDuringExpandedSample = false;
+    let mutateAfterCurrentSample = false;
+    let coverageRebaseActive = false;
+    const coverageWalks: string[] = [];
     let releaseBaseline!: () => void;
     const baselineGate = new Promise<void>((resolve) => {
       releaseBaseline = resolve;
@@ -400,6 +402,11 @@ describe("SharedWorkspaceWatchBroker", () => {
         const paths = observations
           .flatMap((observation) => observation.paths)
           .sort();
+        if (coverageRebaseActive) {
+          coverageWalks.push(
+            paths.includes(invocationPath) ? "current" : "baseline",
+          );
+        }
         const snapshot = new Map([
           [
             agentRoot,
@@ -413,8 +420,8 @@ describe("SharedWorkspaceWatchBroker", () => {
             ),
           ],
         ]);
-        if (mutateDuringExpandedSample && paths.includes(invocationPath)) {
-          mutateDuringExpandedSample = false;
+        if (mutateAfterCurrentSample && paths.includes(invocationPath)) {
+          mutateAfterCurrentSample = false;
           discoveryVersion = "discovery-v2";
         }
         expect(roots).toContain(agentRoot);
@@ -464,9 +471,19 @@ describe("SharedWorkspaceWatchBroker", () => {
     discoveryChange.mockClear();
     graphChange.mockClear();
 
-    mutateDuringExpandedSample = true;
+    let resolvePotential!: () => void;
+    const potentialObserved = new Promise<void>((resolve) => {
+      resolvePotential = resolve;
+    });
+    discoveryPotential.mockImplementation(resolvePotential);
+    const callsBeforeRebase = snapshotSources.mock.calls.length;
+    coverageRebaseActive = true;
+    mutateAfterCurrentSample = true;
     includeInvocation = true;
 
+    await potentialObserved;
+    expect(snapshotSources.mock.calls.length - callsBeforeRebase).toBe(2);
+    expect(coverageWalks).toEqual(["current", "baseline"]);
     await vi.waitFor(() => {
       expect(discoveryPotential).toHaveBeenCalledWith([agentRoot]);
       expect(discoveryChange).toHaveBeenCalledWith([agentRoot]);

--- a/packages/harness/src/core/workspace-watch-broker.test.ts
+++ b/packages/harness/src/core/workspace-watch-broker.test.ts
@@ -217,6 +217,352 @@ describe("SharedWorkspaceWatchBroker", () => {
     broker.unsubscribe(secondKey);
   });
 
+  it("rebases graph-only observation coverage without manufacturing a discovery edit", async () => {
+    const agentRoot = path.join(root, "agent");
+    const discoveryPath = path.join(agentRoot, "discovery.ts");
+    const invocationPath = path.join(agentRoot, "invocation.ts");
+    const discoveryObservation = {
+      workspaceRoot: root,
+      candidateRoot: agentRoot,
+      paths: [discoveryPath],
+    };
+    const invocationObservation = {
+      workspaceRoot: agentRoot,
+      candidateRoot: agentRoot,
+      paths: [invocationPath],
+    };
+    let discoveryVersion = "discovery-v1";
+    let invocationVersion = "invocation-v1";
+    let includeInvocation = true;
+    let releaseBaseline!: () => void;
+    const baselineGate = new Promise<void>((resolve) => {
+      releaseBaseline = resolve;
+    });
+    const snapshotSources = vi.fn(
+      async (
+        roots: readonly string[],
+        observations: readonly {
+          candidateRoot: string;
+          paths: readonly string[];
+        }[],
+      ) => {
+        const retainedRoots = new Set([
+          ...roots,
+          ...observations.map((observation) => observation.candidateRoot),
+        ]);
+        const observedPaths = new Set(
+          observations.flatMap((observation) => observation.paths),
+        );
+        const fingerprint = JSON.stringify(
+          [...observedPaths]
+            .sort()
+            .map((observedPath) => [
+              observedPath,
+              observedPath === discoveryPath
+                ? discoveryVersion
+                : invocationVersion,
+            ]),
+        );
+        return new Map(
+          [...retainedRoots]
+            .sort()
+            .map((sourceRoot) => [sourceRoot, fingerprint]),
+        );
+      },
+    );
+    const discoveryPotential = vi.fn();
+    const discoveryChange = vi.fn();
+    const graphPotential = vi.fn();
+    const graphChange = vi.fn();
+    const onLastLeaseReleased = vi.fn();
+    const broker = new SharedWorkspaceWatchBroker({
+      forcePolling: true,
+      beforeInitialSnapshot: () => baselineGate,
+      pollIntervalMs: 5,
+      sourceDebounceMs: 1,
+      snapshotWorkspace: async () => "inventory",
+      snapshotSources,
+      onLastLeaseReleased,
+    });
+    const discoveryKey = {};
+    const graphKey = {};
+
+    const discoveryStart = broker.subscribe(
+      discoveryKey,
+      subscriber({
+        listSourceRoots: () => [agentRoot],
+        listSourceObservations: () => [discoveryObservation],
+        onPotentialChange: discoveryPotential,
+        onSourceChange: discoveryChange,
+      }),
+    );
+    const graphStart = broker.subscribe(
+      graphKey,
+      subscriber({
+        listSourceRoots: () => [agentRoot],
+        listSourceObservations: () => [
+          discoveryObservation,
+          ...(includeInvocation ? [invocationObservation] : []),
+        ],
+        onPotentialChange: graphPotential,
+        onSourceChange: graphChange,
+      }),
+    );
+    releaseBaseline();
+    await Promise.all([discoveryStart, graphStart]);
+    await vi.waitFor(() => {
+      expect(discoveryChange).toHaveBeenCalledOnce();
+      expect(graphChange).toHaveBeenCalledOnce();
+    });
+    discoveryPotential.mockClear();
+    discoveryChange.mockClear();
+    graphPotential.mockClear();
+    graphChange.mockClear();
+
+    const waitForPollAfter = async (callCount: number): Promise<void> => {
+      await vi.waitFor(() => {
+        expect(snapshotSources.mock.calls.length).toBeGreaterThan(callCount);
+      });
+      await new Promise((resolve) => setTimeout(resolve, 15));
+    };
+
+    let callsBeforeCoverageChange = snapshotSources.mock.calls.length;
+    includeInvocation = false;
+    await waitForPollAfter(callsBeforeCoverageChange);
+    expect(discoveryPotential).not.toHaveBeenCalled();
+    expect(discoveryChange).not.toHaveBeenCalled();
+
+    callsBeforeCoverageChange = snapshotSources.mock.calls.length;
+    includeInvocation = true;
+    await waitForPollAfter(callsBeforeCoverageChange);
+    expect(discoveryPotential).not.toHaveBeenCalled();
+    expect(discoveryChange).not.toHaveBeenCalled();
+
+    invocationVersion = "invocation-v2";
+    await vi.waitFor(() => {
+      expect(graphPotential).toHaveBeenCalledWith([agentRoot]);
+      expect(graphChange).toHaveBeenCalledWith([agentRoot]);
+    });
+    discoveryPotential.mockClear();
+    discoveryChange.mockClear();
+    graphPotential.mockClear();
+    graphChange.mockClear();
+
+    callsBeforeCoverageChange = snapshotSources.mock.calls.length;
+    broker.unsubscribe(graphKey);
+    expect(broker.size).toBe(1);
+    expect(onLastLeaseReleased).not.toHaveBeenCalled();
+    await waitForPollAfter(callsBeforeCoverageChange);
+    expect(discoveryPotential).not.toHaveBeenCalled();
+    expect(discoveryChange).not.toHaveBeenCalled();
+
+    invocationVersion = "invocation-v3";
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(discoveryPotential).not.toHaveBeenCalled();
+    expect(discoveryChange).not.toHaveBeenCalled();
+
+    discoveryVersion = "discovery-v2";
+    await vi.waitFor(() => {
+      expect(discoveryPotential).toHaveBeenCalledWith([agentRoot]);
+      expect(discoveryChange).toHaveBeenCalledWith([agentRoot]);
+    });
+
+    broker.unsubscribe(discoveryKey);
+    expect(onLastLeaseReleased).toHaveBeenCalledOnce();
+  });
+
+  it("detects a real source edit racing an observation coverage rebase", async () => {
+    const agentRoot = path.join(root, "agent");
+    const discoveryPath = path.join(agentRoot, "discovery.ts");
+    const invocationPath = path.join(agentRoot, "invocation.ts");
+    const discoveryObservation = {
+      workspaceRoot: root,
+      candidateRoot: agentRoot,
+      paths: [discoveryPath],
+    };
+    const invocationObservation = {
+      workspaceRoot: agentRoot,
+      candidateRoot: agentRoot,
+      paths: [invocationPath],
+    };
+    let includeInvocation = false;
+    let discoveryVersion = "discovery-v1";
+    let mutateDuringExpandedSample = false;
+    let releaseBaseline!: () => void;
+    const baselineGate = new Promise<void>((resolve) => {
+      releaseBaseline = resolve;
+    });
+    const snapshotSources = vi.fn(
+      async (
+        roots: readonly string[],
+        observations: readonly { paths: readonly string[] }[],
+      ) => {
+        const paths = observations
+          .flatMap((observation) => observation.paths)
+          .sort();
+        const snapshot = new Map([
+          [
+            agentRoot,
+            JSON.stringify(
+              paths.map((observedPath) => [
+                observedPath,
+                observedPath === discoveryPath
+                  ? discoveryVersion
+                  : "invocation-v1",
+              ]),
+            ),
+          ],
+        ]);
+        if (mutateDuringExpandedSample && paths.includes(invocationPath)) {
+          mutateDuringExpandedSample = false;
+          discoveryVersion = "discovery-v2";
+        }
+        expect(roots).toContain(agentRoot);
+        return snapshot;
+      },
+    );
+    const discoveryPotential = vi.fn();
+    const discoveryChange = vi.fn();
+    const graphChange = vi.fn();
+    const broker = new SharedWorkspaceWatchBroker({
+      forcePolling: true,
+      beforeInitialSnapshot: () => baselineGate,
+      pollIntervalMs: 5,
+      sourceDebounceMs: 1,
+      snapshotWorkspace: async () => "inventory",
+      snapshotSources,
+    });
+    const discoveryKey = {};
+    const graphKey = {};
+    const discoveryStart = broker.subscribe(
+      discoveryKey,
+      subscriber({
+        listSourceRoots: () => [agentRoot],
+        listSourceObservations: () => [discoveryObservation],
+        onPotentialChange: discoveryPotential,
+        onSourceChange: discoveryChange,
+      }),
+    );
+    const graphStart = broker.subscribe(
+      graphKey,
+      subscriber({
+        listSourceRoots: () => [agentRoot],
+        listSourceObservations: () => [
+          discoveryObservation,
+          ...(includeInvocation ? [invocationObservation] : []),
+        ],
+        onSourceChange: graphChange,
+      }),
+    );
+    releaseBaseline();
+    await Promise.all([discoveryStart, graphStart]);
+    await vi.waitFor(() => {
+      expect(discoveryChange).toHaveBeenCalledOnce();
+      expect(graphChange).toHaveBeenCalledOnce();
+    });
+    discoveryPotential.mockClear();
+    discoveryChange.mockClear();
+    graphChange.mockClear();
+
+    mutateDuringExpandedSample = true;
+    includeInvocation = true;
+
+    await vi.waitFor(() => {
+      expect(discoveryPotential).toHaveBeenCalledWith([agentRoot]);
+      expect(discoveryChange).toHaveBeenCalledWith([agentRoot]);
+      expect(graphChange).toHaveBeenCalledWith([agentRoot]);
+    });
+
+    broker.unsubscribe(graphKey);
+    broker.unsubscribe(discoveryKey);
+  });
+
+  it("retires the final lease during an in-flight coverage rebase", async () => {
+    const agentRoot = path.join(root, "agent");
+    const discoveryPath = path.join(agentRoot, "discovery.ts");
+    const invocationPath = path.join(agentRoot, "invocation.ts");
+    let includeInvocation = false;
+    let holdExpandedSample = false;
+    let expandedSampleStarted!: () => void;
+    const expandedSample = new Promise<void>((resolve) => {
+      expandedSampleStarted = resolve;
+    });
+    let releaseExpandedSample!: () => void;
+    const expandedSampleGate = new Promise<void>((resolve) => {
+      releaseExpandedSample = resolve;
+    });
+    const snapshotSources = vi.fn(
+      async (
+        _roots: readonly string[],
+        observations: readonly { paths: readonly string[] }[],
+      ) => {
+        const observedPaths = observations
+          .flatMap((observation) => observation.paths)
+          .sort();
+        if (holdExpandedSample && observedPaths.includes(invocationPath)) {
+          holdExpandedSample = false;
+          expandedSampleStarted();
+          await expandedSampleGate;
+        }
+        return new Map([[agentRoot, JSON.stringify(observedPaths)]]);
+      },
+    );
+    const onPotentialChange = vi.fn();
+    const onSourceChange = vi.fn();
+    const onLastLeaseReleased = vi.fn();
+    const broker = new SharedWorkspaceWatchBroker({
+      forcePolling: true,
+      pollIntervalMs: 5,
+      sourceDebounceMs: 1,
+      snapshotWorkspace: async () => "inventory",
+      snapshotSources,
+      onLastLeaseReleased,
+    });
+    const key = {};
+
+    await broker.subscribe(
+      key,
+      subscriber({
+        listSourceRoots: () => [agentRoot],
+        listSourceObservations: () => [
+          {
+            workspaceRoot: root,
+            candidateRoot: agentRoot,
+            paths: [discoveryPath],
+          },
+          ...(includeInvocation
+            ? [
+                {
+                  workspaceRoot: agentRoot,
+                  candidateRoot: agentRoot,
+                  paths: [invocationPath],
+                },
+              ]
+            : []),
+        ],
+        onPotentialChange,
+        onSourceChange,
+      }),
+    );
+    await vi.waitFor(() => expect(onSourceChange).toHaveBeenCalledOnce());
+    onPotentialChange.mockClear();
+    onSourceChange.mockClear();
+
+    holdExpandedSample = true;
+    includeInvocation = true;
+    await expandedSample;
+
+    broker.unsubscribe(key);
+    expect(broker.size).toBe(0);
+    expect(onLastLeaseReleased).toHaveBeenCalledOnce();
+    releaseExpandedSample();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(onPotentialChange).not.toHaveBeenCalled();
+    expect(onSourceChange).not.toHaveBeenCalled();
+    expect(onLastLeaseReleased).toHaveBeenCalledOnce();
+  });
+
   it("cleans a failed lease so a later subscription can retry", async () => {
     let attempts = 0;
     const closes: Array<ReturnType<typeof vi.fn>> = [];

--- a/packages/harness/src/core/workspace-watch-broker.ts
+++ b/packages/harness/src/core/workspace-watch-broker.ts
@@ -66,17 +66,60 @@ function changedSourceRoots(
   const changed = [...new Set([...previous.keys(), ...current.keys()])].filter(
     (root) => previous.get(root) !== current.get(root),
   );
+  return deepestSourceRoots(changed);
+}
+
+function deepestSourceRoots(roots: readonly string[]): string[] {
   // Nested registered projects appear in their parent's recursive snapshot.
   // Attribute the edit only to the deepest changed caller(s).
-  return changed
+  return [...new Set(roots)]
     .filter(
       (root) =>
-        !changed.some(
+        !roots.some(
           (candidate) =>
             candidate !== root && isNestedSourceRoot(root, candidate),
         ),
     )
     .sort();
+}
+
+interface SourceSnapshotRequest {
+  roots: readonly string[];
+  observations: readonly WorkflowSourceObservation[];
+  signature: string;
+}
+
+interface SourceSnapshotSample {
+  request: SourceSnapshotRequest;
+  snapshots: ReadonlyMap<string, string>;
+  changedRoots: readonly string[];
+  baselineRequest: SourceSnapshotRequest | null;
+  baselineSnapshots: ReadonlyMap<string, string> | null;
+}
+
+function sourceSnapshotRequest(
+  roots: readonly string[],
+  observations: readonly WorkflowSourceObservation[],
+): SourceSnapshotRequest {
+  const retainedRoots = [...roots];
+  const retainedObservations = observations.map((observation) => ({
+    workspaceRoot: observation.workspaceRoot,
+    candidateRoot: observation.candidateRoot,
+    paths: [...observation.paths],
+  }));
+  const samplingDeclaration = retainedObservations.map((observation) => [
+    path.resolve(observation.workspaceRoot),
+    path.resolve(observation.candidateRoot),
+    observation.paths,
+  ]);
+  return {
+    roots: retainedRoots,
+    observations: retainedObservations,
+    signature: JSON.stringify([
+      retainedRoots.map((root) => path.resolve(root)),
+      samplingDeclaration,
+    ]),
+  };
 }
 
 export interface WorkspaceWatchCallbacks {
@@ -151,6 +194,7 @@ export class WorkspaceRootWatcher {
   private sourcePaths = new Set<string>();
   private ambiguousSourceChange = false;
   private lastSourceSnapshots: ReadonlyMap<string, string> | null = null;
+  private lastSourceRequest: SourceSnapshotRequest | null = null;
   private lastInventorySnapshot: string | null;
   private failedInventorySnapshot: string | null = null;
   private inventoryGeneration = 0;
@@ -188,32 +232,25 @@ export class WorkspaceRootWatcher {
     const generation = this.rawGeneration;
     await this.options.beforeInitialSnapshot?.();
     if (this.closed) return;
-    let sourceRoots: readonly string[] = [];
-    let sourceObservations: readonly WorkflowSourceObservation[] = [];
-    try {
-      sourceRoots = this.callbacks.listSourceRoots();
-      sourceObservations = this.callbacks.listSourceObservations?.() ?? [];
-    } catch {
-      // The workspace baseline remains useful and the next poll retries.
-    }
-    const [initialInventorySnapshot, initialSourceSnapshots] =
-      await Promise.all([
-        this.snapshotWorkspace(this.root),
-        this.snapshotSources(sourceRoots, sourceObservations),
-      ]);
+    const [initialInventorySnapshot, initialSourceSample] = await Promise.all([
+      this.snapshotWorkspace(this.root),
+      this.sampleSourceSnapshots(),
+    ]);
     if (this.closed) return;
     if (this.lastInventorySnapshot === null) {
       this.lastInventorySnapshot = initialInventorySnapshot;
     } else if (this.lastInventorySnapshot !== initialInventorySnapshot) {
       this.checkInventoryAsync();
     }
-    if (this.lastSourceSnapshots === null) {
-      this.lastSourceSnapshots = initialSourceSnapshots;
-    } else if (
-      changedSourceRoots(this.lastSourceSnapshots, initialSourceSnapshots)
-        .length > 0
-    ) {
-      this.scheduleSourceChange(null);
+    if (this.sourceSampleIsCurrent(initialSourceSample)) {
+      if (
+        initialSourceSample.baselineSnapshots !== null &&
+        initialSourceSample.changedRoots.length > 0
+      ) {
+        this.scheduleSourceChange(null);
+      } else {
+        this.acceptSourceSample(initialSourceSample);
+      }
     }
     if (generation !== this.rawGeneration) {
       this.checkInventoryAsync();
@@ -230,7 +267,7 @@ export class WorkspaceRootWatcher {
       } catch {
         // The source callback below still performs the bounded reconciliation.
       }
-      const retainedRoots = [...initialSourceSnapshots.keys()].sort();
+      const retainedRoots = [...initialSourceSample.snapshots.keys()].sort();
       this.sourceGeneration += 1;
       // An empty concrete list still asks every production subscriber to scan
       // its containing workspace. Avoid null here: null intentionally performs
@@ -254,6 +291,85 @@ export class WorkspaceRootWatcher {
       roots,
       observations,
     );
+  }
+
+  private readSourceSnapshotRequest(): SourceSnapshotRequest {
+    try {
+      return sourceSnapshotRequest(
+        this.callbacks.listSourceRoots(),
+        this.callbacks.listSourceObservations?.() ?? [],
+      );
+    } catch {
+      // Source declarations are hints. A transient reader failure cannot erase
+      // accepted coverage or manufacture a source delta; the next sample
+      // retries while workspace inventory polling remains independent.
+      return this.lastSourceRequest ?? sourceSnapshotRequest([], []);
+    }
+  }
+
+  private async sampleSourceSnapshots(): Promise<SourceSnapshotSample> {
+    const request = this.readSourceSnapshotRequest();
+    const baselineRequest = this.lastSourceRequest;
+    const baselineSnapshots = this.lastSourceSnapshots;
+    if (
+      baselineRequest &&
+      baselineSnapshots &&
+      baselineRequest.signature !== request.signature
+    ) {
+      // Observation membership is consumer-owned configuration, not a
+      // filesystem mutation. Compare like-for-like against the accepted
+      // declaration first so a caller/subscriber retirement cannot manufacture
+      // a discovery edit. Sample the new declaration on both sides of that
+      // comparison so an edit racing the coverage transition is still visible.
+      const [comparableSnapshots, transitionSnapshots] = await Promise.all([
+        this.snapshotSources(
+          baselineRequest.roots,
+          baselineRequest.observations,
+        ),
+        this.snapshotSources(request.roots, request.observations),
+      ]);
+      const snapshots = await this.snapshotSources(
+        request.roots,
+        request.observations,
+      );
+      return {
+        request,
+        snapshots,
+        changedRoots: deepestSourceRoots([
+          ...changedSourceRoots(baselineSnapshots, comparableSnapshots),
+          ...changedSourceRoots(transitionSnapshots, snapshots),
+        ]),
+        baselineRequest,
+        baselineSnapshots,
+      };
+    }
+    const snapshots = await this.snapshotSources(
+      request.roots,
+      request.observations,
+    );
+    return {
+      request,
+      snapshots,
+      changedRoots: baselineSnapshots
+        ? changedSourceRoots(baselineSnapshots, snapshots)
+        : [],
+      baselineRequest,
+      baselineSnapshots,
+    };
+  }
+
+  private sourceSampleIsCurrent(sample: SourceSnapshotSample): boolean {
+    return (
+      this.lastSourceRequest === sample.baselineRequest &&
+      this.lastSourceSnapshots === sample.baselineSnapshots
+    );
+  }
+
+  private acceptSourceSample(sample: SourceSnapshotSample): boolean {
+    if (!this.sourceSampleIsCurrent(sample)) return false;
+    this.lastSourceRequest = sample.request;
+    this.lastSourceSnapshots = sample.snapshots;
+    return true;
   }
 
   private enqueue(
@@ -327,34 +443,30 @@ export class WorkspaceRootWatcher {
       async () => {
         if (generation !== this.sourceGeneration) return;
         let effectivePaths = paths;
-        let observedSnapshots: ReadonlyMap<string, string> | null = null;
+        let sourceSample: SourceSnapshotSample | null = null;
         if (paths === null) {
-          let roots: readonly string[] = [];
-          let observations: readonly WorkflowSourceObservation[] = [];
-          try {
-            roots = this.callbacks.listSourceRoots();
-            observations = this.callbacks.listSourceObservations?.() ?? [];
-          } catch {
-            // Keep the conservative scope-wide callback.
-          }
-          observedSnapshots = await this.snapshotSources(roots, observations);
-          if (this.lastSourceSnapshots) {
-            const changed = changedSourceRoots(
-              this.lastSourceSnapshots,
-              observedSnapshots,
-            );
-            effectivePaths = changed.length > 0 ? changed : null;
+          sourceSample = await this.sampleSourceSnapshots();
+          if (!this.sourceSampleIsCurrent(sourceSample)) {
+            // Another accepted sample won the race. The raw event still
+            // requires conservative reconciliation, but it must not overwrite
+            // that newer baseline when this callback settles.
+            effectivePaths = null;
+          } else if (sourceSample.baselineSnapshots) {
+            effectivePaths =
+              sourceSample.changedRoots.length > 0
+                ? sourceSample.changedRoots
+                : null;
           } else {
             // A raw event raced the initial baseline. The post-edit sample
             // cannot identify a delta, so reconcile every retained root rather
             // than only the parent scope (which may stop at repo/ignore roots).
-            const retainedRoots = [...observedSnapshots.keys()].sort();
+            const retainedRoots = [...sourceSample.snapshots.keys()].sort();
             effectivePaths = retainedRoots.length > 0 ? retainedRoots : null;
           }
         }
         await this.callbacks.onSourceChange(effectivePaths);
         if (generation !== this.sourceGeneration || this.closed) return;
-        if (observedSnapshots) this.lastSourceSnapshots = observedSnapshots;
+        if (sourceSample) this.acceptSourceSample(sourceSample);
       },
       () => {
         if (this.closed || generation !== this.sourceGeneration) return;
@@ -574,27 +686,20 @@ export class WorkspaceRootWatcher {
     const poll = (): void => {
       if (this.closed || this.pollInFlight || !this.initialized) return;
       this.pollInFlight = true;
-      let sourceRoots: readonly string[] = [];
-      let sourceObservations: readonly WorkflowSourceObservation[] = [];
-      try {
-        sourceRoots = this.callbacks.listSourceRoots();
-        sourceObservations = this.callbacks.listSourceObservations?.() ?? [];
-      } catch {
-        // Registry reads are hints too. Inventory polling still proceeds.
-      }
       void Promise.all([
-        this.snapshotSources(sourceRoots, sourceObservations),
+        this.sampleSourceSnapshots(),
         this.snapshotWorkspace(this.root),
       ])
-        .then(([sourceSnapshots, inventorySnapshot]) => {
+        .then(([sourceSample, inventorySnapshot]) => {
           if (this.closed) return;
-          const changedRoots = this.lastSourceSnapshots
-            ? changedSourceRoots(this.lastSourceSnapshots, sourceSnapshots)
+          const sourceSampleCurrent = this.sourceSampleIsCurrent(sourceSample);
+          const changedRoots = sourceSampleCurrent
+            ? sourceSample.changedRoots
             : [];
           const inventoryChanged =
             this.lastInventorySnapshot !== null &&
             inventorySnapshot !== this.lastInventorySnapshot;
-          this.lastSourceSnapshots = sourceSnapshots;
+          if (sourceSampleCurrent) this.acceptSourceSample(sourceSample);
           let sourceChanged = false;
           if (inventoryChanged) {
             // Structural evidence wins when both bounded channels move. A

--- a/packages/harness/src/core/workspace-watch-broker.ts
+++ b/packages/harness/src/core/workspace-watch-broker.ts
@@ -319,26 +319,22 @@ export class WorkspaceRootWatcher {
       // Observation membership is consumer-owned configuration, not a
       // filesystem mutation. Compare like-for-like against the accepted
       // declaration first so a caller/subscriber retirement cannot manufacture
-      // a discovery edit. Sample the new declaration on both sides of that
-      // comparison so an edit racing the coverage transition is still visible.
-      const [comparableSnapshots, transitionSnapshots] = await Promise.all([
+      // a discovery edit. The concurrent current-declaration sample becomes the
+      // next baseline; edits after it remain visible to the next normal sample.
+      const [comparableSnapshots, snapshots] = await Promise.all([
         this.snapshotSources(
           baselineRequest.roots,
           baselineRequest.observations,
         ),
         this.snapshotSources(request.roots, request.observations),
       ]);
-      const snapshots = await this.snapshotSources(
-        request.roots,
-        request.observations,
-      );
       return {
         request,
         snapshots,
-        changedRoots: deepestSourceRoots([
-          ...changedSourceRoots(baselineSnapshots, comparableSnapshots),
-          ...changedSourceRoots(transitionSnapshots, snapshots),
-        ]),
+        changedRoots: changedSourceRoots(
+          baselineSnapshots,
+          comparableSnapshots,
+        ),
         baselineRequest,
         baselineSnapshots,
       };

--- a/packages/harness/src/core/workspace-watch-broker.ts
+++ b/packages/harness/src/core/workspace-watch-broker.ts
@@ -319,15 +319,18 @@ export class WorkspaceRootWatcher {
       // Observation membership is consumer-owned configuration, not a
       // filesystem mutation. Compare like-for-like against the accepted
       // declaration first so a caller/subscriber retirement cannot manufacture
-      // a discovery edit. The concurrent current-declaration sample becomes the
-      // next baseline; edits after it remain visible to the next normal sample.
-      const [comparableSnapshots, snapshots] = await Promise.all([
-        this.snapshotSources(
-          baselineRequest.roots,
-          baselineRequest.observations,
-        ),
-        this.snapshotSources(request.roots, request.observations),
-      ]);
+      // a discovery edit. Sample the current declaration before the comparable
+      // old declaration: a common-coverage edit between those walks is then
+      // reported by the old comparison, while a later edit remains visible
+      // against the earlier current-declaration baseline on the next sample.
+      const snapshots = await this.snapshotSources(
+        request.roots,
+        request.observations,
+      );
+      const comparableSnapshots = await this.snapshotSources(
+        baselineRequest.roots,
+        baselineRequest.observations,
+      );
       return {
         request,
         snapshots,

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -826,15 +826,13 @@ export const startServer = async (
     };
   };
 
-  const acceptedSourceObservationsForRoot = (
+  const discoveryObservationsForRoot = (
     root: string,
-  ): WorkflowSourceObservation[] => {
-    const canonicalRoot = acceptedCanonicalScopeRoot(root);
-    return sourceObservationsWithinScope(canonicalRoot, [
-      ...acceptedSourceObservations,
-      ...systemGraphInvocations.invocationObservations(),
-    ]);
-  };
+  ): WorkflowSourceObservation[] =>
+    sourceObservationsWithinScope(
+      acceptedCanonicalScopeRoot(root),
+      acceptedSourceObservations,
+    );
 
   const markAcceptedInventoryDirty = (root: string): void => {
     const canonicalRoot = acceptedCanonicalScopeRoot(root);
@@ -1130,6 +1128,13 @@ export const startServer = async (
       },
     },
   );
+  const legacyGraphObservationsForRoot = (
+    root: string,
+  ): WorkflowSourceObservation[] =>
+    sourceObservationsWithinScope(acceptedCanonicalScopeRoot(root), [
+      ...acceptedSourceObservations,
+      ...systemGraphInvocations.invocationObservations(),
+    ]);
   const systemGraphInventory = new HarnessRegistryInventoryProvider({
     listWorkflows: () => workflowsCache,
     inventorySnapshot: acceptedInventorySnapshot,
@@ -1372,8 +1377,10 @@ export const startServer = async (
         cwd,
         workflowsCache.map((workflow) => workflow.path),
       ),
+    // Session and rail discovery own accepted registry evidence only. Legacy
+    // invocation observations must remain removable with the System Graph.
     listSourceObservations: (_harnessSessionId, cwd) =>
-      acceptedSourceObservationsForRoot(cwd),
+      discoveryObservationsForRoot(cwd),
     onPotentialChange: (harnessSessionId) => {
       const session = sessionManager.get(harnessSessionId);
       if (session && session.status !== "exited") {
@@ -2200,8 +2207,10 @@ export const startServer = async (
   const systemGraphWatcher = new SystemGraphWatcherManager(
     {
       listSourceRoots: workflowRootsForGraphScope,
+      // Direct-invocation observations are a private legacy graph input during
+      // coexistence; they never participate in session/rail discovery.
       listSourceObservations: (scope) =>
-        acceptedSourceObservationsForRoot(scope.root),
+        legacyGraphObservationsForRoot(scope.root),
       onPotentialChange: (scope, sourcePaths) => {
         const discoveryBudget = workspaceDiscoveryBudget(scope.root);
         prepareDirtyWorkflowRoot(scope.root, undefined, discoveryBudget);

--- a/packages/harness/src/server/system-graph-freshness.test.ts
+++ b/packages/harness/src/server/system-graph-freshness.test.ts
@@ -13,6 +13,7 @@ import type {
   WorkflowInfo,
 } from "../shared/types.js";
 import type { SystemGraphSnapshot } from "../shared/system-graph.js";
+import { CachedAgentInvocationProvider } from "../core/system-graph-relationships.js";
 import type { RegistryWorkflowInfo } from "../core/workflow-registry.js";
 import { startServer, type HarnessServer } from "./index.js";
 
@@ -106,6 +107,7 @@ describe("workspace graph freshness wiring", () => {
     await server?.sessionManager.flush();
     await server?.close();
     server = undefined;
+    vi.restoreAllMocks();
     await fs.rm(tempRoot, {
       recursive: true,
       force: true,
@@ -118,6 +120,10 @@ describe("workspace graph freshness wiring", () => {
     "refreshes source invocations and agent inventory without a session",
     { retry: 1, timeout: 30_000 },
     async () => {
+      const invocationObservations = vi.spyOn(
+        CachedAgentInvocationProvider.prototype,
+        "invocationObservations",
+      );
       const researchRoot = await scaffoldAgent(workspaceRoot, "research");
       await scaffoldAgent(workspaceRoot, "growth");
       server = await startServer({
@@ -174,6 +180,7 @@ describe("workspace graph freshness wiring", () => {
         return JSON.parse(raw) as SystemGraphSnapshot;
       };
       const initial = await readGraph();
+      await vi.waitFor(() => expect(invocationObservations).toHaveBeenCalled());
       // Cold discovery is detached: cached inventory renders immediately,
       // conservatively degraded until this process accepts fresh evidence.
       expect(initial.state).toBe("degraded");

--- a/packages/harness/src/server/workspace-rescan.test.ts
+++ b/packages/harness/src/server/workspace-rescan.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { WebSocket } from "ws";
 
+import { CachedAgentInvocationProvider } from "../core/system-graph-relationships.js";
 import { startServer, type HarnessServer } from "./index.js";
 import type { BusMessage, HarnessAdapter, LaunchOpts, SpawnSpec, WorkflowInfo } from "../shared/types.js";
 
@@ -56,6 +57,7 @@ describe("mid-session workflow rescan", () => {
     await server?.sessionManager.flush();
     await server?.close();
     server = undefined;
+    vi.restoreAllMocks();
     await rm(dir, { recursive: true, force: true });
   });
 
@@ -86,6 +88,10 @@ describe("mid-session workflow rescan", () => {
     "adds a scaffolded workflow and drops it when its marker is removed, broadcasting each change",
     { retry: 1, timeout: 20_000 },
     async () => {
+      const invocationObservations = vi.spyOn(
+        CachedAgentInvocationProvider.prototype,
+        "invocationObservations",
+      );
       server = await startServer({
         port: 0,
         bootToken: "test-token",
@@ -112,6 +118,7 @@ describe("mid-session workflow rescan", () => {
         },
         { timeout: 8_000, interval: 150 },
       );
+      expect(invocationObservations).not.toHaveBeenCalled();
 
       expect(server.sessionManager.get(session.id)?.boundWorkflowPath).toBe(
         join(cwd, "hn-story-images"),
@@ -130,6 +137,7 @@ describe("mid-session workflow rescan", () => {
         },
         { timeout: 8_000, interval: 150 },
       );
+      expect(invocationObservations).not.toHaveBeenCalled();
     },
   );
 });


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [x] Maintenance or refactor

## Problem and motivation

Workspace/session discovery and the legacy System Graph currently share both watch ownership and one combined polling observation declaration. That makes direct-invocation source coverage part of permanent Studio rail/session freshness even though invocation topology belongs only to the removable legacy graph. Retiring the graph subscriber can also look like a source change if the shared polling baseline compares different coverage declarations.

SAP-3087 creates the cutover seam needed to keep accepted discovery fresh while legacy invocation topology is switched off independently in later E8 work.

## Summary and scope

- Route only accepted registry observations to `WorkspaceWatcherManager` for session and Studio rail discovery.
- Give `SystemGraphWatcherManager` an explicit legacy composition of accepted discovery plus direct-invocation observations.
- Track the observation declaration beside each accepted shared polling baseline.
- Rebase coverage transitions using two ordered, like-for-like samples so subscriber retirement does not manufacture a filesystem edit and a shared-path edit cannot be absorbed into the new baseline.
- Preserve one canonical-root native watcher, one polling owner, callback ordering, debounce behavior, failure isolation, and final-lease shutdown.
- Cover graph-first and session-first retirement, invocation-only legacy refresh, accepted-discovery continuity, transition races, and final-lease invalidation.

Intentionally out of scope: Agent Map refresh, endpoint/payload/authority changes, public API changes, or removal of legacy System Graph behavior.

## Related work

Related issue or discussion: SAP-3087

## Validation

```text
pnpm --filter @sapiom/harness exec vitest run src/core/workspace-watch-broker.test.ts src/core/system-graph-watcher.test.ts src/core/workspace-watcher.test.ts src/server/workspace-rescan.test.ts src/server/system-graph-freshness.test.ts — 5 files, 63 tests passed
pnpm --filter @sapiom/harness exec vitest run — 184 files, 3,119 tests passed
pnpm --filter @sapiom/harness test:perf — 3 files, 10 tests passed
pnpm --filter @sapiom/harness typecheck — passed
pnpm --filter @sapiom/harness lint — passed
pnpm --filter @sapiom/harness build — passed
pnpm changeset status — passed
git diff --check — passed
```

### Tests and documentation

Added focused unit and server integration coverage for observation ownership, declaration-only coverage transitions, both consumer-retirement orders, in-flight lease retirement, and continued legacy invocation refresh. Added a patch Changeset documenting the polling-fallback behavior. No broader documentation is needed because this is an internal infrastructure seam with no public API or Agent Map contract change.

## Compatibility and release impact

- Breaking or externally visible changes: On polling fallback, files covered only by legacy invocation scanning no longer trigger session/rail rescans after the legacy graph subscription retires. Accepted discovery inputs continue to refresh normally. No public API break.
- Changeset: Added for `@sapiom/harness` (patch).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex helped research the existing watcher contracts, produce the implementation and tests, and respond to automated review. I reviewed the diff and verified it with the focused tests, full harness suite, performance suite, typecheck, lint, build, Changesets validation, and whitespace checks listed above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
