### PR TITLE
fix(harness): refresh MCP credentials at launch

### DIFF
--- a/.changeset/live-studios-refresh.md
+++ b/.changeset/live-studios-refresh.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/mcp": patch
+"@sapiom/harness": patch
+---
+
+Resolve the latest saved credential and selected environment whenever Agent Studio creates, resumes, or runs a background Claude session. Preserve `--no-auth` as a process-wide opt-out and expose a strict credential-store reader for safe live reconciliation.

--- a/.changeset/live-studios-refresh.md
+++ b/.changeset/live-studios-refresh.md
@@ -3,4 +3,4 @@
 "@sapiom/harness": patch
 ---
 
-Resolve the latest saved credential and selected environment whenever Agent Studio creates, resumes, or runs a background Claude session. Preserve `--no-auth` as a process-wide opt-out and expose a strict credential-store reader for safe live reconciliation.
+Resolve the latest saved credential and selected environment whenever Agent Studio creates, resumes, or runs a background Claude session. A confirmed credential removal now clears the launch key, while a malformed or unreadable store preserves the last-known key. Preserve `--no-auth` as a process-wide opt-out and expose a strict credential-store reader for safe live reconciliation.

--- a/.changeset/live-studios-refresh.md
+++ b/.changeset/live-studios-refresh.md
@@ -1,6 +1,6 @@
 ---
-"@sapiom/mcp": patch
-"@sapiom/harness": patch
+"@sapiom/mcp": minor
+"@sapiom/harness": minor
 ---
 
 Resolve the latest saved credential and selected environment whenever Agent Studio creates, resumes, or runs a background Claude session. A confirmed credential removal now clears the launch key, while a malformed or unreadable store preserves the last-known key. Unknown selected environments now fail the affected launch with an explicit configuration error instead of silently routing it to production. Preserve `--no-auth` as a process-wide opt-out and expose a strict credential-store reader for safe live reconciliation.

--- a/.changeset/live-studios-refresh.md
+++ b/.changeset/live-studios-refresh.md
@@ -3,4 +3,4 @@
 "@sapiom/harness": patch
 ---
 
-Resolve the latest saved credential and selected environment whenever Agent Studio creates, resumes, or runs a background Claude session. A confirmed credential removal now clears the launch key, while a malformed or unreadable store preserves the last-known key. Preserve `--no-auth` as a process-wide opt-out and expose a strict credential-store reader for safe live reconciliation.
+Resolve the latest saved credential and selected environment whenever Agent Studio creates, resumes, or runs a background Claude session. A confirmed credential removal now clears the launch key, while a malformed or unreadable store preserves the last-known key. Unknown selected environments now fail the affected launch with an explicit configuration error instead of silently routing it to production. Preserve `--no-auth` as a process-wide opt-out and expose a strict credential-store reader for safe live reconciliation.

--- a/packages/harness/src/cli/args.ts
+++ b/packages/harness/src/cli/args.ts
@@ -25,6 +25,13 @@ export interface CliOptions {
   stateRoot?: string;
 }
 
+/** Translate the CLI flag into the server's explicit process-wide policy. */
+export function resolveCliAuthMode(
+  options: Pick<CliOptions, "noAuth">,
+): "enabled" | "disabled" {
+  return options.noAuth ? "disabled" : "enabled";
+}
+
 export function parseArgs(argv: string[]): CliOptions {
   let dir: string | undefined;
   let port = DEFAULT_PORT;

--- a/packages/harness/src/cli/bin-boot.test.ts
+++ b/packages/harness/src/cli/bin-boot.test.ts
@@ -5,7 +5,7 @@
  * isolation — the same pattern used by bin.test.ts for signal handlers.
  */
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { parseArgs } from "./args.js";
+import { parseArgs, resolveCliAuthMode } from "./args.js";
 import { printBanner } from "./banner.js";
 import { AGENT_STUDIO_PRODUCT_NAME } from "../shared/branding.js";
 
@@ -24,15 +24,23 @@ describe("parseArgs — --state-root flag", () => {
   });
 
   it("captures the directory it is given", () => {
-    expect(parseArgs(["--state-root", "/tmp/throwaway"]).stateRoot).toBe("/tmp/throwaway");
+    expect(parseArgs(["--state-root", "/tmp/throwaway"]).stateRoot).toBe(
+      "/tmp/throwaway",
+    );
   });
 
   it("rejects a missing value rather than silently ignoring the flag", () => {
-    expect(() => parseArgs(["--state-root"])).toThrow(/requires a directory path/);
+    expect(() => parseArgs(["--state-root"])).toThrow(
+      /requires a directory path/,
+    );
   });
 
   it("composes with a working directory argument", () => {
-    const options = parseArgs(["/Users/demo/scratch", "--state-root", "/tmp/throwaway"]);
+    const options = parseArgs([
+      "/Users/demo/scratch",
+      "--state-root",
+      "/tmp/throwaway",
+    ]);
     expect(options.dir).toBe("/Users/demo/scratch");
     expect(options.stateRoot).toBe("/tmp/throwaway");
   });
@@ -60,7 +68,9 @@ describe("parseArgs — --login flag", () => {
   });
 
   it("--port requires a value", () => {
-    expect(() => parseArgs(["--port"])).toThrow("--port requires a numeric value");
+    expect(() => parseArgs(["--port"])).toThrow(
+      "--port requires a numeric value",
+    );
   });
 });
 
@@ -112,9 +122,11 @@ describe("printBanner — 'Agent Studio' name", () => {
     });
 
     const lines = logSpy.mock.calls.map((c) => String(c[0]));
-    expect(lines.some((l) => l.includes("Acme") && l.includes("u-1") && l.includes("cached"))).toBe(
-      true,
-    );
+    expect(
+      lines.some(
+        (l) => l.includes("Acme") && l.includes("u-1") && l.includes("cached"),
+      ),
+    ).toBe(true);
   });
 
   it("banner shows the UI-authorized launch URL when server started", () => {
@@ -128,7 +140,9 @@ describe("printBanner — 'Agent Studio' name", () => {
     });
 
     const lines = logSpy.mock.calls.map((c) => String(c[0]));
-    expect(lines.some((l) => l.includes("http://localhost:4000/?uiToken=abc123"))).toBe(true);
+    expect(
+      lines.some((l) => l.includes("http://localhost:4000/?uiToken=abc123")),
+    ).toBe(true);
   });
 
   it("banner shows '(server not started)' when server failed to start", () => {
@@ -169,5 +183,10 @@ describe("boot-auth deferral — interactive: false when --login is absent", () 
     const opts = parseArgs(["--no-auth"]);
     expect(opts.noAuth).toBe(true);
     expect(opts.login).toBe(false);
+    expect(resolveCliAuthMode(opts)).toBe("disabled");
+  });
+
+  it("auth remains enabled by default", () => {
+    expect(resolveCliAuthMode(parseArgs([]))).toBe("enabled");
   });
 });

--- a/packages/harness/src/cli/bin.ts
+++ b/packages/harness/src/cli/bin.ts
@@ -28,7 +28,7 @@ import { ensureConsent } from "./consent.js";
 import { loadSettings, recordRecentDir } from "./settings.js";
 import { getOrCreateMachineId } from "./machine-id.js";
 import { resolveStatePaths } from "../core/paths.js";
-import { parseArgs } from "./args.js";
+import { parseArgs, resolveCliAuthMode } from "./args.js";
 import { startServer, type HarnessServer } from "../server/index.js";
 
 const main = async (): Promise<void> => {
@@ -72,9 +72,13 @@ const main = async (): Promise<void> => {
   // out explicitly so "auth silently worked" doesn't read as "nothing
   // happened" (a fresh login is its own visible browser flow already).
   if (identity?.source === "cached") {
-    console.log(`\nSigned in as ${identity.organizationName} (cached credential).`);
+    console.log(
+      `\nSigned in as ${identity.organizationName} (cached credential).`,
+    );
   }
-  const consentResult = await ensureConsent({ noTelemetry: options.noTelemetry });
+  const consentResult = await ensureConsent({
+    noTelemetry: options.noTelemetry,
+  });
   const { telemetryOptIn } = consentResult;
   // First run = no recent directories recorded before this boot. Must be read
   // BEFORE recordRecentDir below stamps the launch dir in — after that the
@@ -82,7 +86,8 @@ const main = async (): Promise<void> => {
   // and suppresses the auto-created boot session, so a brand-new user lands on
   // the welcome panel rather than a bare terminal in whatever directory they
   // happened to launch from.
-  const firstRun = (await loadSettings(statePaths.settings)).recentDirs.length === 0;
+  const firstRun =
+    (await loadSettings(statePaths.settings)).recentDirs.length === 0;
   await recordRecentDir(options.dir, statePaths.settings);
 
   const bootToken = crypto.randomBytes(32).toString("hex");
@@ -93,6 +98,7 @@ const main = async (): Promise<void> => {
       port: options.port,
       bootToken,
       telemetryOptIn,
+      authMode: resolveCliAuthMode(options),
       consentSource: consentResult.source,
       consentEnvReason: consentResult.envReason,
       identity,

--- a/packages/harness/src/core/api-key-provider.test.ts
+++ b/packages/harness/src/core/api-key-provider.test.ts
@@ -43,7 +43,7 @@ describe("createApiKeyProvider", () => {
     expect(readApiKeyForEnv).toHaveBeenCalledWith("staging");
   });
 
-  it("keeps the current key when the store has no credential (does not clobber to null)", async () => {
+  it("clears the current key when a successful store read confirms no credential", async () => {
     const provider = createApiKeyProvider("sk-current", {
       resolveEnvironmentName: () => Promise.resolve("production"),
       readApiKeyForEnv: () => Promise.resolve(null),
@@ -51,11 +51,11 @@ describe("createApiKeyProvider", () => {
 
     const refreshed = await provider.refresh();
 
-    expect(refreshed).toBe("sk-current");
-    expect(provider.getKey()).toBe("sk-current");
+    expect(refreshed).toBeNull();
+    expect(provider.getKey()).toBeNull();
   });
 
-  it("keeps the current key when the store returns an empty string", async () => {
+  it("clears the current key when the store returns an empty string", async () => {
     const provider = createApiKeyProvider("sk-current", {
       resolveEnvironmentName: () => Promise.resolve("production"),
       readApiKeyForEnv: () => Promise.resolve(""),
@@ -63,7 +63,8 @@ describe("createApiKeyProvider", () => {
 
     const refreshed = await provider.refresh();
 
-    expect(refreshed).toBe("sk-current");
+    expect(refreshed).toBeNull();
+    expect(provider.getKey()).toBeNull();
   });
 
   it("keeps the current key when reading the store throws (unreadable HOME, bad file)", async () => {
@@ -105,6 +106,34 @@ describe("createApiKeyProvider", () => {
     expect(provider.getKey()).toBe("sk-just-logged-in");
   });
 
+  it("serializes concurrent refreshes so an older read cannot win last", async () => {
+    let resolveFirst!: (key: string | null) => void;
+    const readApiKeyForEnv = vi
+      .fn<() => Promise<string | null>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce("key-c");
+    const provider = createApiKeyProvider("key-a", {
+      resolveEnvironmentName: () => Promise.resolve("production"),
+      readApiKeyForEnv,
+    });
+
+    const first = provider.refresh();
+    const second = provider.refresh();
+    await vi.waitFor(() => expect(readApiKeyForEnv).toHaveBeenCalledTimes(1));
+
+    resolveFirst("key-b");
+
+    await expect(first).resolves.toBe("key-b");
+    await expect(second).resolves.toBe("key-c");
+    expect(provider.getKey()).toBe("key-c");
+    expect(readApiKeyForEnv).toHaveBeenCalledTimes(2);
+  });
+
   it("clear() sets the in-memory key to null unconditionally", () => {
     const provider = createApiKeyProvider("sk-live", {
       resolveEnvironmentName: () => Promise.resolve("production"),
@@ -127,7 +156,7 @@ describe("createApiKeyProvider", () => {
     expect(provider.getKey()).toBeNull();
   });
 
-  it("refresh() after clear() does NOT re-adopt a non-null store value (clear is permanent until refresh finds a key)", async () => {
+  it("refresh() after clear() re-adopts a non-null store value", async () => {
     // This test documents that refresh() WILL re-adopt a key after clear()
     // if the store has one — clear() only zeros in-memory; the store is
     // separate and managed by clearCredentials().

--- a/packages/harness/src/core/api-key-provider.ts
+++ b/packages/harness/src/core/api-key-provider.ts
@@ -24,11 +24,11 @@
  *
  * NOT in scope (deliberately, per the ticket): triggering an interactive
  * browser re-login from the server, or a broader session-auth redesign. Refresh
- * here is a silent re-read of already-cached credentials; if the store has no
- * newer key, the call surfaces the auth error honestly.
+ * here is a silent re-read of already-cached credentials. A confirmed absence
+ * becomes signed out; a store failure preserves the last-known value.
  */
 
-import { readCredentials, resolveEnvironment } from "@sapiom/mcp/auth";
+import { readCredentialsOrThrow, resolveEnvironment } from "@sapiom/mcp/auth";
 
 /**
  * Reads the currently-held API key and can refresh it from the shared
@@ -41,17 +41,15 @@ export interface ApiKeyProvider {
   /** The current API key, or null when the harness is not signed in. */
   getKey(): string | null;
   /**
-   * Re-read the shared credential store and adopt any newer key found there.
-   * Returns the (possibly updated) current key, or null if none is available.
+   * Re-read the shared credential store and adopt its authoritative result.
+   * Returns the updated current key, or null when signed out.
    * Never throws — a read failure leaves the current key untouched and is
    * reported by returning the existing value.
    */
   refresh(): Promise<string | null>;
   /**
    * Unconditionally zero the in-memory key (sets it to null). Called on
-   * disconnect so that {@link getKey} returns null immediately — distinct from
-   * {@link refresh}, whose `if (latest)` guard deliberately preserves the
-   * cached key when the credential store has nothing to offer.
+   * disconnect so that {@link getKey} returns null immediately.
    */
   clear(): void;
 }
@@ -61,7 +59,7 @@ export interface ApiKeyProvider {
 export interface ApiKeyProviderDeps {
   /** Resolve the active environment name (governs which cached entry to read). */
   resolveEnvironmentName?: () => Promise<string>;
-  /** Read the cached API key for a given environment, or null if absent. */
+  /** Strictly read the cached API key for an environment, or null if absent. */
   readApiKeyForEnv?: (envName: string) => Promise<string | null>;
   /** Overrides SAPIOM_ENVIRONMENT for environment resolution. */
   environment?: string;
@@ -79,15 +77,15 @@ async function defaultResolveEnvironmentName(
 async function defaultReadApiKeyForEnv(
   envName: string,
 ): Promise<string | null> {
-  const entry = await readCredentials(envName);
+  const entry = await readCredentialsOrThrow(envName);
   return entry?.apiKey ?? null;
 }
 
 /**
  * Build an {@link ApiKeyProvider} seeded with the boot-time key. `refresh()`
- * re-reads the shared credential store for the active environment and adopts a
- * newer key when one is present — the reconciliation point between the key the
- * CLI captured at boot and any key rotated/re-logged-in afterward.
+ * re-reads the shared credential store for the active environment and adopts
+ * its current state — including a confirmed signed-out state. Store failures
+ * preserve the last-known key.
  */
 export function createApiKeyProvider(
   initialKey: string | null,
@@ -98,25 +96,36 @@ export function createApiKeyProvider(
     deps.resolveEnvironmentName ??
     (() => defaultResolveEnvironmentName(deps.environment));
   const readApiKey = deps.readApiKeyForEnv ?? defaultReadApiKeyForEnv;
+  let refreshQueue: Promise<void> = Promise.resolve();
+
+  const refreshFromStore = async (): Promise<string | null> => {
+    try {
+      const envName = await resolveEnvName();
+      const latest = await readApiKey(envName);
+      // A completed strict read is authoritative. Null/empty means the
+      // credential was deliberately removed; only a thrown read preserves the
+      // last-known key.
+      current = latest?.trim() ? latest : null;
+    } catch {
+      // Store unreadable (permissions, malformed JSON, transient I/O) or an
+      // invalid environment — preserve the last-known key.
+    }
+    return current;
+  };
 
   return {
     getKey(): string | null {
       return current;
     },
-    async refresh(): Promise<string | null> {
-      try {
-        const envName = await resolveEnvName();
-        const latest = await readApiKey(envName);
-        // Only adopt a real, non-empty key. A missing/emptied credential must
-        // not clobber a key that's simply been rotated out from under us but is
-        // still the best value we have to report an honest auth error with.
-        if (latest) current = latest;
-      } catch {
-        // Store unreadable (HOME missing, malformed file, …) — keep the current
-        // key. The caller's retry will simply hit the same auth error, which is
-        // the correct, honest outcome.
-      }
-      return current;
+    refresh(): Promise<string | null> {
+      // Queue the whole resolve+read+adopt transaction. Without this, a slower
+      // older refresh can finish after a newer one and restore stale state.
+      const result = refreshQueue.then(refreshFromStore);
+      refreshQueue = result.then(
+        () => undefined,
+        () => undefined,
+      );
+      return result;
     },
     clear(): void {
       current = null;

--- a/packages/harness/src/core/api-key-provider.ts
+++ b/packages/harness/src/core/api-key-provider.ts
@@ -41,10 +41,8 @@ export interface ApiKeyProvider {
   /** The current API key, or null when the harness is not signed in. */
   getKey(): string | null;
   /**
-   * Re-read the shared credential store and adopt its authoritative result.
-   * Returns the updated current key, or null when signed out.
-   * Never throws — a read failure leaves the current key untouched and is
-   * reported by returning the existing value.
+   * Re-read the shared credential store. A successful read is authoritative;
+   * a failed read preserves and returns the last-known key. Never throws.
    */
   refresh(): Promise<string | null>;
   /**

--- a/packages/harness/src/core/inject/mcp-config.test.ts
+++ b/packages/harness/src/core/inject/mcp-config.test.ts
@@ -26,10 +26,27 @@ describe("generateMcpConfig", () => {
     else process.env.SAPIOM_ENVIRONMENT = originalEnv;
   });
 
+  async function writeCredentialsFile(file: unknown): Promise<void> {
+    const sapiomDir = path.join(tmpDir, ".sapiom");
+    await fs.mkdir(sapiomDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sapiomDir, "credentials.json"),
+      JSON.stringify(file),
+      "utf-8",
+    );
+  }
+
   it("writes a config file under generated/<sessionId>/", async () => {
     const filePath = await generateMcpConfig("session-123");
     expect(filePath).toBe(
-      path.join(tmpDir, ".sapiom", "harness", "generated", "session-123", "mcp-config.json"),
+      path.join(
+        tmpDir,
+        ".sapiom",
+        "harness",
+        "generated",
+        "session-123",
+        "mcp-config.json",
+      ),
     );
 
     const raw = await fs.readFile(filePath, "utf-8");
@@ -73,14 +90,79 @@ describe("generateMcpConfig", () => {
   });
 
   it("passes SAPIOM_ENVIRONMENT through to the sapiom-dev entry when set", async () => {
-    const filePath = await generateMcpConfig("session-456", { environment: "staging" });
+    const filePath = await generateMcpConfig("session-456", {
+      environment: "staging",
+    });
     const config = JSON.parse(await fs.readFile(filePath, "utf-8"));
 
-    expect(config.mcpServers["sapiom-dev"].env).toEqual({ SAPIOM_ENVIRONMENT: "staging" });
+    expect(config.mcpServers["sapiom-dev"].env).toEqual({
+      SAPIOM_ENVIRONMENT: "staging",
+    });
+  });
+
+  it.each(["staging", "dev"])(
+    "routes the remote sapiom MCP to staging for the %s environment",
+    async (environment) => {
+      const filePath = await generateMcpConfig(`session-${environment}`, {
+        environment,
+      });
+      const config = JSON.parse(await fs.readFile(filePath, "utf-8"));
+
+      expect(config.mcpServers.sapiom.url).toBe(
+        "https://api.sapiom.dev/v1/mcp",
+      );
+    },
+  );
+
+  it("preserves the prod alias for the production endpoint", async () => {
+    const filePath = await generateMcpConfig("session-prod-alias", {
+      environment: "prod",
+    });
+    const config = JSON.parse(await fs.readFile(filePath, "utf-8"));
+
+    expect(config.mcpServers.sapiom.url).toBe("https://api.sapiom.ai/v1/mcp");
+  });
+
+  it("uses SAPIOM_ENVIRONMENT before the credential file's current environment", async () => {
+    await writeCredentialsFile({
+      currentEnvironment: "staging",
+      environments: {},
+    });
+    process.env.SAPIOM_ENVIRONMENT = "production";
+
+    const filePath = await generateMcpConfig("session-process-env");
+    const config = JSON.parse(await fs.readFile(filePath, "utf-8"));
+
+    expect(config.mcpServers.sapiom.url).toBe("https://api.sapiom.ai/v1/mcp");
+  });
+
+  it("uses the credential file's current custom environment and normalizes its API URL", async () => {
+    await writeCredentialsFile({
+      currentEnvironment: "local",
+      environments: {
+        local: {
+          appURL: "http://localhost:2999",
+          apiURL: "http://localhost:3000/",
+        },
+      },
+    });
+
+    const filePath = await generateMcpConfig("session-custom");
+    const config = JSON.parse(await fs.readFile(filePath, "utf-8"));
+
+    expect(config.mcpServers.sapiom.url).toBe("http://localhost:3000/v1/mcp");
+  });
+
+  it("rejects an unknown custom environment instead of routing it to production", async () => {
+    await expect(
+      generateMcpConfig("session-unknown", { environment: "unknown" }),
+    ).rejects.toThrow('Unknown environment "unknown"');
   });
 
   it("advertises the harness version so feedback records can name the build", async () => {
-    const filePath = await generateMcpConfig("session-457", { harnessVersion: "0.2.5" });
+    const filePath = await generateMcpConfig("session-457", {
+      harnessVersion: "0.2.5",
+    });
     const config = JSON.parse(await fs.readFile(filePath, "utf-8"));
 
     expect(config.mcpServers["sapiom-dev"].env).toEqual({
@@ -108,7 +190,9 @@ describe("generateMcpConfig", () => {
   });
 
   it("adds an x-api-key header to the remote sapiom entry when an apiKey is given", async () => {
-    const filePath = await generateMcpConfig("session-auth", { apiKey: "sk_live_test123" });
+    const filePath = await generateMcpConfig("session-auth", {
+      apiKey: "sk_live_test123",
+    });
     const config = JSON.parse(await fs.readFile(filePath, "utf-8"));
 
     expect(config.mcpServers.sapiom).toEqual({
@@ -122,17 +206,24 @@ describe("generateMcpConfig", () => {
   });
 
   it("omits headers entirely when apiKey is null or absent", async () => {
-    const withoutOption = JSON.parse(await fs.readFile(await generateMcpConfig("session-1"), "utf-8"));
+    const withoutOption = JSON.parse(
+      await fs.readFile(await generateMcpConfig("session-1"), "utf-8"),
+    );
     expect(withoutOption.mcpServers.sapiom.headers).toBeUndefined();
 
     const withNull = JSON.parse(
-      await fs.readFile(await generateMcpConfig("session-2", { apiKey: null }), "utf-8"),
+      await fs.readFile(
+        await generateMcpConfig("session-2", { apiKey: null }),
+        "utf-8",
+      ),
     );
     expect(withNull.mcpServers.sapiom.headers).toBeUndefined();
   });
 
   it("writes the config file with owner-only permissions (it can carry a live API key)", async () => {
-    const filePath = await generateMcpConfig("session-perm", { apiKey: "sk_live_test123" });
+    const filePath = await generateMcpConfig("session-perm", {
+      apiKey: "sk_live_test123",
+    });
     const stat = await fs.stat(filePath);
     expect(stat.mode & 0o777).toBe(0o600);
   });

--- a/packages/harness/src/core/inject/mcp-config.ts
+++ b/packages/harness/src/core/inject/mcp-config.ts
@@ -1,5 +1,6 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
+import { resolveEnvironment } from "@sapiom/mcp/auth";
 import { HARNESS_PATHS } from "../../shared/types.js";
 import { expandHome } from "../../cli/paths.js";
 
@@ -63,10 +64,14 @@ export async function generateMcpConfig(
   harnessSessionId: string,
   options: McpConfigOptions = {},
 ): Promise<string> {
-  const dir = path.join(expandHome(options.generatedRoot ?? HARNESS_PATHS.generated), harnessSessionId);
+  const dir = path.join(
+    expandHome(options.generatedRoot ?? HARNESS_PATHS.generated),
+    harnessSessionId,
+  );
   await fs.mkdir(dir, { recursive: true });
 
-  const sapiomEnvironment = options.environment ?? process.env.SAPIOM_ENVIRONMENT;
+  const sapiomEnvironment =
+    options.environment ?? process.env.SAPIOM_ENVIRONMENT;
   const devEnvEntries: Record<string, string> = {
     ...(sapiomEnvironment ? { SAPIOM_ENVIRONMENT: sapiomEnvironment } : {}),
     ...(options.harnessVersion
@@ -75,12 +80,14 @@ export async function generateMcpConfig(
   };
   const devEnv: Record<string, string> | undefined =
     Object.keys(devEnvEntries).length > 0 ? devEnvEntries : undefined;
+  const { apiURL } = await resolveEnvironment(sapiomEnvironment);
+  const remoteMcpUrl = `${apiURL.replace(/\/+$/, "")}/v1/mcp`;
 
   const config = {
     mcpServers: {
       sapiom: {
         type: "http",
-        url: "https://api.sapiom.ai/v1/mcp",
+        url: remoteMcpUrl,
         ...(options.apiKey ? { headers: { "x-api-key": options.apiKey } } : {}),
       },
       "sapiom-dev": options.devServer
@@ -112,6 +119,8 @@ export async function generateMcpConfig(
   const filePath = path.join(dir, "mcp-config.json");
   // May now carry a live API key (the `sapiom` entry's headers) — restrict
   // to the owner, matching how ~/.sapiom/credentials.json is written.
-  await fs.writeFile(filePath, JSON.stringify(config, null, 2) + "\n", { mode: 0o600 });
+  await fs.writeFile(filePath, JSON.stringify(config, null, 2) + "\n", {
+    mode: 0o600,
+  });
   return filePath;
 }

--- a/packages/harness/src/server/auth-mcp-wiring.test.ts
+++ b/packages/harness/src/server/auth-mcp-wiring.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Lifecycle-level regression coverage for SAP-3114.
+ *
+ * These tests boot the real server and exercise the shared launch builder used
+ * by interactive create/resume and headless background tasks. OAuth and the
+ * credential store are in-memory fakes; adapters inspect the generated config
+ * synchronously before launching local throwaway processes. Nothing opens a
+ * browser or contacts a Sapiom environment.
+ */
+import { readFileSync } from "node:fs";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const authFixture = vi.hoisted(() => ({
+  credential: null as null | {
+    apiKey: string;
+    tenantId: string;
+    organizationName: string;
+    apiKeyId: string;
+  },
+  readError: null as Error | null,
+  browserResult: {
+    apiKey: "browser-key",
+    tenantId: "browser-tenant",
+    organizationName: "Browser Org",
+    apiKeyId: "browser-key-id",
+  },
+}));
+
+vi.mock("@sapiom/mcp/auth", () => {
+  const resolveEnvironment = vi.fn(async (environment?: string) => {
+    const requested = environment ?? "production";
+    const name =
+      requested === "prod"
+        ? "production"
+        : requested === "dev"
+          ? "staging"
+          : requested;
+    if (name !== "production" && name !== "staging") {
+      throw new Error(`Unknown environment "${name}"`);
+    }
+    const production = name === "production";
+    return {
+      name,
+      appURL: production
+        ? "https://app.example.test"
+        : "https://app.staging.example.test",
+      apiURL: production
+        ? "https://api.example.test"
+        : "https://api.staging.example.test",
+      services: {},
+      credentials: authFixture.credential,
+    };
+  });
+
+  return {
+    resolveEnvironment,
+    readCredentials: vi.fn(async () => authFixture.credential),
+    readCredentialsOrThrow: vi.fn(async () => {
+      if (authFixture.readError) throw authFixture.readError;
+      return authFixture.credential;
+    }),
+    performBrowserAuth: vi.fn(async () => ({ ...authFixture.browserResult })),
+    writeCredentials: vi.fn(
+      async (
+        _environment: string,
+        _appURL: string,
+        _apiURL: string,
+        credential: NonNullable<typeof authFixture.credential>,
+      ) => {
+        authFixture.credential = { ...credential };
+      },
+    ),
+    clearCredentials: vi.fn(async () => {
+      authFixture.credential = null;
+    }),
+  };
+});
+
+import {
+  clearCredentials,
+  performBrowserAuth,
+  readCredentialsOrThrow,
+  resolveEnvironment,
+  writeCredentials,
+} from "@sapiom/mcp/auth";
+import { startServer, type HarnessServer } from "./index.js";
+import type { HarnessAdapter, LaunchOpts, SpawnSpec } from "../shared/types.js";
+
+type LaunchKind = "create" | "resume" | "background";
+
+interface CapturedLaunch {
+  kind: LaunchKind;
+  remote: {
+    type: string;
+    url: string;
+    headers?: Record<string, string>;
+  };
+}
+
+function capturingClaudeAdapter(captures: CapturedLaunch[]): HarnessAdapter {
+  const capture = (kind: LaunchKind, opts: LaunchOpts): void => {
+    if (!opts.mcpConfigFile) throw new Error("expected an MCP config file");
+    const config = JSON.parse(readFileSync(opts.mcpConfigFile, "utf-8")) as {
+      mcpServers: { sapiom: CapturedLaunch["remote"] };
+    };
+    captures.push({ kind, remote: config.mcpServers.sapiom });
+  };
+  const interactiveSpec = (
+    kind: "create" | "resume",
+    opts: LaunchOpts,
+  ): SpawnSpec => {
+    capture(kind, opts);
+    return { command: "bash", args: [], env: {}, cwd: opts.cwd };
+  };
+
+  return {
+    id: "claude-code",
+    eventSource: "hooks",
+    doctor: async () => [],
+    launch: (opts) => interactiveSpec("create", opts),
+    resume: (_agentSessionId, opts) => interactiveSpec("resume", opts),
+    launchTask: (opts) => {
+      capture("background", opts);
+      return {
+        command: process.execPath,
+        args: ["-e", "process.exit(0)"],
+        env: {},
+        cwd: opts.cwd,
+      };
+    },
+    listPastSessions: async () => [],
+    canResume: async () => true,
+  };
+}
+
+function credential(
+  apiKey: string,
+): NonNullable<typeof authFixture.credential> {
+  return {
+    apiKey,
+    tenantId: "test-tenant",
+    organizationName: "Test Org",
+    apiKeyId: "test-key-id",
+  };
+}
+
+function injectedKey(capture: CapturedLaunch): string | undefined {
+  return capture.remote.headers?.["x-api-key"];
+}
+
+describe("Agent Studio MCP authentication wiring", () => {
+  const originalEnvironment = process.env.SAPIOM_ENVIRONMENT;
+  let root: string;
+  let projectRoot: string;
+  let server: HarnessServer | undefined;
+  let captures: CapturedLaunch[];
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "harness-auth-mcp-wiring-"));
+    projectRoot = join(root, "project");
+    await mkdir(projectRoot, { recursive: true });
+    await writeFile(
+      join(projectRoot, "sapiom.json"),
+      JSON.stringify({ definitionId: null }),
+    );
+    await writeFile(
+      join(projectRoot, "package.json"),
+      JSON.stringify({ name: "auth-wiring-fixture" }),
+    );
+    delete process.env.SAPIOM_ENVIRONMENT;
+    authFixture.credential = null;
+    authFixture.readError = null;
+    captures = [];
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await server?.sessionManager.flush();
+    await server?.close();
+    await server?.sessionManager.flush();
+    server = undefined;
+    await rm(root, {
+      recursive: true,
+      force: true,
+      maxRetries: 5,
+      retryDelay: 50,
+    });
+    if (originalEnvironment === undefined) {
+      delete process.env.SAPIOM_ENVIRONMENT;
+    } else {
+      process.env.SAPIOM_ENVIRONMENT = originalEnvironment;
+    }
+  });
+
+  async function boot(
+    options: Pick<
+      Parameters<typeof startServer>[0],
+      "identity" | "authMode"
+    > = {},
+  ): Promise<HarnessServer> {
+    server = await startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      autoCreateSession: false,
+      stateRoot: root,
+      launchDir: projectRoot,
+      adapters: { "claude-code": capturingClaudeAdapter(captures) },
+      loadSystemPrompt: async () => "test system prompt",
+      ...options,
+    });
+    return server;
+  }
+
+  async function post(path: string, body?: unknown): Promise<Response> {
+    return fetch(`http://127.0.0.1:${server!.port}${path}`, {
+      method: "POST",
+      headers: {
+        "x-harness-token": "test-token",
+        ...(body === undefined ? {} : { "content-type": "application/json" }),
+      },
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    });
+  }
+
+  it("injects a credential obtained through Studio login into the next session", async () => {
+    await boot();
+
+    const login = await post("/api/auth/start");
+    expect(login.status).toBe(200);
+    await vi.waitFor(() => expect(writeCredentials).toHaveBeenCalledOnce());
+
+    await server!.sessionManager.create({
+      cwd: projectRoot,
+      harness: "claude-code",
+    });
+
+    expect(captures).toHaveLength(1);
+    expect(captures[0].kind).toBe("create");
+    expect(injectedKey(captures[0])).toBe("browser-key");
+  });
+
+  it("adopts a credential written externally after boot", async () => {
+    await boot();
+    authFixture.credential = credential("external-key");
+
+    await server!.sessionManager.create({
+      cwd: projectRoot,
+      harness: "claude-code",
+    });
+
+    expect(injectedKey(captures[0])).toBe("external-key");
+  });
+
+  it("refreshes create, resume, and background launches while preserving the last key on read failure", async () => {
+    authFixture.credential = credential("key-a");
+    await boot({
+      identity: {
+        userId: "test-tenant",
+        tenantId: "test-tenant",
+        organizationName: "Test Org",
+        apiKey: "key-a",
+        source: "cached",
+      },
+    });
+
+    const session = await server!.sessionManager.create({
+      cwd: projectRoot,
+      harness: "claude-code",
+    });
+    expect(injectedKey(captures.at(-1)!)).toBe("key-a");
+    expect(
+      await server!.sessionManager.setAgentSessionId(
+        session.id,
+        "agent-session-1",
+      ),
+    ).toBe(true);
+
+    authFixture.credential = credential("key-b");
+    await server!.sessionManager.kill(session.id);
+    await server!.sessionManager.resume(session.id);
+    expect(captures.at(-1)!.kind).toBe("resume");
+    expect(injectedKey(captures.at(-1)!)).toBe("key-b");
+
+    const taskResponse = await post("/api/macros/describe/run", {
+      harnessSessionId: session.id,
+      workflowPath: projectRoot,
+      subject: "Describe this fixture",
+    });
+    expect(taskResponse.status).toBe(200);
+    expect(captures.at(-1)!.kind).toBe("background");
+    expect(injectedKey(captures.at(-1)!)).toBe("key-b");
+
+    authFixture.readError = new Error("temporary credential-store failure");
+    await server!.sessionManager.create({
+      cwd: projectRoot,
+      harness: "claude-code",
+    });
+    expect(injectedKey(captures.at(-1)!)).toBe("key-b");
+
+    authFixture.readError = null;
+    authFixture.credential = null;
+    await server!.sessionManager.create({
+      cwd: projectRoot,
+      harness: "claude-code",
+    });
+    expect(captures.at(-1)!.remote.headers).toBeUndefined();
+  }, 20_000);
+
+  it("treats disabled auth as a hard process-wide opt-out", async () => {
+    authFixture.credential = credential("cached-key");
+    await boot({
+      authMode: "disabled",
+      identity: {
+        userId: "test-tenant",
+        tenantId: "test-tenant",
+        organizationName: "Test Org",
+        apiKey: "boot-key",
+        source: "cached",
+      },
+    });
+
+    await server!.sessionManager.create({
+      cwd: projectRoot,
+      harness: "claude-code",
+    });
+    expect(captures[0].remote.headers).toBeUndefined();
+    expect(readCredentialsOrThrow).not.toHaveBeenCalled();
+
+    vi.mocked(resolveEnvironment).mockClear();
+    const status = await fetch(
+      `http://127.0.0.1:${server!.port}/api/auth/status`,
+      { headers: { "x-harness-token": "test-token" } },
+    );
+    expect(status.status).toBe(200);
+    await expect(status.json()).resolves.toEqual({
+      authenticated: false,
+      organizationName: null,
+    });
+
+    expect((await post("/api/auth/start")).status).toBe(403);
+    expect((await post("/api/auth/disconnect")).status).toBe(403);
+    expect(resolveEnvironment).not.toHaveBeenCalled();
+    expect(performBrowserAuth).not.toHaveBeenCalled();
+    expect(clearCredentials).not.toHaveBeenCalled();
+  });
+});

--- a/packages/harness/src/server/auth-routes.test.ts
+++ b/packages/harness/src/server/auth-routes.test.ts
@@ -33,14 +33,21 @@ vi.mock("@sapiom/mcp/auth", () => ({
   clearCredentials: vi.fn().mockResolvedValue(undefined),
 }));
 
-import { writeCredentials, clearCredentials } from "@sapiom/mcp/auth";
+import {
+  clearCredentials,
+  resolveEnvironment,
+  writeCredentials,
+} from "@sapiom/mcp/auth";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 /** A minimal ApiKeyProvider spy — records refresh() and clear() calls. */
-function makeProvider(refreshResult: string | null = null, initialKey: string | null = null) {
+function makeProvider(
+  refreshResult: string | null = null,
+  initialKey: string | null = null,
+) {
   const calls = { refresh: 0, clear: 0 };
   let currentKey: string | null = initialKey;
   return {
@@ -67,7 +74,9 @@ function collectBusEvents(bus: EventBus): BusMessage[] {
 
 /** Build and start a minimal express app mounting the auth router. */
 function startApp(opts: Partial<AuthRoutesOptions> & { bus: EventBus }) {
-  const authState = opts.authState ?? createMutableAuthState({ authenticated: false, organizationName: null });
+  const authState =
+    opts.authState ??
+    createMutableAuthState({ authenticated: false, organizationName: null });
   const apiKeyProvider = opts.apiKeyProvider ?? makeProvider();
   const app = express();
   app.use(express.json());
@@ -78,6 +87,7 @@ function startApp(opts: Partial<AuthRoutesOptions> & { bus: EventBus }) {
       apiKeyProvider,
       bus: opts.bus,
       environment: "production",
+      authEnabled: opts.authEnabled,
       performBrowserAuthImpl: opts.performBrowserAuthImpl,
       onPlanningUserChanged: opts.onPlanningUserChanged,
     }),
@@ -94,18 +104,33 @@ function startApp(opts: Partial<AuthRoutesOptions> & { bus: EventBus }) {
 
 describe("createMutableAuthState", () => {
   it("returns initial state", () => {
-    const state = createMutableAuthState({ authenticated: true, organizationName: "Acme" });
-    expect(state.get()).toEqual({ authenticated: true, organizationName: "Acme" });
+    const state = createMutableAuthState({
+      authenticated: true,
+      organizationName: "Acme",
+    });
+    expect(state.get()).toEqual({
+      authenticated: true,
+      organizationName: "Acme",
+    });
   });
 
   it("updates on set()", () => {
-    const state = createMutableAuthState({ authenticated: false, organizationName: null });
+    const state = createMutableAuthState({
+      authenticated: false,
+      organizationName: null,
+    });
     state.set({ authenticated: true, organizationName: "Acme" });
-    expect(state.get()).toEqual({ authenticated: true, organizationName: "Acme" });
+    expect(state.get()).toEqual({
+      authenticated: true,
+      organizationName: "Acme",
+    });
   });
 
   it("returns a copy — mutating the returned object does not affect internal state", () => {
-    const state = createMutableAuthState({ authenticated: false, organizationName: null });
+    const state = createMutableAuthState({
+      authenticated: false,
+      organizationName: null,
+    });
     const snap = state.get();
     snap.authenticated = true;
     expect(state.get().authenticated).toBe(false);
@@ -138,7 +163,10 @@ describe("GET /api/auth/status", () => {
 
   it("reflects authenticated state when seeded as authenticated", async () => {
     const bus = new EventBus();
-    const authState = createMutableAuthState({ authenticated: true, organizationName: "Acme" });
+    const authState = createMutableAuthState({
+      authenticated: true,
+      organizationName: "Acme",
+    });
     const result = startApp({ bus, authState });
     server = result.server;
     baseUrl = result.baseUrl;
@@ -147,6 +175,74 @@ describe("GET /api/auth/status", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toEqual({ authenticated: true, organizationName: "Acme" });
+  });
+
+  it("reports unauthenticated when server authentication is disabled", async () => {
+    const bus = new EventBus();
+    const authState = createMutableAuthState({
+      authenticated: true,
+      organizationName: "Acme",
+    });
+    const result = startApp({ bus, authState, authEnabled: false });
+    server = result.server;
+    baseUrl = result.baseUrl;
+
+    const res = await fetch(`${baseUrl}/api/auth/status`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      authenticated: false,
+      organizationName: null,
+    });
+  });
+});
+
+describe("disabled authentication", () => {
+  let server: ReturnType<typeof express.application.listen>;
+
+  afterEach(() => {
+    server?.close();
+    vi.clearAllMocks();
+  });
+
+  it("rejects sign-in without resolving an environment or opening a browser", async () => {
+    const browserAuth = vi.fn();
+    const result = startApp({
+      bus: new EventBus(),
+      authEnabled: false,
+      performBrowserAuthImpl: browserAuth,
+    });
+    server = result.server;
+
+    const res = await fetch(`${result.baseUrl}/api/auth/start`, {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      error: "authentication is disabled for this Studio process",
+    });
+    expect(resolveEnvironment).not.toHaveBeenCalled();
+    expect(browserAuth).not.toHaveBeenCalled();
+    expect(writeCredentials).not.toHaveBeenCalled();
+  });
+
+  it("rejects disconnect without reading or modifying the credential store", async () => {
+    const provider = makeProvider(null, "ignored-key");
+    const result = startApp({
+      bus: new EventBus(),
+      authEnabled: false,
+      apiKeyProvider: provider,
+    });
+    server = result.server;
+
+    const res = await fetch(`${result.baseUrl}/api/auth/disconnect`, {
+      method: "POST",
+    });
+
+    expect(res.status).toBe(403);
+    expect(resolveEnvironment).not.toHaveBeenCalled();
+    expect(clearCredentials).not.toHaveBeenCalled();
+    expect(provider.calls.clear).toBe(0);
   });
 });
 
@@ -226,7 +322,10 @@ describe("POST /api/auth/start — success", () => {
     await new Promise((r) => setTimeout(r, 10));
 
     // Auth state updated.
-    expect(authState.get()).toEqual({ authenticated: true, organizationName: "Acme Corp" });
+    expect(authState.get()).toEqual({
+      authenticated: true,
+      organizationName: "Acme Corp",
+    });
 
     // Credentials were written.
     expect(writeCredentials).toHaveBeenCalledWith(
@@ -258,7 +357,10 @@ describe("POST /api/auth/start — success", () => {
   it("rejects a concurrent start with 409", async () => {
     // A slow browser auth — never resolves during the test.
     const mockBrowserAuth = vi.fn().mockImplementation(
-      () => new Promise<never>(() => {/* never resolves */}),
+      () =>
+        new Promise<never>(() => {
+          /* never resolves */
+        }),
     );
 
     const result = startApp({ bus, performBrowserAuthImpl: mockBrowserAuth });
@@ -299,19 +401,25 @@ describe("POST /api/auth/start — failure", () => {
   });
 
   it("broadcasts auth.changed with authenticated:false on OAuth failure and does not crash", async () => {
-    const mockBrowserAuth = vi.fn().mockRejectedValue(
-      new Error("Authentication timed out after 5 minutes."),
-    );
+    const mockBrowserAuth = vi
+      .fn()
+      .mockRejectedValue(
+        new Error("Authentication timed out after 5 minutes."),
+      );
 
     const provider = makeProvider();
-    const result = startApp({ bus, performBrowserAuthImpl: mockBrowserAuth, apiKeyProvider: provider });
+    const result = startApp({
+      bus,
+      performBrowserAuthImpl: mockBrowserAuth,
+      apiKeyProvider: provider,
+    });
     server = result.server;
     baseUrl = result.baseUrl;
     const { authState } = result;
 
     const res = await fetch(`${baseUrl}/api/auth/start`, { method: "POST" });
     expect(res.status).toBe(200);
-    expect((await res.json() as Record<string, unknown>).started).toBe(true);
+    expect(((await res.json()) as Record<string, unknown>).started).toBe(true);
 
     // Let the async rejection settle.
     await new Promise((r) => setTimeout(r, 20));
@@ -328,7 +436,10 @@ describe("POST /api/auth/start — failure", () => {
     // Bus still broadcasts so the SPA knows the flow ended.
     const authEvents = busEvents.filter((e) => e.type === "auth.changed");
     expect(authEvents).toHaveLength(1);
-    expect(authEvents[0]).toMatchObject({ type: "auth.changed", authenticated: false });
+    expect(authEvents[0]).toMatchObject({
+      type: "auth.changed",
+      authenticated: false,
+    });
   });
 
   it("allows a new start after a failed one (pendingAuth is cleared)", async () => {
@@ -385,7 +496,10 @@ describe("POST /api/auth/disconnect", () => {
   });
 
   it("clears credentials, resets auth state, broadcasts auth.changed, returns { ok: true }", async () => {
-    const authState = createMutableAuthState({ authenticated: true, organizationName: "Acme" });
+    const authState = createMutableAuthState({
+      authenticated: true,
+      organizationName: "Acme",
+    });
     const provider = makeProvider();
     const onPlanningUserChanged = vi.fn();
     const result = startApp({
@@ -397,7 +511,9 @@ describe("POST /api/auth/disconnect", () => {
     server = result.server;
     baseUrl = result.baseUrl;
 
-    const res = await fetch(`${baseUrl}/api/auth/disconnect`, { method: "POST" });
+    const res = await fetch(`${baseUrl}/api/auth/disconnect`, {
+      method: "POST",
+    });
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toEqual({ ok: true });
@@ -406,7 +522,10 @@ describe("POST /api/auth/disconnect", () => {
     expect(clearCredentials).toHaveBeenCalledWith("production");
 
     // Auth state set to unauthenticated.
-    expect(authState.get()).toEqual({ authenticated: false, organizationName: null });
+    expect(authState.get()).toEqual({
+      authenticated: false,
+      organizationName: null,
+    });
     expect(onPlanningUserChanged).toHaveBeenCalledWith(null);
 
     // Bus notified.
@@ -424,7 +543,9 @@ describe("POST /api/auth/disconnect", () => {
     server = result.server;
     baseUrl = result.baseUrl;
 
-    const res = await fetch(`${baseUrl}/api/auth/disconnect`, { method: "POST" });
+    const res = await fetch(`${baseUrl}/api/auth/disconnect`, {
+      method: "POST",
+    });
     expect(res.status).toBe(200);
     expect(clearCredentials).toHaveBeenCalledOnce();
     expect(result.authState.get().authenticated).toBe(false);
@@ -433,7 +554,10 @@ describe("POST /api/auth/disconnect", () => {
   it("zeroes the in-memory key immediately after disconnect", async () => {
     // Seed the provider with a live key (simulates an authenticated session).
     const provider = makeProvider(null, "sk-live-key");
-    const authState = createMutableAuthState({ authenticated: true, organizationName: "Acme" });
+    const authState = createMutableAuthState({
+      authenticated: true,
+      organizationName: "Acme",
+    });
     const result = startApp({ bus, authState, apiKeyProvider: provider });
     server = result.server;
     baseUrl = result.baseUrl;
@@ -441,7 +565,9 @@ describe("POST /api/auth/disconnect", () => {
     // Confirm the key is present before disconnect.
     expect(provider.getKey()).toBe("sk-live-key");
 
-    const res = await fetch(`${baseUrl}/api/auth/disconnect`, { method: "POST" });
+    const res = await fetch(`${baseUrl}/api/auth/disconnect`, {
+      method: "POST",
+    });
     expect(res.status).toBe(200);
 
     // clear() must have been called exactly once.
@@ -467,14 +593,20 @@ describe("POST /api/auth/disconnect", () => {
     );
 
     const provider = makeProvider("sk-fresh", null);
-    const result = startApp({ bus, performBrowserAuthImpl: mockBrowserAuth, apiKeyProvider: provider });
+    const result = startApp({
+      bus,
+      performBrowserAuthImpl: mockBrowserAuth,
+      apiKeyProvider: provider,
+    });
     server = result.server;
     baseUrl = result.baseUrl;
     const { authState } = result;
     const busEvents = collectBusEvents(bus);
 
     // Start an in-flight sign-in.
-    const startRes = await fetch(`${baseUrl}/api/auth/start`, { method: "POST" });
+    const startRes = await fetch(`${baseUrl}/api/auth/start`, {
+      method: "POST",
+    });
     expect(startRes.status).toBe(200);
 
     // Give the async chain time to reach performBrowserAuthImpl.
@@ -482,7 +614,9 @@ describe("POST /api/auth/disconnect", () => {
     expect(capturedResolve).toBeDefined();
 
     // Disconnect while the browser flow is still pending.
-    const disconnectRes = await fetch(`${baseUrl}/api/auth/disconnect`, { method: "POST" });
+    const disconnectRes = await fetch(`${baseUrl}/api/auth/disconnect`, {
+      method: "POST",
+    });
     expect(disconnectRes.status).toBe(200);
 
     // Confirm disconnect zeroed the key and set state to unauthenticated.
@@ -510,7 +644,9 @@ describe("POST /api/auth/disconnect", () => {
     // The bus should have exactly two auth.changed events:
     // one from disconnect (authenticated: false) — the cancelled chain emits nothing.
     const authEvents = busEvents.filter((e) => e.type === "auth.changed");
-    const unauthEvents = authEvents.filter((e) => "authenticated" in e && !e.authenticated);
+    const unauthEvents = authEvents.filter(
+      (e) => "authenticated" in e && !e.authenticated,
+    );
     expect(unauthEvents.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/harness/src/server/auth-routes.ts
+++ b/packages/harness/src/server/auth-routes.ts
@@ -104,6 +104,8 @@ export interface AuthRoutesOptions {
   apiKeyProvider: AuthKeyTarget;
   /** The server event bus — broadcasts `auth.changed` after every state transition. */
   bus: EventBus;
+  /** Whether this Studio process may read or mutate shared authentication. */
+  authEnabled?: boolean;
   /**
    * Overrides SAPIOM_ENVIRONMENT for the OAuth flow. Defaults to
    * `process.env.SAPIOM_ENVIRONMENT` (the same override the CLI uses).
@@ -131,6 +133,7 @@ export function createAuthRouter(opts: AuthRoutesOptions): Router {
     authState,
     apiKeyProvider,
     bus,
+    authEnabled = true,
     environment,
     performBrowserAuthImpl = performBrowserAuth,
     onPlanningUserChanged,
@@ -148,7 +151,11 @@ export function createAuthRouter(opts: AuthRoutesOptions): Router {
   // ---------------------------------------------------------------------------
 
   router.get("/auth/status", (_req, res) => {
-    res.json(authState.get());
+    res.json(
+      authEnabled
+        ? authState.get()
+        : { authenticated: false, organizationName: null },
+    );
   });
 
   // ---------------------------------------------------------------------------
@@ -156,6 +163,13 @@ export function createAuthRouter(opts: AuthRoutesOptions): Router {
   // ---------------------------------------------------------------------------
 
   router.post("/auth/start", (_req, res) => {
+    if (!authEnabled) {
+      res.status(403).json({
+        error: "authentication is disabled for this Studio process",
+      });
+      return;
+    }
+
     if (pendingAuth !== null) {
       res.status(409).json({ error: "authentication already in progress" });
       return;
@@ -230,6 +244,13 @@ export function createAuthRouter(opts: AuthRoutesOptions): Router {
   // ---------------------------------------------------------------------------
 
   router.post("/auth/disconnect", async (_req, res, next) => {
+    if (!authEnabled) {
+      res.status(403).json({
+        error: "authentication is disabled for this Studio process",
+      });
+      return;
+    }
+
     try {
       const env = await resolveEnvironment(
         environment ?? process.env.SAPIOM_ENVIRONMENT,
@@ -244,10 +265,8 @@ export function createAuthRouter(opts: AuthRoutesOptions): Router {
       // Clear the credential store — the next refresh() call will find nothing.
       await clearCredentials(env.name);
 
-      // Zero the in-memory key immediately so getKey() returns null right away.
-      // This is distinct from refresh(), whose `if (latest)` guard deliberately
-      // keeps the cached key when the store has nothing to offer — we want an
-      // unconditional zero on disconnect.
+      // Zero the in-memory key immediately so getKey() returns null right away,
+      // without waiting for the next launch-time or request-retry refresh.
       apiKeyProvider.clear();
 
       authState.set({ authenticated: false, organizationName: null });

--- a/packages/harness/src/server/canvas-build-status-wiring.test.ts
+++ b/packages/harness/src/server/canvas-build-status-wiring.test.ts
@@ -65,7 +65,9 @@ describe("Canvas build-status wiring", () => {
         return;
       }
       definitionRequests += 1;
-      definitionApiKeys.push(req.headers["x-sapiom-api-key"] as string | undefined);
+      definitionApiKeys.push(
+        req.headers["x-sapiom-api-key"] as string | undefined,
+      );
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(
         JSON.stringify({
@@ -128,6 +130,10 @@ describe("Canvas build-status wiring", () => {
         source: "cached",
       },
       adapters: { "claude-code": fakeClaudeAdapter() },
+      // This test exercises Canvas's cloud-status request, not the default
+      // launch builder. Keep its synthetic boot identity in memory without a
+      // real ~/.sapiom credential fixture for launch-time reconciliation.
+      buildLaunchOpts: () => ({}),
       stateRoot,
       launchDir: sessionDir,
       autoCreateSession: false,

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -147,7 +147,11 @@ import {
   resolveManifestName,
 } from "../core/definition-name.js";
 import { createBootTokenMiddleware } from "./auth.js";
-import { createApiKeyProvider } from "../core/api-key-provider.js";
+import {
+  createApiKeyProvider,
+  staticApiKeyProvider,
+  type ApiKeyProvider,
+} from "../core/api-key-provider.js";
 import { createRestRouter } from "./rest.js";
 import { createSystemGraphRouter } from "./system-graph.js";
 import { createAgentMapRouter } from "./agent-map.js";
@@ -224,6 +228,8 @@ export interface HarnessServerOptions {
    */
   bootToken: string;
   telemetryOptIn: boolean;
+  /** Shared Sapiom authentication policy. Defaults to enabled. */
+  authMode?: "enabled" | "disabled";
   /** Sapiom identity from CLI auth; omit/null when unauthenticated or --no-auth. */
   identity?: HarnessIdentity | null;
   /** Stable per-install id for analytics. Defaults to a freshly loaded/created one. */
@@ -481,17 +487,16 @@ function readVersion(): string {
  * and --append-system-prompt source files. Generated uniformly for every
  * harness kind — an adapter that doesn't use one of these fields (codex,
  * today) simply ignores it, same as the claude-code adapter already does for
- * whichever of the three a given launch doesn't set. `apiKey` (from CLI auth,
- * null when unauthenticated / --no-auth) flows into the generated mcp-config
- * so the remote `sapiom` MCP is actually authenticated — a factory rather
- * than a plain function since it's per-server-instance state.
+ * whichever of the three a given launch doesn't set. The live API-key provider
+ * is refreshed at this common boundary so every new process receives the
+ * latest confirmed credential (or no header when signed out / --no-auth).
  *
  * The system prompt itself is FETCHED per session (SAP-2810) rather than read from
  * the bundled profile, so prompt improvements reach installs that never upgrade the
  * package; the bundled profile remains the offline fallback inside that fetch.
  */
 function createDefaultBuildLaunchOpts(
-  apiKey: string | null,
+  apiKeyProvider: ApiKeyProvider,
   generatedRoot?: string,
   rehydration?: {
     /** Brief text for a prior session id, or null when nothing was recorded. */
@@ -549,6 +554,9 @@ function createDefaultBuildLaunchOpts(
     // resolves to the bundled DEFAULT_SYSTEM_PROMPT on any failure rather than
     // throwing; the `.catch` covers an injected loader that does not, because a
     // session must never fail to start over the text of its prompt.
+    // Reconcile with the shared credential store at the common launch
+    // boundary. Create, resume, and background tasks all await this builder.
+    const apiKey = await apiKeyProvider.refresh();
     const [settings, mcpConfigFile, prompt, pluginDir] = await Promise.all([
       generateClaudeSettings({
         harnessSessionId,
@@ -569,7 +577,10 @@ function createDefaultBuildLaunchOpts(
       generateSkillsPlugin(harnessSessionId, { generatedRoot }),
     ]);
     const appendices = [viaSystemPrompt ? brief : null, context?.promptAppendix]
-      .filter((value): value is string => typeof value === "string" && value.trim() !== "")
+      .filter(
+        (value): value is string =>
+          typeof value === "string" && value.trim() !== "",
+      )
       .join("\n\n");
     const systemPromptFile = await generateSystemPromptFile(harnessSessionId, {
       generatedRoot,
@@ -601,15 +612,20 @@ export const startServer = async (
   // The browser launch capability is separate again: it authorizes delivery
   // of the boot token in initial HTML, but cannot call /api by itself.
   const uiToken = randomUUID();
-  const identity = options.identity ?? null;
+  const authEnabled = options.authMode !== "disabled";
+  // Disabled mode is a process-wide hard opt-out: even a programmatic caller
+  // that supplies a cached boot identity cannot seed auth state or injection.
+  const identity = authEnabled ? (options.identity ?? null) : null;
   // The single source of truth for the Sapiom API key (`sk_…`) that Studio
   // actions authenticate with — distinct from the per-boot boot token that only
   // gates the local /api surface. Seeded from the boot-time identity; its
   // refresh() re-reads the shared credential store so a rotated/re-logged-in key
   // recovers a 401 in place instead of locking the Studio.
-  const apiKeyProvider = createApiKeyProvider(identity?.apiKey ?? null, {
-    environment: process.env.SAPIOM_ENVIRONMENT,
-  });
+  const apiKeyProvider = authEnabled
+    ? createApiKeyProvider(identity?.apiKey ?? null, {
+        environment: process.env.SAPIOM_ENVIRONMENT,
+      })
+    : staticApiKeyProvider(null);
 
   // Mutable auth state — seeded from the boot-time identity and updated by the
   // in-app auth routes (POST /api/auth/start, POST /api/auth/disconnect). The
@@ -1070,7 +1086,7 @@ export const startServer = async (
   const innerBuildLaunchOpts =
     options.buildLaunchOpts ??
     createDefaultBuildLaunchOpts(
-      identity?.apiKey ?? null,
+      apiKeyProvider,
       generatedRoot,
       {
         buildBrief: resolveRehydrationBrief,
@@ -1079,7 +1095,11 @@ export const startServer = async (
       options.sapiomDevMcp,
       options.loadSystemPrompt ?? fetchSystemPromptForActiveEnvironment,
     );
-  const buildLaunchOpts: LaunchOptsBuilder = async (harnessSessionId, req, context) => {
+  const buildLaunchOpts: LaunchOptsBuilder = async (
+    harnessSessionId,
+    req,
+    context,
+  ) => {
     await pendingGeneratedRemovals.get(harnessSessionId);
     return innerBuildLaunchOpts(harnessSessionId, req, context);
   };
@@ -2721,7 +2741,10 @@ export const startServer = async (
   });
   sessionManager.onStatusChange((session) => {
     void plannerGreeting.onSessionStatus(session).catch((error: unknown) => {
-      console.error("[harness] planner greeting status transition failed:", error);
+      console.error(
+        "[harness] planner greeting status transition failed:",
+        error,
+      );
     });
   });
 
@@ -2816,8 +2839,7 @@ export const startServer = async (
       catalog: studioProjectCatalog,
       store: agentMapWorkspaceStore,
       preferences: studioWorkspacePreferences,
-      currentUserId: () =>
-        localPlanningPrincipal(planningUserId, machineId),
+      currentUserId: () => localPlanningPrincipal(planningUserId, machineId),
       listWorkflows: () => workflowsCache,
       isWorkflowScanComplete,
       listWorkspaceScopes: () => workspaceScopeCatalog.list(),
@@ -3183,6 +3205,7 @@ export const startServer = async (
       authState,
       apiKeyProvider,
       bus,
+      authEnabled,
       environment: process.env.SAPIOM_ENVIRONMENT,
       onPlanningUserChanged: (userId) => {
         planningUserId = userId;
@@ -3214,8 +3237,7 @@ export const startServer = async (
     batcher,
     enrichFromTranscript: enrichTurnCompleted,
     decorateEvent: (event) => plannerGreeting.decorateLocalEvent(event),
-    projectTelemetryEvent: (event) =>
-      plannerGreeting.redactForTelemetry(event),
+    projectTelemetryEvent: (event) => plannerGreeting.redactForTelemetry(event),
     onNormalizedEvent: (event: AnalyticsEvent) => {
       // Synchronous and total — it counts turns and detaches any fold it
       // decides to start, so the ingest path never waits on a summary.

--- a/packages/harness/src/test-setup.ts
+++ b/packages/harness/src/test-setup.ts
@@ -1,3 +1,8 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll } from "vitest";
+
 // Telemetry is live by default: an unconfigured emitter delivers to the real
 // production collector. Disable it globally here; tests that assert delivery
 // opt back in explicitly via the mock collector (SAPIOM_ANALYTICS_ENDPOINT).
@@ -8,3 +13,22 @@ process.env.SAPIOM_TELEMETRY_DISABLED = "1";
 // request. Pin the bundled prompt globally here; the fetch itself is covered by
 // profiles/system-prompt-fetch.test.ts, which calls it directly.
 process.env.SAPIOM_HARNESS_PROMPT_FETCH_DISABLED = "1";
+
+// Launch-time MCP generation reads ~/.sapiom/credentials.json by design. Give
+// every test file an isolated home so a developer's real credential and
+// current environment can never enter a generated config or affect assertions.
+// Tests that intentionally exercise home-directory behavior can still replace
+// HOME/USERPROFILE or mock os.homedir() within their own scope.
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+const isolatedHome = mkdtempSync(join(tmpdir(), "sapiom-harness-test-home-"));
+process.env.HOME = isolatedHome;
+process.env.USERPROFILE = isolatedHome;
+
+afterAll(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = originalUserProfile;
+  rmSync(isolatedHome, { recursive: true, force: true });
+});

--- a/packages/mcp/src/auth-api.ts
+++ b/packages/mcp/src/auth-api.ts
@@ -7,6 +7,7 @@ export { performBrowserAuth, type AuthResult } from "./auth.js";
 export {
   resolveEnvironment,
   readCredentials,
+  readCredentialsOrThrow,
   writeCredentials,
   clearCredentials,
   type CredentialEntry,

--- a/packages/mcp/src/credentials.test.ts
+++ b/packages/mcp/src/credentials.test.ts
@@ -10,6 +10,7 @@ vi.mock("node:os");
 import {
   resolveEnvironment,
   readCredentials,
+  readCredentialsOrThrow,
   writeCredentials,
   clearCredentials,
 } from "./credentials.js";
@@ -42,7 +43,9 @@ const sampleFile = {
 
 beforeEach(() => {
   vi.mocked(os.homedir).mockReturnValue(mockHomedir);
-  vi.mocked(fs.readFile).mockRejectedValue(new Error("ENOENT"));
+  vi.mocked(fs.readFile).mockRejectedValue(
+    Object.assign(new Error("credentials file not found"), { code: "ENOENT" }),
+  );
   vi.mocked(fs.writeFile).mockResolvedValue();
   vi.mocked(fs.mkdir).mockResolvedValue(undefined);
 });
@@ -171,6 +174,49 @@ describe("readCredentials", () => {
 
     const creds = await readCredentials("nonexistent");
     expect(creds).toBeNull();
+  });
+
+  it("should remain forgiving when the file is malformed", async () => {
+    vi.mocked(fs.readFile).mockResolvedValue("{not-json");
+
+    await expect(readCredentials("production")).resolves.toBeNull();
+  });
+});
+
+describe("readCredentialsOrThrow", () => {
+  it("returns credentials when the store is valid", async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(sampleFile));
+
+    await expect(readCredentialsOrThrow("production")).resolves.toEqual(
+      sampleCredentials,
+    );
+  });
+
+  it("returns null when the credentials file does not exist", async () => {
+    await expect(readCredentialsOrThrow("production")).resolves.toBeNull();
+  });
+
+  it("returns null when the selected environment has no credential", async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(sampleFile));
+
+    await expect(readCredentialsOrThrow("staging")).resolves.toBeNull();
+  });
+
+  it("throws when the credentials file contains malformed JSON", async () => {
+    vi.mocked(fs.readFile).mockResolvedValue("{not-json");
+
+    await expect(readCredentialsOrThrow("production")).rejects.toBeInstanceOf(
+      SyntaxError,
+    );
+  });
+
+  it("throws when the credentials file cannot be read", async () => {
+    const error = Object.assign(new Error("permission denied"), {
+      code: "EACCES",
+    });
+    vi.mocked(fs.readFile).mockRejectedValue(error);
+
+    await expect(readCredentialsOrThrow("production")).rejects.toBe(error);
   });
 });
 

--- a/packages/mcp/src/credentials.ts
+++ b/packages/mcp/src/credentials.ts
@@ -16,10 +16,17 @@ const ENVIRONMENT_ALIASES: Record<string, string> = {
  * environment defined in the file always takes precedence over a preset (so a
  * custom override, or one carrying credentials, still wins).
  */
-const ENVIRONMENT_PRESETS: Record<string, { appURL: string; apiURL: string }> = {
-  production: { appURL: "https://app.sapiom.ai", apiURL: "https://api.sapiom.ai" },
-  staging: { appURL: "https://app.sapiom.dev", apiURL: "https://api.sapiom.dev" },
-};
+const ENVIRONMENT_PRESETS: Record<string, { appURL: string; apiURL: string }> =
+  {
+    production: {
+      appURL: "https://app.sapiom.ai",
+      apiURL: "https://api.sapiom.ai",
+    },
+    staging: {
+      appURL: "https://app.sapiom.dev",
+      apiURL: "https://api.sapiom.dev",
+    },
+  };
 
 function canonicalEnvironmentName(name: string): string {
   return ENVIRONMENT_ALIASES[name] ?? name;
@@ -56,10 +63,36 @@ function getCredentialsPath(): string {
   return path.join(os.homedir(), ".sapiom", "credentials.json");
 }
 
-async function readCredentialsFile(): Promise<CredentialsFile | null> {
+function isMissingCredentialsFile(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    error.code === "ENOENT"
+  );
+}
+
+/**
+ * Read and parse the shared credential store without hiding failures.
+ * A genuinely absent file is a valid signed-out state; every other failure
+ * must stay distinguishable so live consumers do not erase a last-known key
+ * because of a transient I/O or parse problem.
+ */
+async function readCredentialsFileOrThrow(): Promise<CredentialsFile | null> {
   try {
     const content = await fs.readFile(getCredentialsPath(), "utf-8");
     return JSON.parse(content) as CredentialsFile;
+  } catch (error) {
+    if (isMissingCredentialsFile(error)) return null;
+    throw error;
+  }
+}
+
+/** Compatibility reader for existing MCP callers that treat any store
+ * failure as signed out. New reconciliation code should use the strict read. */
+async function readCredentialsFile(): Promise<CredentialsFile | null> {
+  try {
+    return await readCredentialsFileOrThrow();
   } catch {
     return null;
   }
@@ -142,6 +175,20 @@ export async function readCredentials(
   envName: string,
 ): Promise<CredentialEntry | null> {
   const file = await readCredentialsFile();
+  return file?.environments[envName]?.credentials ?? null;
+}
+
+/**
+ * Read one environment's cached credential while preserving the difference
+ * between a confirmed absence and a store failure.
+ *
+ * Returns `null` for a missing file or missing credential. Permission, I/O,
+ * and JSON parsing failures are allowed to throw.
+ */
+export async function readCredentialsOrThrow(
+  envName: string,
+): Promise<CredentialEntry | null> {
+  const file = await readCredentialsFileOrThrow();
   return file?.environments[envName]?.credentials ?? null;
 }
 


### PR DESCRIPTION
## Summary

Agent Studio now resolves the latest saved credential at the shared Claude launch boundary, so created, resumed, and background sessions cannot keep using a boot-time key. Remote MCP URLs also follow the selected environment, while `--no-auth` remains a hard process-wide opt-out.

## Changes

- Add an additive strict MCP credential reader and serialized provider reconciliation.
- Refresh immediately before each default session/task MCP config is generated.
- Route the remote MCP URL through the resolved production, staging, alias, or custom environment.
- Prevent shared credential adoption and auth mutations when Studio runs with `--no-auth`.
- Add unit and real `startServer()` lifecycle coverage, plus minor changesets for MCP and Harness.

## Testing

- [x] `pnpm --filter @sapiom/mcp test` — 146 tests
- [x] `pnpm --filter @sapiom/harness test` — 3,157 unit/integration and 10 performance tests
- [x] `pnpm --filter @sapiom/mcp typecheck`
- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `pnpm --filter "@sapiom/harness..." build`
- [x] MCP and Harness lint
- [x] New lifecycle coverage uses fake credentials and mocked OAuth; it does not open a browser or contact production

## Boundaries

Already-running session reconnection remains SAP-3116. Unified verified auth state and observability remain SAP-3115. Codex MCP injection remains out of scope because its adapter does not consume the generated Claude MCP configuration.

## Related

Closes: SAP-3114
