### PR TITLE
feat(harness): add Agent Map concept demo

### DIFF
--- a/packages/harness/web/e2e/agent-map-demo.spec.ts
+++ b/packages/harness/web/e2e/agent-map-demo.spec.ts
@@ -1,0 +1,405 @@
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+const GOLDEN_PATH_REQUEST =
+  "Build a research agent that finds the top ten stocks trading today. Store the research report, then give it to a marketing agent connected to TikTok that turns it into a news-format video and publishes it.";
+
+async function send(page: Page, text: string): Promise<void> {
+  await page.getByTestId("agent-map-demo-input").fill(text);
+  await page.getByTestId("agent-map-demo-send").click();
+}
+
+test("walks the local Agent Map proposal from empty plan through reset", async ({
+  page,
+}) => {
+  const productRequests: string[] = [];
+  page.on("request", (request) => {
+    const pathname = new URL(request.url()).pathname;
+    if (
+      pathname.startsWith("/api/") ||
+      pathname.startsWith("/canvas/") ||
+      pathname.startsWith("/ws/")
+    ) {
+      productRequests.push(pathname);
+    }
+  });
+  await page.setViewportSize({ width: 1440, height: 1714 });
+  await page.goto("/?mockFixtures=agent-map");
+
+  const demo = page.getByTestId("agent-map-demo");
+  const map = page.getByTestId("agent-map-demo-map");
+  await expect(demo).toBeVisible();
+  await expect(page.getByTestId("agent-map-demo-rail-map")).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+  await expect(
+    page.getByTestId("agent-map-demo-project-toggle"),
+  ).toHaveAttribute("aria-expanded", "true");
+  await expect(map.locator('[data-testid^="agent-map-node-"]')).toHaveCount(0);
+  await expect(page.getByTestId("agent-map-demo-transcript")).toContainText(
+    "I’ll plan the project’s agents, responsibilities, data flow, resources, and connectors with you. What outcome do you want this project to create?",
+  );
+  await page.screenshot({
+    path: "web/e2e/screenshots/agent-map-demo-opening.png",
+    fullPage: true,
+  });
+
+  // The project label is disclosure only. It folds and restores its children;
+  // the pinned map remains the selected destination when it comes back.
+  await page.getByTestId("agent-map-demo-project-toggle").click();
+  await expect(
+    page.getByTestId("agent-map-demo-project-toggle"),
+  ).toHaveAttribute("aria-expanded", "false");
+  await expect(page.getByTestId("agent-map-demo-rail-map")).toHaveCount(0);
+  await page.getByTestId("agent-map-demo-project-toggle").click();
+  await expect(page.getByTestId("agent-map-demo-rail-map")).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+
+  // Presentation chip follows the Studio composer precedent: it prefills the
+  // normal chat box, then the ordinary Send action advances the script.
+  await page.getByTestId("agent-map-demo-suggestion").click();
+  await expect(page.getByTestId("agent-map-demo-input")).toHaveValue(
+    GOLDEN_PATH_REQUEST,
+  );
+  await page.getByTestId("agent-map-demo-send").click();
+
+  await expect(
+    page.getByTestId("agent-map-node-market-research"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("agent-map-node-marketing-publisher"),
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("agent-map-node-research-database"),
+  ).toBeVisible();
+  await expect(page.getByTestId("agent-map-node-tiktok")).toBeVisible();
+  await expect(page.getByTestId("agent-map-node-news-editor")).toHaveCount(0);
+  await expect(page.getByTestId("agent-map-demo-map-status")).toContainText(
+    "Proposal · rev 1",
+  );
+  await expect(page.getByTestId("agent-map-demo-graph")).toContainText(
+    "ResearchReport",
+  );
+  await expect(
+    page.getByTestId("agent-map-demo-proposal-card"),
+  ).toHaveAttribute("data-revision", "1");
+
+  // Regression: the board used to inherit the entire tall pane height while
+  // its SVG continued to draw in a 1000×600 coordinate system. Keep cards,
+  // labels, and paths inside one compact 5:3 scene instead.
+  const graph = page.getByTestId("agent-map-demo-graph");
+  const tallGraphGeometry = await graph.evaluate((element) => {
+    const graphRect = element.getBoundingClientRect();
+    const canvasRect = element.parentElement?.getBoundingClientRect();
+    if (!canvasRect) throw new Error("Agent Map graph has no canvas parent");
+
+    const cards = Array.from(
+      element.querySelectorAll<HTMLElement>('[data-testid^="agent-map-node-"]'),
+      (card) => {
+        const rect = card.getBoundingClientRect();
+        return {
+          top: rect.top - graphRect.top,
+          right: rect.right - graphRect.left,
+          bottom: rect.bottom - graphRect.top,
+          left: rect.left - graphRect.left,
+        };
+      },
+    );
+
+    return {
+      width: graphRect.width,
+      height: graphRect.height,
+      canvasHeight: canvasRect.height,
+      cards,
+      verticalSpan:
+        Math.max(...cards.map((card) => card.bottom)) -
+        Math.min(...cards.map((card) => card.top)),
+    };
+  });
+
+  expect(tallGraphGeometry.width / tallGraphGeometry.height).toBeCloseTo(
+    5 / 3,
+    2,
+  );
+  expect(tallGraphGeometry.height).toBeLessThan(500);
+  expect(tallGraphGeometry.height).toBeLessThan(
+    tallGraphGeometry.canvasHeight / 2,
+  );
+  expect(tallGraphGeometry.cards).toHaveLength(4);
+  for (const card of tallGraphGeometry.cards) {
+    expect(card.top).toBeGreaterThanOrEqual(-1);
+    expect(card.left).toBeGreaterThanOrEqual(-1);
+    expect(card.right).toBeLessThanOrEqual(tallGraphGeometry.width + 1);
+    expect(card.bottom).toBeLessThanOrEqual(tallGraphGeometry.height + 1);
+  }
+  expect(tallGraphGeometry.verticalSpan).toBeLessThan(
+    tallGraphGeometry.height * 0.9,
+  );
+  await page.screenshot({
+    path: "web/e2e/screenshots/agent-map-demo-tall-proposal.png",
+    fullPage: true,
+  });
+
+  await page.getByTestId("agent-map-demo-suggestion").click();
+  await page.getByTestId("agent-map-demo-send").click();
+  await expect(page.getByTestId("agent-map-node-news-editor")).toBeVisible();
+  await expect(page.getByTestId("agent-map-node-news-editor")).toContainText(
+    "Owned subagent",
+  );
+  await expect(page.getByTestId("agent-map-demo-map-status")).toContainText(
+    "Proposal · rev 2",
+  );
+  await expect(
+    page.getByTestId("agent-map-demo-agent-rows").getByRole("button"),
+  ).toHaveCount(2);
+
+  // Confirmation is conversational; no separate architecture button exists.
+  await expect(
+    page.getByRole("button", { name: /confirm architecture/i }),
+  ).toHaveCount(0);
+  await send(page, "yes");
+  await expect(
+    page.getByTestId("agent-map-demo-confirmed-revision"),
+  ).toContainText("Revision 2 confirmed");
+  await expect(page.getByTestId("agent-map-demo-map-status")).toContainText(
+    "Confirmed · rev 2",
+  );
+
+  await send(page, "Show me the build plan.");
+  await expect(page.getByTestId("agent-map-demo-build-plan")).toBeVisible();
+  await expect(page.getByTestId("agent-map-demo-build-plan")).toContainText(
+    "2 scoped builders",
+  );
+  await expect(page.getByTestId("agent-map-demo-build-plan")).toContainText(
+    "Owned News Editor",
+  );
+
+  // A second conversational approval stages UI-only builder-session rows.
+  await send(page, "Approve and launch the builders.");
+  await expect(
+    page.getByTestId("agent-map-demo-builder-market-research"),
+  ).toContainText("simulated");
+  await expect(
+    page.getByTestId("agent-map-demo-builder-marketing-publisher"),
+  ).toContainText("simulated");
+  await expect(page.getByTestId("agent-map-demo-launch-summary")).toContainText(
+    "nothing was created",
+  );
+  await expect(page.getByTestId("agent-map-demo-map-status")).toContainText(
+    "Builders simulated",
+  );
+  await page.screenshot({
+    path: "web/e2e/screenshots/agent-map-demo-builders.png",
+    fullPage: true,
+  });
+
+  // Builder rows are navigation targets into deterministic session snapshots.
+  // The project map remains the default surface until one is selected.
+  const mapRow = page.getByTestId("agent-map-demo-rail-map");
+  const researchBuilder = page.getByTestId(
+    "agent-map-demo-builder-market-research",
+  );
+  const publisherBuilder = page.getByTestId(
+    "agent-map-demo-builder-marketing-publisher",
+  );
+  await researchBuilder.click();
+  await expect(researchBuilder).toHaveAttribute("aria-current", "page");
+  await expect(mapRow).not.toHaveAttribute("aria-current", "page");
+  await expect(
+    page.getByTestId("agent-map-demo-builder-session"),
+  ).toHaveAttribute("data-builder-session", "market-research-builder");
+
+  const context = page.getByTestId("agent-map-demo-builder-context");
+  await expect(context).toHaveAttribute("open", "");
+  await expect(
+    page.getByTestId("agent-map-demo-builder-context-layer-role"),
+  ).toContainText("child implementation session");
+  const projectContext = page.getByTestId(
+    "agent-map-demo-builder-context-layer-project-context",
+  );
+  await expect(projectContext).toContainText("Stock video desk");
+  await expect(projectContext).toContainText("Agent Map revision 2");
+  await expect(projectContext).toContainText("Market Research");
+  await expect(projectContext).toContainText("Marketing / Publisher");
+  await expect(projectContext).toContainText("Research Database");
+  await expect(projectContext).toContainText("TikTok");
+  await expect(projectContext).toContainText("Persisted handoff");
+  const researchAssignment = page.getByTestId(
+    "agent-map-demo-builder-context-layer-assignment",
+  );
+  await expect(researchAssignment).toContainText(
+    "finding and ranking today’s top ten stocks",
+  );
+  await expect(researchAssignment).toContainText(
+    "evidence-backed ResearchReport",
+  );
+  const researchContracts = page.getByTestId(
+    "agent-map-demo-builder-context-layer-contracts",
+  );
+  await expect(researchContracts).toContainText("ResearchReport handoff");
+  await expect(researchContracts).toContainText("Research Database");
+  const researchBoundaries = page.getByTestId(
+    "agent-map-demo-builder-context-layer-boundaries",
+  );
+  await expect(researchBoundaries).toContainText("editorial selection");
+  await expect(researchBoundaries).toContainText("video generation");
+  await expect(researchBoundaries).toContainText("TikTok publishing");
+  await expect(
+    page.getByTestId("agent-map-demo-builder-context-layer-operating-rule"),
+  ).toContainText("Begin by planning the implementation with the user");
+  await expect(
+    page.getByTestId(
+      "agent-map-demo-builder-context-layer-reconciliation-rule",
+    ),
+  ).toContainText("proposed Agent Map revision back to the Planner");
+  const provenance = page.getByTestId(
+    "agent-map-demo-builder-context-layer-provenance",
+  );
+  await expect(provenance).toContainText(
+    "Injected by Planner from confirmed Agent Map revision 2",
+  );
+  await expect(provenance).toContainText("not a production prompt contract");
+
+  const builderReply = page.getByTestId("agent-map-demo-builder-first-reply");
+  await expect(builderReply).toContainText("planning mode");
+  await expect(builderReply).toContainText(
+    "Please confirm or refine this decomposition before implementation",
+  );
+  const builderSteps = page.getByTestId("agent-map-demo-builder-steps");
+  await expect(
+    builderSteps.locator('[data-testid^="agent-map-demo-builder-step-"]'),
+  ).toHaveCount(5);
+  for (const label of [
+    "Define ResearchReport contract",
+    "Fetch today’s active market data",
+    "Rank and select the top ten",
+    "Compose the evidence-backed report",
+    "Persist and verify the Research Database handoff",
+  ]) {
+    await expect(builderSteps).toContainText(label);
+  }
+  await expect(
+    page.getByTestId("agent-map-demo-builder-composer").getByRole("textbox"),
+  ).toBeDisabled();
+
+  // A project-agent row leaves the builder snapshot, restores the global map,
+  // and opens that project agent's inspector.
+  await page.getByTestId("agent-map-demo-rail-agent-market-research").click();
+  await expect(page.getByTestId("agent-map-demo-builder-session")).toHaveCount(
+    0,
+  );
+  await expect(mapRow).toHaveAttribute("aria-current", "page");
+  await expect(page.getByTestId("agent-map-demo-inspector")).toContainText(
+    "Market Research",
+  );
+
+  await publisherBuilder.click();
+  await expect(publisherBuilder).toHaveAttribute("aria-current", "page");
+  await expect(mapRow).not.toHaveAttribute("aria-current", "page");
+  await expect(
+    page.getByTestId("agent-map-demo-builder-session"),
+  ).toHaveAttribute("data-builder-session", "marketing-publisher-builder");
+  await expect(context).toHaveAttribute("open", "");
+  const publisherAssignment = page.getByTestId(
+    "agent-map-demo-builder-context-layer-assignment",
+  );
+  await expect(publisherAssignment).toContainText(
+    "ResearchReport / EditorialBrief",
+  );
+  await expect(publisherAssignment).toContainText("Own News Editor");
+  await expect(publisherAssignment).toContainText("publish through TikTok");
+  const publisherBoundaries = page.getByTestId(
+    "agent-map-demo-builder-context-layer-boundaries",
+  );
+  await expect(publisherBoundaries).toContainText(
+    "Do not redo market research",
+  );
+  await expect(publisherBoundaries).toContainText(
+    "upstream ranking responsibility",
+  );
+  await expect(
+    builderSteps.locator('[data-testid^="agent-map-demo-builder-step-"]'),
+  ).toHaveCount(5);
+  for (const label of [
+    "Read and validate ResearchReport",
+    "Have owned News Editor select the strongest points",
+    "Draft the news script/storyboard",
+    "Generate the news-format video",
+    "Publish through TikTok and report the result",
+  ]) {
+    await expect(builderSteps).toContainText(label);
+  }
+  await expect(
+    builderSteps.locator('[data-step-kind="owned-subagent"]'),
+  ).toContainText("News Editor");
+  await expect(
+    builderSteps.locator('[data-step-kind="connector-boundary"]'),
+  ).toContainText("TikTok");
+  await page.screenshot({
+    path: "web/e2e/screenshots/agent-map-demo-builder-session.png",
+    fullPage: true,
+  });
+
+  // Returning to the pinned map preserves the planner transcript and the
+  // launched revision; builder navigation does not fork or reset either.
+  await mapRow.click();
+  await expect(mapRow).toHaveAttribute("aria-current", "page");
+  await expect(page.getByTestId("agent-map-demo-builder-session")).toHaveCount(
+    0,
+  );
+  await expect(page.getByTestId("agent-map-demo-transcript")).toBeVisible();
+  await expect(page.getByTestId("agent-map-demo-launch-summary")).toContainText(
+    "nothing was created",
+  );
+  await expect(page.getByTestId("agent-map-demo-map-status")).toContainText(
+    "Builders simulated",
+  );
+  await expect(page.getByTestId("agent-map-node-news-editor")).toBeVisible();
+
+  // Node inspection stays inside the map while the planning transcript and
+  // composer remain mounted on the left.
+  await page.getByTestId("agent-map-node-market-research").click();
+  const inspector = page.getByTestId("agent-map-demo-inspector");
+  await expect(inspector).toBeVisible();
+  await expect(inspector).toContainText("Market Research");
+  await expect(inspector).toContainText("Kind");
+  await expect(inspector).toContainText("Agent");
+  await expect(inspector).toContainText("Purpose");
+  await expect(inspector).toContainText("builder staged");
+  await expect(inspector).toContainText("Relationships");
+  await expect(inspector).toContainText("writes");
+  await expect(page.getByTestId("agent-map-demo-transcript")).toBeVisible();
+  await expect(page.getByTestId("agent-map-demo-input")).toBeVisible();
+  await expect(inspector).toHaveCSS("opacity", "1");
+  await page.screenshot({
+    path: "web/e2e/screenshots/agent-map-demo-inspector.png",
+    fullPage: true,
+  });
+
+  await page.getByTestId("agent-map-demo-reset").click();
+  await expect(
+    page.getByTestId("agent-map-demo-project-toggle"),
+  ).toHaveAttribute("aria-expanded", "true");
+  await expect(page.getByTestId("agent-map-demo-rail-map")).toHaveAttribute(
+    "aria-current",
+    "page",
+  );
+  await expect(map.locator('[data-testid^="agent-map-node-"]')).toHaveCount(0);
+  await expect(page.getByTestId("agent-map-demo-inspector")).toHaveCount(0);
+  await expect(
+    page.locator('[data-testid^="agent-map-demo-builder-"]'),
+  ).toHaveCount(0);
+  await expect(page.getByTestId("agent-map-demo-turn-planner")).toHaveCount(1);
+  await expect(page.getByTestId("agent-map-demo-map-status")).toContainText(
+    "Empty draft",
+  );
+  await expect(page.getByTestId("agent-map-demo-input")).toHaveValue("");
+
+  await page.setViewportSize({ width: 900, height: 760 });
+  await expect(page.getByTestId("agent-map-demo-transcript")).toBeVisible();
+  await expect(page.getByTestId("agent-map-demo-map")).toBeVisible();
+  await expect(productRequests).toEqual([]);
+});

--- a/packages/harness/web/src/components/AgentMapDemo.tsx
+++ b/packages/harness/web/src/components/AgentMapDemo.tsx
@@ -1,0 +1,1311 @@
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
+import type {
+  CSSProperties,
+  FormEvent,
+  JSX,
+  KeyboardEvent,
+  RefObject,
+} from "react";
+
+import {
+  BUILD_PLAN_REQUEST,
+  EDITOR_FOLLOW_UP,
+  GOLDEN_PATH_REQUEST,
+  LAUNCH_BUILDERS_REQUEST,
+  agentMapDemoBuilderSession,
+  agentMapDemoHasProposal,
+  agentMapDemoNodeStatus,
+  agentMapDemoNodes,
+  agentMapDemoReducer,
+  agentMapDemoRelationships,
+  createInitialAgentMapDemoState,
+  type AgentMapDemoBuilderSession,
+  type AgentMapDemoBuilderSessionId,
+  type AgentMapDemoBuilderStep,
+  type AgentMapDemoNode,
+  type AgentMapDemoNodeId,
+  type AgentMapDemoNodeKind,
+  type AgentMapDemoRelationship,
+  type AgentMapDemoState,
+  type AgentMapDemoTurn,
+} from "../lib/agent-map-demo";
+import { BrandHeader } from "./BrandHeader";
+import { Icon } from "./Icon";
+import { Markdown } from "./Markdown";
+
+interface ComposerSuggestion {
+  label: string;
+  text: string;
+}
+
+const MAP_NODE_SUMMARIES: Record<AgentMapDemoNodeId, string> = {
+  "market-research": "Ranks today’s market leaders",
+  "marketing-publisher": "Owns the video and publish",
+  "research-database": "Persists ResearchReport",
+  tiktok: "Publishes the news video",
+  "news-editor": "Selects the strongest points",
+};
+
+const NODE_ICONS: Record<AgentMapDemoNodeKind, string> = {
+  Agent: "Brain",
+  Resource: "BookOpen",
+  Connector: "Plug",
+  "Owned subagent": "Sparkles",
+};
+
+function suggestionFor(state: AgentMapDemoState): ComposerSuggestion | null {
+  switch (state.phase) {
+    case "opening":
+      return { label: "Use demo brief", text: GOLDEN_PATH_REQUEST };
+    case "proposal":
+      return { label: "Add editorial review", text: EDITOR_FOLLOW_UP };
+    case "subagent-proposal":
+      return { label: "Reply “yes”", text: "yes" };
+    case "confirmed":
+      return { label: "Show build plan", text: BUILD_PLAN_REQUEST };
+    case "build-plan":
+      return {
+        label: "Approve simulated launch",
+        text: LAUNCH_BUILDERS_REQUEST,
+      };
+    case "builders-launched":
+      return null;
+  }
+}
+
+function mapStatus(state: AgentMapDemoState): {
+  label: string;
+  tone: "neutral" | "confirmed" | "staged";
+} {
+  switch (state.phase) {
+    case "opening":
+      return { label: "Empty draft", tone: "neutral" };
+    case "proposal":
+    case "subagent-proposal":
+      return { label: `Proposal · rev ${state.revision}`, tone: "neutral" };
+    case "confirmed":
+    case "build-plan":
+      return { label: `Confirmed · rev ${state.revision}`, tone: "confirmed" };
+    case "builders-launched":
+      return { label: "Builders simulated", tone: "staged" };
+  }
+}
+
+export function AgentMapDemo(): JSX.Element {
+  const [state, dispatch] = useReducer(
+    agentMapDemoReducer,
+    undefined,
+    createInitialAgentMapDemoState,
+  );
+  const [draft, setDraft] = useState("");
+  const [railCollapsed, setRailCollapsed] = useState(false);
+  const transcriptRef = useRef<HTMLDivElement | null>(null);
+  const composerRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    const transcript = transcriptRef.current;
+    if (!transcript) return;
+    transcript.scrollTop = state.selectedBuilderId
+      ? 0
+      : transcript.scrollHeight;
+  }, [state.selectedBuilderId, state.turns.length]);
+
+  const nodes = useMemo(() => agentMapDemoNodes(state), [state]);
+  const relationships = useMemo(
+    () => agentMapDemoRelationships(state),
+    [state],
+  );
+  const selectedNode =
+    nodes.find((node) => node.id === state.selectedNodeId) ?? null;
+  const selectedBuilder = state.selectedBuilderId
+    ? agentMapDemoBuilderSession(state.selectedBuilderId)
+    : null;
+  const suggestion = suggestionFor(state);
+
+  const submit = (): void => {
+    const text = draft.trim();
+    if (!text) return;
+    dispatch({ type: "submit", text });
+    setDraft("");
+  };
+
+  const reset = (): void => {
+    dispatch({ type: "reset" });
+    setDraft("");
+    setRailCollapsed(false);
+    requestAnimationFrame(() => composerRef.current?.focus());
+  };
+
+  return (
+    <div
+      className={
+        "agent-map-demo-shell" + (railCollapsed ? " is-rail-collapsed" : "")
+      }
+      data-testid="agent-map-demo"
+    >
+      {!railCollapsed && (
+        <AgentMapRail
+          state={state}
+          onCollapse={() => setRailCollapsed(true)}
+          onToggleProject={() => dispatch({ type: "toggle-project" })}
+          onSelectNode={(nodeId) => dispatch({ type: "select-node", nodeId })}
+          onSelectBuilder={(builderId) =>
+            dispatch({ type: "select-builder", builderId })
+          }
+          onReset={reset}
+        />
+      )}
+
+      <main className="agent-map-demo-workspace">
+        {selectedBuilder ? (
+          <BuilderSessionPane
+            session={selectedBuilder}
+            railCollapsed={railCollapsed}
+            onExpandRail={() => setRailCollapsed(false)}
+            transcriptRef={transcriptRef}
+          />
+        ) : (
+          <section
+            className="agent-map-demo-conversation center-pane"
+            aria-label="Planning conversation"
+          >
+            <header className="agent-map-demo-pane-header agent-map-demo-conversation-header">
+              {railCollapsed && (
+                <button
+                  type="button"
+                  className="theme-toggle"
+                  aria-label="Expand workspace panel"
+                  data-testid="agent-map-demo-rail-expand"
+                  onClick={() => setRailCollapsed(false)}
+                >
+                  <Icon name="PanelLeftOpen" size={14} />
+                </button>
+              )}
+              <span className="agent-map-demo-header-icon">
+                <Icon name="MessageSquare" size={15} />
+              </span>
+              <div className="agent-map-demo-header-copy">
+                <span className="agent-map-demo-header-title">
+                  Plan with Planner
+                </span>
+                <span className="agent-map-demo-header-meta">
+                  Stock video desk
+                </span>
+              </div>
+              <span className="status-tag agent-map-demo-local-status">
+                <Icon name="FlaskConical" size={12} />
+                Concept demo
+              </span>
+            </header>
+
+            <div
+              className="agent-map-demo-transcript"
+              data-testid="agent-map-demo-transcript"
+              ref={transcriptRef}
+            >
+              <div className="agent-map-demo-transcript-inner">
+                {state.turns.map((turn) => (
+                  <DemoTurn key={turn.id} turn={turn} state={state} />
+                ))}
+              </div>
+            </div>
+
+            <form
+              className="agent-map-demo-composer-wrap"
+              onSubmit={(event: FormEvent<HTMLFormElement>) => {
+                event.preventDefault();
+                submit();
+              }}
+            >
+              {suggestion && (
+                <div className="agent-map-demo-suggestion-row">
+                  <span>Prepared walkthrough</span>
+                  <button
+                    type="button"
+                    className="composer-chip agent-map-demo-suggestion"
+                    data-testid="agent-map-demo-suggestion"
+                    onClick={() => {
+                      setDraft(suggestion.text);
+                      composerRef.current?.focus();
+                    }}
+                  >
+                    <Icon name="Sparkles" size={13} />
+                    {suggestion.label}
+                  </button>
+                </div>
+              )}
+              <div className="composer-box agent-map-demo-composer">
+                <textarea
+                  ref={composerRef}
+                  className="composer-input"
+                  data-testid="agent-map-demo-input"
+                  aria-label="Message the demo planner"
+                  placeholder="Continue the planning conversation…"
+                  rows={2}
+                  value={draft}
+                  onChange={(event) => setDraft(event.currentTarget.value)}
+                  onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
+                    if (
+                      event.key === "Enter" &&
+                      !event.shiftKey &&
+                      !event.nativeEvent.isComposing
+                    ) {
+                      event.preventDefault();
+                      event.currentTarget.form?.requestSubmit();
+                    }
+                  }}
+                />
+                <div className="composer-box-actions">
+                  <span className="agent-map-demo-composer-note">
+                    Scripted locally · no calls are made
+                  </span>
+                  <div className="composer-box-right">
+                    <button
+                      type="submit"
+                      className="composer-send"
+                      data-testid="agent-map-demo-send"
+                      disabled={!draft.trim()}
+                      aria-label="Send message"
+                    >
+                      <Icon name="ArrowUp" size={15} />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </section>
+        )}
+
+        <section
+          className="agent-map-demo-map right-pane"
+          aria-label={
+            selectedBuilder ? "Builder step structure" : "Project Agent Map"
+          }
+        >
+          {selectedBuilder ? (
+            <BuilderStepsPane session={selectedBuilder} />
+          ) : (
+            <AgentMapPane
+              state={state}
+              nodes={nodes}
+              relationships={relationships}
+              selectedNode={selectedNode}
+              onSelectNode={(nodeId) =>
+                dispatch({ type: "select-node", nodeId })
+              }
+            />
+          )}
+        </section>
+      </main>
+    </div>
+  );
+}
+
+function AgentMapRail({
+  state,
+  onCollapse,
+  onToggleProject,
+  onSelectNode,
+  onSelectBuilder,
+  onReset,
+}: {
+  state: AgentMapDemoState;
+  onCollapse: () => void;
+  onToggleProject: () => void;
+  onSelectNode: (nodeId: AgentMapDemoNodeId | null) => void;
+  onSelectBuilder: (builderId: AgentMapDemoBuilderSessionId) => void;
+  onReset: () => void;
+}): JSX.Element {
+  const hasProposal = agentMapDemoHasProposal(state);
+  const buildersLaunched = state.phase === "builders-launched";
+
+  return (
+    <aside className="rail rail-workflows agent-map-demo-rail">
+      <BrandHeader
+        onCollapse={onCollapse}
+        canGoBack={false}
+        canGoForward={false}
+        onGoBack={() => undefined}
+        onGoForward={() => undefined}
+      />
+      <div className="rail-header">
+        <span className="rail-header-label">Projects</span>
+      </div>
+      <div className="rail-tree">
+        <div className="rail-list agent-map-demo-rail-list">
+          <div className="workspace-group agent-map-demo-project">
+            <div
+              className={
+                "workspace-row" + (state.projectExpanded ? "" : " is-collapsed")
+              }
+            >
+              <button
+                type="button"
+                className="workspace-row-main"
+                data-testid="agent-map-demo-project-toggle"
+                aria-expanded={state.projectExpanded}
+                aria-controls="agent-map-demo-project-children"
+                onClick={onToggleProject}
+              >
+                <Icon name="Folder" size={13} />
+                <span className="tree-row-label">Stock video desk</span>
+                <span
+                  className={
+                    "workspace-caret" +
+                    (state.projectExpanded ? " is-open" : "")
+                  }
+                >
+                  <Icon name="ChevronDown" size={12} />
+                </span>
+              </button>
+            </div>
+
+            {state.projectExpanded && (
+              <div
+                id="agent-map-demo-project-children"
+                className="agent-map-demo-project-children"
+              >
+                <button
+                  type="button"
+                  className={
+                    "agent-map-demo-rail-row" +
+                    (state.selectedBuilderId ? "" : " is-selected")
+                  }
+                  data-testid="agent-map-demo-rail-map"
+                  aria-current={state.selectedBuilderId ? undefined : "page"}
+                  onClick={() => onSelectNode(null)}
+                >
+                  <Icon name="Waypoints" size={13} />
+                  <span>Agent Map</span>
+                  <span className="agent-map-demo-pin" aria-label="Pinned">
+                    pinned
+                  </span>
+                </button>
+
+                {hasProposal && (
+                  <div
+                    className="agent-map-demo-agent-rows"
+                    data-testid="agent-map-demo-agent-rows"
+                  >
+                    <AgentRailRow
+                      label="Market Research"
+                      nodeId="market-research"
+                      builderLabel={
+                        buildersLaunched ? "Research builder" : null
+                      }
+                      builderId={
+                        buildersLaunched ? "market-research-builder" : null
+                      }
+                      selectedBuilderId={state.selectedBuilderId}
+                      onSelectNode={(nodeId) => onSelectNode(nodeId)}
+                      onSelectBuilder={onSelectBuilder}
+                    />
+                    <AgentRailRow
+                      label="Marketing / Publisher"
+                      nodeId="marketing-publisher"
+                      builderLabel={
+                        buildersLaunched ? "Publisher builder" : null
+                      }
+                      builderId={
+                        buildersLaunched ? "marketing-publisher-builder" : null
+                      }
+                      selectedBuilderId={state.selectedBuilderId}
+                      onSelectNode={(nodeId) => onSelectNode(nodeId)}
+                      onSelectBuilder={onSelectBuilder}
+                    />
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      <footer className="rail-footer agent-map-demo-rail-footer">
+        <span className="status-tag">
+          <Icon name="FlaskConical" size={12} />
+          Local concept fixture
+        </span>
+        <button
+          type="button"
+          className="btn-ghost agent-map-demo-reset"
+          data-testid="agent-map-demo-reset"
+          onClick={onReset}
+        >
+          <Icon name="RefreshCw" size={13} />
+          Reset demo
+        </button>
+      </footer>
+    </aside>
+  );
+}
+
+function AgentRailRow({
+  label,
+  nodeId,
+  builderLabel,
+  builderId,
+  selectedBuilderId,
+  onSelectNode,
+  onSelectBuilder,
+}: {
+  label: string;
+  nodeId: AgentMapDemoNodeId;
+  builderLabel: string | null;
+  builderId: AgentMapDemoBuilderSessionId | null;
+  selectedBuilderId: AgentMapDemoBuilderSessionId | null;
+  onSelectNode: (nodeId: AgentMapDemoNodeId) => void;
+  onSelectBuilder: (builderId: AgentMapDemoBuilderSessionId) => void;
+}): JSX.Element {
+  return (
+    <div className="agent-map-demo-agent-rail-group">
+      <button
+        type="button"
+        className="agent-map-demo-rail-row agent-map-demo-agent-row"
+        data-testid={`agent-map-demo-rail-agent-${nodeId}`}
+        onClick={() => onSelectNode(nodeId)}
+      >
+        <Icon name="Brain" size={13} />
+        <span>{label}</span>
+        <span className="status-tag-dot" aria-hidden="true" />
+      </button>
+      {builderLabel && builderId && (
+        <button
+          type="button"
+          className={
+            "agent-map-demo-builder-row" +
+            (selectedBuilderId === builderId ? " is-selected" : "")
+          }
+          data-testid={`agent-map-demo-builder-${nodeId}`}
+          aria-current={selectedBuilderId === builderId ? "page" : undefined}
+          onClick={() => onSelectBuilder(builderId)}
+        >
+          <Icon name="Hammer" size={12} />
+          <span>{builderLabel}</span>
+          <span className="agent-map-demo-builder-meta">simulated</span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function BuilderSessionPane({
+  session,
+  railCollapsed,
+  onExpandRail,
+  transcriptRef,
+}: {
+  session: AgentMapDemoBuilderSession;
+  railCollapsed: boolean;
+  onExpandRail: () => void;
+  transcriptRef: RefObject<HTMLDivElement | null>;
+}): JSX.Element {
+  return (
+    <section
+      className="agent-map-demo-conversation agent-map-demo-builder-session center-pane"
+      aria-label={`${session.agentLabel} simulated builder session`}
+      data-testid="agent-map-demo-builder-session"
+      data-builder-session={session.id}
+    >
+      <header className="agent-map-demo-pane-header agent-map-demo-conversation-header">
+        {railCollapsed && (
+          <button
+            type="button"
+            className="theme-toggle"
+            aria-label="Expand workspace panel"
+            data-testid="agent-map-demo-rail-expand"
+            onClick={onExpandRail}
+          >
+            <Icon name="PanelLeftOpen" size={14} />
+          </button>
+        )}
+        <span className="agent-map-demo-header-icon">
+          <Icon name="SquareTerminal" size={15} />
+        </span>
+        <div className="agent-map-demo-header-copy">
+          <span className="agent-map-demo-header-title">
+            {session.agentLabel} builder
+          </span>
+          <span className="agent-map-demo-header-meta">
+            Simulated child implementation session
+          </span>
+        </div>
+        <span className="status-tag agent-map-demo-local-status">
+          <Icon name="FlaskConical" size={12} />
+          Snapshot · no session
+        </span>
+      </header>
+
+      <div
+        className="agent-map-demo-transcript agent-map-demo-builder-transcript"
+        data-testid="agent-map-demo-builder-transcript"
+        ref={transcriptRef}
+      >
+        <div className="agent-map-demo-transcript-inner agent-map-demo-builder-transcript-inner">
+          <details
+            className="agent-map-demo-builder-context"
+            data-testid="agent-map-demo-builder-context"
+            open
+          >
+            <summary>
+              <span className="agent-map-demo-planner-mark">
+                <Icon name="GitBranch" size={12} />
+              </span>
+              <span className="agent-map-demo-builder-context-title">
+                <strong>Mock startup context</strong>
+                <span>Planner injection preview · expanded by default</span>
+              </span>
+              <span className="status-tag">mock only</span>
+              <Icon name="ChevronDown" size={13} />
+            </summary>
+            <div className="agent-map-demo-builder-context-layers">
+              {session.contextLayers.map((layer) => (
+                <section
+                  key={layer.id}
+                  className={`agent-map-demo-builder-context-layer is-${layer.id}`}
+                  data-testid={`agent-map-demo-builder-context-layer-${layer.id}`}
+                >
+                  <h3>{layer.label}</h3>
+                  <ul>
+                    {layer.items.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          </details>
+
+          <article
+            className="agent-map-demo-turn is-planner agent-map-demo-builder-reply"
+            data-testid="agent-map-demo-builder-first-reply"
+          >
+            <div className="agent-map-demo-turn-role">
+              <span className="agent-map-demo-planner-mark">
+                <Icon name="Hammer" size={12} />
+              </span>
+              <span>{session.railLabel}</span>
+              <span className="agent-map-demo-turn-meta">
+                scripted snapshot
+              </span>
+            </div>
+            <div className="agent-map-demo-turn-body">
+              <Markdown text={session.firstReply} />
+              <ol className="agent-map-demo-builder-reply-steps">
+                {session.steps.map((step) => (
+                  <li key={step.id}>{step.label}</li>
+                ))}
+              </ol>
+              <p className="agent-map-demo-builder-reply-gate">
+                Please confirm or refine this decomposition before
+                implementation.
+              </p>
+            </div>
+          </article>
+        </div>
+      </div>
+
+      <div
+        className="agent-map-demo-composer-wrap agent-map-demo-builder-composer-wrap"
+        data-testid="agent-map-demo-builder-composer"
+      >
+        <div className="agent-map-demo-suggestion-row">
+          <span>Simulated session snapshot</span>
+          <span className="status-tag">non-interactive</span>
+        </div>
+        <div className="composer-box agent-map-demo-composer agent-map-demo-builder-composer">
+          <textarea
+            className="composer-input"
+            aria-label="Simulated builder composer"
+            placeholder="This concept snapshot cannot send messages."
+            rows={2}
+            value=""
+            readOnly
+            disabled
+          />
+          <div className="composer-box-actions">
+            <span className="agent-map-demo-composer-note">
+              Mock builder · no session or calls
+            </span>
+            <div className="composer-box-right">
+              <button
+                type="button"
+                className="composer-send"
+                disabled
+                aria-label="Sending is unavailable in this snapshot"
+              >
+                <Icon name="ArrowUp" size={15} />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function builderStepIcon(step: AgentMapDemoBuilderStep): string {
+  switch (step.kind) {
+    case "contract":
+      return "Code";
+    case "data":
+      return "Radio";
+    case "decision":
+      return "ListChecks";
+    case "report":
+    case "resource-boundary":
+      return "BookOpen";
+    case "owned-subagent":
+      return "Sparkles";
+    case "story":
+      return "Pencil";
+    case "media":
+      return "Frame";
+    case "connector-boundary":
+      return "Plug";
+  }
+}
+
+function BuilderStepsPane({
+  session,
+}: {
+  session: AgentMapDemoBuilderSession;
+}): JSX.Element {
+  return (
+    <>
+      <header className="agent-map-demo-pane-header agent-map-demo-map-header">
+        <span className="agent-map-demo-header-icon">
+          <Icon name="ListChecks" size={15} />
+        </span>
+        <div className="agent-map-demo-header-copy">
+          <span className="agent-map-demo-header-title">
+            {session.agentLabel} · Steps
+          </span>
+          <span className="agent-map-demo-header-meta">
+            Confirmed Agent Map revision 2
+          </span>
+        </div>
+        <span className="status-tag agent-map-demo-map-status">
+          <Icon name="FlaskConical" size={12} />
+          Simulated structure
+        </span>
+      </header>
+
+      <div
+        className="canvas-steps-surface agent-map-demo-builder-steps"
+        data-testid="agent-map-demo-builder-steps"
+        data-builder-session={session.id}
+      >
+        <div className="agent-map-demo-builder-steps-intro">
+          <div>
+            <strong>Agent implementation plan</strong>
+            <span className="status-tag">snapshot</span>
+          </div>
+          <p>
+            Granular decomposition for this selected agent only. These are
+            proposed steps, not live execution state.
+          </p>
+        </div>
+
+        <div className="canvas-steps-list">
+          <div className="canvas-steps-label">
+            Steps
+            <span className="canvas-steps-run-note">
+              {session.steps.length} proposed · not running
+            </span>
+          </div>
+          {session.steps.map((step, index) => (
+            <div
+              key={step.id}
+              className={`canvas-step-item agent-map-demo-builder-step-item is-${step.kind}`}
+              data-step-kind={step.kind}
+            >
+              <div
+                className="canvas-step-row is-static agent-map-demo-builder-step-row"
+                data-testid={`agent-map-demo-builder-step-${index + 1}`}
+              >
+                <span className="canvas-step-index">
+                  {String(index + 1).padStart(2, "0")}
+                </span>
+                <span className="agent-map-demo-builder-step-icon">
+                  <Icon name={builderStepIcon(step)} size={13} />
+                </span>
+                <span className="canvas-step-copy">
+                  <span className="canvas-step-name">{step.label}</span>
+                  <span className="canvas-step-role">Owner · {step.owner}</span>
+                </span>
+                <span
+                  className={`canvas-step-meta status-tag agent-map-demo-builder-step-kind is-${step.kind}`}
+                >
+                  {step.kindLabel}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="agent-map-demo-builder-step-gate">
+          <Icon name="MessageSquare" size={13} />
+          <div>
+            <strong>Planning checkpoint</strong>
+            <span>Confirm or refine the five steps before implementation.</span>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function DemoTurn({
+  turn,
+  state,
+}: {
+  turn: AgentMapDemoTurn;
+  state: AgentMapDemoState;
+}): JSX.Element {
+  const isPlanner = turn.role === "planner";
+  return (
+    <article
+      className={
+        "agent-map-demo-turn" + (isPlanner ? " is-planner" : " is-user")
+      }
+      data-testid={`agent-map-demo-turn-${turn.role}`}
+    >
+      <div className="agent-map-demo-turn-role">
+        {isPlanner ? (
+          <>
+            <span className="agent-map-demo-planner-mark">
+              <Icon name="Sparkles" size={12} />
+            </span>
+            <span>Planner</span>
+            <span className="agent-map-demo-turn-meta">scripted</span>
+          </>
+        ) : (
+          <span>You</span>
+        )}
+      </div>
+      <div className="agent-map-demo-turn-body">
+        {isPlanner ? <Markdown text={turn.body} /> : <p>{turn.body}</p>}
+        {turn.kind === "proposal" && (
+          <ProposalPreview editorIncluded={turn.body.includes("News Editor")} />
+        )}
+        {turn.kind === "confirmed" && (
+          <ConfirmedRevision revision={state.revision} />
+        )}
+        {turn.kind === "build-plan" && (
+          <BuildPlanPreview editorIncluded={state.editorIncluded} />
+        )}
+        {turn.kind === "builders-launched" && <SimulatedLaunchSummary />}
+      </div>
+    </article>
+  );
+}
+
+function ProposalPreview({
+  editorIncluded,
+}: {
+  editorIncluded: boolean;
+}): JSX.Element {
+  return (
+    <div
+      className="agent-map-demo-inline-card"
+      data-testid="agent-map-demo-proposal-card"
+      data-revision={editorIncluded ? "2" : "1"}
+    >
+      <div className="agent-map-demo-inline-card-head">
+        <span>Architecture proposal</span>
+        <span className="status-tag">revision {editorIncluded ? 2 : 1}</span>
+      </div>
+      <div className="agent-map-demo-handoff">
+        <span>Market Research</span>
+        <span className="agent-map-demo-relationship-chip">writes</span>
+        <code>ResearchReport</code>
+        <span className="agent-map-demo-relationship-chip">feeds</span>
+        <span>{editorIncluded ? "News Editor" : "Marketing"}</span>
+      </div>
+      {editorIncluded && (
+        <div className="agent-map-demo-inline-note">
+          News Editor is owned inside Marketing / Publisher.
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ConfirmedRevision({ revision }: { revision: number }): JSX.Element {
+  return (
+    <div
+      className="agent-map-demo-inline-card is-confirmed"
+      data-testid="agent-map-demo-confirmed-revision"
+    >
+      <span className="agent-map-demo-confirmed-icon">
+        <Icon name="CircleCheck" size={15} />
+      </span>
+      <div>
+        <strong>Revision {revision} confirmed</strong>
+        <span>Exact proposal retained for the build plan</span>
+      </div>
+    </div>
+  );
+}
+
+function BuildPlanPreview({
+  editorIncluded,
+}: {
+  editorIncluded: boolean;
+}): JSX.Element {
+  return (
+    <div
+      className="agent-map-demo-build-plan"
+      data-testid="agent-map-demo-build-plan"
+    >
+      <div className="agent-map-demo-inline-card-head">
+        <span>Project build plan</span>
+        <span className="status-tag">2 scoped builders</span>
+      </div>
+      <ol>
+        <li>
+          <span className="agent-map-demo-plan-number">01</span>
+          <div>
+            <strong>Market Research</strong>
+            <span>
+              Market scan, top-ten ranking, ResearchReport contract, and
+              database write.
+            </span>
+          </div>
+        </li>
+        <li>
+          <span className="agent-map-demo-plan-number">02</span>
+          <div>
+            <strong>Marketing / Publisher</strong>
+            <span>
+              {editorIncluded
+                ? "Owned News Editor, editorial handoff, video production, and TikTok publish."
+                : "Report intake, video production, and TikTok publish."}
+            </span>
+          </div>
+        </li>
+      </ol>
+      <div className="agent-map-demo-plan-gate">
+        <Icon name="GitBranch" size={13} />
+        Handoff gate · ResearchReport validates before publishing work begins
+      </div>
+    </div>
+  );
+}
+
+function SimulatedLaunchSummary(): JSX.Element {
+  return (
+    <div
+      className="agent-map-demo-inline-card is-launched"
+      data-testid="agent-map-demo-launch-summary"
+    >
+      <span className="agent-map-demo-launch-count">2</span>
+      <div>
+        <strong>Builder sessions staged</strong>
+        <span>Local UI state only · nothing was created</span>
+      </div>
+    </div>
+  );
+}
+
+function AgentMapPane({
+  state,
+  nodes,
+  relationships,
+  selectedNode,
+  onSelectNode,
+}: {
+  state: AgentMapDemoState;
+  nodes: readonly AgentMapDemoNode[];
+  relationships: readonly AgentMapDemoRelationship[];
+  selectedNode: AgentMapDemoNode | null;
+  onSelectNode: (nodeId: AgentMapDemoNodeId | null) => void;
+}): JSX.Element {
+  const status = mapStatus(state);
+  const nodeById = useMemo(
+    () => new Map(nodes.map((node) => [node.id, node])),
+    [nodes],
+  );
+
+  return (
+    <>
+      <header className="agent-map-demo-pane-header agent-map-demo-map-header">
+        <span className="agent-map-demo-header-icon">
+          <Icon name="Waypoints" size={15} />
+        </span>
+        <div className="agent-map-demo-header-copy">
+          <span className="agent-map-demo-header-title">Agent Map</span>
+          <span className="agent-map-demo-header-meta">Stock video desk</span>
+        </div>
+        <span
+          className={`status-tag agent-map-demo-map-status is-${status.tone}`}
+          data-testid="agent-map-demo-map-status"
+        >
+          {status.tone === "confirmed" ? (
+            <Icon name="CircleCheck" size={12} />
+          ) : status.tone === "staged" ? (
+            <Icon name="Hammer" size={12} />
+          ) : (
+            <Icon name="Square" size={10} />
+          )}
+          {status.label}
+        </span>
+      </header>
+
+      <div className="agent-map-demo-map-body" data-testid="agent-map-demo-map">
+        <div
+          className={
+            "agent-map-demo-canvas-stage" +
+            (nodes.length === 0 ? " is-empty" : "")
+          }
+          data-testid="agent-map-demo-canvas"
+        >
+          {nodes.length === 0 ? (
+            <span className="visually-hidden">The Agent Map is empty.</span>
+          ) : (
+            <AgentMapGraph
+              state={state}
+              nodes={nodes}
+              selectedNodeId={state.selectedNodeId}
+              onSelectNode={onSelectNode}
+            />
+          )}
+        </div>
+
+        {selectedNode && (
+          <NodeInspector
+            state={state}
+            node={selectedNode}
+            nodeById={nodeById}
+            relationships={relationships}
+            onClose={() => onSelectNode(null)}
+          />
+        )}
+      </div>
+    </>
+  );
+}
+
+function AgentMapGraph({
+  state,
+  nodes,
+  selectedNodeId,
+  onSelectNode,
+}: {
+  state: AgentMapDemoState;
+  nodes: readonly AgentMapDemoNode[];
+  selectedNodeId: AgentMapDemoNodeId | null;
+  onSelectNode: (nodeId: AgentMapDemoNodeId) => void;
+}): JSX.Element {
+  const nodeById = new Map(nodes.map((node) => [node.id, node]));
+  const marketing = nodeById.get("marketing-publisher");
+  const editor = nodeById.get("news-editor");
+
+  return (
+    <div
+      className="agent-map-demo-graph"
+      data-testid="agent-map-demo-graph"
+      data-revision={state.revision}
+    >
+      <svg
+        className="agent-map-demo-edges"
+        viewBox="0 0 1000 600"
+        preserveAspectRatio="none"
+        aria-hidden="true"
+      >
+        <defs>
+          <marker
+            id="agent-map-demo-arrow"
+            markerWidth="7"
+            markerHeight="7"
+            refX="6"
+            refY="3.5"
+            orient="auto"
+          >
+            <path d="M0,0 L7,3.5 L0,7 Z" />
+          </marker>
+        </defs>
+        <path d="M400 142 C485 142 520 142 610 142" />
+        <path d="M755 205 C755 305 565 310 395 386" />
+        <path d="M520 454 C600 454 635 454 700 454" />
+      </svg>
+
+      <RelationshipLabel
+        className="is-write"
+        type="writes"
+        contract="ResearchReport"
+      />
+      <RelationshipLabel
+        className="is-feed"
+        type="feeds"
+        contract="ResearchReport"
+      />
+      <RelationshipLabel className="is-use" type="uses" />
+
+      {nodeById.get("market-research") && (
+        <MapNode
+          node={nodeById.get("market-research")!}
+          status={agentMapDemoNodeStatus(
+            state,
+            nodeById.get("market-research")!,
+          )}
+          selected={selectedNodeId === "market-research"}
+          className="is-market-research"
+          order={0}
+          onSelect={onSelectNode}
+        />
+      )}
+      {nodeById.get("research-database") && (
+        <MapNode
+          node={nodeById.get("research-database")!}
+          status={agentMapDemoNodeStatus(
+            state,
+            nodeById.get("research-database")!,
+          )}
+          selected={selectedNodeId === "research-database"}
+          className="is-research-database"
+          order={1}
+          onSelect={onSelectNode}
+        />
+      )}
+      {marketing && (
+        <div
+          className={
+            "agent-map-demo-marketing-group" +
+            (selectedNodeId === marketing.id ? " is-selected" : "")
+          }
+          style={{ "--demo-node-order": 2 } as CSSProperties}
+        >
+          <button
+            type="button"
+            className="agent-map-demo-marketing-primary"
+            data-testid={`agent-map-node-${marketing.id}`}
+            aria-pressed={selectedNodeId === marketing.id}
+            onClick={() => onSelectNode(marketing.id)}
+          >
+            <NodeHeading node={marketing} />
+            <strong>{marketing.label}</strong>
+            <span className="agent-map-demo-node-summary">
+              {MAP_NODE_SUMMARIES[marketing.id]}
+            </span>
+            <NodeStatus status={agentMapDemoNodeStatus(state, marketing)} />
+          </button>
+          {editor && (
+            <button
+              type="button"
+              className={
+                "agent-map-demo-owned-node" +
+                (selectedNodeId === editor.id ? " is-selected" : "")
+              }
+              data-testid={`agent-map-node-${editor.id}`}
+              aria-pressed={selectedNodeId === editor.id}
+              onClick={() => onSelectNode(editor.id)}
+            >
+              <span className="agent-map-demo-owned-node-icon">
+                <Icon name="Sparkles" size={12} />
+              </span>
+              <span className="agent-map-demo-owned-node-copy">
+                <strong>{editor.label}</strong>
+                <span>Owned subagent · selects strongest points</span>
+              </span>
+              <span className="agent-map-demo-owned-flow">feeds</span>
+            </button>
+          )}
+        </div>
+      )}
+      {nodeById.get("tiktok") && (
+        <MapNode
+          node={nodeById.get("tiktok")!}
+          status={agentMapDemoNodeStatus(state, nodeById.get("tiktok")!)}
+          selected={selectedNodeId === "tiktok"}
+          className="is-tiktok"
+          order={3}
+          onSelect={onSelectNode}
+        />
+      )}
+    </div>
+  );
+}
+
+function RelationshipLabel({
+  className,
+  type,
+  contract,
+}: {
+  className: string;
+  type: AgentMapDemoRelationship["type"];
+  contract?: string;
+}): JSX.Element {
+  return (
+    <div className={`agent-map-demo-edge-label ${className}`}>
+      <span>{type}</span>
+      {contract && <code>{contract}</code>}
+    </div>
+  );
+}
+
+function MapNode({
+  node,
+  status,
+  selected,
+  className,
+  order,
+  onSelect,
+}: {
+  node: AgentMapDemoNode;
+  status: ReturnType<typeof agentMapDemoNodeStatus>;
+  selected: boolean;
+  className: string;
+  order: number;
+  onSelect: (nodeId: AgentMapDemoNodeId) => void;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      className={
+        `agent-map-demo-node is-${node.kind.toLocaleLowerCase().replace(/\s+/g, "-")} ${className}` +
+        (selected ? " is-selected" : "")
+      }
+      style={{ "--demo-node-order": order } as CSSProperties}
+      data-testid={`agent-map-node-${node.id}`}
+      aria-pressed={selected}
+      onClick={() => onSelect(node.id)}
+    >
+      <NodeHeading node={node} />
+      <strong>{node.label}</strong>
+      <span className="agent-map-demo-node-summary">
+        {MAP_NODE_SUMMARIES[node.id]}
+      </span>
+      <NodeStatus status={status} />
+    </button>
+  );
+}
+
+function NodeHeading({ node }: { node: AgentMapDemoNode }): JSX.Element {
+  return (
+    <span className="agent-map-demo-node-heading">
+      <span className="agent-map-demo-node-icon">
+        <Icon name={NODE_ICONS[node.kind]} size={13} />
+      </span>
+      <span>{node.kind}</span>
+    </span>
+  );
+}
+
+function NodeStatus({
+  status,
+}: {
+  status: ReturnType<typeof agentMapDemoNodeStatus>;
+}): JSX.Element {
+  return (
+    <span
+      className={`status-tag agent-map-demo-node-status is-${status.replace(/\s+/g, "-")}`}
+    >
+      <span className="status-tag-dot" />
+      {status}
+    </span>
+  );
+}
+
+function NodeInspector({
+  state,
+  node,
+  nodeById,
+  relationships,
+  onClose,
+}: {
+  state: AgentMapDemoState;
+  node: AgentMapDemoNode;
+  nodeById: ReadonlyMap<AgentMapDemoNodeId, AgentMapDemoNode>;
+  relationships: readonly AgentMapDemoRelationship[];
+  onClose: () => void;
+}): JSX.Element {
+  const relevant = relationships.filter(
+    (relationship) =>
+      relationship.from === node.id || relationship.to === node.id,
+  );
+  const owner = node.ownerId ? nodeById.get(node.ownerId) : null;
+
+  return (
+    <aside
+      className="agent-map-demo-inspector"
+      data-testid="agent-map-demo-inspector"
+      aria-label={`${node.label} inspector`}
+    >
+      <div className="agent-map-demo-inspector-head">
+        <span className="agent-map-demo-inspector-icon">
+          <Icon name={NODE_ICONS[node.kind]} size={15} />
+        </span>
+        <div>
+          <span className="agent-map-demo-inspector-kind">{node.kind}</span>
+          <h2>{node.label}</h2>
+        </div>
+        <button
+          type="button"
+          className="theme-toggle"
+          data-testid="agent-map-demo-inspector-close"
+          aria-label="Close inspector"
+          onClick={onClose}
+        >
+          <Icon name="X" size={14} />
+        </button>
+      </div>
+
+      <div className="agent-map-demo-inspector-body">
+        <dl>
+          <div>
+            <dt>Kind</dt>
+            <dd>{node.kind}</dd>
+          </div>
+          <div>
+            <dt>Purpose</dt>
+            <dd>{node.purpose}</dd>
+          </div>
+          <div>
+            <dt>Status</dt>
+            <dd>
+              <NodeStatus status={agentMapDemoNodeStatus(state, node)} />
+            </dd>
+          </div>
+          {owner && (
+            <div>
+              <dt>Owner</dt>
+              <dd>{owner.label}</dd>
+            </div>
+          )}
+        </dl>
+
+        <section className="agent-map-demo-inspector-relationships">
+          <h3>Relationships</h3>
+          <ul>
+            {relevant.map((relationship) => {
+              const outgoing = relationship.from === node.id;
+              const other = nodeById.get(
+                outgoing ? relationship.to : relationship.from,
+              );
+              return (
+                <li key={relationship.id}>
+                  <span className="agent-map-demo-relationship-direction">
+                    {outgoing ? "Outbound" : "Inbound"}
+                  </span>
+                  <span className="agent-map-demo-relationship-line">
+                    <span>{outgoing ? node.label : other?.label}</span>
+                    <Icon name="ArrowRight" size={12} />
+                    <span className="agent-map-demo-relationship-chip">
+                      {relationship.type}
+                    </span>
+                    <Icon name="ArrowRight" size={12} />
+                    <span>{outgoing ? other?.label : node.label}</span>
+                  </span>
+                  {relationship.contract && (
+                    <code>{relationship.contract}</code>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/packages/harness/web/src/lib/agent-map-demo.test.ts
+++ b/packages/harness/web/src/lib/agent-map-demo.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  BUILD_PLAN_REQUEST,
+  EDITOR_FOLLOW_UP,
+  GOLDEN_PATH_REQUEST,
+  LAUNCH_BUILDERS_REQUEST,
+  agentMapDemoFixtureEnabled,
+  agentMapDemoNodes,
+  agentMapDemoReducer,
+  agentMapDemoRelationships,
+  createInitialAgentMapDemoState,
+  type AgentMapDemoState,
+} from "./agent-map-demo";
+
+function createLaunchedState(): AgentMapDemoState {
+  let state = createInitialAgentMapDemoState();
+  state = agentMapDemoReducer(state, {
+    type: "submit",
+    text: GOLDEN_PATH_REQUEST,
+  });
+  state = agentMapDemoReducer(state, {
+    type: "submit",
+    text: EDITOR_FOLLOW_UP,
+  });
+  state = agentMapDemoReducer(state, { type: "submit", text: "yes" });
+  state = agentMapDemoReducer(state, {
+    type: "submit",
+    text: BUILD_PLAN_REQUEST,
+  });
+  return agentMapDemoReducer(state, {
+    type: "submit",
+    text: LAUNCH_BUILDERS_REQUEST,
+  });
+}
+
+describe("Agent Map demo fixture gate", () => {
+  it("requires both mock mode and the exact agent-map fixture", () => {
+    expect(agentMapDemoFixtureEnabled("1", "?mockFixtures=agent-map")).toBe(
+      true,
+    );
+    expect(
+      agentMapDemoFixtureEnabled(undefined, "?mockFixtures=agent-map"),
+    ).toBe(false);
+    expect(agentMapDemoFixtureEnabled("0", "?mockFixtures=agent-map")).toBe(
+      false,
+    );
+    expect(agentMapDemoFixtureEnabled("1", "?mockFixtures=deep")).toBe(false);
+    expect(agentMapDemoFixtureEnabled("1", "")).toBe(false);
+  });
+});
+
+describe("Agent Map demo reducer", () => {
+  it("walks the golden path through proposal, owned editor, confirmation, plan, and simulated builders", () => {
+    let state = createInitialAgentMapDemoState();
+    expect(state.phase).toBe("opening");
+    expect(agentMapDemoNodes(state)).toEqual([]);
+    expect(state.turns).toHaveLength(1);
+
+    state = agentMapDemoReducer(state, {
+      type: "submit",
+      text: GOLDEN_PATH_REQUEST,
+    });
+    expect(state.phase).toBe("proposal");
+    expect(state.revision).toBe(1);
+    expect(agentMapDemoNodes(state).map((node) => node.label)).toEqual([
+      "Market Research",
+      "Marketing / Publisher",
+      "Research Database",
+      "TikTok",
+    ]);
+    expect(agentMapDemoRelationships(state)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "writes",
+          contract: "ResearchReport",
+        }),
+        expect.objectContaining({
+          type: "feeds",
+          contract: "ResearchReport",
+        }),
+        expect.objectContaining({ type: "uses", to: "tiktok" }),
+      ]),
+    );
+
+    state = agentMapDemoReducer(state, {
+      type: "submit",
+      text: EDITOR_FOLLOW_UP,
+    });
+    expect(state.phase).toBe("subagent-proposal");
+    expect(state.revision).toBe(2);
+    expect(agentMapDemoNodes(state).at(-1)).toMatchObject({
+      label: "News Editor",
+      kind: "Owned subagent",
+      ownerId: "marketing-publisher",
+    });
+    expect(agentMapDemoRelationships(state)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          from: "research-database",
+          to: "news-editor",
+          type: "feeds",
+          contract: "ResearchReport",
+        }),
+        expect.objectContaining({
+          from: "news-editor",
+          to: "marketing-publisher",
+          type: "feeds",
+          contract: "EditorialBrief",
+        }),
+      ]),
+    );
+
+    state = agentMapDemoReducer(state, { type: "submit", text: "yes" });
+    expect(state.phase).toBe("confirmed");
+    expect(state.revision).toBe(2);
+
+    state = agentMapDemoReducer(state, {
+      type: "submit",
+      text: BUILD_PLAN_REQUEST,
+    });
+    expect(state.phase).toBe("build-plan");
+
+    state = agentMapDemoReducer(state, {
+      type: "submit",
+      text: LAUNCH_BUILDERS_REQUEST,
+    });
+    expect(state.phase).toBe("builders-launched");
+    expect(state.turns.at(-1)?.body).toContain("no repository");
+  });
+
+  it("does not treat ambiguous conversation as architecture confirmation", () => {
+    let state = createInitialAgentMapDemoState();
+    state = agentMapDemoReducer(state, {
+      type: "submit",
+      text: GOLDEN_PATH_REQUEST,
+    });
+    state = agentMapDemoReducer(state, {
+      type: "submit",
+      text: "Maybe that sounds good?",
+    });
+
+    expect(state.phase).toBe("proposal");
+    expect(state.turns.at(-1)?.kind).toBe("bounded");
+  });
+
+  it("rejects builder navigation until the simulated builders are launched", () => {
+    const state = createInitialAgentMapDemoState();
+    const attemptedNavigation = agentMapDemoReducer(state, {
+      type: "select-builder",
+      builderId: "market-research-builder",
+    });
+
+    expect(attemptedNavigation).toBe(state);
+    expect(attemptedNavigation.selectedBuilderId).toBeNull();
+  });
+
+  it("keeps builder and map inspection navigation mutually exclusive", () => {
+    let state = createLaunchedState();
+    state = agentMapDemoReducer(state, {
+      type: "select-node",
+      nodeId: "market-research",
+    });
+    expect(state.selectedNodeId).toBe("market-research");
+
+    state = agentMapDemoReducer(state, {
+      type: "select-builder",
+      builderId: "market-research-builder",
+    });
+    expect(state.selectedBuilderId).toBe("market-research-builder");
+    expect(state.selectedNodeId).toBeNull();
+
+    const builderTurns = state.turns;
+    const ignoredBuilderSubmit = agentMapDemoReducer(state, {
+      type: "submit",
+      text: "Change the other agent too.",
+    });
+    expect(ignoredBuilderSubmit).toBe(state);
+    expect(ignoredBuilderSubmit.turns).toBe(builderTurns);
+
+    state = agentMapDemoReducer(state, {
+      type: "select-builder",
+      builderId: "marketing-publisher-builder",
+    });
+    expect(state.selectedBuilderId).toBe("marketing-publisher-builder");
+
+    state = agentMapDemoReducer(state, {
+      type: "select-node",
+      nodeId: "marketing-publisher",
+    });
+    expect(state.selectedBuilderId).toBeNull();
+    expect(state.selectedNodeId).toBe("marketing-publisher");
+
+    state = agentMapDemoReducer(state, {
+      type: "select-builder",
+      builderId: "market-research-builder",
+    });
+    state = agentMapDemoReducer(state, {
+      type: "select-node",
+      nodeId: null,
+    });
+    expect(state.selectedBuilderId).toBeNull();
+    expect(state.selectedNodeId).toBeNull();
+  });
+
+  it("resets the complete local walkthrough to its expanded empty opening", () => {
+    let state = createLaunchedState();
+    state = agentMapDemoReducer(state, {
+      type: "select-builder",
+      builderId: "marketing-publisher-builder",
+    });
+    state = agentMapDemoReducer(state, { type: "toggle-project" });
+    state = agentMapDemoReducer(state, { type: "reset" });
+
+    expect(state).toEqual(createInitialAgentMapDemoState());
+    expect(state.projectExpanded).toBe(true);
+    expect(state.selectedNodeId).toBeNull();
+    expect(state.selectedBuilderId).toBeNull();
+    expect(agentMapDemoNodes(state)).toEqual([]);
+  });
+});

--- a/packages/harness/web/src/lib/agent-map-demo.ts
+++ b/packages/harness/web/src/lib/agent-map-demo.ts
@@ -1,0 +1,699 @@
+/**
+ * Browser-only state for the `?mockFixtures=agent-map` concept walkthrough.
+ *
+ * This is deliberately not a SystemGraph adapter. The map describes a plan —
+ * including a resource, connector, contract-bearing handoff, and owned
+ * subagent — while SystemGraph describes discovered project agents. Keeping a
+ * small view model here prevents an experiment from widening a production
+ * contract or teaching the legacy graph to author architecture.
+ */
+
+export const AGENT_MAP_DEMO_FIXTURE = "agent-map";
+
+export const GOLDEN_PATH_REQUEST =
+  "Build a research agent that finds the top ten stocks trading today. Store the research report, then give it to a marketing agent connected to TikTok that turns it into a news-format video and publishes it.";
+
+export const EDITOR_FOLLOW_UP =
+  "Before marketing receives the report, have an LLM select the strongest points.";
+
+export const BUILD_PLAN_REQUEST = "Show me the build plan.";
+
+export const LAUNCH_BUILDERS_REQUEST = "Approve and launch the builders.";
+
+export type AgentMapDemoPhase =
+  | "opening"
+  | "proposal"
+  | "subagent-proposal"
+  | "confirmed"
+  | "build-plan"
+  | "builders-launched";
+
+export type AgentMapDemoTurnKind =
+  | "opening"
+  | "proposal"
+  | "confirmed"
+  | "build-plan"
+  | "builders-launched"
+  | "bounded";
+
+export interface AgentMapDemoTurn {
+  id: string;
+  role: "planner" | "user";
+  body: string;
+  kind?: AgentMapDemoTurnKind;
+}
+
+export interface AgentMapDemoState {
+  phase: AgentMapDemoPhase;
+  revision: 0 | 1 | 2;
+  editorIncluded: boolean;
+  projectExpanded: boolean;
+  selectedNodeId: AgentMapDemoNodeId | null;
+  selectedBuilderId: AgentMapDemoBuilderSessionId | null;
+  turns: AgentMapDemoTurn[];
+}
+
+export type AgentMapDemoAction =
+  | { type: "submit"; text: string }
+  | { type: "toggle-project" }
+  | { type: "select-node"; nodeId: AgentMapDemoNodeId | null }
+  | { type: "select-builder"; builderId: AgentMapDemoBuilderSessionId }
+  | { type: "reset" };
+
+export type AgentMapDemoNodeId =
+  | "market-research"
+  | "marketing-publisher"
+  | "research-database"
+  | "tiktok"
+  | "news-editor";
+
+export type AgentMapDemoNodeKind =
+  | "Agent"
+  | "Resource"
+  | "Connector"
+  | "Owned subagent";
+
+export interface AgentMapDemoNode {
+  id: AgentMapDemoNodeId;
+  label: string;
+  kind: AgentMapDemoNodeKind;
+  purpose: string;
+  ownerId?: AgentMapDemoNodeId;
+}
+
+export type AgentMapDemoRelationshipType =
+  | "feeds"
+  | "writes"
+  | "reads"
+  | "uses";
+
+export interface AgentMapDemoRelationship {
+  id: string;
+  from: AgentMapDemoNodeId;
+  to: AgentMapDemoNodeId;
+  type: AgentMapDemoRelationshipType;
+  contract?: string;
+}
+
+export type AgentMapDemoBuilderSessionId =
+  | "market-research-builder"
+  | "marketing-publisher-builder";
+
+export type AgentMapDemoBuilderContextLayerId =
+  | "role"
+  | "project-context"
+  | "assignment"
+  | "contracts"
+  | "boundaries"
+  | "operating-rule"
+  | "reconciliation-rule"
+  | "provenance";
+
+export interface AgentMapDemoBuilderContextLayer {
+  id: AgentMapDemoBuilderContextLayerId;
+  label: string;
+  items: readonly string[];
+}
+
+export type AgentMapDemoBuilderStepKind =
+  | "contract"
+  | "data"
+  | "decision"
+  | "report"
+  | "resource-boundary"
+  | "owned-subagent"
+  | "story"
+  | "media"
+  | "connector-boundary";
+
+export interface AgentMapDemoBuilderStep {
+  id: string;
+  label: string;
+  kind: AgentMapDemoBuilderStepKind;
+  kindLabel: string;
+  owner: string;
+}
+
+export interface AgentMapDemoBuilderSession {
+  id: AgentMapDemoBuilderSessionId;
+  agentId: "market-research" | "marketing-publisher";
+  agentLabel: string;
+  railLabel: string;
+  contextLayers: readonly AgentMapDemoBuilderContextLayer[];
+  firstReply: string;
+  steps: readonly AgentMapDemoBuilderStep[];
+}
+
+const BASE_NODES: readonly AgentMapDemoNode[] = [
+  {
+    id: "market-research",
+    label: "Market Research",
+    kind: "Agent",
+    purpose:
+      "Finds and ranks the ten strongest stocks trading today, then owns the research handoff.",
+  },
+  {
+    id: "marketing-publisher",
+    label: "Marketing / Publisher",
+    kind: "Agent",
+    purpose:
+      "Turns approved research into a news-format video and owns publishing.",
+  },
+  {
+    id: "research-database",
+    label: "Research Database",
+    kind: "Resource",
+    purpose:
+      "Persists the ResearchReport between research and publishing responsibilities.",
+  },
+  {
+    id: "tiktok",
+    label: "TikTok",
+    kind: "Connector",
+    purpose:
+      "The publishing destination used by Marketing / Publisher for the finished video.",
+  },
+];
+
+const NEWS_EDITOR_NODE: AgentMapDemoNode = {
+  id: "news-editor",
+  label: "News Editor",
+  kind: "Owned subagent",
+  purpose:
+    "Selects the strongest report points and shapes the editorial brief before production.",
+  ownerId: "marketing-publisher",
+};
+
+const BASE_RELATIONSHIPS: readonly AgentMapDemoRelationship[] = [
+  {
+    id: "research-writes-report",
+    from: "market-research",
+    to: "research-database",
+    type: "writes",
+    contract: "ResearchReport",
+  },
+  {
+    id: "report-feeds-marketing",
+    from: "research-database",
+    to: "marketing-publisher",
+    type: "feeds",
+    contract: "ResearchReport",
+  },
+  {
+    id: "marketing-uses-tiktok",
+    from: "marketing-publisher",
+    to: "tiktok",
+    type: "uses",
+  },
+];
+
+const EDITOR_RELATIONSHIPS: readonly AgentMapDemoRelationship[] = [
+  BASE_RELATIONSHIPS[0],
+  {
+    id: "report-feeds-editor",
+    from: "research-database",
+    to: "news-editor",
+    type: "feeds",
+    contract: "ResearchReport",
+  },
+  {
+    id: "editor-feeds-marketing",
+    from: "news-editor",
+    to: "marketing-publisher",
+    type: "feeds",
+    contract: "EditorialBrief",
+  },
+  BASE_RELATIONSHIPS[2],
+];
+
+const CONFIRMED_PROJECT_CONTEXT = [
+  "Project: Stock video desk",
+  "Confirmed architecture: Agent Map revision 2",
+  "Project agents: Market Research; Marketing / Publisher",
+  "Resource: Research Database",
+  "Connector: TikTok",
+  "Persisted handoff: ResearchReport is written to Research Database and feeds Marketing / Publisher; the owned News Editor returns EditorialBrief inside Marketing’s ownership boundary.",
+] as const;
+
+const BUILDER_OPERATING_RULE =
+  "Begin by planning the implementation with the user; do not silently change another agent’s scope.";
+
+const BUILDER_RECONCILIATION_RULE =
+  "If the user changes architecture in this child session, surface a proposed Agent Map revision back to the Planner instead of letting global project context drift.";
+
+const BUILDER_PROVENANCE =
+  "Injected by Planner from confirmed Agent Map revision 2. Mock startup context only; these strings are not a production prompt contract.";
+
+function builderContextLayers({
+  role,
+  assignment,
+  contracts,
+  boundaries,
+}: {
+  role: string;
+  assignment: readonly string[];
+  contracts: readonly string[];
+  boundaries: readonly string[];
+}): readonly AgentMapDemoBuilderContextLayer[] {
+  return [
+    {
+      id: "role",
+      label: "Builder role",
+      items: [role],
+    },
+    {
+      id: "project-context",
+      label: "Confirmed project context",
+      items: CONFIRMED_PROJECT_CONTEXT,
+    },
+    {
+      id: "assignment",
+      label: "Agent-specific assignment and ownership",
+      items: assignment,
+    },
+    {
+      id: "contracts",
+      label: "Inputs / outputs / contracts and dependencies",
+      items: contracts,
+    },
+    {
+      id: "boundaries",
+      label: "Scope boundaries / non-goals",
+      items: boundaries,
+    },
+    {
+      id: "operating-rule",
+      label: "Operating rule",
+      items: [BUILDER_OPERATING_RULE],
+    },
+    {
+      id: "reconciliation-rule",
+      label: "Reconciliation rule",
+      items: [BUILDER_RECONCILIATION_RULE],
+    },
+    {
+      id: "provenance",
+      label: "Provenance",
+      items: [BUILDER_PROVENANCE],
+    },
+  ];
+}
+
+const BUILDER_SESSIONS: Record<
+  AgentMapDemoBuilderSessionId,
+  AgentMapDemoBuilderSession
+> = {
+  "market-research-builder": {
+    id: "market-research-builder",
+    agentId: "market-research",
+    agentLabel: "Market Research",
+    railLabel: "Research builder",
+    contextLayers: builderContextLayers({
+      role: "You are the Market Research builder: a child implementation session, distinct from the project planning agent.",
+      assignment: [
+        "Own finding and ranking today’s top ten stocks.",
+        "Produce an evidence-backed ResearchReport and write it to Research Database.",
+      ],
+      contracts: [
+        "Input: today’s active market data and supporting evidence.",
+        "Output: an evidence-backed ResearchReport containing the ranked top ten.",
+        "Contract: preserve the confirmed ResearchReport handoff.",
+        "Dependency: Research Database must accept and verify the persisted report.",
+      ],
+      boundaries: [
+        "Do not own editorial selection.",
+        "Do not own news-format script or video generation.",
+        "Do not own TikTok publishing.",
+      ],
+    }),
+    firstReply:
+      "I received the **confirmed Agent Map revision 2** and the **Market Research** assignment. I’ll start in **planning mode**; I am not claiming implementation has begun.\n\nHere is my proposed five-step breakdown before implementation:",
+    steps: [
+      {
+        id: "define-research-report",
+        label: "Define ResearchReport contract",
+        kind: "contract",
+        kindLabel: "Contract",
+        owner: "Market Research",
+      },
+      {
+        id: "fetch-active-market-data",
+        label: "Fetch today’s active market data",
+        kind: "data",
+        kindLabel: "Data intake",
+        owner: "Market Research",
+      },
+      {
+        id: "rank-top-ten",
+        label: "Rank and select the top ten",
+        kind: "decision",
+        kindLabel: "Decision",
+        owner: "Market Research",
+      },
+      {
+        id: "compose-research-report",
+        label: "Compose the evidence-backed report",
+        kind: "report",
+        kindLabel: "Report",
+        owner: "Market Research",
+      },
+      {
+        id: "persist-research-handoff",
+        label: "Persist and verify the Research Database handoff",
+        kind: "resource-boundary",
+        kindLabel: "Resource boundary",
+        owner: "Market Research → Research Database",
+      },
+    ],
+  },
+  "marketing-publisher-builder": {
+    id: "marketing-publisher-builder",
+    agentId: "marketing-publisher",
+    agentLabel: "Marketing / Publisher",
+    railLabel: "Publisher builder",
+    contextLayers: builderContextLayers({
+      role: "You are the Marketing / Publisher builder: a child implementation session, distinct from the project planning agent.",
+      assignment: [
+        "Consume ResearchReport / EditorialBrief and own the downstream publishing path.",
+        "Own News Editor as a subagent with a distinct editorial responsibility.",
+        "Create the news-format script and video, then publish through TikTok.",
+      ],
+      contracts: [
+        "Inputs: persisted ResearchReport and the owned News Editor’s EditorialBrief.",
+        "Outputs: news-format script, video, and TikTok publish result.",
+        "Contract: validate the upstream ResearchReport before editorial work begins.",
+        "Dependencies: Research Database, owned News Editor, and TikTok connector.",
+      ],
+      boundaries: [
+        "Do not redo market research.",
+        "Do not alter Market Research’s upstream ranking responsibility.",
+      ],
+    }),
+    firstReply:
+      "I received the **confirmed Agent Map revision 2** and the **Marketing / Publisher** assignment. I’ll start in **planning mode**; I am not claiming implementation has begun.\n\nHere is my proposed five-step breakdown before implementation:",
+    steps: [
+      {
+        id: "validate-research-report",
+        label: "Read and validate ResearchReport",
+        kind: "contract",
+        kindLabel: "Contract",
+        owner: "Marketing / Publisher",
+      },
+      {
+        id: "news-editor-selection",
+        label: "Have owned News Editor select the strongest points",
+        kind: "owned-subagent",
+        kindLabel: "Owned subagent",
+        owner: "News Editor · owned by Marketing / Publisher",
+      },
+      {
+        id: "draft-news-storyboard",
+        label: "Draft the news script/storyboard",
+        kind: "story",
+        kindLabel: "Story",
+        owner: "Marketing / Publisher",
+      },
+      {
+        id: "generate-news-video",
+        label: "Generate the news-format video",
+        kind: "media",
+        kindLabel: "Media",
+        owner: "Marketing / Publisher",
+      },
+      {
+        id: "publish-tiktok",
+        label: "Publish through TikTok and report the result",
+        kind: "connector-boundary",
+        kindLabel: "Connector boundary",
+        owner: "Marketing / Publisher → TikTok",
+      },
+    ],
+  },
+};
+
+const OPENING_TURN: AgentMapDemoTurn = {
+  id: "planner-opening",
+  role: "planner",
+  kind: "opening",
+  body: "I’ll plan the project’s agents, responsibilities, data flow, resources, and connectors with you. What outcome do you want this project to create?",
+};
+
+export function agentMapDemoFixtureEnabled(
+  mockMode: string | boolean | undefined,
+  search: string,
+): boolean {
+  return (
+    (mockMode === "1" || mockMode === true) &&
+    new URLSearchParams(search).get("mockFixtures") === AGENT_MAP_DEMO_FIXTURE
+  );
+}
+
+export function createInitialAgentMapDemoState(): AgentMapDemoState {
+  return {
+    phase: "opening",
+    revision: 0,
+    editorIncluded: false,
+    projectExpanded: true,
+    selectedNodeId: null,
+    selectedBuilderId: null,
+    turns: [{ ...OPENING_TURN }],
+  };
+}
+
+function normalized(text: string): string {
+  return text
+    .trim()
+    .toLocaleLowerCase()
+    .replace(/[’']/g, "'")
+    .replace(/\s+/g, " ");
+}
+
+function isGoldenPathRequest(text: string): boolean {
+  const value = normalized(text);
+  return (
+    /\bstocks?\b/.test(value) &&
+    value.includes("research") &&
+    value.includes("tiktok") &&
+    (value.includes("marketing") || value.includes("video"))
+  );
+}
+
+function isEditorFollowUp(text: string): boolean {
+  const value = normalized(text);
+  return (
+    (value.includes("strongest") || value.includes("best")) &&
+    (value.includes("point") || value.includes("editor")) &&
+    (value.includes("llm") ||
+      value.includes("model") ||
+      value.includes("editor"))
+  );
+}
+
+function isUnambiguousYes(text: string): boolean {
+  return /^(yes|yes[,.]? please|yes[,.]? it does|yes[,.]? (that )?looks right|looks right|that looks right|the architecture looks right)[.!]?$/i.test(
+    text.trim(),
+  );
+}
+
+function requestsBuildPlan(text: string): boolean {
+  const value = normalized(text);
+  return value.includes("build") && value.includes("plan");
+}
+
+function approvesLaunch(text: string): boolean {
+  const value = normalized(text).replace(/[.!]$/, "");
+  return (
+    isUnambiguousYes(text) ||
+    value.includes("launch") ||
+    value.includes("start the builders") ||
+    value.includes("go ahead") ||
+    (value.includes("approve") && value.includes("builder"))
+  );
+}
+
+function appendExchange(
+  state: AgentMapDemoState,
+  userBody: string,
+  plannerBody: string,
+  kind: AgentMapDemoTurnKind,
+  patch: Partial<AgentMapDemoState> = {},
+): AgentMapDemoState {
+  const index = state.turns.length;
+  return {
+    ...state,
+    ...patch,
+    turns: [
+      ...state.turns,
+      { id: `user-${index}`, role: "user", body: userBody },
+      {
+        id: `planner-${index + 1}`,
+        role: "planner",
+        body: plannerBody,
+        kind,
+      },
+    ],
+  };
+}
+
+function boundedResponse(
+  state: AgentMapDemoState,
+  text: string,
+): AgentMapDemoState {
+  const messageByPhase: Record<AgentMapDemoPhase, string> = {
+    opening:
+      "This concept demo is bounded to the stock-research walkthrough. Use the prepared brief to see its deterministic proposal.",
+    proposal:
+      "For this walkthrough, refine the draft with the editorial follow-up or answer with an unambiguous yes to confirm the current proposal.",
+    "subagent-proposal":
+      "The revised proposal is staged. Answer with an unambiguous yes to confirm this exact revision.",
+    confirmed:
+      "The architecture is confirmed. Ask to see the build plan to continue the scripted walkthrough.",
+    "build-plan":
+      "The build plan is staged. Approve or launch the builders conversationally to continue; no real session will be created.",
+    "builders-launched":
+      "The simulated builders are already visible in the rail. Reset the demo to replay the walkthrough from its empty opening state.",
+  };
+  return appendExchange(state, text, messageByPhase[state.phase], "bounded");
+}
+
+export function agentMapDemoReducer(
+  state: AgentMapDemoState,
+  action: AgentMapDemoAction,
+): AgentMapDemoState {
+  if (action.type === "reset") return createInitialAgentMapDemoState();
+
+  if (action.type === "toggle-project") {
+    return { ...state, projectExpanded: !state.projectExpanded };
+  }
+
+  if (action.type === "select-builder") {
+    if (state.phase !== "builders-launched") return state;
+    return {
+      ...state,
+      selectedBuilderId: action.builderId,
+      selectedNodeId: null,
+    };
+  }
+
+  if (action.type === "select-node") {
+    return {
+      ...state,
+      selectedBuilderId: null,
+      selectedNodeId: action.nodeId,
+    };
+  }
+
+  // Builder snapshots never feed the planner conversation. The visible
+  // builder composer is non-interactive, and this guard keeps an accidental
+  // submit dispatch from mutating the preserved planner transcript.
+  if (state.selectedBuilderId) return state;
+
+  const text = action.text.trim();
+  if (!text) return state;
+
+  if (state.phase === "opening" && isGoldenPathRequest(text)) {
+    return appendExchange(
+      state,
+      text,
+      "I’ve drafted a two-agent plan with one persisted handoff. **Market Research** owns the daily ranking and writes a typed **ResearchReport** to **Research Database**. That report feeds **Marketing / Publisher**, which owns the news-format video and uses the **TikTok** connector to publish it.\n\n**Does this architecture look right?**",
+      "proposal",
+      {
+        phase: "proposal",
+        revision: 1,
+        editorIncluded: false,
+        selectedNodeId: null,
+      },
+    );
+  }
+
+  if (state.phase === "proposal" && isEditorFollowUp(text)) {
+    return appendExchange(
+      state,
+      text,
+      "That adds a distinct editorial responsibility, not an ordinary model call. I’ve proposed **News Editor** as an owned subagent inside **Marketing / Publisher**: it reads the persisted **ResearchReport**, selects the strongest points, and feeds an **EditorialBrief** to its owning agent. It is not an independently deployed project agent.\n\n**Does this revised architecture look right?**",
+      "proposal",
+      {
+        phase: "subagent-proposal",
+        revision: 2,
+        editorIncluded: true,
+        selectedNodeId: null,
+      },
+    );
+  }
+
+  if (
+    (state.phase === "proposal" || state.phase === "subagent-proposal") &&
+    isUnambiguousYes(text)
+  ) {
+    return appendExchange(
+      state,
+      text,
+      `Revision ${state.revision} is now **confirmed**. The exact agents, ownership boundary, persisted handoff, and connector shown on the map are locked for this concept walkthrough. Ask me to show the build plan when you’re ready to continue.`,
+      "confirmed",
+      { phase: "confirmed", selectedNodeId: null },
+    );
+  }
+
+  if (state.phase === "confirmed" && requestsBuildPlan(text)) {
+    return appendExchange(
+      state,
+      text,
+      "Here is the compact project build plan. Each builder stays scoped to one project agent, while the data contract and connector checks remain explicit handoff criteria. Approve the simulated launch in the conversation when you’re ready.",
+      "build-plan",
+      { phase: "build-plan", selectedNodeId: null },
+    );
+  }
+
+  if (state.phase === "build-plan" && approvesLaunch(text)) {
+    return appendExchange(
+      state,
+      text,
+      "Simulated launch complete. Two scoped builder-session rows are now visible beneath their owning project agents. This remains a local concept fixture: no repository, agent, session, network request, or deployment was created.",
+      "builders-launched",
+      { phase: "builders-launched", selectedNodeId: null },
+    );
+  }
+
+  return boundedResponse(state, text);
+}
+
+export function agentMapDemoHasProposal(state: AgentMapDemoState): boolean {
+  return state.phase !== "opening";
+}
+
+export function agentMapDemoBuilderSession(
+  builderId: AgentMapDemoBuilderSessionId,
+): AgentMapDemoBuilderSession {
+  return BUILDER_SESSIONS[builderId];
+}
+
+export function agentMapDemoNodes(
+  state: AgentMapDemoState,
+): readonly AgentMapDemoNode[] {
+  if (!agentMapDemoHasProposal(state)) return [];
+  return state.editorIncluded ? [...BASE_NODES, NEWS_EDITOR_NODE] : BASE_NODES;
+}
+
+export function agentMapDemoRelationships(
+  state: AgentMapDemoState,
+): readonly AgentMapDemoRelationship[] {
+  if (!agentMapDemoHasProposal(state)) return [];
+  return state.editorIncluded ? EDITOR_RELATIONSHIPS : BASE_RELATIONSHIPS;
+}
+
+export function agentMapDemoNodeStatus(
+  state: AgentMapDemoState,
+  node: AgentMapDemoNode,
+): "planned" | "confirmed" | "builder staged" {
+  if (state.phase === "builders-launched" && node.kind === "Agent") {
+    return "builder staged";
+  }
+  if (
+    state.phase === "confirmed" ||
+    state.phase === "build-plan" ||
+    state.phase === "builders-launched"
+  ) {
+    return "confirmed";
+  }
+  return "planned";
+}

--- a/packages/harness/web/src/main.tsx
+++ b/packages/harness/web/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { App } from "./App.js";
+import { agentMapDemoFixtureEnabled } from "./lib/agent-map-demo.js";
 import { interceptMockTrack } from "./lib/api.js";
 import { observeWindowFocus } from "./lib/window-focus.js";
 import { appFrameFromSearch } from "./lib/window-frame.js";
@@ -46,8 +47,29 @@ window.addEventListener("drop", (e) => {
   if (e.dataTransfer?.types.includes("Files")) e.preventDefault();
 });
 
-createRoot(document.getElementById("root")!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+const root = createRoot(document.getElementById("root")!);
+
+// Experiment seam: both gates are load-bearing. The Agent Map fixture is a
+// browser-only concept surface and must never replace the ordinary Harness in
+// a real build or merely because a query string was carried into one.
+if (
+  import.meta.env.VITE_MOCK === "1" &&
+  agentMapDemoFixtureEnabled(import.meta.env.VITE_MOCK, window.location.search)
+) {
+  void Promise.all([
+    import("./components/AgentMapDemo.js"),
+    import("./styles/agent-map-demo.css"),
+  ]).then(([{ AgentMapDemo }]) => {
+    root.render(
+      <StrictMode>
+        <AgentMapDemo />
+      </StrictMode>,
+    );
+  });
+} else {
+  root.render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}

--- a/packages/harness/web/src/styles/agent-map-demo.css
+++ b/packages/harness/web/src/styles/agent-map-demo.css
@@ -1,0 +1,1443 @@
+/* ── Agent Map concept fixture ────────────────────────────────────────────
+   UI-only and demo-local by construction: this namespace is mounted only by
+   main.tsx's VITE_MOCK + ?mockFixtures=agent-map gate. It consumes the same
+   Studio tokens and shell anatomy as the ordinary Harness, but none of these
+   selectors are shared contracts and none style the production graph. */
+.agent-map-demo-shell {
+  display: grid;
+  grid-template-columns: var(--col-w) minmax(0, 1fr);
+  height: 100vh;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--surface-base);
+  color: var(--text);
+}
+
+.agent-map-demo-shell.is-rail-collapsed {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.agent-map-demo-workspace {
+  display: grid;
+  grid-template-columns: minmax(20rem, 0.95fr) minmax(20rem, 1.05fr);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.agent-map-demo-rail {
+  width: var(--col-w);
+  height: 100%;
+}
+
+.agent-map-demo-rail .brand-header {
+  width: 100%;
+}
+
+.agent-map-demo-rail-list {
+  padding-top: var(--sp2);
+}
+
+.agent-map-demo-project {
+  margin-bottom: 0;
+}
+
+.agent-map-demo-project-children {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: var(--tree-row-gap);
+}
+
+.agent-map-demo-project-children::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: calc(var(--tree-indent) - var(--sp2));
+  width: 1px;
+  background: var(--ui-line);
+  pointer-events: none;
+}
+
+.agent-map-demo-rail-row {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  width: 100%;
+  min-width: 0;
+  height: var(--tree-row-h);
+  padding: 0 var(--tree-pad-x) 0 var(--tree-indent);
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: var(--type-label);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.agent-map-demo-rail-row > svg {
+  flex: 0 0 auto;
+  color: var(--text-faint);
+}
+
+.agent-map-demo-rail-row > span:not(.agent-map-demo-pin, .status-tag-dot) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-map-demo-rail-row:hover {
+  background: var(--surface-hover);
+  color: var(--text);
+}
+
+.agent-map-demo-rail-row:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
+
+.agent-map-demo-rail-row.is-selected,
+.agent-map-demo-rail-row.is-selected:hover {
+  background: var(--active-shade);
+  color: var(--text);
+  font-weight: 550;
+}
+
+.agent-map-demo-rail-row.is-selected > svg:first-child {
+  color: var(--brand);
+}
+
+.agent-map-demo-pin {
+  display: inline-flex;
+  margin-left: auto;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  font-weight: 400;
+}
+
+.agent-map-demo-agent-rows,
+.agent-map-demo-agent-rail-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tree-row-gap);
+}
+
+.agent-map-demo-agent-row {
+  padding-left: calc(var(--tree-indent) + var(--sp4));
+}
+
+.agent-map-demo-agent-row .status-tag-dot {
+  margin-left: auto;
+  color: var(--text-faint);
+  background: transparent;
+  box-shadow: inset 0 0 0 1px currentColor;
+}
+
+.agent-map-demo-builder-row {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  min-width: 0;
+  min-height: var(--tree-row-h);
+  margin-left: calc(var(--tree-indent) + var(--sp4));
+  padding: 0 var(--tree-pad-x) 0 var(--sp4);
+  color: var(--text-dim);
+  border: 0;
+  border-left: 1px solid var(--ui-line-strong);
+  border-radius: var(--radius);
+  background: transparent;
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  text-align: left;
+  cursor: pointer;
+  transition:
+    color var(--transition-fast),
+    background-color var(--transition-fast),
+    border-color var(--transition-fast);
+}
+
+.agent-map-demo-builder-row:hover {
+  color: var(--text);
+  background: var(--surface-hover);
+}
+
+.agent-map-demo-builder-row.is-selected,
+.agent-map-demo-builder-row.is-selected:hover {
+  color: var(--text);
+  border-left-color: var(--brand);
+  background: var(--active-shade);
+}
+
+.agent-map-demo-builder-row:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
+
+.agent-map-demo-builder-row > svg {
+  flex: 0 0 auto;
+  color: var(--text-faint);
+}
+
+.agent-map-demo-builder-row.is-selected > svg {
+  color: var(--brand);
+}
+
+.agent-map-demo-builder-row > span:not(.agent-map-demo-builder-meta) {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-map-demo-builder-meta {
+  margin-left: auto;
+  color: var(--text-faint);
+}
+
+.agent-map-demo-rail-footer {
+  align-items: flex-start;
+}
+
+.agent-map-demo-reset {
+  width: 100%;
+  justify-content: flex-start;
+  color: var(--text-dim);
+}
+
+.agent-map-demo-pane-header {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  flex: 0 0 auto;
+  height: var(--pane-header-h);
+  padding: 0 var(--pane-pad-x);
+}
+
+.agent-map-demo-header-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: var(--control-h-xs);
+  height: var(--control-h-xs);
+  color: var(--text-dim);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+}
+
+.agent-map-demo-header-copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.25;
+}
+
+.agent-map-demo-header-title {
+  overflow: hidden;
+  color: var(--text);
+  font-size: var(--type-label);
+  font-weight: 590;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-map-demo-header-meta {
+  overflow: hidden;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-map-demo-local-status,
+.agent-map-demo-map-status {
+  margin-left: auto;
+}
+
+.agent-map-demo-conversation {
+  background: var(--surface-base);
+}
+
+.agent-map-demo-transcript {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.agent-map-demo-transcript-inner {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp5);
+  width: 100%;
+  max-width: var(--assistant-measure-ide);
+  min-height: 100%;
+  margin: 0 auto;
+  padding: var(--sp6) var(--sp5) var(--sp7);
+}
+
+.agent-map-demo-turn {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp2);
+  max-width: 100%;
+  animation: agent-map-demo-turn-in var(--base) var(--ease) both;
+}
+
+.agent-map-demo-turn.is-user {
+  align-items: flex-end;
+}
+
+.agent-map-demo-turn-role {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  font-weight: 510;
+}
+
+.agent-map-demo-planner-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--control-h-2xs);
+  height: var(--control-h-2xs);
+  color: var(--brand);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+}
+
+.agent-map-demo-turn-meta {
+  color: var(--text-faint);
+  font-weight: 400;
+}
+
+.agent-map-demo-turn-body {
+  color: var(--text-dim);
+  font-size: var(--type-body);
+  line-height: 1.58;
+}
+
+.agent-map-demo-turn-body .chat-paragraph {
+  margin: 0 0 var(--sp3);
+}
+
+.agent-map-demo-turn-body .chat-paragraph:last-child,
+.agent-map-demo-turn-body > p:last-child {
+  margin-bottom: 0;
+}
+
+.agent-map-demo-turn-body strong {
+  color: var(--text);
+  font-weight: 590;
+}
+
+.agent-map-demo-turn.is-user .agent-map-demo-turn-body {
+  max-width: 88%;
+  padding: var(--sp3) var(--sp4);
+  color: var(--text);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+}
+
+.agent-map-demo-turn.is-user .agent-map-demo-turn-body p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.agent-map-demo-builder-transcript-inner {
+  min-height: 0;
+}
+
+.agent-map-demo-builder-context {
+  overflow: hidden;
+  border: 1px solid var(--ui-line-strong);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-xs);
+}
+
+.agent-map-demo-builder-context > summary {
+  display: grid;
+  grid-template-columns: var(--control-h-2xs) minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: var(--sp2);
+  min-height: var(--row-h);
+  padding: var(--sp3) var(--sp4);
+  color: var(--text);
+  cursor: pointer;
+  list-style: none;
+}
+
+.agent-map-demo-builder-context > summary::-webkit-details-marker {
+  display: none;
+}
+
+.agent-map-demo-builder-context > summary:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: -2px;
+}
+
+.agent-map-demo-builder-context > summary > svg {
+  color: var(--text-faint);
+  transition: transform var(--transition-fast);
+}
+
+.agent-map-demo-builder-context[open] > summary > svg {
+  transform: rotate(180deg);
+}
+
+.agent-map-demo-builder-context-title {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: var(--sp0);
+}
+
+.agent-map-demo-builder-context-title strong {
+  font-size: var(--type-label);
+  font-weight: 590;
+}
+
+.agent-map-demo-builder-context-title span {
+  overflow: hidden;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-map-demo-builder-context-layers {
+  border-top: 1px solid var(--ui-line);
+}
+
+.agent-map-demo-builder-context-layer {
+  display: grid;
+  grid-template-columns: minmax(calc(var(--sp8) * 3), 0.7fr) minmax(0, 1.3fr);
+  gap: var(--sp4);
+  padding: var(--sp3) var(--sp4);
+}
+
+.agent-map-demo-builder-context-layer + .agent-map-demo-builder-context-layer {
+  border-top: 1px solid var(--ui-line);
+}
+
+.agent-map-demo-builder-context-layer h3 {
+  margin: 0;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.agent-map-demo-builder-context-layer ul {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp1);
+  margin: 0;
+  padding: 0;
+  color: var(--text-dim);
+  font-size: var(--type-meta);
+  line-height: 1.5;
+  list-style: none;
+}
+
+.agent-map-demo-builder-context-layer li {
+  position: relative;
+  padding-left: var(--sp3);
+}
+
+.agent-map-demo-builder-context-layer li::before {
+  content: "";
+  position: absolute;
+  top: 0.65em;
+  left: 0;
+  width: var(--sp1);
+  height: var(--sp1);
+  border-radius: 50%;
+  background: var(--text-faint);
+}
+
+.agent-map-demo-builder-context-layer.is-provenance {
+  background: var(--surface-inset);
+}
+
+.agent-map-demo-builder-context-layer.is-provenance li::before {
+  background: var(--brand);
+}
+
+.agent-map-demo-builder-reply-steps {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp2);
+  margin: var(--sp3) 0;
+  padding-left: var(--sp6);
+  color: var(--text);
+}
+
+.agent-map-demo-builder-reply-steps li {
+  padding-left: var(--sp1);
+}
+
+.agent-map-demo-builder-reply-gate {
+  margin: 0;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-builder-composer .composer-input {
+  color: var(--text-faint);
+  cursor: not-allowed;
+}
+
+.agent-map-demo-inline-card,
+.agent-map-demo-build-plan {
+  margin-top: var(--sp4);
+  padding: var(--sp4);
+  color: var(--text-dim);
+  border: 1px solid var(--ui-line-strong);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-xs);
+}
+
+.agent-map-demo-inline-card-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  margin-bottom: var(--sp3);
+  color: var(--text);
+  font-size: var(--type-label);
+  font-weight: 590;
+}
+
+.agent-map-demo-inline-card-head .status-tag {
+  margin-left: auto;
+  font-weight: 400;
+}
+
+.agent-map-demo-handoff {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--sp2);
+  color: var(--text-dim);
+  font-size: var(--type-label);
+}
+
+.agent-map-demo-handoff code,
+.agent-map-demo-inspector code {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-relationship-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--control-h-2xs);
+  padding: 0 var(--sp2);
+  color: var(--text-dim);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-inline-note {
+  margin-top: var(--sp3);
+  padding-top: var(--sp3);
+  color: var(--text-faint);
+  border-top: 1px solid var(--ui-line);
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-inline-card.is-confirmed,
+.agent-map-demo-inline-card.is-launched {
+  display: flex;
+  align-items: center;
+  gap: var(--sp3);
+}
+
+.agent-map-demo-confirmed-icon {
+  display: inline-flex;
+  color: var(--green-text);
+}
+
+.agent-map-demo-inline-card.is-confirmed > div,
+.agent-map-demo-inline-card.is-launched > div {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp0);
+}
+
+.agent-map-demo-inline-card.is-confirmed span,
+.agent-map-demo-inline-card.is-launched span {
+  color: var(--text-faint);
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-build-plan ol {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.agent-map-demo-build-plan li {
+  display: flex;
+  gap: var(--sp3);
+  padding: var(--sp3);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+}
+
+.agent-map-demo-build-plan li > div {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp1);
+}
+
+.agent-map-demo-build-plan li span:last-child {
+  color: var(--text-faint);
+  font-size: var(--type-meta);
+  line-height: 1.5;
+}
+
+.agent-map-demo-plan-number {
+  flex: 0 0 auto;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-plan-gate {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  margin-top: var(--sp3);
+  padding-top: var(--sp3);
+  color: var(--text-faint);
+  border-top: 1px solid var(--ui-line);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-launch-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: var(--control-h-xs);
+  height: var(--control-h-xs);
+  color: var(--amber-text) !important;
+  border: 1px solid var(--ui-line-strong);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+  font-family: var(--font-mono);
+  font-size: var(--type-label) !important;
+  font-weight: 590;
+}
+
+.agent-map-demo-composer-wrap {
+  flex: 0 0 auto;
+  width: 100%;
+  max-width: var(--assistant-measure-ide);
+  margin: 0 auto;
+  padding: 0 var(--sp5) var(--sp5);
+}
+
+.agent-map-demo-suggestion-row {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--sp2);
+  margin-bottom: var(--sp2);
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-suggestion {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp2);
+  height: var(--control-h-xs);
+}
+
+.agent-map-demo-suggestion > svg {
+  color: var(--brand);
+}
+
+.agent-map-demo-composer {
+  border-radius: var(--radius);
+}
+
+.agent-map-demo-composer-note {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-map-demo-builder-steps {
+  background: var(--surface-raised);
+}
+
+.agent-map-demo-builder-steps-intro {
+  margin-bottom: var(--sp4);
+  padding: var(--sp4);
+  border: 1px solid var(--ui-line-strong);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+}
+
+.agent-map-demo-builder-steps-intro > div {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+}
+
+.agent-map-demo-builder-steps-intro strong {
+  color: var(--text);
+  font-size: var(--type-label);
+  font-weight: 590;
+}
+
+.agent-map-demo-builder-steps-intro .status-tag {
+  margin-left: auto;
+}
+
+.agent-map-demo-builder-steps-intro p {
+  margin: var(--sp2) 0 0;
+  color: var(--text-faint);
+  font-size: var(--type-meta);
+  line-height: 1.5;
+}
+
+.agent-map-demo-builder-step-row,
+.canvas-step-row.is-static.agent-map-demo-builder-step-row {
+  grid-template-columns:
+    var(--control-h-2xs) var(--control-h-2xs) minmax(0, 1fr)
+    auto;
+  min-height: calc(var(--row-h) + var(--sp3));
+  border: 1px solid transparent;
+  transition: none;
+}
+
+.agent-map-demo-builder-step-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--control-h-2xs);
+  height: var(--control-h-2xs);
+  color: var(--text-faint);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+}
+
+.agent-map-demo-builder-step-kind {
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-builder-step-item.is-owned-subagent
+  .agent-map-demo-builder-step-row,
+.agent-map-demo-builder-step-item.is-resource-boundary
+  .agent-map-demo-builder-step-row {
+  border-style: dashed;
+  border-color: var(--ui-line-strong);
+  background: var(--surface-inset);
+}
+
+.agent-map-demo-builder-step-item.is-connector-boundary
+  .agent-map-demo-builder-step-row {
+  border-style: dotted;
+  border-color: var(--ui-line-strong);
+  background: var(--surface-inset);
+}
+
+.agent-map-demo-builder-step-item.is-owned-subagent
+  .agent-map-demo-builder-step-icon,
+.agent-map-demo-builder-step-item.is-owned-subagent
+  .agent-map-demo-builder-step-kind {
+  color: var(--brand);
+}
+
+.agent-map-demo-builder-step-item.is-connector-boundary
+  .agent-map-demo-builder-step-icon,
+.agent-map-demo-builder-step-item.is-connector-boundary
+  .agent-map-demo-builder-step-kind {
+  color: var(--text);
+}
+
+.agent-map-demo-builder-step-gate {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--sp3);
+  margin-top: var(--sp5);
+  padding: var(--sp4);
+  color: var(--text-faint);
+  border-top: 1px solid var(--ui-line);
+}
+
+.agent-map-demo-builder-step-gate > svg {
+  flex: 0 0 auto;
+  margin-top: var(--sp1);
+  color: var(--brand);
+}
+
+.agent-map-demo-builder-step-gate > div {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp1);
+}
+
+.agent-map-demo-builder-step-gate strong {
+  color: var(--text);
+  font-size: var(--type-label);
+  font-weight: 590;
+}
+
+.agent-map-demo-builder-step-gate span {
+  font-size: var(--type-meta);
+  line-height: 1.5;
+}
+
+.agent-map-demo-map {
+  background: var(--surface-raised);
+  box-shadow: -4px 0 16px -6px color-mix(in srgb, var(--ink) 24%, transparent);
+}
+
+.agent-map-demo-map-status.is-confirmed {
+  color: var(--green-text);
+}
+
+.agent-map-demo-map-status.is-staged {
+  color: var(--amber-text);
+}
+
+.agent-map-demo-map-body {
+  position: relative;
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.agent-map-demo-canvas-stage {
+  position: relative;
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  background-image: radial-gradient(var(--ui-line) 1px, transparent 1px);
+  background-size: var(--sp4) var(--sp4);
+}
+
+.agent-map-demo-canvas-stage:not(.is-empty) {
+  display: flex;
+  padding: var(--sp4);
+}
+
+.agent-map-demo-canvas-stage.is-empty {
+  background-color: var(--surface-raised);
+}
+
+.agent-map-demo-graph {
+  position: relative;
+  flex: 0 0 auto;
+  width: 100%;
+  max-width: 1000px;
+  min-width: calc(var(--col-w) + var(--sp8) * 3);
+  aspect-ratio: 5 / 3;
+  margin: auto;
+}
+
+.agent-map-demo-edges {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: visible;
+  color: var(--text-faint);
+  pointer-events: none;
+}
+
+.agent-map-demo-edges > path {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.5;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vector-effect: non-scaling-stroke;
+  marker-end: url("#agent-map-demo-arrow");
+  opacity: 0.72;
+  animation: agent-map-demo-edge-in var(--base) var(--ease) both;
+}
+
+.agent-map-demo-edges marker path {
+  fill: currentColor;
+}
+
+.agent-map-demo-edge-label {
+  position: absolute;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp2);
+  min-height: var(--control-h-2xs);
+  padding: 0 var(--sp2);
+  color: var(--text-dim);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-xs);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  pointer-events: none;
+}
+
+.agent-map-demo-edge-label code {
+  color: var(--text);
+  font-family: inherit;
+}
+
+.agent-map-demo-edge-label.is-write {
+  top: 19%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.agent-map-demo-edge-label.is-feed {
+  top: 51%;
+  left: 59%;
+  transform: translate(-50%, -50%);
+}
+
+.agent-map-demo-edge-label.is-use {
+  top: 76%;
+  left: 62%;
+  transform: translate(-50%, -50%);
+}
+
+.agent-map-demo-node,
+.agent-map-demo-marketing-group {
+  position: absolute;
+  z-index: 1;
+  box-sizing: border-box;
+  animation: agent-map-demo-node-in var(--base) var(--ease) both;
+  animation-delay: calc(var(--demo-node-order) * var(--fast));
+}
+
+.agent-map-demo-node {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp2);
+  min-height: calc(var(--row-h) * 2);
+  padding: var(--sp3);
+  overflow: hidden;
+  color: var(--text);
+  border: 1px solid var(--ui-line-strong);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-xs);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    background-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.agent-map-demo-node:hover,
+.agent-map-demo-marketing-primary:hover,
+.agent-map-demo-owned-node:hover {
+  background: var(--surface-hover-raised);
+}
+
+.agent-map-demo-node:hover {
+  transform: translateY(-1px);
+}
+
+.agent-map-demo-node:focus-visible,
+.agent-map-demo-marketing-primary:focus-visible,
+.agent-map-demo-owned-node:focus-visible {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.agent-map-demo-node.is-selected,
+.agent-map-demo-marketing-group.is-selected {
+  border-color: var(--text-faint);
+  box-shadow:
+    0 0 0 2px var(--active-shade-raised),
+    var(--shadow-xs);
+}
+
+.agent-map-demo-node.is-market-research {
+  top: 10%;
+  left: 5%;
+  width: 35%;
+}
+
+.agent-map-demo-node.is-research-database {
+  top: 12%;
+  right: 5%;
+  width: 30%;
+  min-height: calc(var(--row-h) + var(--sp6));
+  border-style: dashed;
+  background: var(--surface-inset);
+  box-shadow: none;
+}
+
+.agent-map-demo-node.is-tiktok {
+  right: 5%;
+  bottom: 13%;
+  width: 25%;
+  min-height: calc(var(--row-h) + var(--sp5));
+  border-style: dotted;
+  box-shadow: none;
+}
+
+.agent-map-demo-node-heading {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  width: 100%;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.agent-map-demo-node-icon {
+  display: inline-flex;
+  color: var(--text-dim);
+}
+
+.agent-map-demo-node > strong,
+.agent-map-demo-marketing-primary > strong {
+  width: 100%;
+  overflow: hidden;
+  color: var(--text);
+  font-size: var(--type-label);
+  font-weight: 590;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-map-demo-node-summary {
+  width: 100%;
+  overflow: hidden;
+  color: var(--text-faint);
+  font-size: var(--type-meta);
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-map-demo-node-status {
+  margin-top: auto;
+}
+
+.agent-map-demo-node-status.is-confirmed {
+  color: var(--green-text);
+}
+
+.agent-map-demo-node-status.is-builder-staged {
+  color: var(--amber-text);
+}
+
+.agent-map-demo-marketing-group {
+  left: 5%;
+  bottom: 8%;
+  display: flex;
+  flex-direction: column;
+  width: 48%;
+  overflow: hidden;
+  border: 1px solid var(--ui-line-strong);
+  border-radius: var(--radius);
+  background: var(--surface-raised);
+  box-shadow: var(--shadow-xs);
+}
+
+.agent-map-demo-marketing-primary {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--sp2);
+  min-height: calc(var(--row-h) * 2);
+  padding: var(--sp3);
+  color: var(--text);
+  border: 0;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.agent-map-demo-owned-node {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  margin: 0 var(--sp2) var(--sp2);
+  padding: var(--sp2);
+  color: var(--text-dim);
+  border: 1px dashed var(--ui-line-strong);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color var(--transition-fast),
+    background-color var(--transition-fast);
+}
+
+.agent-map-demo-owned-node.is-selected {
+  border-color: var(--text-faint);
+  background: var(--active-shade-raised);
+}
+
+.agent-map-demo-owned-node-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--brand);
+}
+
+.agent-map-demo-owned-node-copy {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.3;
+}
+
+.agent-map-demo-owned-node-copy strong {
+  overflow: hidden;
+  color: var(--text);
+  font-size: var(--type-meta);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-map-demo-owned-node-copy span {
+  overflow: hidden;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-map-demo-owned-flow {
+  flex: 0 0 auto;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-inspector {
+  position: absolute;
+  z-index: 5;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  width: min(var(--col-w), calc(100% - var(--sp8)));
+  min-width: 0;
+  overflow: hidden;
+  border-left: 1px solid var(--ui-line-strong);
+  /* A drawer overlays the board, so it needs the opaque raised plane rather
+     than the Studio preset's compositing wash (which is correct for cards). */
+  background: var(--bg-1);
+  box-shadow: var(--shadow);
+  animation: agent-map-demo-inspector-in var(--base) var(--ease) both;
+}
+
+.agent-map-demo-inspector-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp3);
+  min-height: var(--pane-header-h);
+  padding: var(--sp3) var(--sp3) var(--sp3) var(--sp4);
+  border-bottom: 1px solid var(--ui-line);
+}
+
+.agent-map-demo-inspector-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: var(--control-h-xs);
+  height: var(--control-h-xs);
+  color: var(--text-dim);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+}
+
+.agent-map-demo-inspector-head > div {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.agent-map-demo-inspector-kind {
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-inspector h2 {
+  margin: 0;
+  overflow: hidden;
+  color: var(--text);
+  font-size: var(--type-label);
+  font-weight: 590;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-map-demo-inspector-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--sp4);
+}
+
+.agent-map-demo-inspector dl {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp4);
+  margin: 0;
+}
+
+.agent-map-demo-inspector dl > div {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp1);
+}
+
+.agent-map-demo-inspector dt,
+.agent-map-demo-inspector-relationships h3 {
+  margin: 0;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.agent-map-demo-inspector dd {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: var(--type-label);
+  line-height: 1.5;
+}
+
+.agent-map-demo-inspector-relationships {
+  margin-top: var(--sp5);
+  padding-top: var(--sp4);
+  border-top: 1px solid var(--ui-line);
+}
+
+.agent-map-demo-inspector-relationships ul {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp2);
+  margin: var(--sp3) 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.agent-map-demo-inspector-relationships li {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp2);
+  padding: var(--sp3);
+  border: 1px solid var(--ui-line);
+  border-radius: var(--radius);
+  background: var(--surface-inset);
+}
+
+.agent-map-demo-relationship-direction {
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: var(--type-meta);
+}
+
+.agent-map-demo-relationship-line {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--sp1);
+  color: var(--text-dim);
+  font-size: var(--type-meta);
+}
+
+@keyframes agent-map-demo-turn-in {
+  from {
+    opacity: 0;
+    transform: translateY(var(--sp2));
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes agent-map-demo-node-in {
+  from {
+    opacity: 0;
+    transform: translateY(var(--sp2)) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes agent-map-demo-edge-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.72;
+  }
+}
+
+@keyframes agent-map-demo-inspector-in {
+  from {
+    opacity: 0;
+    transform: translateX(var(--sp4));
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@media (max-width: 1024px) {
+  .agent-map-demo-workspace {
+    grid-template-columns: minmax(18rem, 0.9fr) minmax(20rem, 1.1fr);
+  }
+
+  .agent-map-demo-transcript-inner,
+  .agent-map-demo-composer-wrap {
+    padding-right: var(--sp4);
+    padding-left: var(--sp4);
+  }
+}
+
+@media (max-width: 768px) {
+  .agent-map-demo-workspace {
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(calc(var(--sp8) * 6), 1fr) minmax(
+        calc(var(--sp8) * 7),
+        1fr
+      );
+    overflow-y: auto;
+  }
+
+  .agent-map-demo-conversation,
+  .agent-map-demo-map {
+    min-height: 0;
+  }
+
+  .agent-map-demo-map {
+    border-top: 1px solid var(--ui-line-strong);
+    box-shadow: 0 -4px 16px -6px color-mix(in srgb, var(--ink) 24%, transparent);
+  }
+}
+
+@media (max-width: 640px) {
+  .agent-map-demo-shell,
+  .agent-map-demo-shell.is-rail-collapsed {
+    display: block;
+    height: 100vh;
+    overflow-y: auto;
+  }
+
+  .agent-map-demo-rail {
+    width: 100%;
+    height: auto;
+    min-height: calc(var(--sp8) * 3);
+  }
+
+  .agent-map-demo-rail .rail-tree {
+    min-height: calc(var(--sp8) * 2);
+  }
+
+  .agent-map-demo-rail-footer {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .agent-map-demo-reset {
+    width: auto;
+    margin-left: auto;
+  }
+
+  .agent-map-demo-workspace {
+    height: auto;
+    min-height: calc(var(--sp8) * 13);
+  }
+
+  .agent-map-demo-local-status {
+    display: none;
+  }
+
+  .agent-map-demo-suggestion-row > span:first-child,
+  .agent-map-demo-composer-note {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-map-demo-turn,
+  .agent-map-demo-node,
+  .agent-map-demo-marketing-group,
+  .agent-map-demo-edges > path,
+  .agent-map-demo-inspector {
+    animation-duration: 1ms;
+    animation-delay: 0ms;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a deterministic, browser-only Agent Map concept fixture for product and design review. It demonstrates a project-level planning conversation, iterative map revision and confirmation, simulated builder-session launch, injected child-session context, and per-agent step decomposition.

This is intentionally a concept surface, not a production graph-authoring implementation or prompt contract.

## Changes

- Add the three-pane Agent Map walkthrough with a project rail, planning chat, and project map.
- Model project agents, a persisted resource, a connector, contract-bearing handoffs, and an owned subagent without putting ordinary capabilities on the project map.
- Add conversational proposal, refinement, confirmation, build-plan, launch, and reset phases.
- Add simulated Research and Publisher builder sessions with scoped startup-context layers and five implementation steps each.
- Preserve project-planner state when navigating between the Agent Map and child builder snapshots.
- Gate the fixture behind both `VITE_MOCK=1` and `?mockFixtures=agent-map`.
- Add reducer coverage and a complete Playwright walkthrough.

## Motivation

The concept explores treating the Agent Map as a collaborative project plan created before implementation, rather than only as a post-hoc dependency graph inferred from existing agents. The confirmed map can then become shared context for scoped implementation sessions while keeping project topology separate from per-agent execution detail.

## Testing

- [x] Prettier check for all six changed files
- [x] `pnpm --filter @sapiom/harness exec vitest run web/src/lib/agent-map-demo.test.ts` — 6/6 tests
- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `VITE_MOCK=1 pnpm --filter @sapiom/harness build:web`
- [x] `pnpm --filter @sapiom/harness build:web`
- [x] Verified the ordinary build emits no Agent Map demo chunk
- [x] `pnpm --filter @sapiom/harness exec playwright test --config web/e2e/playwright.config.ts agent-map-demo.spec.ts` — 1/1 Chromium test

## Interactive demo

Run from the repository root:

```bash
VITE_MOCK=1 pnpm --filter @sapiom/harness dev:web --host 127.0.0.1 --port 5299
```

Then open:

```text
http://127.0.0.1:5299/?mockFixtures=agent-map
```

Use the prepared walkthrough through **Approve and launch builders**, then select either builder row to inspect its injected context and agent-specific steps.

## Safety and scope

- No real agents, repositories, sessions, connectors, deployments, or network requests are created.
- The scripted state is browser-only and resets on reload.
- The builder composers are intentionally disabled.
- No production `SystemGraph` contract is widened or reused for graph authoring.
- Ordinary non-mock builds exclude the concept chunk.

## Checklist

- [x] Diff is limited to one logical concept fixture
- [x] Existing Harness design tokens and component anatomy are reused
- [x] No hardcoded secrets or production side effects
- [x] Self-reviewed against current `main`
