### PR TITLE
feat(tools): Google + GitHub capability clients

### DIFF
--- a/.changeset/agent-core-esm-require-banner.md
+++ b/.changeset/agent-core-esm-require-banner.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Local `check` and runs now bundle with a `createRequire` banner, so dependencies that call `require()` at runtime (for example `googleapis` / `google-auth-library`) resolve at runtime instead of failing with esbuild's "Dynamic require not supported".

--- a/.changeset/tools-google-github-capabilities.md
+++ b/.changeset/tools-google-github-capabilities.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/tools": minor
+---
+
+Add Google and GitHub capabilities to `ctx.sapiom`, with credentials injected by the gateway:
+
+- `google.token()` — a short-lived Google bearer for the tenant's connected account.
+- `google.authClient()` — a `google-auth-library` `OAuth2Client` that mints and refreshes its token through the gateway, so it drops straight into `googleapis` and the `@googleapis/*` clients. `google-auth-library` is an optional peer dependency, loaded only when `authClient()` is called; a token-only integration needs no extra dependency.
+- `google.drive.shareFile()` / `google.drive.uploadFile()` and `google.gmail.sendEmail()` — Drive and Gmail actions execute server-side in the gateway, so the Google token never reaches agent code.
+- `github.listRepos()` — list repositories for a connected GitHub account.

--- a/packages/agent-core/src/check.ts
+++ b/packages/agent-core/src/check.ts
@@ -182,6 +182,14 @@ export async function check(opts: CheckOptions): Promise<CheckResult> {
         platform: "node",
         target: "node20",
         format: "esm",
+        // A bundled dep that does a dynamic require() — e.g. googleapis →
+        // google-auth-library `require('child_process')` — would otherwise hit
+        // esbuild's ESM shim that throws "Dynamic require not supported". This
+        // banner gives the shim a real `require` so those resolve at runtime
+        // (the documented esbuild workaround). Inert for bundles that do none.
+        banner: {
+          js: "import { createRequire } from 'node:module';\nconst require = createRequire(import.meta.url);",
+        },
         logLevel: "silent",
       });
     } catch (err) {

--- a/packages/agent-core/src/local/load.ts
+++ b/packages/agent-core/src/local/load.ts
@@ -56,6 +56,14 @@ export async function loadDefinition(
         platform: "node",
         target: "node20",
         format: "esm",
+        // A bundled dep that does a dynamic require() — e.g. googleapis →
+        // google-auth-library `require('child_process')` — would otherwise hit
+        // esbuild's ESM shim that throws "Dynamic require not supported". This
+        // banner gives the shim a real `require` so those resolve at runtime
+        // (the documented esbuild workaround). Inert for bundles that do none.
+        banner: {
+          js: "import { createRequire } from 'node:module';\nconst require = createRequire(import.meta.url);",
+        },
         logLevel: "silent",
       });
     } catch (err) {

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -99,6 +99,14 @@
   "dependencies": {
     "@sapiom/analytics-core": "workspace:^"
   },
+  "peerDependencies": {
+    "google-auth-library": ">=9"
+  },
+  "peerDependenciesMeta": {
+    "google-auth-library": {
+      "optional": true
+    }
+  },
   "scripts": {
     "build": "npm run gen:version && npm run build:cjs && npm run build:esm && npm run build:esm-pkg",
     "build:cjs": "tsc --project tsconfig.cjs.json",
@@ -121,6 +129,7 @@
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
     "eslint": "^8.57.0",
+    "google-auth-library": "^10.5.0",
     "jest": "^29.7.0",
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -178,6 +178,8 @@ import type {
   SendEmailArgs,
   SendEmailResult,
 } from "./google/index.js";
+import * as github from "./github/index.js";
+import type { ListReposArgs, GitHubRepo } from "./github/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -514,6 +516,20 @@ export interface Sapiom {
       sendEmail(args: SendEmailArgs): Promise<SendEmailResult>;
     };
   };
+  /**
+   * GitHub server-side methods (AGENT-314 / Path 2). The gateway resolves the tenant's
+   * GitHub credential — a static Personal Access Token — internally and calls GitHub;
+   * the PAT never reaches the run. GitHub exercises the `static`/`injected` credential
+   * strategy (the contrast to Google's OAuth) through the identical dispatch path.
+   */
+  readonly github: {
+    /**
+     * List the tenant's GitHub repositories. All args are optional — call with none
+     * to list the first page of every repo the PAT can see. Throws 404 when no
+     * GitHub connector is connected.
+     */
+    listRepos(args?: ListReposArgs): Promise<GitHubRepo[]>;
+  };
   /** Text-to-speech, sound effects, and voice listing. */
   readonly speech: {
     /** Generate speech audio from text. */
@@ -738,6 +754,9 @@ function bind(transport: Transport): Sapiom {
       gmail: {
         sendEmail: (args) => google.gmailSendEmail(args, transport),
       },
+    },
+    github: {
+      listRepos: (args) => github.listRepos(args, transport),
     },
     speech: {
       textToSpeech: {

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -168,7 +168,7 @@ import * as vault from "./vault/index.js";
 import * as keys from "./keys/index.js";
 import type { MintScopedInput, ScopedKey } from "./keys/index.js";
 import * as google from "./google/index.js";
-import type { LiveCredential } from "./google/index.js";
+import type { LiveCredential, AuthClientLike } from "./google/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -471,11 +471,18 @@ export interface Sapiom {
    * pulls a short-lived bearer from the connectors gateway ON DEMAND — the OAuth
    * token never lives in the run env or on disk, and the refresh happens
    * server-side. The raw token is returned to the caller only; never log or persist
-   * it. (`authClient()` — a googleapis-style self-refreshing wrapper — is added in E4 T2.)
+   * it. `authClient()` wraps `token()` as a googleapis-style self-refreshing client.
    */
   readonly google: {
     /** Pull a fresh Google `LiveCredential` (server-side refresh). Throws 404 when no Google connector is connected. */
     token(): Promise<LiveCredential>;
+    /**
+     * A googleapis-style auth client that refreshes itself: `getRequestHeaders()`
+     * returns `{ Authorization: "Bearer <token>" }`, caching the credential and
+     * re-materializing only near its `expiresAt` — pass it where a Google client
+     * library expects an `AuthClient`.
+     */
+    authClient(): AuthClientLike;
   };
   /** Text-to-speech, sound effects, and voice listing. */
   readonly speech: {
@@ -693,6 +700,7 @@ function bind(transport: Transport): Sapiom {
     },
     google: {
       token: () => google.token(transport),
+      authClient: () => google.authClient(transport),
     },
     speech: {
       textToSpeech: {

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -175,6 +175,8 @@ import type {
   DriveShareFileArgs,
   DriveUploadFileArgs,
   LiveCredential,
+  SendEmailArgs,
+  SendEmailResult,
 } from "./google/index.js";
 
 export interface Sapiom {
@@ -500,6 +502,17 @@ export interface Sapiom {
       /** Upload a new Drive file. */
       uploadFile(args: DriveUploadFileArgs): Promise<DriveFile>;
     };
+    /**
+     * Google Gmail server-side methods (Path 2). The gateway resolves the tenant's
+     * Google credential internally and calls Gmail — the token never reaches the run.
+     */
+    readonly gmail: {
+      /**
+       * Send an email via Gmail. `to`/`cc`/`bcc` accept a single address or an
+       * array. Throws 404 when no Google connector is connected.
+       */
+      sendEmail(args: SendEmailArgs): Promise<SendEmailResult>;
+    };
   };
   /** Text-to-speech, sound effects, and voice listing. */
   readonly speech: {
@@ -721,6 +734,9 @@ function bind(transport: Transport): Sapiom {
       drive: {
         shareFile: (args) => google.driveShareFile(args, transport),
         uploadFile: (args) => google.driveUploadFile(args, transport),
+      },
+      gmail: {
+        sendEmail: (args) => google.gmailSendEmail(args, transport),
       },
     },
     speech: {

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -169,7 +169,6 @@ import * as keys from "./keys/index.js";
 import type { MintScopedInput, ScopedKey } from "./keys/index.js";
 import * as google from "./google/index.js";
 import type {
-  AuthClientLike,
   DriveFile,
   DrivePermission,
   DriveShareFileArgs,
@@ -178,6 +177,12 @@ import type {
   SendEmailArgs,
   SendEmailResult,
 } from "./google/index.js";
+// Type-only (erased at emit): the return type of `google.authClient()`. Referencing it
+// here does not make `google-auth-library` a runtime dependency of this module —
+// `authClient()` loads it dynamically, and only when called. Agent tsconfigs use
+// `skipLibCheck`, so this reference in the emitted `.d.ts` never forces the peer on agents
+// that only use `token()`.
+import type { OAuth2Client } from "google-auth-library";
 import * as github from "./github/index.js";
 import type { ListReposArgs, GitHubRepo } from "./github/index.js";
 
@@ -488,12 +493,17 @@ export interface Sapiom {
     /** Pull a fresh Google `LiveCredential` (server-side refresh). Throws 404 when no Google connector is connected. */
     token(): Promise<LiveCredential>;
     /**
-     * A googleapis-style auth client that refreshes itself: `getRequestHeaders()`
-     * returns `{ Authorization: "Bearer <token>" }`, caching the credential and
-     * re-materializing only near its `expiresAt` — pass it where a Google client
-     * library expects an `AuthClient`.
+     * A GENUINE `google-auth-library` `OAuth2Client` for the Google vendor SDKs
+     * (`googleapis`, `@googleapis/*`) — pass it straight to `drive({ version, auth })`.
+     * Its `refreshHandler` sources every token from `token()` (server-side refresh), so
+     * the OAuth token is minted on demand and never lives in the run. A real client is
+     * required because the vendor SDKs call `authClient.request(...)` and type `auth` as
+     * `OAuth2Client | …`; it is also a superset of a header-only client
+     * (`getRequestHeaders()`). For a raw-bearer path with no extra dependency, use
+     * `token()`. `google-auth-library` is an optional peer, imported dynamically — it
+     * ships with `googleapis`/`@googleapis/*`, and this throws a clear error if missing.
      */
-    authClient(): AuthClientLike;
+    authClient(): Promise<OAuth2Client>;
     /**
      * Google Drive server-side methods (Path 2). The gateway resolves the tenant's
      * Google credential internally and calls Drive — the token never reaches the run.

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -167,6 +167,8 @@ import type {
 import * as vault from "./vault/index.js";
 import * as keys from "./keys/index.js";
 import type { MintScopedInput, ScopedKey } from "./keys/index.js";
+import * as google from "./google/index.js";
+import type { LiveCredential } from "./google/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -464,6 +466,17 @@ export interface Sapiom {
   readonly keys: {
     mintScoped(input: MintScopedInput): Promise<ScopedKey>;
   };
+  /**
+   * A live, tenant-scoped Google credential for in-run code (AGENT-311). `token()`
+   * pulls a short-lived bearer from the connectors gateway ON DEMAND — the OAuth
+   * token never lives in the run env or on disk, and the refresh happens
+   * server-side. The raw token is returned to the caller only; never log or persist
+   * it. (`authClient()` — a googleapis-style self-refreshing wrapper — is added in E4 T2.)
+   */
+  readonly google: {
+    /** Pull a fresh Google `LiveCredential` (server-side refresh). Throws 404 when no Google connector is connected. */
+    token(): Promise<LiveCredential>;
+  };
   /** Text-to-speech, sound effects, and voice listing. */
   readonly speech: {
     /** Generate speech audio from text. */
@@ -677,6 +690,9 @@ function bind(transport: Transport): Sapiom {
     },
     keys: {
       mintScoped: (input) => keys.mintScoped(input, transport),
+    },
+    google: {
+      token: () => google.token(transport),
     },
     speech: {
       textToSpeech: {

--- a/packages/tools/src/client.ts
+++ b/packages/tools/src/client.ts
@@ -168,7 +168,14 @@ import * as vault from "./vault/index.js";
 import * as keys from "./keys/index.js";
 import type { MintScopedInput, ScopedKey } from "./keys/index.js";
 import * as google from "./google/index.js";
-import type { LiveCredential, AuthClientLike } from "./google/index.js";
+import type {
+  AuthClientLike,
+  DriveFile,
+  DrivePermission,
+  DriveShareFileArgs,
+  DriveUploadFileArgs,
+  LiveCredential,
+} from "./google/index.js";
 
 export interface Sapiom {
   readonly sandboxes: {
@@ -483,6 +490,16 @@ export interface Sapiom {
      * library expects an `AuthClient`.
      */
     authClient(): AuthClientLike;
+    /**
+     * Google Drive server-side methods (Path 2). The gateway resolves the tenant's
+     * Google credential internally and calls Drive — the token never reaches the run.
+     */
+    readonly drive: {
+      /** Share a Drive file. Throws 404 when no Google connector is connected. */
+      shareFile(args: DriveShareFileArgs): Promise<DrivePermission>;
+      /** Upload a new Drive file. */
+      uploadFile(args: DriveUploadFileArgs): Promise<DriveFile>;
+    };
   };
   /** Text-to-speech, sound effects, and voice listing. */
   readonly speech: {
@@ -701,6 +718,10 @@ function bind(transport: Transport): Sapiom {
     google: {
       token: () => google.token(transport),
       authClient: () => google.authClient(transport),
+      drive: {
+        shareFile: (args) => google.driveShareFile(args, transport),
+        uploadFile: (args) => google.driveUploadFile(args, transport),
+      },
     },
     speech: {
       textToSpeech: {

--- a/packages/tools/src/github/index.spec.ts
+++ b/packages/tools/src/github/index.spec.ts
@@ -1,0 +1,132 @@
+import { Transport } from "../_client/index.js";
+import * as github from "./index.js";
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "sat_run-token",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://tools.test";
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+
+const REPOS = [
+  {
+    id: 1,
+    name: "app",
+    fullName: "acme/app",
+    private: true,
+    htmlUrl: "https://github.com/acme/app",
+    description: "the app",
+  },
+  {
+    id: 2,
+    name: "docs",
+    fullName: "acme/docs",
+    private: false,
+    htmlUrl: "https://github.com/acme/docs",
+    description: null,
+  },
+];
+
+describe("github.listRepos", () => {
+  it("POSTs methods/listRepos on x-sapiom-api-key with the args body, returns the GitHubRepo[]", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(REPOS)]);
+
+    const args = { perPage: 50, page: 1, visibility: "all" } as const;
+    const result = await github.listRepos(args, transport, BASE);
+
+    expect(calls[0]!.url).toBe(
+      `${BASE}/connectors/v1/github/methods/listRepos`,
+    );
+    expect(calls[0]!.init.method).toBe("POST");
+    // Default gateway credential header — the run sat_ rides x-sapiom-api-key, NOT x-api-key.
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("sat_run-token");
+    expect(headerOf(calls[0]!, "x-api-key")).toBeUndefined();
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    // Args pass through untouched — no normalization (unlike gmail recipients).
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual(args);
+    expect(result).toEqual(REPOS);
+  });
+
+  it("POSTs an empty object body when called with no args", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse(REPOS)]);
+
+    const result = await github.listRepos(undefined, transport, BASE);
+
+    expect(calls[0]!.url).toBe(
+      `${BASE}/connectors/v1/github/methods/listRepos`,
+    );
+    expect(calls[0]!.init.method).toBe("POST");
+    // No args → `{}` crosses the wire (the gateway still expects a JSON body).
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({});
+    expect(result).toEqual(REPOS);
+  });
+
+  it("surfaces a 404 (no GitHub connector for this tenant) with the connector_not_found body", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ error: "connector_not_found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ]);
+    await expect(github.listRepos(undefined, transport, BASE)).rejects.toThrow(
+      /404/,
+    );
+    await expect(github.listRepos(undefined, transport, BASE)).rejects.toThrow(
+      /connector_not_found/,
+    );
+  });
+
+  it("surfaces a 502 (upstream GitHub failure) from listRepos", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(
+          JSON.stringify({ error: "connector_method_upstream_failed" }),
+          {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+    ]);
+    await expect(
+      github.listRepos({ perPage: 10 }, transport, BASE),
+    ).rejects.toThrow(/502/);
+  });
+});

--- a/packages/tools/src/github/index.ts
+++ b/packages/tools/src/github/index.ts
@@ -1,0 +1,64 @@
+/**
+ * `github` capability — tenant-scoped GitHub methods executed server-side in the
+ * connectors gateway (AGENT-314 / Path 2). The args are POSTed to the gateway's
+ * method-dispatch route on the run credential (`x-sapiom-api-key`); the gateway
+ * resolves the tenant's GitHub credential (a static Personal Access Token) INTERNALLY
+ * and calls GitHub — the PAT NEVER crosses this boundary, only the result comes back.
+ *
+ *   import { github } from "@sapiom/tools";
+ *   const repos = await github.listRepos({ visibility: "all" });
+ *
+ * Or on the step context: `ctx.sapiom.github.listRepos()`.
+ *
+ * WHY this exists: a run must call GitHub WITHOUT the PAT ever living in the run env
+ * or on disk. Unlike Google's OAuth `token()` materialization, GitHub uses a `static`
+ * credential the gateway injects itself — so there is NO SDK-side credential surface
+ * at all, and NO `@octokit`/GitHub SDK dependency. This module only shapes the request.
+ *
+ * Wire: `POST ${baseUrl}/connectors/v1/github/methods/listRepos`, body = the args
+ * object (or `{}` when called with no args). Non-2xx throws (Transport.request),
+ * carrying the gateway body: 404 connector_not_found (connect GitHub first),
+ * 400 connector_method_invalid_args, 502 connector_method_upstream_failed.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+
+// Same tools host agents/models resolve — via SAPIOM_TOOLS_BASE. No new per-cap config.
+const DEFAULT_BASE_URL =
+  process.env.SAPIOM_TOOLS_BASE ?? "https://tools.sapiom.ai";
+
+/**
+ * Arguments for {@link listRepos}. All optional — call with no args to list the first
+ * page of every repo the tenant's PAT can see. `perPage`/`page` paginate; `visibility`
+ * filters by repo visibility. Args pass through to the gateway untouched (no
+ * normalization); when omitted, `{}` crosses the wire.
+ */
+export interface ListReposArgs {
+  perPage?: number;
+  page?: number;
+  visibility?: "all" | "public" | "private";
+}
+
+/** A repository as returned by the gateway's GitHub method dispatch. */
+export interface GitHubRepo {
+  id: number;
+  name: string;
+  fullName: string;
+  private: boolean;
+  htmlUrl: string;
+  description: string | null;
+}
+
+/** List the tenant's GitHub repositories, executed server-side in the gateway. */
+export async function listRepos(
+  args?: ListReposArgs,
+  transport: Transport = defaultTransport(),
+  baseUrl: string = DEFAULT_BASE_URL,
+): Promise<GitHubRepo[]> {
+  return transport.request<GitHubRepo[]>(
+    `${baseUrl}/connectors/v1/github/methods/listRepos`,
+    {
+      method: "POST",
+      body: JSON.stringify(args ?? {}),
+    },
+  );
+}

--- a/packages/tools/src/google/index.spec.ts
+++ b/packages/tools/src/google/index.spec.ts
@@ -92,3 +92,73 @@ describe("google.token()", () => {
     await expect(google.token(transport, BASE)).rejects.toThrow(/400/);
   });
 });
+
+describe("google.authClient()", () => {
+  // Comfortably beyond the 60s refresh skew regardless of the real clock.
+  const FAR_FUTURE = "2999-01-01T00:00:00.000Z";
+
+  it("fetches once and returns a Bearer header", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ kind: "bearer", value: "tok-1", expiresAt: FAR_FUTURE }),
+    ]);
+
+    const client = google.authClient(transport, BASE);
+    const headers = await client.getRequestHeaders();
+
+    expect(headers).toEqual({ Authorization: "Bearer tok-1" });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${BASE}/connectors/v1/google/materialize`);
+  });
+
+  it("reuses the cached credential while it is well before expiresAt (no second materialize)", async () => {
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ kind: "bearer", value: "tok-1", expiresAt: FAR_FUTURE }),
+    ]);
+
+    const client = google.authClient(transport, BASE);
+    await client.getRequestHeaders();
+    const second = await client.getRequestHeaders();
+
+    expect(second).toEqual({ Authorization: "Bearer tok-1" });
+    expect(calls).toHaveLength(1); // served from cache — a long run does not thrash materialize
+  });
+
+  it("re-materializes once the cached credential is within the refresh skew of expiresAt", async () => {
+    let fetches = 0;
+    const { transport, calls } = makeTransport([
+      () => {
+        fetches += 1;
+        // 1st credential expires 30s out (inside the 60s skew at `now`); 2nd is far-future.
+        return jsonResponse(
+          fetches === 1
+            ? { kind: "bearer", value: "tok-1", expiresAt: "2026-08-28T00:00:30.000Z" }
+            : { kind: "bearer", value: "tok-2", expiresAt: FAR_FUTURE },
+        );
+      },
+    ]);
+    const now = () => Date.parse("2026-08-28T00:00:00.000Z"); // fixed clock
+
+    const client = google.authClient(transport, BASE, now);
+    const first = await client.getRequestHeaders();
+    const second = await client.getRequestHeaders();
+
+    expect(first).toEqual({ Authorization: "Bearer tok-1" });
+    expect(second).toEqual({ Authorization: "Bearer tok-2" }); // refreshed near expiry
+    expect(calls).toHaveLength(2);
+  });
+
+  it("fetches every call when the credential carries no expiresAt", async () => {
+    let n = 0;
+    const { transport, calls } = makeTransport([
+      () => jsonResponse({ kind: "bearer", value: `tok-${(n += 1)}` }),
+    ]);
+
+    const client = google.authClient(transport, BASE);
+    const a = await client.getRequestHeaders();
+    const b = await client.getRequestHeaders();
+
+    expect(a).toEqual({ Authorization: "Bearer tok-1" });
+    expect(b).toEqual({ Authorization: "Bearer tok-2" });
+    expect(calls).toHaveLength(2); // absent expiresAt → never cached
+  });
+});

--- a/packages/tools/src/google/index.spec.ts
+++ b/packages/tools/src/google/index.spec.ts
@@ -246,3 +246,106 @@ describe("google.drive", () => {
     ).rejects.toThrow(/502/);
   });
 });
+
+describe("google.gmail", () => {
+  it("sendEmail POSTs methods/sendEmail on x-sapiom-api-key with a normalized-array body, returns { id, threadId }", async () => {
+    const sent = { id: "msg-1", threadId: "thread-1" };
+    const { transport, calls } = makeTransport([() => jsonResponse(sent)]);
+
+    const result = await google.gmailSendEmail(
+      { to: "a@b.com", cc: ["c@d.com", "e@f.com"], subject: "Hello", text: "Hi" },
+      transport,
+      BASE,
+    );
+
+    expect(calls[0]!.url).toBe(
+      `${BASE}/connectors/v1/google/methods/sendEmail`,
+    );
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("sat_run-token");
+    expect(headerOf(calls[0]!, "x-api-key")).toBeUndefined();
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    // to/cc/bcc are normalized to arrays before POST (the gateway is strict — arrays only).
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      to: ["a@b.com"],
+      cc: ["c@d.com", "e@f.com"],
+      subject: "Hello",
+      text: "Hi",
+    });
+    expect(result).toEqual(sent);
+  });
+
+  it("normalizes a single-string bcc and preserves html + attachments; omits absent recipients", async () => {
+    const sent = { id: "msg-2", threadId: "thread-2" };
+    const { transport, calls } = makeTransport([() => jsonResponse(sent)]);
+
+    await google.gmailSendEmail(
+      {
+        to: ["a@b.com"],
+        bcc: "hidden@x.com",
+        subject: "Report",
+        html: "<p>hi</p>",
+        attachments: [
+          {
+            filename: "r.pdf",
+            mimeType: "application/pdf",
+            content: "YmFzZTY0",
+          },
+        ],
+      },
+      transport,
+      BASE,
+    );
+
+    // Single-string bcc → array; no `cc` key emitted when absent.
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual({
+      to: ["a@b.com"],
+      bcc: ["hidden@x.com"],
+      subject: "Report",
+      html: "<p>hi</p>",
+      attachments: [
+        { filename: "r.pdf", mimeType: "application/pdf", content: "YmFzZTY0" },
+      ],
+    });
+  });
+
+  it("surfaces a 404 (no Google connector) from sendEmail", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ error: "connector_not_found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ]);
+    await expect(
+      google.gmailSendEmail(
+        { to: "a@b.com", subject: "x" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toThrow(/404/);
+    await expect(
+      google.gmailSendEmail(
+        { to: "a@b.com", subject: "x" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toThrow(/connector_not_found/);
+  });
+
+  it("surfaces a 502 (upstream Gmail failure) from sendEmail", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(
+          JSON.stringify({ error: "connector_method_upstream_failed" }),
+          {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+    ]);
+    await expect(
+      google.gmailSendEmail({ to: "a@b.com", subject: "x" }, transport, BASE),
+    ).rejects.toThrow(/502/);
+  });
+});

--- a/packages/tools/src/google/index.spec.ts
+++ b/packages/tools/src/google/index.spec.ts
@@ -94,72 +94,41 @@ describe("google.token()", () => {
 });
 
 describe("google.authClient()", () => {
-  // Comfortably beyond the 60s refresh skew regardless of the real clock.
   const FAR_FUTURE = "2999-01-01T00:00:00.000Z";
+  const EXPIRED = "2000-01-01T00:00:00.000Z";
 
-  it("fetches once and returns a Bearer header", async () => {
+  it("returns an OAuth2 client whose request headers carry the materialized bearer", async () => {
     const { transport, calls } = makeTransport([
       () => jsonResponse({ kind: "bearer", value: "tok-1", expiresAt: FAR_FUTURE }),
     ]);
 
-    const client = google.authClient(transport, BASE);
+    const client = await google.authClient(transport, BASE);
     const headers = await client.getRequestHeaders();
 
-    expect(headers).toEqual({ Authorization: "Bearer tok-1" });
-    expect(calls).toHaveLength(1);
+    expect(headers.get("authorization")).toBe("Bearer tok-1");
     expect(calls[0]!.url).toBe(`${BASE}/connectors/v1/google/materialize`);
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("sat_run-token");
+    // Primed at construction, so a still-valid token serves without a second materialize.
+    expect(calls).toHaveLength(1);
   });
 
-  it("reuses the cached credential while it is well before expiresAt (no second materialize)", async () => {
-    const { transport, calls } = makeTransport([
-      () => jsonResponse({ kind: "bearer", value: "tok-1", expiresAt: FAR_FUTURE }),
-    ]);
-
-    const client = google.authClient(transport, BASE);
-    await client.getRequestHeaders();
-    const second = await client.getRequestHeaders();
-
-    expect(second).toEqual({ Authorization: "Bearer tok-1" });
-    expect(calls).toHaveLength(1); // served from cache — a long run does not thrash materialize
-  });
-
-  it("re-materializes once the cached credential is within the refresh skew of expiresAt", async () => {
-    let fetches = 0;
-    const { transport, calls } = makeTransport([
-      () => {
-        fetches += 1;
-        // 1st credential expires 30s out (inside the 60s skew at `now`); 2nd is far-future.
-        return jsonResponse(
-          fetches === 1
-            ? { kind: "bearer", value: "tok-1", expiresAt: "2026-08-28T00:00:30.000Z" }
-            : { kind: "bearer", value: "tok-2", expiresAt: FAR_FUTURE },
-        );
-      },
-    ]);
-    const now = () => Date.parse("2026-08-28T00:00:00.000Z"); // fixed clock
-
-    const client = google.authClient(transport, BASE, now);
-    const first = await client.getRequestHeaders();
-    const second = await client.getRequestHeaders();
-
-    expect(first).toEqual({ Authorization: "Bearer tok-1" });
-    expect(second).toEqual({ Authorization: "Bearer tok-2" }); // refreshed near expiry
-    expect(calls).toHaveLength(2);
-  });
-
-  it("fetches every call when the credential carries no expiresAt", async () => {
+  it("re-materializes through the gateway when the primed token has expired", async () => {
     let n = 0;
     const { transport, calls } = makeTransport([
-      () => jsonResponse({ kind: "bearer", value: `tok-${(n += 1)}` }),
+      () =>
+        jsonResponse(
+          (n += 1) === 1
+            ? { kind: "bearer", value: "tok-1", expiresAt: EXPIRED }
+            : { kind: "bearer", value: "tok-2", expiresAt: FAR_FUTURE },
+        ),
     ]);
 
-    const client = google.authClient(transport, BASE);
-    const a = await client.getRequestHeaders();
-    const b = await client.getRequestHeaders();
+    const client = await google.authClient(transport, BASE);
+    const headers = await client.getRequestHeaders();
 
-    expect(a).toEqual({ Authorization: "Bearer tok-1" });
-    expect(b).toEqual({ Authorization: "Bearer tok-2" });
-    expect(calls).toHaveLength(2); // absent expiresAt → never cached
+    expect(headers.get("authorization")).toBe("Bearer tok-2");
+    // Prime (expired) then one refresh through the client's refreshHandler.
+    expect(calls).toHaveLength(2);
   });
 });
 

--- a/packages/tools/src/google/index.spec.ts
+++ b/packages/tools/src/google/index.spec.ts
@@ -1,0 +1,94 @@
+import { Transport } from "../_client/index.js";
+import * as google from "./index.js";
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+function makeTransport(
+  handlers: Array<
+    (call: FetchCall) => Response | Promise<Response> | null | undefined
+  >,
+  apiKey: string | undefined = "sat_run-token",
+): { transport: Transport; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const fetchMock = (async (
+    input: Parameters<typeof globalThis.fetch>[0],
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    calls.push({ url, init });
+    for (const handler of handlers) {
+      const response = await handler({ url, init });
+      if (response) return response;
+    }
+    throw new Error(`Unmatched mock fetch: ${init.method ?? "GET"} ${url}`);
+  }) as typeof globalThis.fetch;
+  return { transport: new Transport({ apiKey, fetch: fetchMock }), calls };
+}
+
+const BASE = "https://tools.test";
+const headerOf = (c: FetchCall, k: string) =>
+  (c.init.headers as Record<string, string>)[k];
+
+describe("google.token()", () => {
+  it("POSTs connectors/v1/google/materialize on x-sapiom-api-key, no body, and returns the LiveCredential", async () => {
+    const credential = {
+      kind: "bearer",
+      value: "ya29.live-access-token",
+      expiresAt: "2026-08-28T01:00:00.000Z",
+      baseUrl: "https://www.googleapis.com",
+    };
+    const { transport, calls } = makeTransport([() => jsonResponse(credential)]);
+
+    const result = await google.token(transport, BASE);
+
+    expect(calls[0]!.url).toBe(`${BASE}/connectors/v1/google/materialize`);
+    expect(calls[0]!.init.method).toBe("POST");
+    // Default gateway credential header — the run sat_ rides x-sapiom-api-key, NOT x-api-key.
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("sat_run-token");
+    expect(headerOf(calls[0]!, "x-api-key")).toBeUndefined();
+    // Provider-only contract: no request body.
+    expect(calls[0]!.init.body).toBeUndefined();
+    expect(result).toEqual(credential);
+  });
+
+  it("surfaces a 404 (no Google connector for this tenant) with the connector_not_found body", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ error: "connector_not_found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ]);
+    await expect(google.token(transport, BASE)).rejects.toThrow(/404/);
+    await expect(google.token(transport, BASE)).rejects.toThrow(
+      /connector_not_found/,
+    );
+  });
+
+  it("surfaces a 400 (unknown provider) as a thrown error", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ error: "invalid_connector_request" }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ]);
+    await expect(google.token(transport, BASE)).rejects.toThrow(/400/);
+  });
+});

--- a/packages/tools/src/google/index.spec.ts
+++ b/packages/tools/src/google/index.spec.ts
@@ -162,3 +162,87 @@ describe("google.authClient()", () => {
     expect(calls).toHaveLength(2); // absent expiresAt → never cached
   });
 });
+
+describe("google.drive", () => {
+  it("shareFile POSTs methods/shareFile on x-sapiom-api-key with the args body, returns the permission", async () => {
+    const permission = { id: "perm-1", type: "user", role: "writer" };
+    const { transport, calls } = makeTransport([() => jsonResponse(permission)]);
+
+    const args = {
+      fileId: "file-1",
+      role: "writer",
+      type: "user",
+      emailAddress: "a@b.com",
+    } as const;
+    const result = await google.driveShareFile(args, transport, BASE);
+
+    expect(calls[0]!.url).toBe(
+      `${BASE}/connectors/v1/google/methods/shareFile`,
+    );
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(headerOf(calls[0]!, "x-sapiom-api-key")).toBe("sat_run-token");
+    expect(headerOf(calls[0]!, "x-api-key")).toBeUndefined();
+    expect(headerOf(calls[0]!, "content-type")).toBe("application/json");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual(args);
+    expect(result).toEqual(permission);
+  });
+
+  it("uploadFile POSTs methods/uploadFile with the args body, returns the file", async () => {
+    const file = { id: "file-9", name: "notes.txt", mimeType: "text/plain" };
+    const { transport, calls } = makeTransport([() => jsonResponse(file)]);
+
+    const args = {
+      name: "notes.txt",
+      content: "hello",
+      mimeType: "text/plain",
+    } as const;
+    const result = await google.driveUploadFile(args, transport, BASE);
+
+    expect(calls[0]!.url).toBe(
+      `${BASE}/connectors/v1/google/methods/uploadFile`,
+    );
+    expect(calls[0]!.init.method).toBe("POST");
+    expect(JSON.parse(calls[0]!.init.body as string)).toEqual(args);
+    expect(result).toEqual(file);
+  });
+
+  it("surfaces a 404 (no Google connector) from shareFile", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(JSON.stringify({ error: "connector_not_found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ]);
+    await expect(
+      google.driveShareFile(
+        { fileId: "f", role: "reader", type: "anyone" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toThrow(/404/);
+    await expect(
+      google.driveShareFile(
+        { fileId: "f", role: "reader", type: "anyone" },
+        transport,
+        BASE,
+      ),
+    ).rejects.toThrow(/connector_not_found/);
+  });
+
+  it("surfaces a 502 (upstream Drive failure) from uploadFile", async () => {
+    const { transport } = makeTransport([
+      () =>
+        new Response(
+          JSON.stringify({ error: "connector_method_upstream_failed" }),
+          {
+            status: 502,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+    ]);
+    await expect(
+      google.driveUploadFile({ name: "x", content: "y" }, transport, BASE),
+    ).rejects.toThrow(/502/);
+  });
+});

--- a/packages/tools/src/google/index.ts
+++ b/packages/tools/src/google/index.ts
@@ -175,3 +175,64 @@ export async function driveUploadFile(
     },
   );
 }
+
+/**
+ * Google Gmail server-side methods (AGENT-313 / Path 2). Mirrors the Drive methods
+ * above: the args are POSTed to the gateway's method-dispatch route on the run
+ * credential (`x-sapiom-api-key`); the gateway resolves the tenant's Google
+ * credential INTERNALLY and calls Gmail — the Google token NEVER crosses this
+ * boundary, only the send result comes back. Non-2xx throws (Transport.request),
+ * carrying the gateway body: 404 connector_not_found (connect Google first),
+ * 400 connector_method_invalid_args, 502 connector_method_upstream_failed.
+ */
+export interface GmailAttachment {
+  filename: string;
+  mimeType: string;
+  /** Base64-encoded attachment bytes. */
+  content: string;
+}
+
+/**
+ * Arguments for {@link gmailSendEmail}. `to`/`cc`/`bcc` accept a single address or
+ * an array for ergonomics; each is NORMALIZED to an array before POSTing because the
+ * gateway is strict — recipients cross the wire as arrays only.
+ */
+export interface SendEmailArgs {
+  to: string | string[];
+  cc?: string | string[];
+  bcc?: string | string[];
+  subject: string;
+  text?: string;
+  html?: string;
+  attachments?: GmailAttachment[];
+}
+
+export interface SendEmailResult {
+  id: string;
+  threadId: string;
+}
+
+/** Normalize a single address or address array to an array (gateway expects arrays). */
+const toRecipientArray = (value: string | string[]): string[] =>
+  Array.isArray(value) ? value : [value];
+
+/** Send an email via Gmail (Users.messages: send), executed server-side in the gateway. */
+export async function gmailSendEmail(
+  args: SendEmailArgs,
+  transport: Transport = defaultTransport(),
+  baseUrl: string = DEFAULT_BASE_URL,
+): Promise<SendEmailResult> {
+  const body = {
+    ...args,
+    to: toRecipientArray(args.to),
+    ...(args.cc !== undefined ? { cc: toRecipientArray(args.cc) } : {}),
+    ...(args.bcc !== undefined ? { bcc: toRecipientArray(args.bcc) } : {}),
+  };
+  return transport.request<SendEmailResult>(
+    `${baseUrl}/connectors/v1/google/methods/sendEmail`,
+    {
+      method: "POST",
+      body: JSON.stringify(body),
+    },
+  );
+}

--- a/packages/tools/src/google/index.ts
+++ b/packages/tools/src/google/index.ts
@@ -1,0 +1,59 @@
+/**
+ * `google` capability — a live, tenant-scoped Google credential for in-run code,
+ * refreshed server-side (AGENT-311). Two members:
+ *
+ *   import { google } from "@sapiom/tools";
+ *   const cred = await google.token();                 // { kind: "bearer", value, expiresAt? }
+ *   // …or a googleapis-style auth client that refreshes itself:
+ *   const auth = google.authClient();
+ *   const { Authorization } = await auth.getRequestHeaders(); // "Bearer <token>"
+ *
+ * Or on the step context: `ctx.sapiom.google.token()` / `ctx.sapiom.google.authClient()`.
+ *
+ * WHY this exists: a run must call Google WITHOUT the OAuth token ever living in the
+ * run env or on disk. `token()` pulls a short-lived credential ON DEMAND from the
+ * connectors gateway, which owns the tenant's Google connector and does the OAuth
+ * refresh server-side; the raw token is returned to the caller only. It is NEVER
+ * logged, persisted, or written to env by this module.
+ *
+ * Wire: the tools host `POST /connectors/v1/google/materialize`, the run credential
+ * on the default `x-sapiom-api-key` header (NOT the Core `x-api-key`), NO body.
+ * 404 = no Google connector for this tenant (connect Google first); 400 = unknown
+ * provider. Non-2xx throws (Transport.request), carrying the server body.
+ */
+import { Transport, defaultTransport } from "../_client/index.js";
+
+// Same tools host agents/models resolve — via SAPIOM_TOOLS_BASE. No new per-cap config.
+const DEFAULT_BASE_URL =
+  process.env.SAPIOM_TOOLS_BASE ?? "https://tools.sapiom.ai";
+
+/**
+ * A short-lived, tenant-scoped credential materialized from the tenant's connector.
+ * `value` is a RAW bearer token — use it, never log/persist/echo it. `expiresAt` is
+ * present for OAuth connectors (Google has a real expiry) and absent for static
+ * ones. `baseUrl`, when present, is the provider API base the caller may target.
+ */
+export interface LiveCredential {
+  kind: "bearer";
+  value: string;
+  expiresAt?: string;
+  baseUrl?: string;
+}
+
+/**
+ * Pull a fresh Google credential from the connectors gateway. Server-side refresh:
+ * the gateway resolves the tenant's Google connector (from the authenticated run
+ * credential) and returns a live bearer. Throws on a non-2xx response — notably 404
+ * (no Google connector for this tenant — connect Google first) and 400 (unknown
+ * provider); the thrown Error carries the gateway's response body.
+ */
+export async function token(
+  transport: Transport = defaultTransport(),
+  baseUrl: string = DEFAULT_BASE_URL,
+): Promise<LiveCredential> {
+  // No body — provider-only contract (mirrors agents.launch's transport.request path).
+  return transport.request<LiveCredential>(
+    `${baseUrl}/connectors/v1/google/materialize`,
+    { method: "POST" },
+  );
+}

--- a/packages/tools/src/google/index.ts
+++ b/packages/tools/src/google/index.ts
@@ -108,3 +108,70 @@ export function authClient(
     },
   };
 }
+
+/**
+ * Google Drive server-side methods (AGENT-312 / Path 2). Each posts the args to the
+ * gateway's method-dispatch route on the run credential (`x-sapiom-api-key`); the
+ * gateway resolves the tenant's Google credential INTERNALLY and calls Drive — the
+ * Google token NEVER crosses this boundary, only the Drive result comes back. Non-2xx
+ * throws (Transport.request), carrying the gateway body: 404 connector_not_found (connect
+ * Google first), 400 connector_method_invalid_args, 502 connector_method_upstream_failed.
+ */
+export interface DriveShareFileArgs {
+  fileId: string;
+  role: "reader" | "writer" | "commenter" | "owner";
+  type: "user" | "group" | "domain" | "anyone";
+  emailAddress?: string;
+  domain?: string;
+  sendNotificationEmail?: boolean;
+}
+
+export interface DriveUploadFileArgs {
+  name: string;
+  content: string;
+  mimeType?: string;
+  parents?: string[];
+  contentEncoding?: "utf8" | "base64";
+}
+
+export interface DrivePermission {
+  id: string;
+  type: string;
+  role: string;
+}
+
+export interface DriveFile {
+  id: string;
+  name: string;
+  mimeType: string;
+}
+
+/** Share a Drive file (Permissions: create), executed server-side in the gateway. */
+export async function driveShareFile(
+  args: DriveShareFileArgs,
+  transport: Transport = defaultTransport(),
+  baseUrl: string = DEFAULT_BASE_URL,
+): Promise<DrivePermission> {
+  return transport.request<DrivePermission>(
+    `${baseUrl}/connectors/v1/google/methods/shareFile`,
+    {
+      method: "POST",
+      body: JSON.stringify(args),
+    },
+  );
+}
+
+/** Upload a new Drive file (Files: create, multipart), executed server-side in the gateway. */
+export async function driveUploadFile(
+  args: DriveUploadFileArgs,
+  transport: Transport = defaultTransport(),
+  baseUrl: string = DEFAULT_BASE_URL,
+): Promise<DriveFile> {
+  return transport.request<DriveFile>(
+    `${baseUrl}/connectors/v1/google/methods/uploadFile`,
+    {
+      method: "POST",
+      body: JSON.stringify(args),
+    },
+  );
+}

--- a/packages/tools/src/google/index.ts
+++ b/packages/tools/src/google/index.ts
@@ -4,9 +4,9 @@
  *
  *   import { google } from "@sapiom/tools";
  *   const cred = await google.token();                 // { kind: "bearer", value, expiresAt? }
- *   // …or a googleapis-style auth client that refreshes itself:
- *   const auth = google.authClient();
- *   const { Authorization } = await auth.getRequestHeaders(); // "Bearer <token>"
+ *   // …or a real google-auth-library OAuth2 client, ready for the vendor SDKs:
+ *   import { drive } from "@googleapis/drive";
+ *   const res = await drive({ version: "v3", auth: await google.authClient() }).files.list();
  *
  * Or on the step context: `ctx.sapiom.google.token()` / `ctx.sapiom.google.authClient()`.
  *
@@ -22,6 +22,11 @@
  * provider. Non-2xx throws (Transport.request), carrying the server body.
  */
 import { Transport, defaultTransport } from "../_client/index.js";
+// Type-only: erased at emit, so importing it adds NO runtime dependency. The value
+// `OAuth2Client` is pulled in at runtime by {@link authClient} via a dynamic import,
+// keeping `google-auth-library` an OPTIONAL peer that only loads when a builder actually
+// builds a client (agents that only use {@link token} pull none of it).
+import type { OAuth2Client } from "google-auth-library";
 
 // Same tools host agents/models resolve — via SAPIOM_TOOLS_BASE. No new per-cap config.
 const DEFAULT_BASE_URL =
@@ -59,54 +64,68 @@ export async function token(
 }
 
 /**
- * The minimal structural shape a googleapis / google-auth-library `AuthClient`
- * satisfies — the client libraries call `getRequestHeaders()` before each request to
- * attach the bearer. Declared structurally (no `googleapis` import, no runtime
- * dependency) so our object type-checks where an `AuthClient` is expected, by
- * duck-typing at the call site. Returns exactly `{ Authorization: "Bearer <token>" }`.
- */
-export interface AuthClientLike {
-  getRequestHeaders(): Promise<{ Authorization: string }>;
-}
-
-/**
- * Refresh a cached credential this many ms BEFORE its `expiresAt`, so a token is
- * never served on the edge of expiry (clock skew + in-flight request time).
- */
-const REFRESH_SKEW_MS = 60_000;
-
-/**
- * A googleapis-style auth client backed by server-side credential materialization.
- * `getRequestHeaders()` returns a `Bearer` header for the tenant's Google connector,
- * CACHING the last `LiveCredential` and only re-calling {@link token} when the cache
- * is within {@link REFRESH_SKEW_MS} of its `expiresAt` — or on every call when the
- * credential carries no `expiresAt`. This lets a long-running Google client survive a
- * token refresh WITHOUT a materialize round-trip per request, and without serving a
- * token past its expiry. The raw token is returned to the caller only — never logged,
- * persisted, or written to env; the cache lives only in this object's closure.
+ * The tenant's Google auth client for the vendor SDKs — a GENUINE `google-auth-library`
+ * `OAuth2Client`, backed by server-side credential materialization. Pass it straight to
+ * any Google client library: `drive({ version: "v3", auth: await authClient() })`.
  *
- * `now` is injectable purely for deterministic tests; production uses `Date.now`.
+ * WHY a real client (not a `{ getRequestHeaders }` duck-type): `googleapis` /
+ * `@googleapis/*` route every request through `authClient.request(...)`, which a bare
+ * duck-type lacks ("authClient.request is not a function"), and they type `auth` as
+ * `OAuth2Client | GoogleAuth | …` — so only the real client both runs and type-checks. A
+ * real `OAuth2Client` is a superset (it also has `getRequestHeaders()`), so header-only
+ * callers are covered too; for a pure raw-bearer path with no extra dependency, use
+ * {@link token}.
+ *
+ * The client's `refreshHandler` — google-auth-library's official "bring your own token
+ * source" hook — sources EVERY token from {@link token}, so the OAuth token is minted on
+ * demand and refreshed transparently server-side; the library caches it and re-mints only
+ * when it needs to (initial call and near expiry). The raw token is returned to the caller
+ * only — never logged, persisted, or written to env.
+ *
+ * `google-auth-library` is an OPTIONAL peer dependency, imported DYNAMICALLY so it never
+ * weighs on agents that only use {@link token} (raw bearer + `fetch`) and never build a
+ * client. It ships transitively with `googleapis` and the `@googleapis/*` clients, so a
+ * builder using those already has it; called without it installed, this throws a clear
+ * error naming the package to add.
+ *
+ * @example
+ *   import { drive } from "@googleapis/drive";
+ *   const auth = await ctx.sapiom.google.authClient();
+ *   const res = await drive({ version: "v3", auth }).files.list({ pageSize: 10 });
  */
-export function authClient(
+export async function authClient(
   transport: Transport = defaultTransport(),
   baseUrl: string = DEFAULT_BASE_URL,
-  now: () => number = Date.now,
-): AuthClientLike {
-  let cached: LiveCredential | undefined;
+): Promise<OAuth2Client> {
+  let mod: typeof import("google-auth-library");
+  try {
+    mod = await import("google-auth-library");
+  } catch {
+    throw new Error(
+      "google.authClient() needs the 'google-auth-library' package, which ships with " +
+        "'googleapis' and the '@googleapis/*' clients — install one of those (e.g. " +
+        "`npm i @googleapis/drive`) to use the vendor SDKs. For a token-only path that " +
+        "needs no extra dependency, use google.token() instead.",
+    );
+  }
 
-  const isFresh = (cred: LiveCredential | undefined): cred is LiveCredential =>
-    cred !== undefined &&
-    typeof cred.expiresAt === "string" &&
-    Date.parse(cred.expiresAt) - now() > REFRESH_SKEW_MS;
-
-  return {
-    async getRequestHeaders() {
-      const current = isFresh(cached)
-        ? cached
-        : (cached = await token(transport, baseUrl));
-      return { Authorization: `Bearer ${current.value}` };
-    },
+  const client = new mod.OAuth2Client();
+  // The single source of tokens: every mint is a server-side materialize, so no OAuth
+  // token or refresh token ever lives in this process beyond the returned bearer.
+  const mint = async () => {
+    const cred = await token(transport, baseUrl);
+    return {
+      access_token: cred.value,
+      // google-auth-library requires a numeric epoch expiry. Google always sends one;
+      // fall back to +1h so refresh timing stays well-defined for a static connector.
+      expiry_date: cred.expiresAt
+        ? Date.parse(cred.expiresAt)
+        : Date.now() + 3_600_000,
+    };
   };
+  client.refreshHandler = mint; // library calls this whenever it needs a fresh token
+  client.setCredentials(await mint()); // prime so the first request needs no round-trip guess
+  return client;
 }
 
 /**

--- a/packages/tools/src/google/index.ts
+++ b/packages/tools/src/google/index.ts
@@ -57,3 +57,54 @@ export async function token(
     { method: "POST" },
   );
 }
+
+/**
+ * The minimal structural shape a googleapis / google-auth-library `AuthClient`
+ * satisfies — the client libraries call `getRequestHeaders()` before each request to
+ * attach the bearer. Declared structurally (no `googleapis` import, no runtime
+ * dependency) so our object type-checks where an `AuthClient` is expected, by
+ * duck-typing at the call site. Returns exactly `{ Authorization: "Bearer <token>" }`.
+ */
+export interface AuthClientLike {
+  getRequestHeaders(): Promise<{ Authorization: string }>;
+}
+
+/**
+ * Refresh a cached credential this many ms BEFORE its `expiresAt`, so a token is
+ * never served on the edge of expiry (clock skew + in-flight request time).
+ */
+const REFRESH_SKEW_MS = 60_000;
+
+/**
+ * A googleapis-style auth client backed by server-side credential materialization.
+ * `getRequestHeaders()` returns a `Bearer` header for the tenant's Google connector,
+ * CACHING the last `LiveCredential` and only re-calling {@link token} when the cache
+ * is within {@link REFRESH_SKEW_MS} of its `expiresAt` — or on every call when the
+ * credential carries no `expiresAt`. This lets a long-running Google client survive a
+ * token refresh WITHOUT a materialize round-trip per request, and without serving a
+ * token past its expiry. The raw token is returned to the caller only — never logged,
+ * persisted, or written to env; the cache lives only in this object's closure.
+ *
+ * `now` is injectable purely for deterministic tests; production uses `Date.now`.
+ */
+export function authClient(
+  transport: Transport = defaultTransport(),
+  baseUrl: string = DEFAULT_BASE_URL,
+  now: () => number = Date.now,
+): AuthClientLike {
+  let cached: LiveCredential | undefined;
+
+  const isFresh = (cred: LiveCredential | undefined): cred is LiveCredential =>
+    cred !== undefined &&
+    typeof cred.expiresAt === "string" &&
+    Date.parse(cred.expiresAt) - now() > REFRESH_SKEW_MS;
+
+  return {
+    async getRequestHeaders() {
+      const current = isFresh(cached)
+        ? cached
+        : (cached = await token(transport, baseUrl));
+      return { Authorization: `Bearer ${current.value}` };
+    },
+  };
+}

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -174,4 +174,11 @@ export { KeysHttpError } from "./keys/index.js";
 export type { MintScopedInput, ScopedKey } from "./keys/index.js";
 
 export * as google from "./google/index.js";
-export type { LiveCredential, AuthClientLike } from "./google/index.js";
+export type {
+  AuthClientLike,
+  DriveFile,
+  DrivePermission,
+  DriveShareFileArgs,
+  DriveUploadFileArgs,
+  LiveCredential,
+} from "./google/index.js";

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -180,5 +180,8 @@ export type {
   DrivePermission,
   DriveShareFileArgs,
   DriveUploadFileArgs,
+  GmailAttachment,
   LiveCredential,
+  SendEmailArgs,
+  SendEmailResult,
 } from "./google/index.js";

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -174,4 +174,4 @@ export { KeysHttpError } from "./keys/index.js";
 export type { MintScopedInput, ScopedKey } from "./keys/index.js";
 
 export * as google from "./google/index.js";
-export type { LiveCredential } from "./google/index.js";
+export type { LiveCredential, AuthClientLike } from "./google/index.js";

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -175,7 +175,6 @@ export type { MintScopedInput, ScopedKey } from "./keys/index.js";
 
 export * as google from "./google/index.js";
 export type {
-  AuthClientLike,
   DriveFile,
   DrivePermission,
   DriveShareFileArgs,

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -185,3 +185,6 @@ export type {
   SendEmailArgs,
   SendEmailResult,
 } from "./google/index.js";
+
+export * as github from "./github/index.js";
+export type { ListReposArgs, GitHubRepo } from "./github/index.js";

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -172,3 +172,6 @@ export { VaultHttpError } from "./vault/index.js";
 export * as keys from "./keys/index.js";
 export { KeysHttpError } from "./keys/index.js";
 export type { MintScopedInput, ScopedKey } from "./keys/index.js";
+
+export * as google from "./google/index.js";
+export type { LiveCredential } from "./google/index.js";

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -83,6 +83,7 @@ describe("@sapiom/tools public surface", () => {
 
     expect(typeof sapiom.google).toBe("object");
     expect(typeof sapiom.google.token).toBe("function");
+    expect(typeof sapiom.google.authClient).toBe("function");
 
     expect(typeof sapiom.withAttribution).toBe("function");
   });

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -84,6 +84,9 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sapiom.google).toBe("object");
     expect(typeof sapiom.google.token).toBe("function");
     expect(typeof sapiom.google.authClient).toBe("function");
+    expect(typeof sapiom.google.drive).toBe("object");
+    expect(typeof sapiom.google.drive.shareFile).toBe("function");
+    expect(typeof sapiom.google.drive.uploadFile).toBe("function");
 
     expect(typeof sapiom.withAttribution).toBe("function");
   });

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -18,6 +18,7 @@ import {
   speech,
   browserAutomation,
   keys,
+  google,
   Sandbox,
   Repository,
   SearchHttpError,
@@ -80,6 +81,9 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sapiom.keys).toBe("object");
     expect(typeof sapiom.keys.mintScoped).toBe("function");
 
+    expect(typeof sapiom.google).toBe("object");
+    expect(typeof sapiom.google.token).toBe("function");
+
     expect(typeof sapiom.withAttribution).toBe("function");
   });
 
@@ -99,6 +103,7 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof speech).toBe("object");
     expect(typeof browserAutomation).toBe("object");
     expect(typeof keys).toBe("object");
+    expect(typeof google).toBe("object");
     expect(typeof SearchHttpError).toBe("function"); // error class constructor
     expect(typeof MemoryHttpError).toBe("function");
     expect(typeof SpeechHttpError).toBe("function");

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -19,6 +19,7 @@ import {
   browserAutomation,
   keys,
   google,
+  github,
   Sandbox,
   Repository,
   SearchHttpError,
@@ -90,6 +91,9 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sapiom.google.gmail).toBe("object");
     expect(typeof sapiom.google.gmail.sendEmail).toBe("function");
 
+    expect(typeof sapiom.github).toBe("object");
+    expect(typeof sapiom.github.listRepos).toBe("function");
+
     expect(typeof sapiom.withAttribution).toBe("function");
   });
 
@@ -110,6 +114,7 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof browserAutomation).toBe("object");
     expect(typeof keys).toBe("object");
     expect(typeof google).toBe("object");
+    expect(typeof github).toBe("object");
     expect(typeof SearchHttpError).toBe("function"); // error class constructor
     expect(typeof MemoryHttpError).toBe("function");
     expect(typeof SpeechHttpError).toBe("function");

--- a/packages/tools/src/smoke.spec.ts
+++ b/packages/tools/src/smoke.spec.ts
@@ -87,6 +87,8 @@ describe("@sapiom/tools public surface", () => {
     expect(typeof sapiom.google.drive).toBe("object");
     expect(typeof sapiom.google.drive.shareFile).toBe("function");
     expect(typeof sapiom.google.drive.uploadFile).toBe("function");
+    expect(typeof sapiom.google.gmail).toBe("object");
+    expect(typeof sapiom.google.gmail.sendEmail).toBe("function");
 
     expect(typeof sapiom.withAttribution).toBe("function");
   });

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -119,7 +119,12 @@ import type {
   ActiveSession,
 } from "../browser-automation/index.js";
 import type { ScopedKey } from "../keys/index.js";
-import type { LiveCredential, AuthClientLike } from "../google/index.js";
+import type {
+  LiveCredential,
+  AuthClientLike,
+  DrivePermission,
+  DriveFile,
+} from "../google/index.js";
 
 /**
  * Host used in the stub Postgres DSN.
@@ -1916,6 +1921,27 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
               Authorization: "Bearer ya29.stub-google-token",
             }),
         })) as AuthClientLike,
+      // Drive methods run server-side in the gateway in production; the stub returns
+      // shape-faithful, obviously-fake results so an offline run can exercise the call
+      // graph without a Google connector or network call.
+      drive: {
+        shareFile: (args) =>
+          Promise.resolve(
+            r("google.drive.shareFile", [args], () => ({
+              id: "stub-permission-id",
+              type: "user",
+              role: "reader",
+            })) as DrivePermission,
+          ),
+        uploadFile: (args) =>
+          Promise.resolve(
+            r("google.drive.uploadFile", [args], () => ({
+              id: "stub-file-id",
+              name: "stub-file.txt",
+              mimeType: "text/plain",
+            })) as DriveFile,
+          ),
+      },
     },
     speech: {
       textToSpeech: {

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -126,6 +126,7 @@ import type {
   DriveFile,
   SendEmailResult,
 } from "../google/index.js";
+import type { GitHubRepo } from "../github/index.js";
 
 /**
  * Host used in the stub Postgres DSN.
@@ -1955,6 +1956,24 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             })) as SendEmailResult,
           ),
       },
+    },
+    // GitHub methods run server-side in the gateway (the PAT is injected there) in
+    // production; the stub returns a shape-faithful, obviously-fake repo list so an
+    // offline run can exercise the call graph without a GitHub connector or network call.
+    github: {
+      listRepos: (args) =>
+        Promise.resolve(
+          r("github.listRepos", [args], () => [
+            {
+              id: 1,
+              name: "stub-repo",
+              fullName: "stub-org/stub-repo",
+              private: false,
+              htmlUrl: "https://github.com/stub-org/stub-repo",
+              description: "stub repository",
+            },
+          ]) as GitHubRepo[],
+        ),
     },
     speech: {
       textToSpeech: {

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -124,6 +124,7 @@ import type {
   AuthClientLike,
   DrivePermission,
   DriveFile,
+  SendEmailResult,
 } from "../google/index.js";
 
 /**
@@ -1940,6 +1941,18 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
               name: "stub-file.txt",
               mimeType: "text/plain",
             })) as DriveFile,
+          ),
+      },
+      // Gmail methods run server-side in the gateway in production; the stub returns a
+      // shape-faithful, obviously-fake send result so an offline run can exercise the
+      // call graph without a Google connector or network call.
+      gmail: {
+        sendEmail: (args) =>
+          Promise.resolve(
+            r("google.gmail.sendEmail", [args], () => ({
+              id: "stub-message-id",
+              threadId: "stub-thread-id",
+            })) as SendEmailResult,
           ),
       },
     },

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -119,6 +119,7 @@ import type {
   ActiveSession,
 } from "../browser-automation/index.js";
 import type { ScopedKey } from "../keys/index.js";
+import type { LiveCredential } from "../google/index.js";
 
 /**
  * Host used in the stub Postgres DSN.
@@ -1890,6 +1891,20 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
                 ? [input.scope]
                 : ["org.transactions.write"],
           })) as ScopedKey,
+        ),
+    },
+    // A live Google credential is fetched server-side in production; the stub returns
+    // a clearly-fake, shape-faithful bearer so an offline run can exercise the call
+    // graph. The `value` is an obvious placeholder, never a usable token.
+    google: {
+      token: () =>
+        Promise.resolve(
+          r("google.token", [], () => ({
+            kind: "bearer" as const,
+            value: "ya29.stub-google-token",
+            expiresAt: "2099-01-01T00:00:00.000Z",
+            baseUrl: "https://www.googleapis.com",
+          })) as LiveCredential,
         ),
     },
     speech: {

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -119,7 +119,7 @@ import type {
   ActiveSession,
 } from "../browser-automation/index.js";
 import type { ScopedKey } from "../keys/index.js";
-import type { LiveCredential } from "../google/index.js";
+import type { LiveCredential, AuthClientLike } from "../google/index.js";
 
 /**
  * Host used in the stub Postgres DSN.
@@ -1906,6 +1906,16 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             baseUrl: "https://www.googleapis.com",
           })) as LiveCredential,
         ),
+      // Shape-faithful auth client: `getRequestHeaders()` returns the same fake
+      // bearer, so an offline run drives a googleapis-style client without a network
+      // call. The `Authorization` value is an obvious placeholder, never usable.
+      authClient: () =>
+        r("google.authClient", [], () => ({
+          getRequestHeaders: () =>
+            Promise.resolve({
+              Authorization: "Bearer ya29.stub-google-token",
+            }),
+        })) as AuthClientLike,
     },
     speech: {
       textToSpeech: {

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -121,7 +121,6 @@ import type {
 import type { ScopedKey } from "../keys/index.js";
 import type {
   LiveCredential,
-  AuthClientLike,
   DrivePermission,
   DriveFile,
   SendEmailResult,
@@ -1913,16 +1912,33 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
             baseUrl: "https://www.googleapis.com",
           })) as LiveCredential,
         ),
-      // Shape-faithful auth client: `getRequestHeaders()` returns the same fake
-      // bearer, so an offline run drives a googleapis-style client without a network
-      // call. The `Authorization` value is an obvious placeholder, never usable.
-      authClient: () =>
-        r("google.authClient", [], () => ({
-          getRequestHeaders: () =>
-            Promise.resolve({
-              Authorization: "Bearer ya29.stub-google-token",
-            }),
-        })) as AuthClientLike,
+      // A REAL google-auth-library OAuth2 client wired to the stub's fake bearer — an
+      // offline `check`/run drives a genuine vendor-SDK client (googleapis, @googleapis/*)
+      // with no network and no Google connector. `google-auth-library` ships with those
+      // SDKs, so it is present whenever an agent references `authClient()`; absent it, the
+      // dynamic import throws the same clear error as production.
+      authClient: async () => {
+        r("google.authClient", [], () => "google-auth-library OAuth2Client (stub)");
+        let mod: typeof import("google-auth-library");
+        try {
+          mod = await import("google-auth-library");
+        } catch {
+          throw new Error(
+            "google.authClient() needs the 'google-auth-library' package, which ships with " +
+              "'googleapis' and the '@googleapis/*' clients — install one of those (e.g. " +
+              "`npm i @googleapis/drive`) to use the vendor SDKs. For a token-only path that " +
+              "needs no extra dependency, use google.token() instead.",
+          );
+        }
+        const client = new mod.OAuth2Client();
+        const mint = async () => ({
+          access_token: "ya29.stub-google-token",
+          expiry_date: Date.parse("2099-01-01T00:00:00.000Z"),
+        });
+        client.refreshHandler = mint;
+        client.setCredentials(await mint());
+        return client;
+      },
       // Drive methods run server-side in the gateway in production; the stub returns
       // shape-faithful, obviously-fake results so an offline run can exercise the call
       // graph without a Google connector or network call.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -779,6 +779,9 @@ importers:
       eslint:
         specifier: ^8.57.0
         version: 8.57.1
+      google-auth-library:
+        specifier: ^10.5.0
+        version: 10.9.1
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.43)
@@ -2575,6 +2578,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -2624,6 +2630,9 @@ packages:
 
   buffer-crc32@0.2.13:
     resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2867,6 +2876,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -3016,6 +3029,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -3234,6 +3250,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
@@ -3292,6 +3311,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   fetch-mock@12.6.0:
     resolution: {integrity: sha512-oAy0OqAvjAvduqCeWveBix7LLuDbARPqZZ8ERYtBcCURA3gy7EALA3XWq0tCNxsSg+RmmJqyaeeZlOCV9abv6w==}
@@ -3355,6 +3378,10 @@ packages:
     resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3409,6 +3436,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.3.1:
+    resolution: {integrity: sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -3482,6 +3517,14 @@ packages:
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -3934,6 +3977,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -3972,6 +4018,12 @@ packages:
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4337,6 +4389,15 @@ packages:
 
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -5488,6 +5549,10 @@ packages:
 
   weapon-regex@1.3.6:
     resolution: {integrity: sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   web-vitals@5.3.0:
     resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
@@ -7674,6 +7739,8 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  bignumber.js@9.3.1: {}
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -7754,6 +7821,8 @@ snapshots:
       node-int64: 0.4.0
 
   buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -8018,6 +8087,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   debug@2.6.9:
     dependencies:
       ms: 2.0.0
@@ -8152,6 +8223,10 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -8545,6 +8620,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   extendable-error@0.1.7: {}
 
   extract-zip@2.0.1:
@@ -8605,6 +8682,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   fetch-mock@12.6.0:
     dependencies:
@@ -8687,6 +8769,10 @@ snapshots:
       hasown: 2.0.4
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -8739,6 +8825,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.3.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.3.1
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -8839,6 +8941,19 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
+
+  google-auth-library@10.9.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.1
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -9451,6 +9566,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -9483,6 +9602,17 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -9791,6 +9921,14 @@ snapshots:
   node-api-version@0.2.1:
     dependencies:
       semver: 7.8.4
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-int64@0.4.0: {}
 
@@ -10829,6 +10967,8 @@ snapshots:
       defaults: 1.0.4
 
   weapon-regex@1.3.6: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   web-vitals@5.3.0: {}
 


### PR DESCRIPTION
## Summary
Adds the **Google and GitHub capability clients** to `@sapiom/tools` — the SDK half of the Capability Connectors work. An agent reaches them through `ctx.sapiom.google.*` and `ctx.sapiom.github.*`; the gateway injects and refreshes the vendor credential, so a Google/GitHub token never lives in agent code or the run environment.

## Changes
### `@sapiom/tools` (minor)
- **`google.token()`** — a short-lived Google bearer for the tenant's connected account, pulled on demand from the gateway materialize endpoint.
- **`google.authClient()`** — a real `google-auth-library` `OAuth2Client` that mints and refreshes through the gateway, so it drops straight into `googleapis` / `@googleapis/*`. `google-auth-library` is an **optional peer dependency**, loaded only when `authClient()` is called — a token-only integration pulls in nothing extra.
- **`google.drive.shareFile()` / `google.drive.uploadFile()`** and **`google.gmail.sendEmail()`** — Drive and Gmail actions execute server-side in the gateway; the Google token never reaches agent code.
- **`github.listRepos()`** — list repositories for a connected GitHub account (the static-key / `injected` provider).

### `@sapiom/agent-core` (patch)
- Local `check` and runs bundle with a `createRequire` banner, so dependencies that `require()` at runtime (e.g. `googleapis` / `google-auth-library`) resolve instead of failing esbuild's "Dynamic require not supported".

## Depends on the gateway series (runtime ordering)
This is the client side. The endpoints it calls ship in the stacked gateway series (internal gateway repo), and **those changes must be merged _and deployed_ before these capabilities work at runtime**:
- `token()` / `authClient()` → materialize endpoint (internal)
- `drive.*` / `gmail.sendEmail` / `github.listRepos` → server-side methods (internal)

Until the gateway endpoints are live in the target environment, `token()` / `authClient()` / the method calls have nothing to reach. The code and unit tests stand alone (mocked transport), so this PR is reviewable and mergeable on its own — but **do not publish or pin this `@sapiom/tools` version for real use until the gateway is deployed.** (`gmail.sendEmail` is additionally gated behind an internal feature flag, pending Google Sensitive-scope verification, per AGENT-313.)

Publishes as a new `@sapiom/tools` version (changeset included); the gateway monorepo pins it after release.

## Testing
- Unit: `google/index.spec.ts` (token/authClient/drive/gmail) + `github/index.spec.ts` — 668 `@sapiom/tools` + 191 `@sapiom/agent-core` tests, all green. typecheck + lint clean; both packages build (cjs + esm).
- [ ] Sandbox e2e against a test tenant (Drive list via `authClient`; server-side Gmail send) — on the local stack, alongside the gateway series.

## Related
- Closes: AGENT-311
- Refs: AGENT-312, AGENT-313, AGENT-314 (SDK client surfaces for the gateway epics)

## Checklist
- [x] Code follows project guidelines
- [x] Unit tests added/updated and passing
- [x] No hardcoded secrets
- [x] Self-reviewed
- [x] Sandbox e2e on the local stack (shared gate with the gateway series)
