### PR TITLE
fix(fetch): preserve Request __sapiom metadata across cloning

### DIFF
--- a/.changeset/fetch-preserve-sapiom-metadata.md
+++ b/.changeset/fetch-preserve-sapiom-metadata.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/fetch": patch
+---
+
+Preserve `Request.__sapiom` metadata across internal Request cloning so per-request `enabled: false` overrides work when the input is a Request object.

--- a/packages/fetch/src/fetch.ts
+++ b/packages/fetch/src/fetch.ts
@@ -12,6 +12,7 @@ import {
   PaymentConfig,
   CompletionConfig,
 } from "./interceptors.js";
+import { cloneRequest, requestFromInput } from "./sapiom-request.js";
 
 /**
  * Configuration for Sapiom-enabled Fetch client
@@ -120,7 +121,7 @@ export function createFetch(config?: SapiomFetchConfig): typeof fetch {
     input: string | URL | Request,
     init?: RequestInit,
   ): Promise<Response> => {
-    let request = new Request(input, init);
+    let request = requestFromInput(input, init);
 
     const requestMetadata = (request as any).__sapiom || {};
     const userMetadata = { ...defaultMetadata, ...requestMetadata };
@@ -137,7 +138,7 @@ export function createFetch(config?: SapiomFetchConfig): typeof fetch {
       if (identityHeaders["Sapiom-Identity"]) {
         const headers = new Headers(request.headers);
         headers.set("Sapiom-Identity", identityHeaders["Sapiom-Identity"]);
-        request = new Request(request, { headers });
+        request = cloneRequest(request, { headers });
       }
     }
 

--- a/packages/fetch/src/interceptors.ts
+++ b/packages/fetch/src/interceptors.ts
@@ -12,6 +12,8 @@ import {
 
 import type { FailureMode, TransactionPollingConfig } from "@sapiom/core";
 
+import { cloneRequest } from "./sapiom-request.js";
+
 /**
  * Authorization configuration for fetch
  */
@@ -304,7 +306,7 @@ export async function handleAuthorization(
   const headers = new Headers(request.headers);
   setHeader(headers, "X-Sapiom-Transaction-Id", transaction.id);
 
-  return new Request(request, { headers });
+  return cloneRequest(request, { headers });
 }
 
 /**
@@ -503,7 +505,7 @@ export async function handlePayment(
   setHeader(retryHeaders, headerName, paymentHeaderValue);
 
   return await globalThis.fetch(
-    new Request(requestForRetry, { headers: retryHeaders }),
+    cloneRequest(requestForRetry, { headers: retryHeaders }),
   );
 }
 

--- a/packages/fetch/src/sapiom-request.test.ts
+++ b/packages/fetch/src/sapiom-request.test.ts
@@ -1,0 +1,52 @@
+import {
+  cloneRequest,
+  copySapiomMetadata,
+  readSapiomMetadata,
+  requestFromInput,
+} from "./sapiom-request";
+
+describe("sapiom-request metadata", () => {
+  it("reads __sapiom from Request input before cloning", () => {
+    const original = new Request("https://example.test/public");
+    (original as any).__sapiom = { enabled: false };
+
+    expect(readSapiomMetadata(original)).toEqual({ enabled: false });
+    expect(readSapiomMetadata("https://example.test")).toBeUndefined();
+  });
+
+  it("carries __sapiom through requestFromInput", () => {
+    const original = new Request("https://example.test/public");
+    (original as any).__sapiom = { enabled: false, serviceName: "demo" };
+
+    const copy = requestFromInput(original);
+
+    expect((copy as any).__sapiom).toEqual({
+      enabled: false,
+      serviceName: "demo",
+    });
+  });
+
+  it("carries __sapiom through cloneRequest", () => {
+    const original = new Request("https://example.test/api");
+    (original as any).__sapiom = { actionName: "fetch" };
+
+    const headers = new Headers(original.headers);
+    headers.set("X-Test", "1");
+    const cloned = cloneRequest(original, { headers });
+
+    expect((cloned as any).__sapiom).toEqual({ actionName: "fetch" });
+    expect(cloned.headers.get("X-Test")).toBe("1");
+  });
+
+  it("matches issue #690 reproduction shape", () => {
+    const original = new Request("https://example.test/public");
+    (original as any).__sapiom = { enabled: false };
+
+    const copy = new Request(original);
+    copySapiomMetadata(original, copy);
+
+    expect((original as any).__sapiom).toEqual({ enabled: false });
+    expect((copy as any).__sapiom).toEqual({ enabled: false });
+    expect(Object.prototype.hasOwnProperty.call(copy, "__sapiom")).toBe(true);
+  });
+});

--- a/packages/fetch/src/sapiom-request.ts
+++ b/packages/fetch/src/sapiom-request.ts
@@ -1,0 +1,44 @@
+export type SapiomRequestMeta = Record<string, unknown>;
+
+type RequestWithSapiom = Request & { __sapiom?: SapiomRequestMeta };
+
+/** Read per-request metadata from a Request input before native cloning drops it. */
+export function readSapiomMetadata(
+  input: string | URL | Request,
+): SapiomRequestMeta | undefined {
+  if (input instanceof Request) {
+    return (input as RequestWithSapiom).__sapiom;
+  }
+  return undefined;
+}
+
+/** Copy `__sapiom` from one Request onto another (native Request clones drop it). */
+export function copySapiomMetadata(from: Request, to: Request): Request {
+  const meta = (from as RequestWithSapiom).__sapiom;
+  if (meta) {
+    (to as RequestWithSapiom).__sapiom = meta;
+  }
+  return to;
+}
+
+/** `new Request` wrapper that preserves `__sapiom` custom properties. */
+export function cloneRequest(
+  request: Request,
+  init?: RequestInit,
+): Request {
+  return copySapiomMetadata(request, new Request(request, init));
+}
+
+/** Build a Request from fetch input, carrying metadata from a Request source. */
+export function requestFromInput(
+  input: string | URL | Request,
+  init?: RequestInit,
+): Request {
+  const inputMetadata = readSapiomMetadata(input);
+  const request = new Request(input, init);
+  if (inputMetadata) {
+    const existing = (request as RequestWithSapiom).__sapiom;
+    (request as RequestWithSapiom).__sapiom = { ...inputMetadata, ...existing };
+  }
+  return request;
+}


### PR DESCRIPTION
## Summary
- `@sapiom/fetch` cloned Request inputs with `new Request(input, init)` before reading `__sapiom`, so per-request `{ enabled: false }` overrides were silently dropped.
- Read metadata from the source Request before cloning and copy it onto every internal `new Request` (identity header, authorization, 402 retry).

Fixes #690

## Test plan
- [x] `sapiom-request.test.ts` — reproduces issue #690 shape + clone helpers
- [ ] CI (`@sapiom/fetch` jest)

Made with [Cursor](https://cursor.com)