### PR TITLE
docs(agent): pauseUntilSignal timeoutMs is a hard failure

### DIFF
--- a/.changeset/pause-timeout-hard-fail.md
+++ b/.changeset/pause-timeout-hard-fail.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/agent": patch
+"@sapiom/agent-runtime": patch
+---
+
+Document that `pauseUntilSignal({ timeoutMs })` is a hard failure (`PauseTimeoutError`), not an in-workflow timeout→resume branch. Authors who need wait-or-proceed should fire the same signal from an external timer.

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -573,6 +573,11 @@ Key rules:
   Passing the handle to `pauseUntilSignal(handle, ...)` wires the signal automatically.
 - The **resumed step's `input` is the run's result payload** (`CodingResultPayload`).
   Annotate it explicitly — don't hand-roll the shape.
+- **`timeoutMs` on `pauseUntilSignal` is a hard failure**, not a branch. When it
+  elapses the run becomes `failed` with `PauseTimeoutError`; `resumeStep` is not
+  invoked. Omit it for an indefinite wait. Drive reminders/escalation by firing
+  the same signal (see `examples/approval-chain`), not by sizing `timeoutMs` to
+  a reminder interval.
 - The payload crossed a process boundary: **no live handles**. Re-attach a sandbox from
   `result.executionEnvironment.id` if needed; stash everything else in `ctx.shared` before pausing.
 - For a **manual human-gate** (no capability handle), use the object form and fire the signal

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -573,6 +573,11 @@ Key rules:
   Passing the handle to `pauseUntilSignal(handle, ...)` wires the signal automatically.
 - The **resumed step's `input` is the run's result payload** (`CodingResultPayload`).
   Annotate it explicitly — don't hand-roll the shape.
+- **`timeoutMs` on `pauseUntilSignal` is a hard failure**, not a branch. When it
+  elapses the run becomes `failed` with `PauseTimeoutError`; `resumeStep` is not
+  invoked. Omit it for an indefinite wait. Drive reminders/escalation by firing
+  the same signal (see `examples/approval-chain`), not by sizing `timeoutMs` to
+  a reminder interval.
 - The payload crossed a process boundary: **no live handles**. Re-attach a sandbox from
   `result.executionEnvironment.id` if needed; stash everything else in `ctx.shared` before pausing.
 - For a **manual human-gate** (no capability handle), use the object form and fire the signal

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -573,6 +573,11 @@ Key rules:
   Passing the handle to `pauseUntilSignal(handle, ...)` wires the signal automatically.
 - The **resumed step's `input` is the run's result payload** (`CodingResultPayload`).
   Annotate it explicitly — don't hand-roll the shape.
+- **`timeoutMs` on `pauseUntilSignal` is a hard failure**, not a branch. When it
+  elapses the run becomes `failed` with `PauseTimeoutError`; `resumeStep` is not
+  invoked. Omit it for an indefinite wait. Drive reminders/escalation by firing
+  the same signal (see `examples/approval-chain`), not by sizing `timeoutMs` to
+  a reminder interval.
 - The payload crossed a process boundary: **no live handles**. Re-attach a sandbox from
   `result.executionEnvironment.id` if needed; stash everything else in `ctx.shared` before pausing.
 - For a **manual human-gate** (no capability handle), use the object form and fire the signal

--- a/packages/agent-runtime/src/runner-core.ts
+++ b/packages/agent-runtime/src/runner-core.ts
@@ -409,6 +409,10 @@ export class AgentRunnerCore {
   /**
    * Finalize a paused execution whose `paused_until` elapsed with no signal.
    * Called by the sweep processor; null on benign races.
+   *
+   * This is a terminal failure (`PauseTimeoutError`), not a resume. Authors
+   * who need "wait-or-proceed" must fire the same signal from an external
+   * timer; `timeoutMs` cannot branch inside the workflow.
    */
   async expirePausedExecution(executionId: string): Promise<AdvanceResult | null> {
     const row = await this.deps.store.loadExecution(executionId);

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -176,6 +176,10 @@ Things to know:
     return pauseUntilSignal(run, { resumeStep: "review" });
   }
   ```
+- **`timeoutMs` fails the run.** If the signal never arrives, the engine marks
+  the execution `failed` with `PauseTimeoutError`. It does not resume
+  `resumeStep`. Omit `timeoutMs` for an indefinite wait; drive "wait-or-proceed"
+  by firing the same signal from an external timer.
 - **Outside an agent run nothing changes** — `await launch().wait()` the capability as
   usual; the pause wiring only engages when a step pauses on the handle.
 

--- a/packages/agent/src/directives.ts
+++ b/packages/agent/src/directives.ts
@@ -62,6 +62,13 @@ export interface RetryDirective {
  * (status='paused', signal name + correlationId stored on the execution row)
  * and the inline runner exits via AgentPausedError.
  *
+ * `timeoutMs` is a **hard failure**, not an in-workflow branch. When it
+ * elapses with no signal, the sweep calls `expirePausedExecution` and the
+ * run becomes `failed` with `PauseTimeoutError`. It does **not** resume
+ * `resumeStep` with a timeout payload. "Wait for an event, otherwise
+ * proceed" belongs on an external timer that fires the same signal (see
+ * `examples/approval-chain`).
+ *
  * Signal-routed resume is implemented in `signals.service.ts`:
  * `AgentSignals.fireSignal(name, correlationId, payload)` looks up paused
  * executions by (signal.name, correlationId) and wakes each one with the
@@ -74,7 +81,7 @@ export interface PauseUntilSignalDirective {
     readonly correlationId?: string;
   };
   readonly timeoutMs?: number;
-  /** Step to run when the signal arrives. Defaults to the paused step. */
+  /** Step to run when the signal arrives. Defaults to the paused step. Not used on pause timeout. */
   readonly resumeStep?: string;
 }
 
@@ -189,6 +196,10 @@ export interface Pause<Resume extends string> {
   readonly kind: typeof DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL;
   readonly signal: { readonly name: string; readonly correlationId?: string };
   readonly resumeStep?: Resume;
+  /**
+   * Hard deadline for the pause. On expiry the execution **fails** with
+   * `PauseTimeoutError`; it does not resume `resumeStep`.
+   */
   readonly timeoutMs?: number;
   /** Optional audit output recorded for the pausing step. */
   readonly output?: unknown;
@@ -237,6 +248,13 @@ export function fail(reason?: string, opts?: { output?: unknown }): Fail {
  * Both are consumed as `return pauseUntilSignal(...)` from an async `run()`, so
  * async-return flattening makes the sync/async distinction invisible at the call
  * site.
+ *
+ * **`timeoutMs` fails the run.** If the signal has not arrived when
+ * `pausedUntil` elapses, the engine raises `PauseTimeoutError` and marks the
+ * execution `failed`. There is no timeout→resume payload and no `timeoutStep`.
+ * Omit `timeoutMs` for an indefinite wait. For "close bidding after 48h or
+ * 3 bids, whichever first", fire the same signal from an external timer
+ * (cron / webhook) instead of relying on `timeoutMs`.
  */
 export function pauseUntilSignal<const Resume extends string>(args: {
   signal: string;

--- a/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
@@ -573,6 +573,11 @@ Key rules:
   Passing the handle to `pauseUntilSignal(handle, ...)` wires the signal automatically.
 - The **resumed step's `input` is the run's result payload** (`CodingResultPayload`).
   Annotate it explicitly — don't hand-roll the shape.
+- **`timeoutMs` on `pauseUntilSignal` is a hard failure**, not a branch. When it
+  elapses the run becomes `failed` with `PauseTimeoutError`; `resumeStep` is not
+  invoked. Omit it for an indefinite wait. Drive reminders/escalation by firing
+  the same signal (see `examples/approval-chain`), not by sizing `timeoutMs` to
+  a reminder interval.
 - The payload crossed a process boundary: **no live handles**. Re-attach a sandbox from
   `result.executionEnvironment.id` if needed; stash everything else in `ctx.shared` before pausing.
 - For a **manual human-gate** (no capability handle), use the object form and fire the signal


### PR DESCRIPTION
## Summary
- Document that `pauseUntilSignal({ timeoutMs })` expires into `PauseTimeoutError` and **fails the run**.
- It does not resume `resumeStep` with a timeout payload and there is no `timeoutStep`.
- Point authors at the external-timer / same-signal pattern (`examples/approval-chain`) for wait-or-proceed workflows.

Addresses #156 (documentation slice; runtime timeout→resume is unchanged).

## Test plan
- [ ] Read `pauseUntilSignal` JSDoc and the agent-authoring skill pause rules.
- [ ] Confirm `expirePausedExecution` still fails the execution (behavior unchanged).