### PR TITLE
feat(harness): version management in Agent Studio

### DIFF
--- a/.changeset/agent-core-archive-deploy.md
+++ b/.changeset/agent-core-archive-deploy.md
@@ -1,0 +1,31 @@
+---
+"@sapiom/agent-core": minor
+---
+
+Deploy by uploading a source archive instead of pushing to git.
+
+`deploy()` now packs the agent's raw source into a gzipped tar, uploads it, and
+builds the exact digest the server computed. No git repository, no push
+credential handed to the client, and no force-push erasing history — and
+`DeployOptions.message` finally lets a version carry a real label instead of the
+hardcoded `deploy` every push produced.
+
+Transport selection is **server-driven**: the archive path is tried first, and a
+409 from the upload route (the engine's own switch being off) is the one signal
+that falls back to the git push. A client-side toggle would be a second source of
+truth able to disagree with the engine. `DeployOptions.transport` pins one path
+for tests or a rollback.
+
+Two properties of the old path are deliberately preserved, because losing either
+would change what customers actually run: dependency versions are still pinned
+from the author's installed tree rather than shipped as ranges, and the archive
+contains exactly the files the entry reaches — read from esbuild's metafile, not
+a directory sweep.
+
+`packSource` refuses source that imports from outside the agent's own directory.
+esbuild inlined those files for the push path; a raw archive cannot, because
+relative imports must still resolve after extraction. It fails with
+`UNSUPPORTED_LAYOUT` rather than building an agent whose shared code is missing.
+
+Adds `createTarGz` — a minimal ustar writer, hand-rolled so a published SDK gains
+no dependency and does not shell out to a `tar` binary Windows lacks.

--- a/.changeset/agent-core-clone-archive.md
+++ b/.changeset/agent-core-clone-archive.md
@@ -1,0 +1,17 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Clone a deployed agent from its stored source, not from git.
+
+A deploy uploads an archive and no longer pushes, so the agent's repo is empty or
+frozen at whatever was last committed — a git clone handed back stale code with
+nothing to signal it. `clone` now reads the stored archive and extracts it,
+preserving nested layouts so relative imports still resolve in the checkout.
+
+Falls back to the git clone on a 404, so an agent that only ever deployed through
+the push path — or an engine older than the download route — keeps working.
+
+Adds a tar reader alongside the existing writer. Regular files only: a symlink or
+device node is refused rather than skipped, and any path that would escape the
+target directory is rejected before anything is written.

--- a/.changeset/agent-core-clone-flag-off.md
+++ b/.changeset/agent-core-clone-flag-off.md
@@ -1,0 +1,12 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Fall back to a git clone when archives are switched off, not just when absent.
+
+The engine ships with the source-archive flag OFF, so against a freshly deployed
+engine every `GET /source` returns 409, not 404. Handling only 404 meant `clone`
+failed outright at the exact stage of the rollout that is meant to change nothing.
+
+A 403 still propagates: falling back there would turn a real permission error into
+a stale checkout that looks like success.

--- a/.changeset/agent-core-layout-fallback.md
+++ b/.changeset/agent-core-layout-fallback.md
@@ -1,0 +1,11 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Fall back to the git transport when an agent's layout cannot be archived.
+
+An agent importing code from outside its own directory (a shared `kit/` a level
+up) deployed fine via the push path, because esbuild inlined those files. It now
+falls back instead of failing, so an author who upgrades the SDK does not lose a
+layout that previously worked. The transport metric still records these as `git`,
+so the remaining work stays visible rather than hidden.

--- a/.changeset/agent-core-pack-shared-code.md
+++ b/.changeset/agent-core-pack-shared-code.md
@@ -1,0 +1,18 @@
+---
+"@sapiom/agent-core": patch
+---
+
+Archive shared code instead of falling back to git for it.
+
+An agent importing from outside its own directory now uploads like any other: the
+archive is rooted at the lowest directory containing everything the entry
+imports, and the entry is declared relative to that root so the relative import
+still resolves after the server extracts it. Only the files the entry actually
+reaches are packed, so a higher root makes paths longer, never archives bigger.
+
+A flat agent is unaffected — no manifest is written when the entry is already
+`index.ts` at the root, keeping existing archives byte-identical and their
+digests stable, so redeploying unchanged code still stores nothing.
+
+`UNSUPPORTED_LAYOUT` now means only that the imports have no common parent short
+of the filesystem root; the git fallback remains for that case.

--- a/.changeset/cli-deploy-message.md
+++ b/.changeset/cli-deploy-message.md
@@ -1,0 +1,14 @@
+---
+"@sapiom/cli": minor
+---
+
+`sapiom agents deploy` gains `-m, --message` to label a version in history —
+previously every deploy was recorded as the hardcoded `deploy`.
+
+Also adds `--transport archive|git` as an escape hatch. The transport is normally
+decided by the server, so this exists for a rollback or for reproducing an issue,
+not as a routine choice. An unrecognised value is rejected rather than passed
+through, since it would otherwise silently take the default path — the opposite
+of pinning one.
+
+`--branch` now documents that it only applies to the git transport.

--- a/.changeset/mcp-deploy-message.md
+++ b/.changeset/mcp-deploy-message.md
@@ -1,0 +1,12 @@
+---
+"@sapiom/mcp": minor
+---
+
+`sapiom_dev_agents_deploy` gains an optional `message` to label a version in the
+agent's history.
+
+The tool description no longer claims a git repository with at least one commit
+is required — it isn't. Source is uploaded as an archive, and a server with
+archives switched off falls back to the old push transparently. That sentence
+mattered: an agent reading it would tell a user to run `git init` and `git commit`
+before deploying, which is now advice for a requirement that no longer exists.

--- a/packages/agent-core/src/__tests__/analytics-events.test.ts
+++ b/packages/agent-core/src/__tests__/analytics-events.test.ts
@@ -210,7 +210,7 @@ async function runHappyFlow(gatewayHost: string) {
   const client = createClient({ host: gatewayHost, apiKey: "sk_test" });
   const linked = await link({ name: "my-workflow" }, client);
   const deployed = await deploy(
-    { projectDir: "/tmp/fake-project", definitionId: linked.definitionId },
+    { projectDir: "/tmp/fake-project", definitionId: linked.definitionId, transport: "git" },
     client,
   );
   const started = await run({ definitionId: linked.definitionId }, client);

--- a/packages/agent-core/src/client.ts
+++ b/packages/agent-core/src/client.ts
@@ -83,6 +83,22 @@ export class GatewayClient {
   }
 
   /**
+   * POST raw bytes as `application/gzip` — the source-archive upload
+   * (AGENT-289). `path` is relative to `/v1/workflows`.
+   *
+   * Routed through {@link send} rather than a bare `fetch` so it inherits the one
+   * NETWORK / HTTP_* / 401-hint mapping. A separate method rather than a flag on
+   * {@link post}: a caller must state that it is sending an opaque body, never
+   * have it inferred from the value's runtime type.
+   *
+   * The shared request timeout applies unchanged: a source archive measures in
+   * kilobytes, so this is still a short round-trip.
+   */
+  postArchive<T = unknown>(path: string, archive: Uint8Array): Promise<T> {
+    return this.send<T>('POST', `${this.base}${path}`, archive, 'application/gzip');
+  }
+
+  /**
    * The single JSON request path — every method above funnels here so the
    * NETWORK / HTTP_* / 401-hint mapping is defined exactly once.
    *
@@ -95,13 +111,24 @@ export class GatewayClient {
    * deploy.ts's pollBuild — and streams go through openStream, which is
    * deliberately NOT bounded this way), so one generous cap fits all.
    */
-  private async send<T>(method: string, url: string, body?: unknown): Promise<T> {
+  private async send<T>(
+    method: string,
+    url: string,
+    body?: unknown,
+    /** Non-JSON media type; the body is then sent verbatim rather than stringified. */
+    contentType = 'application/json',
+  ): Promise<T> {
     let res: Response;
     try {
       res = await fetch(url, {
         method,
-        headers: { 'x-api-key': this.apiKey, 'content-type': 'application/json' },
-        body: body === undefined ? undefined : JSON.stringify(body),
+        headers: { 'x-api-key': this.apiKey, 'content-type': contentType },
+        body:
+          body === undefined
+            ? undefined
+            : contentType === 'application/json'
+              ? JSON.stringify(body)
+              : (body as Uint8Array),
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
     } catch (err) {

--- a/packages/agent-core/src/client.ts
+++ b/packages/agent-core/src/client.ts
@@ -99,6 +99,52 @@ export class GatewayClient {
   }
 
   /**
+   * GET raw bytes — the source-archive download that backs `clone` (AGENT-289).
+   * `path` is relative to `/v1/workflows`.
+   *
+   * Deliberately NOT routed through {@link send}: that path reads the response as
+   * text and JSON-parses it, which would corrupt gzip. It repeats the timeout and
+   * the error mapping instead of threading a response-decoding mode through the
+   * shared path for one caller.
+   *
+   * The HTTP_* codes match {@link send} exactly, because `clone` decides whether
+   * to fall back to git by inspecting `HTTP_404`.
+   */
+  async getArchive(path: string): Promise<Buffer> {
+    const url = `${this.base}${path}`;
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: 'GET',
+        headers: { 'x-api-key': this.apiKey },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (err) {
+      throw networkError(url, err);
+    }
+
+    if (!res.ok) {
+      // Body read as text: an error response is JSON even on this route.
+      const text = await res.text().catch(() => '');
+      const data = text ? safeParse(text) : undefined;
+      throw new AgentOperationError({
+        code: `HTTP_${res.status}`,
+        message: messageFrom(data) ?? `Request failed (${res.status} ${res.statusText}).`,
+        hint:
+          res.status === 401 || res.status === 403
+            ? 'Check your API key (`sapiom login` or SAPIOM_API_KEY) and that it has access to this agent.'
+            : undefined,
+      });
+    }
+
+    try {
+      return Buffer.from(await res.arrayBuffer());
+    } catch (err) {
+      throw networkError(url, err);
+    }
+  }
+
+  /**
    * The single JSON request path — every method above funnels here so the
    * NETWORK / HTTP_* / 401-hint mapping is defined exactly once.
    *

--- a/packages/agent-core/src/clone.spec.ts
+++ b/packages/agent-core/src/clone.spec.ts
@@ -259,6 +259,48 @@ describe("clone", () => {
     }
   });
 
+  it("falls back to a git clone when archives are switched off (409)", async () => {
+    // The engine ships with the flag OFF, so against a freshly deployed engine
+    // EVERY clone gets a 409 — not a 404. Handling only 404 broke clone outright
+    // at the exact stage of the rollout that is meant to change nothing.
+    const spy = mockFetch([
+      { status: 409, body: { message: "Source archives are disabled." } },
+      { status: 200, body: DEFINITION_TOKEN_BODY },
+    ]);
+    const base = makeTmp();
+    const target = path.join(base, "project");
+    const rec = recordingClone();
+    try {
+      await clone({ definitionId: "253", targetDir: target, cloneRepo: rec.fn }, client);
+
+      const urls = spy.mock.calls.map((c) => (c as [string])[0]);
+      expect(urls).toEqual([
+        "https://example.com/v1/workflows/definitions/253/source",
+        "https://example.com/v1/workflows/definitions/253/clone-token",
+      ]);
+      expect(rec.calls).toHaveLength(1);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT fall back when the archive read is genuinely forbidden", async () => {
+    // A 403 is a real error. Falling back would turn it into a stale checkout that
+    // looks like a success, which is the failure mode this whole rewire exists to
+    // remove.
+    mockFetch([{ status: 403, body: { message: "no access" } }]);
+    const base = makeTmp();
+    const rec = recordingClone();
+    try {
+      await expect(
+        clone({ definitionId: "253", targetDir: path.join(base, "project"), cloneRepo: rec.fn }, client),
+      ).rejects.toMatchObject({ code: "HTTP_403" });
+      expect(rec.calls).toHaveLength(0);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
   it("falls back to a git clone when the agent has no stored archive", async () => {
     // An agent that only ever deployed through the push path, or an engine older
     // than the download route: 404 means "no archive", so the git clone still

--- a/packages/agent-core/src/clone.spec.ts
+++ b/packages/agent-core/src/clone.spec.ts
@@ -19,12 +19,14 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createClient } from "./client";
+import { createTarGz } from "./tar";
 import { clone } from "./clone";
 import { CONFIG_FILE } from "./config";
 import { AgentOperationError } from "./errors";
 import type { CloneRepoOptions } from "./git";
 
-type MockResponse = { status: number; body: unknown };
+/** `archive` for the raw-bytes download route; `body` for every JSON route. */
+type MockResponse = { status: number; body?: unknown; archive?: Buffer };
 
 function mockFetch(responses: MockResponse[]): jest.SpyInstance {
   let i = 0;
@@ -36,7 +38,14 @@ function mockFetch(responses: MockResponse[]): jest.SpyInstance {
       status: r.status,
       statusText: r.status === 200 ? "OK" : "Error",
       text: async () => text,
-    } as Response;
+      arrayBuffer: async () => {
+        if (!r.archive) throw new Error("mockFetch: this response has no archive body.");
+        return r.archive.buffer.slice(
+          r.archive.byteOffset,
+          r.archive.byteOffset + r.archive.byteLength,
+        );
+      },
+    } as unknown as Response;
   }) as never);
 }
 
@@ -212,8 +221,16 @@ describe("clone", () => {
     }
   });
 
-  it("clones by definitionId directly (no fork step), and pre-links sapiom.json", async () => {
-    const spy = mockFetch([{ status: 200, body: DEFINITION_TOKEN_BODY }]);
+  it("clones a deployed agent from its stored archive, with no repo and no git", async () => {
+    // Since AGENT-289 a deploy uploads source and does not push, so the agent's
+    // repo is empty or frozen. Cloning must read the archive, or it hands back
+    // stale code with nothing to signal it.
+    const archive = createTarGz([
+      { path: "agent/index.ts", content: "export default 1;\n" },
+      { path: "shared/util.ts", content: "export const util = 2;\n" },
+      { path: ".sapiom-source.json", content: '{"entry":"agent/index.ts"}\n' },
+    ]);
+    const spy = mockFetch([{ status: 200, archive }]);
     const base = makeTmp();
     const target = path.join(base, "project");
     const rec = recordingClone();
@@ -223,9 +240,46 @@ describe("clone", () => {
         client,
       );
 
-      // Hits the definitions clone-token endpoint directly — no fork call.
+      // One request, to the source route. No fork, no clone-token, no credential.
+      const urls = spy.mock.calls.map((c) => (c as [string])[0]);
+      expect(urls).toEqual(["https://example.com/v1/workflows/definitions/253/source"]);
+      expect(rec.calls).toHaveLength(0);
+
+      // The nested layout is restored verbatim, so the relative import between
+      // the two files still resolves in the checkout.
+      expect(readFileSync(path.join(target, "agent", "index.ts"), "utf8")).toBe("export default 1;\n");
+      expect(readFileSync(path.join(target, "shared", "util.ts"), "utf8")).toBe("export const util = 2;\n");
+
+      // Pre-linked, and with no repo there is no repoFullName or branch to record.
+      expect(result).toEqual({ definitionId: "253", targetDir: target });
+      const cfg = JSON.parse(readFileSync(path.join(target, CONFIG_FILE), "utf8"));
+      expect(cfg).toEqual({ definitionId: "253" });
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to a git clone when the agent has no stored archive", async () => {
+    // An agent that only ever deployed through the push path, or an engine older
+    // than the download route: 404 means "no archive", so the git clone still
+    // runs and such an agent keeps cloning exactly as before.
+    const spy = mockFetch([
+      { status: 404, body: { message: "no source" } },
+      { status: 200, body: DEFINITION_TOKEN_BODY },
+    ]);
+    const base = makeTmp();
+    const target = path.join(base, "project");
+    const rec = recordingClone();
+    try {
+      const result = await clone(
+        { definitionId: "253", targetDir: target, cloneRepo: rec.fn },
+        client,
+      );
+
+      // Tries the archive first, then the clone-token — and never forks.
       const urls = spy.mock.calls.map((c) => (c as [string])[0]);
       expect(urls).toEqual([
+        "https://example.com/v1/workflows/definitions/253/source",
         "https://example.com/v1/workflows/definitions/253/clone-token",
       ]);
 

--- a/packages/agent-core/src/clone.ts
+++ b/packages/agent-core/src/clone.ts
@@ -337,10 +337,20 @@ export async function clone(
 /**
  * Materialise a deployed agent from its stored source archive.
  *
- * Returns false when the agent has no archive to read (HTTP 404), which is the
- * caller's signal to fall back to the git clone. Every other failure propagates:
- * a 403 or a corrupt archive is a real error, and silently falling back would
- * turn it into a stale checkout that looks like a success.
+ * Returns false when this server cannot give us an archive, which is the caller's
+ * signal to fall back to the git clone:
+ *
+ *   404 — no archive for this agent, or an engine older than the route.
+ *   409 — archives are switched off, or this tenant is not in the rollout yet.
+ *
+ * 409 matters as much as 404 and is easier to miss: the engine ships with the
+ * flag OFF, so against a freshly deployed engine EVERY clone gets a 409. Handling
+ * only 404 would have broken clone outright at exactly the stage that is supposed
+ * to be a no-op. The deploy path treats both the same way, for the same reason.
+ *
+ * Every other failure propagates: a 403 or a corrupt archive is a real error, and
+ * silently falling back would turn it into a stale checkout that looks like
+ * success.
  */
 async function cloneFromArchive(
   client: GatewayClient,
@@ -351,7 +361,12 @@ async function cloneFromArchive(
   try {
     archive = await client.getArchive(`/definitions/${encodeURIComponent(definitionId)}/source`);
   } catch (error) {
-    if (error instanceof AgentOperationError && error.code === "HTTP_404") return false;
+    if (
+      error instanceof AgentOperationError &&
+      (error.code === "HTTP_404" || error.code === "HTTP_409")
+    ) {
+      return false;
+    }
     throw error;
   }
 

--- a/packages/agent-core/src/clone.ts
+++ b/packages/agent-core/src/clone.ts
@@ -42,6 +42,7 @@ import {
   readdirSync,
   renameSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import path from "node:path";
 
@@ -49,6 +50,7 @@ import { GatewayClient } from "./client.js";
 import { writeConfig } from "./config.js";
 import { AgentOperationError } from "./errors.js";
 import { cloneRepo as defaultCloneRepo, type CloneRepoOptions } from "./git.js";
+import { readTarGz } from "./tar.js";
 
 /** Response of `POST /v1/workflows/templates/:id/fork`. */
 interface ForkTemplateResponse {
@@ -134,14 +136,18 @@ export interface CloneResult {
    * already pre-linked (see {@link CloneOptions.definitionId}).
    */
   definitionId?: string;
-  /** Full repo name `owner/repo` of the cloned repo. */
-  repoFullName: string;
-  /** Default branch checked out. */
-  defaultBranch: string;
+  /**
+   * Full repo name `owner/repo` — ABSENT when the source came from the object
+   * store, which is the normal case for a deployed agent since AGENT-289: there
+   * is no repo, no branch and no clone token involved.
+   */
+  repoFullName?: string;
+  /** Default branch checked out. Absent for an archive clone. */
+  defaultBranch?: string;
   /** Local directory the repo was cloned into. */
   targetDir: string;
-  /** ISO-8601 expiry of the (now-discarded) clone token, for observability. */
-  tokenExpiresAt: string;
+  /** ISO-8601 expiry of the (now-discarded) clone token. Absent for an archive clone. */
+  tokenExpiresAt?: string;
 }
 
 /**
@@ -191,6 +197,22 @@ export async function clone(
         code: "DIR_NOT_EMPTY",
         message: `Target directory '${targetDir}' already exists and is not empty.`,
       });
+    }
+  }
+
+  // 0. A deployed agent's source lives in the object store, not in a repo. Read
+  // it from there first: since AGENT-289 a deploy uploads an archive and does not
+  // push, so the `ag-*` repo is empty or frozen at whatever was last committed —
+  // a git clone would hand back stale code without any error to notice.
+  //
+  // Falls back to the git clone when there is no archive (404): an agent that
+  // only ever deployed through the push path, or an engine older than the
+  // download route.
+  if (definitionId) {
+    const cloned = await cloneFromArchive(client, definitionId, targetDir);
+    if (cloned) {
+      writeConfig(targetDir, { definitionId });
+      return { definitionId, targetDir };
     }
   }
 
@@ -310,4 +332,61 @@ export async function clone(
     targetDir,
     tokenExpiresAt: token.expiresAt,
   };
+}
+
+/**
+ * Materialise a deployed agent from its stored source archive.
+ *
+ * Returns false when the agent has no archive to read (HTTP 404), which is the
+ * caller's signal to fall back to the git clone. Every other failure propagates:
+ * a 403 or a corrupt archive is a real error, and silently falling back would
+ * turn it into a stale checkout that looks like a success.
+ */
+async function cloneFromArchive(
+  client: GatewayClient,
+  definitionId: string,
+  targetDir: string,
+): Promise<boolean> {
+  let archive: Buffer;
+  try {
+    archive = await client.getArchive(`/definitions/${encodeURIComponent(definitionId)}/source`);
+  } catch (error) {
+    if (error instanceof AgentOperationError && error.code === "HTTP_404") return false;
+    throw error;
+  }
+
+  const files = readTarGz(archive);
+  if (files.length === 0) {
+    throw new AgentOperationError({
+      code: "EMPTY_SOURCE",
+      message: `The stored source for agent ${definitionId} contains no files.`,
+    });
+  }
+
+  // Staged in a sibling and moved, matching the git path: a failure part-way
+  // through must not leave a half-written checkout in the target, and Studio's
+  // existing `.sapiom/` has to survive.
+  const parent = path.dirname(path.resolve(targetDir));
+  mkdirSync(parent, { recursive: true });
+  const staged = mkdtempSync(path.join(parent, ".sapiom-clone-"));
+  try {
+    for (const file of files) {
+      if (file.path === ".sapiom" || file.path.startsWith(".sapiom/")) {
+        throw new AgentOperationError({
+          code: "STUDIO_STATE_CONFLICT",
+          message: "The stored source contains a reserved .sapiom path.",
+        });
+      }
+      const target = path.join(staged, file.path);
+      mkdirSync(path.dirname(target), { recursive: true });
+      writeFileSync(target, file.content, "utf8");
+    }
+    mkdirSync(targetDir, { recursive: true });
+    for (const entry of readdirSync(staged)) {
+      renameSync(path.join(staged, entry), path.join(targetDir, entry));
+    }
+  } finally {
+    rmSync(staged, { recursive: true, force: true });
+  }
+  return true;
 }

--- a/packages/agent-core/src/deploy-transport.spec.ts
+++ b/packages/agent-core/src/deploy-transport.spec.ts
@@ -71,6 +71,20 @@ describe('deploy transport selection', () => {
     expect(build?.[1]).toEqual({ digest: 'a'.repeat(64), message: 'fix retry backoff' });
   });
 
+  it('falls back when the engine predates the upload route (404)', async () => {
+    // The case that actually happens: the CLI ships on npm independently of the
+    // engine deploy, so a user can be on a new SDK against an old engine. Without
+    // this their deploy fails outright rather than using the path that still works.
+    const client = makeClient({
+      uploadFails: new AgentOperationError({ code: 'HTTP_404', message: 'Cannot POST /source' }),
+    });
+    const result = await load()(OPTS, client as unknown as GatewayClient);
+
+    expect(result.status).toBe('ready');
+    const posts = client.post.mock.calls as Array<[string, ...unknown[]]>;
+    expect(posts.filter(([p]) => p.includes('push-credentials'))).toHaveLength(1);
+  });
+
   it('falls back to the git push when the server reports archives disabled', async () => {
     const client = makeClient({
       uploadFails: new AgentOperationError({ code: 'HTTP_409', message: 'disabled' }),
@@ -86,7 +100,7 @@ describe('deploy transport selection', () => {
     // A rejected archive (400) or an auth problem (401) is a real error the author
     // must see. Falling back would hide it and silently deploy by a different
     // route — the transport is not a retry strategy for genuine failures.
-    for (const code of ['HTTP_400', 'HTTP_401', 'NETWORK']) {
+    for (const code of ['HTTP_400', 'HTTP_401', 'HTTP_500', 'NETWORK']) {
       const client = makeClient({ uploadFails: new AgentOperationError({ code, message: code }) });
       await expect(load()(OPTS, client as unknown as GatewayClient)).rejects.toMatchObject({ code });
       const posts = client.post.mock.calls as Array<[string, ...unknown[]]>;

--- a/packages/agent-core/src/deploy-transport.spec.ts
+++ b/packages/agent-core/src/deploy-transport.spec.ts
@@ -1,0 +1,113 @@
+/**
+ * Transport selection for deploy (AGENT-289).
+ *
+ * The behaviour under test is the fallback rule: try the archive upload, and drop
+ * back to the git push ONLY when the server says archives are off. That signal is
+ * server-side on purpose — a client-side toggle would be a second source of truth
+ * able to disagree with the engine's own switch — so these tests drive it entirely
+ * through the response the fake client returns.
+ */
+import { AgentOperationError } from './errors';
+
+jest.mock('./git.js', () => ({
+  assertDeployable: jest.fn(),
+  pushSynthesizedTree: jest.fn(),
+  pushHead: jest.fn(),
+}));
+jest.mock('./bundle.js', () => ({
+  bundleForDeploy: jest.fn(async () => ({ code: 'export {};', dependencies: {} })),
+}));
+jest.mock('./pack-source.js', () => ({
+  packSource: jest.fn(async () => ({
+    archive: Buffer.from('fake-archive'),
+    files: ['index.ts', 'package.json'],
+    dependencies: {},
+  })),
+}));
+
+import type { GatewayClient } from './client';
+
+/** A client whose `/source` upload either succeeds or fails with a given error. */
+function makeClient(opts: { uploadFails?: AgentOperationError } = {}) {
+  return {
+    postArchive: jest.fn(async () => {
+      if (opts.uploadFails) throw opts.uploadFails;
+      return { digest: 'a'.repeat(64), sizeBytes: 12, entryCount: 2, deduped: false };
+    }),
+    post: jest.fn(async (path: string, body?: unknown) => {
+      void body;
+      if (path.includes('push-credentials')) return { pushUrl: 'https://x@example.invalid/r.git' };
+      return { buildRunId: 'build_1' };
+    }),
+    get: jest.fn(async () => ({ status: 'ready' })),
+  };
+}
+
+const load = () => (require('./deploy.js') as typeof import('./deploy.js')).deploy;
+const OPTS = { projectDir: '/tmp/fake-project', definitionId: 'def_1' };
+
+afterEach(() => jest.clearAllMocks());
+
+describe('deploy transport selection', () => {
+  it('uploads an archive by default and never mints a push credential', async () => {
+    const client = makeClient();
+    const result = await load()(OPTS, client as unknown as GatewayClient);
+
+    expect(result.status).toBe('ready');
+    expect(client.postArchive).toHaveBeenCalledTimes(1);
+    // The point of the redesign: no credential is ever handed to the client.
+    const posts = client.post.mock.calls as Array<[string, ...unknown[]]>;
+    expect(posts.filter(([p]) => p.includes('push-credentials'))).toHaveLength(0);
+  });
+
+  it('builds the digest the SERVER returned, with the author message', async () => {
+    const client = makeClient();
+    await load()({ ...OPTS, message: 'fix retry backoff' }, client as unknown as GatewayClient);
+
+    const build = (client.post.mock.calls as Array<[string, unknown]>).find(([p]) =>
+      p.endsWith('/builds'),
+    );
+    // Never a locally-computed digest: the server hashes what it actually received.
+    expect(build?.[1]).toEqual({ digest: 'a'.repeat(64), message: 'fix retry backoff' });
+  });
+
+  it('falls back to the git push when the server reports archives disabled', async () => {
+    const client = makeClient({
+      uploadFails: new AgentOperationError({ code: 'HTTP_409', message: 'disabled' }),
+    });
+    const result = await load()(OPTS, client as unknown as GatewayClient);
+
+    expect(result.status).toBe('ready');
+    const posts = client.post.mock.calls as Array<[string, ...unknown[]]>;
+    expect(posts.filter(([p]) => p.includes('push-credentials'))).toHaveLength(1);
+  });
+
+  it('does NOT fall back on an unrelated upload failure', async () => {
+    // A rejected archive (400) or an auth problem (401) is a real error the author
+    // must see. Falling back would hide it and silently deploy by a different
+    // route — the transport is not a retry strategy for genuine failures.
+    for (const code of ['HTTP_400', 'HTTP_401', 'NETWORK']) {
+      const client = makeClient({ uploadFails: new AgentOperationError({ code, message: code }) });
+      await expect(load()(OPTS, client as unknown as GatewayClient)).rejects.toMatchObject({ code });
+      const posts = client.post.mock.calls as Array<[string, ...unknown[]]>;
+      expect(posts.filter(([p]) => p.includes('push-credentials'))).toHaveLength(0);
+      jest.clearAllMocks();
+    }
+  });
+
+  it('surfaces the 409 instead of falling back when archive is pinned', async () => {
+    const client = makeClient({
+      uploadFails: new AgentOperationError({ code: 'HTTP_409', message: 'disabled' }),
+    });
+    await expect(
+      load()({ ...OPTS, transport: 'archive' }, client as unknown as GatewayClient),
+    ).rejects.toMatchObject({ code: 'HTTP_409' });
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('never attempts an upload when git is pinned', async () => {
+    const client = makeClient();
+    await load()({ ...OPTS, transport: 'git' }, client as unknown as GatewayClient);
+    expect(client.postArchive).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-core/src/deploy-transport.spec.ts
+++ b/packages/agent-core/src/deploy-transport.spec.ts
@@ -71,6 +71,23 @@ describe('deploy transport selection', () => {
     expect(build?.[1]).toEqual({ digest: 'a'.repeat(64), message: 'fix retry backoff' });
   });
 
+  it('falls back when the agent imports code outside its own directory', async () => {
+    // An existing agent with a shared `kit/` a level up deployed fine via the push
+    // path, because esbuild inlined it. It must keep deploying — an author who
+    // upgrades the SDK did not ask for their layout to stop working.
+    const { packSource } = require('./pack-source.js') as { packSource: jest.Mock };
+    packSource.mockRejectedValueOnce(
+      new AgentOperationError({ code: 'UNSUPPORTED_LAYOUT', message: 'imports outside' }),
+    );
+    const client = makeClient();
+    const result = await load()(OPTS, client as unknown as GatewayClient);
+
+    expect(result.status).toBe('ready');
+    expect(client.postArchive).not.toHaveBeenCalled();
+    const posts = client.post.mock.calls as Array<[string, ...unknown[]]>;
+    expect(posts.filter(([p]) => p.includes('push-credentials'))).toHaveLength(1);
+  });
+
   it('falls back when the engine predates the upload route (404)', async () => {
     // The case that actually happens: the CLI ships on npm independently of the
     // engine deploy, so a user can be on a new SDK against an old engine. Without

--- a/packages/agent-core/src/deploy.spec.ts
+++ b/packages/agent-core/src/deploy.spec.ts
@@ -107,7 +107,7 @@ describe('deploy — push retry on auth failure', () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { deploy } = require('./deploy.js') as typeof import('./deploy.js');
     const result = await deploy(
-      { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main' },
+      { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main', transport: 'git' },
       client as unknown as GatewayClient,
     );
 
@@ -143,7 +143,7 @@ describe('deploy — push retry on auth failure', () => {
     const { deploy } = require('./deploy.js') as typeof import('./deploy.js');
     await expect(
       deploy(
-        { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main' },
+        { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main', transport: 'git' },
         client as unknown as GatewayClient,
       ),
     ).rejects.toMatchObject({ code: 'GIT', hint: expect.stringContaining('rejected') });
@@ -185,7 +185,7 @@ describe('deploy — push retry on auth failure', () => {
     const { deploy } = require('./deploy.js') as typeof import('./deploy.js');
     await expect(
       deploy(
-        { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main' },
+        { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main', transport: 'git' },
         client as unknown as GatewayClient,
       ),
     ).rejects.toMatchObject({ code: 'GIT', hint: expect.stringContaining('retry') });
@@ -223,7 +223,7 @@ describe('deploy — superseded build messaging', () => {
     const { deploy } = require('./deploy.js') as typeof import('./deploy.js');
     await expect(
       deploy(
-        { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main' },
+        { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main', transport: 'git' },
         client as unknown as GatewayClient,
       ),
     ).rejects.toMatchObject({
@@ -242,7 +242,7 @@ describe('deploy — superseded build messaging', () => {
     const { deploy } = require('./deploy.js') as typeof import('./deploy.js');
     await expect(
       deploy(
-        { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main' },
+        { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main', transport: 'git' },
         client as unknown as GatewayClient,
       ),
     ).rejects.toMatchObject({
@@ -261,7 +261,7 @@ describe('deploy — superseded build messaging', () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { deploy } = require('./deploy.js') as typeof import('./deploy.js');
     const result = await deploy(
-      { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main' },
+      { projectDir: makeTmpDir(), definitionId: 'def_1', branch: 'main', transport: 'git' },
       client as unknown as GatewayClient,
     );
     expect(result.status).toBe('ready');

--- a/packages/agent-core/src/deploy.ts
+++ b/packages/agent-core/src/deploy.ts
@@ -11,6 +11,7 @@ import path from "node:path";
 
 import { getOrchestrationAnalytics, telemetryErrorCode } from "./analytics.js";
 import { bundleForDeploy } from "./bundle.js";
+import { packSource } from "./pack-source.js";
 import { GatewayClient } from "./client.js";
 import { AgentOperationError } from "./errors.js";
 import { assertDeployable, pushHead, pushSynthesizedTree } from "./git.js";
@@ -51,8 +52,22 @@ export interface DeployOptions {
   projectDir: string;
   /** Server-side definition ID (from sapiom.json or resolved by the caller). */
   definitionId: string;
-  /** Branch to push to; defaults to 'main'. */
+  /** Branch to push to; defaults to 'main'. Only used by the git transport. */
   branch?: string;
+  /**
+   * Version label recorded against this deploy (AGENT-289). What version history
+   * shows instead of the hardcoded `deploy` every push produced.
+   */
+  message?: string;
+  /**
+   * Force a transport instead of auto-selecting.
+   *
+   * Default behaviour tries `archive` and falls back to `git` when the server
+   * says archives are not enabled. Deliberately server-driven: a client-side
+   * flag would be a second source of truth that could disagree with the engine's
+   * own switch. Set explicitly only to pin one path — tests, or a rollback.
+   */
+  transport?: "archive" | "git";
 }
 
 export interface DeployResult {
@@ -104,6 +119,64 @@ export async function deploy(
 
 /** The operation body — unchanged from before the analytics wrapper. */
 async function deployOperation(
+  opts: DeployOptions,
+  client: GatewayClient,
+): Promise<DeployResult> {
+  const { definitionId, transport } = opts;
+
+  // Archive first unless pinned to git. A 409 from the upload route means the
+  // engine has archives switched off (or not configured), which is the ONE
+  // signal that decides the transport — so there is no client flag to drift out
+  // of step with the server.
+  if (transport !== "git") {
+    try {
+      return await deployArchive(opts, client);
+    } catch (err) {
+      const disabled = err instanceof AgentOperationError && err.code === "HTTP_409";
+      if (transport === "archive" || !disabled) throw err;
+      // else: fall through to the git path below
+    }
+  }
+
+  return deployGitPush(opts, client);
+}
+
+/**
+ * Git-free deploy: pack the raw source, upload it, build the exact digest.
+ *
+ * No git repository, no push credential, no force-push. The digest is returned
+ * by the server, not asserted by us — it decides where the bytes are stored and
+ * becomes the version identity, so the server computes it from what it actually
+ * received.
+ */
+async function deployArchive(
+  opts: DeployOptions,
+  client: GatewayClient,
+): Promise<DeployResult> {
+  const { projectDir, definitionId, message } = opts;
+
+  const { archive } = await packSource(projectDir);
+  const { digest } = await client.postArchive<{ digest: string }>(
+    `/definitions/${definitionId}/source`,
+    archive,
+  );
+
+  const triggered = await client.post<BuildRun>(`/definitions/${definitionId}/builds`, {
+    digest,
+    ...(message ? { message } : {}),
+  });
+  const buildRunId = triggered.buildRunId ?? triggered.id;
+  if (!buildRunId) {
+    throw new AgentOperationError({
+      code: "BUILD_NO_ID",
+      message: "The build was triggered but no build id was returned.",
+    });
+  }
+  return settleBuild(client, definitionId, buildRunId);
+}
+
+/** The original push-a-synthesized-tree deploy, retained for rollback and older engines. */
+async function deployGitPush(
   opts: DeployOptions,
   client: GatewayClient,
 ): Promise<DeployResult> {
@@ -174,6 +247,15 @@ async function deployOperation(
     });
   }
 
+  return settleBuild(client, definitionId, buildRunId);
+}
+
+/** Poll to terminal and translate a non-ready outcome. Shared by both transports. */
+async function settleBuild(
+  client: GatewayClient,
+  definitionId: string,
+  buildRunId: string,
+): Promise<DeployResult> {
   const final = await pollBuild(client, definitionId, buildRunId);
   if (final.status !== "ready") {
     if (final.status === "superseded") {

--- a/packages/agent-core/src/deploy.ts
+++ b/packages/agent-core/src/deploy.ts
@@ -139,9 +139,17 @@ async function deployOperation(
       //       independently of the engine deploy, so a user can upgrade the SDK
       //       first. Without it, that user's deploy fails outright instead of
       //       falling back.
-      const cannotAcceptArchives =
-        err instanceof AgentOperationError && (err.code === "HTTP_409" || err.code === "HTTP_404");
-      if (transport === "archive" || !cannotAcceptArchives) throw err;
+      // UNSUPPORTED_LAYOUT is the CLIENT-side equivalent: this agent imports code
+      // from outside its own directory, which a raw archive cannot represent.
+      // esbuild inlined those files for the push path, so the git transport still
+      // handles it — and falling back means such an agent keeps deploying exactly
+      // as before instead of failing on an upgrade the author did not ask for.
+      // The transport metric still shows it as `git`, so this defers the work
+      // rather than hiding it.
+      const archiveNotUsable =
+        err instanceof AgentOperationError &&
+        (err.code === "HTTP_409" || err.code === "HTTP_404" || err.code === "UNSUPPORTED_LAYOUT");
+      if (transport === "archive" || !archiveNotUsable) throw err;
       // else: fall through to the git path below
     }
   }

--- a/packages/agent-core/src/deploy.ts
+++ b/packages/agent-core/src/deploy.ts
@@ -139,13 +139,13 @@ async function deployOperation(
       //       independently of the engine deploy, so a user can upgrade the SDK
       //       first. Without it, that user's deploy fails outright instead of
       //       falling back.
-      // UNSUPPORTED_LAYOUT is the CLIENT-side equivalent: this agent imports code
-      // from outside its own directory, which a raw archive cannot represent.
-      // esbuild inlined those files for the push path, so the git transport still
-      // handles it — and falling back means such an agent keeps deploying exactly
-      // as before instead of failing on an upgrade the author did not ask for.
-      // The transport metric still shows it as `git`, so this defers the work
-      // rather than hiding it.
+      // UNSUPPORTED_LAYOUT no longer covers shared code above the agent
+      // directory — that is packed now, rooted at the common parent. What is left
+      // is the pathological case: imports with no common parent short of the
+      // filesystem root. The git path inlines everything into one file, so it can
+      // still deploy that; falling back beats refusing a deploy that worked
+      // yesterday. The transport metric still reports `git`, so it stays visible
+      // rather than hidden.
       const archiveNotUsable =
         err instanceof AgentOperationError &&
         (err.code === "HTTP_409" || err.code === "HTTP_404" || err.code === "UNSUPPORTED_LAYOUT");

--- a/packages/agent-core/src/deploy.ts
+++ b/packages/agent-core/src/deploy.ts
@@ -132,8 +132,16 @@ async function deployOperation(
     try {
       return await deployArchive(opts, client);
     } catch (err) {
-      const disabled = err instanceof AgentOperationError && err.code === "HTTP_409";
-      if (transport === "archive" || !disabled) throw err;
+      // 409 — the route exists and the engine has archives switched off.
+      // 404 — the route does not exist at all, i.e. an engine older than this
+      //       SDK. Both mean "this server cannot take an archive", and 404 is the
+      //       one that actually happens in the wild: the CLI is published to npm
+      //       independently of the engine deploy, so a user can upgrade the SDK
+      //       first. Without it, that user's deploy fails outright instead of
+      //       falling back.
+      const cannotAcceptArchives =
+        err instanceof AgentOperationError && (err.code === "HTTP_409" || err.code === "HTTP_404");
+      if (transport === "archive" || !cannotAcceptArchives) throw err;
       // else: fall through to the git path below
     }
   }

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -187,3 +187,7 @@ export type {
   LocalStepTraceSink,
   LogEntry,
 } from "./local/dispatcher.js";
+export { packSource } from './pack-source.js';
+export type { SourcePackage } from './pack-source.js';
+export { createTarGz } from './tar.js';
+export type { TarFile } from './tar.js';

--- a/packages/agent-core/src/pack-source.spec.ts
+++ b/packages/agent-core/src/pack-source.spec.ts
@@ -97,23 +97,38 @@ describe("packSource", () => {
     expect(packed.files.some((f) => f.includes("node_modules"))).toBe(false);
   });
 
-  it("refuses source that escapes the project directory instead of silently dropping it", async () => {
-    // esbuild INLINED these for the push path, so the old transport handled them.
-    // A raw archive cannot: relative imports must still resolve after extraction,
-    // and the server looks for the entry at the archive root. Failing loudly beats
-    // building an agent whose shared code is missing.
-    const shared = path.join(root, "..", `shared-${path.basename(root)}`);
-    mkdirSync(shared, { recursive: true });
-    try {
-      writeFileSync(path.join(shared, "util.ts"), "export const util = 1;\n");
-      write("agent/index.ts", `import { util } from '${path.join(shared, "util.js")}';\nexport default util;\n`);
+  it("packs source from above the agent directory, rooting the archive at the common parent", async () => {
+    // Shared code outside the agent folder used to send the whole deploy to git.
+    // It is now archived like anything else: the archive is rooted at the lowest
+    // directory holding both, and the entry is declared relative to that root, so
+    // the relative import still resolves once the server extracts it.
+    write("shared/util.ts", "export const util = 1;\n");
+    write("agent/index.ts", "import { util } from '../shared/util.js';\nexport default util;\n");
 
-      await expect(packSource(path.join(root, "agent"))).rejects.toMatchObject({
-        code: "UNSUPPORTED_LAYOUT",
-      });
-    } finally {
-      rmSync(shared, { recursive: true, force: true });
-    }
+    const packed = await packSource(path.join(root, "agent"));
+
+    expect(packed.entry).toBe("agent/index.ts");
+    const contents = archived(packed.archive);
+    expect(Object.keys(contents).sort()).toEqual([
+      ".sapiom-source.json",
+      "agent/index.ts",
+      "package.json",
+      "shared/util.ts",
+    ]);
+    // The server reads the entry from here; without it the build would look for
+    // index.ts at the archive root and find nothing.
+    expect(JSON.parse(contents[".sapiom-source.json"])).toEqual({ entry: "agent/index.ts" });
+  });
+
+  it("writes no entry manifest for a flat agent, keeping its archive byte-identical", async () => {
+    // A redeploy of unchanged code must still hash the same and store nothing, so
+    // the manifest is added only where it is actually needed.
+    write("index.ts", "export default 1;\n");
+
+    const packed = await packSource(root);
+
+    expect(packed.entry).toBe("index.ts");
+    expect(Object.keys(archived(packed.archive))).not.toContain(".sapiom-source.json");
   });
 
   it("reports a missing entry as NO_ENTRY", async () => {

--- a/packages/agent-core/src/pack-source.spec.ts
+++ b/packages/agent-core/src/pack-source.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for source packing.
+ *
+ * These run REAL esbuild over real temp projects rather than mocking it, because
+ * the thing being tested is exactly what esbuild reports: which files the entry
+ * reaches. A mocked metafile would only assert that the mock was read back.
+ */
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+
+import { AgentOperationError } from "./errors";
+import { packSource } from "./pack-source";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(path.join(tmpdir(), "sapiom-pack-spec-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function write(relative: string, content: string): void {
+  const target = path.join(root, relative);
+  mkdirSync(path.dirname(target), { recursive: true });
+  writeFileSync(target, content);
+}
+
+/**
+ * Walk the raw tar headers and return path → content.
+ *
+ * Deliberately a hand-written reader rather than the writer's own code: reading
+ * the archive back with the module under test would only prove it is
+ * self-consistent. (The engine's independent reader is exercised by a committed
+ * fixture on that side.)
+ */
+function archived(archive: Buffer): Record<string, string> {
+  const raw = gunzipSync(archive);
+  const files: Record<string, string> = {};
+  for (let offset = 0; offset + 512 <= raw.length; ) {
+    const name = raw.toString("utf8", offset, offset + 100).replace(/\0.*$/, "");
+    if (!name) break;
+    const size = parseInt(raw.toString("utf8", offset + 124, offset + 135).trim(), 8) || 0;
+    files[name] = raw.toString("utf8", offset + 512, offset + 512 + size);
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+  return files;
+}
+
+describe("packSource", () => {
+  it("archives the entry and a generated package.json", async () => {
+    write("index.ts", "export default { name: 'a' };\n");
+    const packed = await packSource(root);
+
+    expect(packed.files).toEqual(["index.ts", "package.json"]);
+    expect(Object.keys(archived(packed.archive)).sort()).toEqual(["index.ts", "package.json"]);
+  });
+
+  it("includes files the entry reaches, and excludes files it does not", async () => {
+    // A directory sweep would archive `scratch.ts`. The metafile knows better —
+    // it lists what the entry actually imports.
+    write("index.ts", "import { helper } from './kit/helper.js';\nexport default helper;\n");
+    write("kit/helper.ts", "export const helper = 1;\n");
+    write("scratch.ts", "export const unused = 'not imported';\n");
+
+    const packed = await packSource(root);
+    expect(packed.files).toEqual(["index.ts", "kit/helper.ts", "package.json"]);
+    expect(packed.files).not.toContain("scratch.ts");
+  });
+
+  it("pins dependency versions from the installed tree rather than shipping ranges", async () => {
+    // The property inherited from the push path: the server's install must resolve
+    // exactly what the author developed against, so a caret range in the author's
+    // own package.json must not decide the build.
+    write("index.ts", "import { z } from 'zod';\nexport default z;\n");
+    write("node_modules/zod/package.json", JSON.stringify({ name: "zod", version: "3.24.1" }));
+    write("node_modules/zod/index.js", "export const z = 1;\n");
+
+    const packed = await packSource(root);
+    expect(packed.dependencies).toEqual({ zod: "3.24.1" });
+
+    // And the pin travels inside the archive, not just in the return value.
+    const manifest = JSON.parse(archived(packed.archive)["package.json"]) as {
+      dependencies: Record<string, string>;
+    };
+    expect(manifest.dependencies).toEqual({ zod: "3.24.1" });
+  });
+
+  it("never archives node_modules", async () => {
+    write("index.ts", "export default 1;\n");
+    write("node_modules/pkg/index.js", "module.exports = 1;\n");
+
+    const packed = await packSource(root);
+    expect(packed.files.some((f) => f.includes("node_modules"))).toBe(false);
+  });
+
+  it("refuses source that escapes the project directory instead of silently dropping it", async () => {
+    // esbuild INLINED these for the push path, so the old transport handled them.
+    // A raw archive cannot: relative imports must still resolve after extraction,
+    // and the server looks for the entry at the archive root. Failing loudly beats
+    // building an agent whose shared code is missing.
+    const shared = path.join(root, "..", `shared-${path.basename(root)}`);
+    mkdirSync(shared, { recursive: true });
+    try {
+      writeFileSync(path.join(shared, "util.ts"), "export const util = 1;\n");
+      write("agent/index.ts", `import { util } from '${path.join(shared, "util.js")}';\nexport default util;\n`);
+
+      await expect(packSource(path.join(root, "agent"))).rejects.toMatchObject({
+        code: "UNSUPPORTED_LAYOUT",
+      });
+    } finally {
+      rmSync(shared, { recursive: true, force: true });
+    }
+  });
+
+  it("reports a missing entry as NO_ENTRY", async () => {
+    await expect(packSource(root)).rejects.toBeInstanceOf(AgentOperationError);
+    await expect(packSource(root)).rejects.toMatchObject({ code: "NO_ENTRY" });
+  });
+
+  it("is reproducible — the same source packs to identical bytes", async () => {
+    write("index.ts", "export default 1;\n");
+    const a = await packSource(root);
+    const b = await packSource(root);
+    // Content-addressing depends on this: otherwise every deploy of unchanged
+    // source uploads again and pays for another build.
+    expect(a.archive.equals(b.archive)).toBe(true);
+  });
+});

--- a/packages/agent-core/src/pack-source.ts
+++ b/packages/agent-core/src/pack-source.ts
@@ -42,7 +42,18 @@ export interface SourcePackage {
   files: string[];
   /** npm dependencies pinned to the author's installed versions. */
   dependencies: Record<string, string>;
+  /** Entry file, relative to the archive root. */
+  entry: string;
 }
+
+/**
+ * Manifest naming the entry, read by the server build.
+ *
+ * Written only when the entry is not `index.ts` at the archive root. Distinct
+ * from the author's `sapiom.json`, which is theirs and must not become something
+ * the build depends on.
+ */
+const SOURCE_MANIFEST = ".sapiom-source.json";
 
 /** Never archived: build output, VCS metadata, and installed packages. */
 const EXCLUDED_SEGMENTS = new Set(["node_modules", ".git", "dist", ".turbo"]);
@@ -50,9 +61,14 @@ const EXCLUDED_SEGMENTS = new Set(["node_modules", ".git", "dist", ".turbo"]);
 /**
  * Pack `<projectDir>` for upload.
  *
+ * Source that lives ABOVE the agent directory is packed too: the archive is
+ * rooted at the lowest directory containing everything the entry imports, and the
+ * entry is declared relative to that root. Shared code therefore deploys by
+ * upload like anything else, instead of falling back to git.
+ *
  * Throws `AgentOperationError` — `NO_ENTRY` when there is no `index.ts`,
- * `BUNDLE_FAILED` when the entry cannot be analysed, `UNSUPPORTED_LAYOUT` when
- * source escapes the project directory.
+ * `BUNDLE_FAILED` when the entry cannot be analysed, `UNSUPPORTED_LAYOUT` only
+ * when the imports have no common parent short of the filesystem root.
  */
 export async function packSource(projectDir: string): Promise<SourcePackage> {
   const root = path.resolve(projectDir);
@@ -67,29 +83,19 @@ export async function packSource(projectDir: string): Promise<SourcePackage> {
 
   const { inputs, dependencies } = await analyse(root, entryFile);
 
+  // Where the archive is rooted. Normally the agent directory; when the agent
+  // imports shared code from above it, the lowest directory that contains
+  // everything the entry reaches. Only the files esbuild actually named are
+  // packed either way — a higher root makes paths longer, never the archive
+  // bigger.
+  const absoluteInputs = inputs.map((input) => path.resolve(root, input));
+  const packRoot = resolvePackRoot(root, absoluteInputs);
+
   const files: TarFile[] = [];
-  const escaping: string[] = [];
-  for (const input of inputs) {
-    const absolute = path.resolve(root, input);
-    const relative = path.relative(root, absolute);
-    // `..` means the file sits above the project directory; an archive rooted at
-    // the project cannot represent it without breaking the import that reaches it.
-    if (relative.startsWith("..") || path.isAbsolute(relative)) {
-      escaping.push(relative);
-      continue;
-    }
+  for (const absolute of absoluteInputs) {
+    const relative = path.relative(packRoot, absolute);
     if (relative.split(path.sep).some((segment) => EXCLUDED_SEGMENTS.has(segment))) continue;
     files.push({ path: toPosix(relative), content: readFileSync(absolute, "utf8") });
-  }
-
-  if (escaping.length > 0) {
-    throw new AgentOperationError({
-      code: "UNSUPPORTED_LAYOUT",
-      message: `This agent imports code from outside its own directory: ${escaping.slice(0, 5).join(", ")}.`,
-      hint:
-        "Archive deploys require every imported file to live inside the agent directory. " +
-        "Move the shared code in, or keep using the git deploy path for this agent.",
-    });
   }
 
   // The generated manifest, not the author's: exact versions, so the server
@@ -104,7 +110,52 @@ export async function packSource(projectDir: string): Promise<SourcePackage> {
       ) + "\n",
   });
 
-  return { archive: createTarGz(files), files: files.map((f) => f.path).sort(), dependencies };
+  // Declare the entry ONLY when it is not `index.ts` at the archive root. The
+  // build falls back to that name, so staying silent in the common case keeps
+  // every existing agent's archive byte-identical — and therefore its digest
+  // stable, so redeploying unchanged code still stores nothing.
+  const entry = toPosix(path.relative(packRoot, entryFile));
+  if (entry !== "index.ts") {
+    files.push({ path: SOURCE_MANIFEST, content: JSON.stringify({ entry }, null, 2) + "\n" });
+  }
+
+  return { archive: createTarGz(files), files: files.map((f) => f.path).sort(), dependencies, entry };
+}
+
+/**
+ * The directory the archive is rooted at.
+ *
+ * Never deeper than the agent directory, so an agent whose files all sit in a
+ * subfolder keeps the layout it has today. Higher only when something the entry
+ * imports lives above the agent directory.
+ */
+function resolvePackRoot(projectDir: string, absoluteInputs: string[]): string {
+  const ancestor = commonAncestor(absoluteInputs);
+  if (ancestor === projectDir || ancestor.startsWith(projectDir + path.sep)) return projectDir;
+  if (ancestor === path.parse(ancestor).root) {
+    // Nothing shy of the filesystem root contains every input — two unrelated
+    // trees, or a symlink out. Packing from `/` would be absurd, so this stays a
+    // hard error rather than something the deploy silently does.
+    throw new AgentOperationError({
+      code: "UNSUPPORTED_LAYOUT",
+      message: "This agent's imports span unrelated directories, with no common parent short of the filesystem root.",
+      hint: "Keep the agent and the code it imports under one project directory.",
+    });
+  }
+  return ancestor;
+}
+
+/** Lowest directory containing every given file. */
+function commonAncestor(absolutePaths: string[]): string {
+  const segmentLists = absolutePaths.map((p) => path.dirname(p).split(path.sep));
+  const first = segmentLists[0] ?? [];
+  let shared = first.length;
+  for (const segments of segmentLists.slice(1)) {
+    let i = 0;
+    while (i < shared && i < segments.length && segments[i] === first[i]) i += 1;
+    shared = i;
+  }
+  return first.slice(0, shared).join(path.sep) || path.sep;
 }
 
 /**

--- a/packages/agent-core/src/pack-source.ts
+++ b/packages/agent-core/src/pack-source.ts
@@ -1,0 +1,216 @@
+/**
+ * pack-source — collect an agent's raw source into a gzipped tar for upload
+ * (AGENT-289).
+ *
+ * The git-free replacement for the synthesized-tree push in `deploy.ts`. Two
+ * properties from the old path are deliberately preserved, because losing either
+ * would change what customers actually run:
+ *
+ *  1. **Pinned dependency versions.** `bundleForDeploy` resolved every external
+ *     package to the version installed in the author's tree and shipped that as a
+ *     generated `package.json`. Sending the author's own package.json instead
+ *     would ship RANGES, so the server's `npm install` could resolve a different
+ *     version than the author developed against. The synthesis is kept.
+ *
+ *  2. **Knowing which files matter.** esbuild's metafile lists exactly the files
+ *     the entry actually reaches, so the archive is the real dependency set
+ *     rather than a directory sweep — no `node_modules`, no stray scratch files,
+ *     nothing that merely happens to sit nearby.
+ *
+ * What is NOT yet supported, and fails loudly rather than silently: source that
+ * reaches OUTSIDE the project directory (a shared `kit/` a level up). esbuild
+ * inlined those into one file for the push path, but a raw archive cannot —
+ * relative imports must still resolve after extraction, and the server looks for
+ * the entry at the archive root. Supporting it needs the entry path to travel
+ * from config through BuildInput into `build-definition.mjs`; until then this
+ * refuses with an explanation instead of producing an archive that builds
+ * without the shared code.
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import * as esbuild from "esbuild";
+
+import { AgentOperationError } from "./errors.js";
+import { createTarGz, type TarFile } from "./tar.js";
+
+export interface SourcePackage {
+  /** The gzipped tar to upload. */
+  archive: Buffer;
+  /** Archive-relative paths included, for logging and tests. */
+  files: string[];
+  /** npm dependencies pinned to the author's installed versions. */
+  dependencies: Record<string, string>;
+}
+
+/** Never archived: build output, VCS metadata, and installed packages. */
+const EXCLUDED_SEGMENTS = new Set(["node_modules", ".git", "dist", ".turbo"]);
+
+/**
+ * Pack `<projectDir>` for upload.
+ *
+ * Throws `AgentOperationError` — `NO_ENTRY` when there is no `index.ts`,
+ * `BUNDLE_FAILED` when the entry cannot be analysed, `UNSUPPORTED_LAYOUT` when
+ * source escapes the project directory.
+ */
+export async function packSource(projectDir: string): Promise<SourcePackage> {
+  const root = path.resolve(projectDir);
+  const entryFile = path.join(root, "index.ts");
+  if (!existsSync(entryFile)) {
+    throw new AgentOperationError({
+      code: "NO_ENTRY",
+      message: `No index.ts found in ${projectDir}.`,
+      hint: "Run this from an agent project, or pass its directory.",
+    });
+  }
+
+  const { inputs, dependencies } = await analyse(root, entryFile);
+
+  const files: TarFile[] = [];
+  const escaping: string[] = [];
+  for (const input of inputs) {
+    const absolute = path.resolve(root, input);
+    const relative = path.relative(root, absolute);
+    // `..` means the file sits above the project directory; an archive rooted at
+    // the project cannot represent it without breaking the import that reaches it.
+    if (relative.startsWith("..") || path.isAbsolute(relative)) {
+      escaping.push(relative);
+      continue;
+    }
+    if (relative.split(path.sep).some((segment) => EXCLUDED_SEGMENTS.has(segment))) continue;
+    files.push({ path: toPosix(relative), content: readFileSync(absolute, "utf8") });
+  }
+
+  if (escaping.length > 0) {
+    throw new AgentOperationError({
+      code: "UNSUPPORTED_LAYOUT",
+      message: `This agent imports code from outside its own directory: ${escaping.slice(0, 5).join(", ")}.`,
+      hint:
+        "Archive deploys require every imported file to live inside the agent directory. " +
+        "Move the shared code in, or keep using the git deploy path for this agent.",
+    });
+  }
+
+  // The generated manifest, not the author's: exact versions, so the server
+  // installs precisely what they developed against.
+  files.push({
+    path: "package.json",
+    content:
+      JSON.stringify(
+        { name: "sapiom-agent-source", private: true, type: "module", dependencies },
+        null,
+        2,
+      ) + "\n",
+  });
+
+  return { archive: createTarGz(files), files: files.map((f) => f.path).sort(), dependencies };
+}
+
+/**
+ * Run esbuild purely for its metafile: which files the entry reaches, and which
+ * npm packages stay external. Output is discarded — only the analysis is wanted.
+ */
+async function analyse(
+  root: string,
+  entryFile: string,
+): Promise<{ inputs: string[]; dependencies: Record<string, string> }> {
+  const tmp = mkdtempSync(path.join(tmpdir(), "sapiom-pack-source-"));
+  try {
+    let result: esbuild.BuildResult;
+    try {
+      result = await esbuild.build({
+        entryPoints: [entryFile],
+        outfile: path.join(tmp, "index.js"),
+        // Anchored to the project for the same reason as `bundleForDeploy`: with
+        // no working directory of its own, esbuild also walks OUR cwd's ancestors,
+        // and the harness calls this in-process from deep inside its app bundle.
+        absWorkingDir: root,
+        bundle: true,
+        platform: "node",
+        target: "node20",
+        format: "esm",
+        packages: "external",
+        metafile: true,
+        logLevel: "silent",
+      });
+    } catch (err) {
+      throw new AgentOperationError({
+        code: "BUNDLE_FAILED",
+        message: "Failed to analyse the agent's source for packing.",
+        hint: err instanceof Error ? err.message : String(err),
+      });
+    }
+
+    const metafile = result.metafile!;
+    return {
+      // Metafile keys are relative to esbuild's working directory, which is the
+      // project root — not this process's cwd.
+      inputs: Object.keys(metafile.inputs),
+      dependencies: resolveInstalledVersions(root, externalPackagesOf(metafile)),
+    };
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Packages left external, read from the INPUT graph rather than the output's
+ * import list.
+ *
+ * `bundleForDeploy` reads `outputs[].imports`, which is right for a single
+ * emitted file. Reading the inputs is equivalent here and does not depend on
+ * matching the output key back to the outfile path.
+ */
+function externalPackagesOf(metafile: esbuild.Metafile): string[] {
+  const names = new Set<string>();
+  for (const input of Object.values(metafile.inputs)) {
+    for (const imported of input.imports) {
+      if (!imported.external) continue;
+      const name = packageNameOf(imported.path);
+      if (name) names.add(name);
+    }
+  }
+  return [...names].sort();
+}
+
+/** `zod/v4` → `zod`; `@sapiom/agent/x` → `@sapiom/agent`; a builtin → null. */
+function packageNameOf(importPath: string): string | null {
+  if (importPath.startsWith("node:")) return null;
+  const parts = importPath.split("/");
+  if (importPath.startsWith("@")) return parts.length >= 2 ? `${parts[0]}/${parts[1]}` : null;
+  return parts[0] || null;
+}
+
+/** Exact installed version per package, walking up like Node resolution. */
+function resolveInstalledVersions(
+  fromDir: string,
+  packages: readonly string[],
+): Record<string, string> {
+  const deps: Record<string, string> = {};
+  for (const pkg of packages) deps[pkg] = readInstalledVersion(fromDir, pkg) ?? "latest";
+  return deps;
+}
+
+function readInstalledVersion(fromDir: string, pkg: string): string | null {
+  let dir = path.resolve(fromDir);
+  for (;;) {
+    const manifest = path.join(dir, "node_modules", ...pkg.split("/"), "package.json");
+    if (existsSync(manifest)) {
+      try {
+        const version = (JSON.parse(readFileSync(manifest, "utf8")) as { version?: string }).version;
+        if (version) return version;
+      } catch {
+        // unreadable — keep walking up
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+/** tar paths are always POSIX, even when built on Windows. */
+function toPosix(relative: string): string {
+  return relative.split(path.sep).join("/");
+}

--- a/packages/agent-core/src/tar.spec.ts
+++ b/packages/agent-core/src/tar.spec.ts
@@ -11,7 +11,7 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { createTarGz } from "./tar";
+import { createTarGz, readTarGz } from "./tar";
 
 /** Extract with the SYSTEM tar and return path → content. */
 function extract(archive: Buffer): Record<string, string> {
@@ -93,5 +93,106 @@ describe("createTarGz", () => {
     // fails loudly instead.
     const unsplittable = `${"a".repeat(120)}.ts`;
     expect(() => createTarGz([{ path: unsplittable, content: "x" }])).toThrow(/too long/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reader
+//
+// Same interop standard as the writer: the archives read here are produced by
+// the SYSTEM tar, not by createTarGz, so a shared misunderstanding of the format
+// cannot make these pass. The round-trip case is the exception, and it is there
+// to pin the pair together.
+// ---------------------------------------------------------------------------
+
+/** Build an archive with the SYSTEM tar from a file map. */
+function packWithSystemTar(files: Record<string, string>, extraArgs: string[] = []): Buffer {
+  const dir = mkdtempSync(path.join(tmpdir(), "sapiom-tar-read-"));
+  try {
+    for (const [relative, content] of Object.entries(files)) {
+      const target = path.join(dir, relative);
+      execFileSync("mkdir", ["-p", path.dirname(target)]);
+      writeFileSync(target, content);
+    }
+    const archivePath = path.join(tmpdir(), `read-${path.basename(dir)}.tar.gz`);
+    execFileSync("tar", ["-czf", archivePath, "-C", dir, ...extraArgs, "."], { stdio: "pipe" });
+    const bytes = readFileSync(archivePath);
+    rmSync(archivePath, { force: true });
+    return bytes;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function asMap(files: { path: string; content: string }[]): Record<string, string> {
+  return Object.fromEntries(files.map((f) => [f.path.replace(/^\.\//, ""), f.content]));
+}
+
+describe("readTarGz", () => {
+  it("reads an archive the system tar produced, including nested paths", () => {
+    const archive = packWithSystemTar({
+      "index.ts": "export default 1;\n",
+      "shared/util.ts": "export const util = 2;\n",
+      ".sapiom-source.json": '{"entry":"index.ts"}\n',
+    });
+
+    expect(asMap(readTarGz(archive))).toEqual({
+      "index.ts": "export default 1;\n",
+      "shared/util.ts": "export const util = 2;\n",
+      ".sapiom-source.json": '{"entry":"index.ts"}\n',
+    });
+  });
+
+  it("round-trips whatever the writer produced", () => {
+    // `clone` reads what `deploy` wrote, so this pair has to agree exactly —
+    // including the long-path prefix split the writer performs.
+    const files = [
+      { path: "index.ts", content: "export default 1;\n" },
+      { path: `${"nested/".repeat(15)}deep.ts`, content: "export const deep = true;\n" },
+      { path: "kit/helper.ts", content: "export const help = () => 1;\n" },
+    ];
+
+    expect(asMap(readTarGz(createTarGz(files)))).toEqual({
+      "index.ts": "export default 1;\n",
+      [`${"nested/".repeat(15)}deep.ts`]: "export const deep = true;\n",
+      "kit/helper.ts": "export const help = () => 1;\n",
+    });
+  });
+
+  it("refuses a path that escapes the archive root", () => {
+    // This output is written to a developer's filesystem, so a traversal must not
+    // be extracted. `-P` stops tar sanitising the path it stores.
+    const dir = mkdtempSync(path.join(tmpdir(), "sapiom-tar-evil-"));
+    try {
+      writeFileSync(path.join(dir, "ok.ts"), "export default 1;\n");
+      const archivePath = path.join(dir, "evil.tar.gz");
+      execFileSync(
+        "tar",
+        ["-czf", archivePath, "-P", "-C", dir, "--transform=s|^\\./ok.ts|../escaped.ts|", "./ok.ts"],
+        { stdio: "pipe" },
+      );
+      expect(() => readTarGz(readFileSync(archivePath))).toThrow(/escapes the archive root/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a symlink rather than silently skipping it", () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sapiom-tar-link-"));
+    try {
+      writeFileSync(path.join(dir, "real.ts"), "export default 1;\n");
+      execFileSync("ln", ["-s", "real.ts", path.join(dir, "link.ts")]);
+      // Outside `dir`: writing it inside means tar archives its own output and
+      // aborts with "file changed as we read it".
+      const archivePath = path.join(tmpdir(), `link-${path.basename(dir)}.tar.gz`);
+      try {
+        execFileSync("tar", ["-czf", archivePath, "-C", dir, "."], { stdio: "pipe" });
+        expect(() => readTarGz(readFileSync(archivePath))).toThrow(/not a regular file/);
+      } finally {
+        rmSync(archivePath, { force: true });
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agent-core/src/tar.spec.ts
+++ b/packages/agent-core/src/tar.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for the hand-rolled tar writer.
+ *
+ * The claim that matters is INTEROP, not internal consistency: this archive is
+ * read by the real `tar` binary and by the server's `tar-stream` reader, so
+ * asserting my writer agrees with itself would prove nothing. Every test here
+ * therefore extracts with the system `tar`.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createTarGz } from "./tar";
+
+/** Extract with the SYSTEM tar and return path → content. */
+function extract(archive: Buffer): Record<string, string> {
+  const dir = mkdtempSync(path.join(tmpdir(), "sapiom-tar-spec-"));
+  try {
+    const archivePath = path.join(dir, "a.tar.gz");
+    writeFileSync(archivePath, archive);
+    const out = path.join(dir, "out");
+    execFileSync("mkdir", ["-p", out]);
+    execFileSync("tar", ["-xzf", archivePath, "-C", out], { stdio: "pipe" });
+    const listed = execFileSync("tar", ["-tzf", archivePath], { encoding: "utf8" })
+      .split("\n")
+      .filter(Boolean);
+    const files: Record<string, string> = {};
+    for (const name of listed) files[name] = readFileSync(path.join(out, name), "utf8");
+    return files;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe("createTarGz", () => {
+  it("produces an archive the system tar can extract", () => {
+    const files = extract(
+      createTarGz([
+        { path: "index.ts", content: "export const a = 1;\n" },
+        { path: "kit/helper.ts", content: "export const b = 2;\n" },
+      ]),
+    );
+    expect(files).toEqual({
+      "index.ts": "export const a = 1;\n",
+      "kit/helper.ts": "export const b = 2;\n",
+    });
+  });
+
+  it("round-trips content that is not 512-byte aligned", () => {
+    // Every realistic file lands mid-block, so the data padding is exercised by
+    // practically every archive — a broken pad shifts every later header.
+    for (const size of [0, 1, 511, 512, 513, 1024, 1025]) {
+      const content = "x".repeat(size);
+      expect(extract(createTarGz([{ path: "f.ts", content }]))["f.ts"]).toBe(content);
+    }
+  });
+
+  it("round-trips multi-byte characters by byte length, not character count", () => {
+    // The size field is BYTES. Using string length would truncate any non-ASCII
+    // file and corrupt the archive from that header onward.
+    const content = "const gruß = 'héllo κόσμε';\n";
+    expect(extract(createTarGz([{ path: "u.ts", content }]))["u.ts"]).toBe(content);
+  });
+
+  it("is reproducible — identical input yields identical bytes", () => {
+    // Content-addressing depends on this. A clock-derived mtime would make every
+    // deploy a new digest, so unchanged source would re-upload and rebuild.
+    const files = [{ path: "index.ts", content: "export const a = 1;\n" }];
+    expect(createTarGz(files).equals(createTarGz(files))).toBe(true);
+  });
+
+  it("is order-independent — the same set in any order yields identical bytes", () => {
+    const a = createTarGz([
+      { path: "b.ts", content: "b" },
+      { path: "a.ts", content: "a" },
+    ]);
+    const b = createTarGz([
+      { path: "a.ts", content: "a" },
+      { path: "b.ts", content: "b" },
+    ]);
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it("handles a path longer than the 100-character name field", () => {
+    const deep = `${"nested/".repeat(15)}file.ts`;
+    expect(deep.length).toBeGreaterThan(100);
+    expect(extract(createTarGz([{ path: deep, content: "deep" }]))[deep]).toBe("deep");
+  });
+
+  it("refuses a path it cannot split rather than truncating it", () => {
+    // A truncated path would deploy the file somewhere else entirely, so this
+    // fails loudly instead.
+    const unsplittable = `${"a".repeat(120)}.ts`;
+    expect(() => createTarGz([{ path: unsplittable, content: "x" }])).toThrow(/too long/i);
+  });
+});

--- a/packages/agent-core/src/tar.ts
+++ b/packages/agent-core/src/tar.ts
@@ -4,17 +4,19 @@
  * WHY HAND-ROLLED rather than a dependency: this is a published SDK, so every
  * dependency is installed by every consumer of `@sapiom/cli` and
  * `@sapiom/harness`. Writing a ustar archive of regular files is a small,
- * well-specified job — and only the WRITE side is needed here, because the
- * server reads archives with a vetted library. Shelling out to the `tar` binary
- * was the other option and was rejected: it does not exist on a default Windows
- * install, which would make `sapiom deploy` platform-dependent.
+ * well-specified job. Shelling out to the `tar` binary was the other option and
+ * was rejected: it does not exist on a default Windows install, which would make
+ * `sapiom deploy` platform-dependent.
+ *
+ * The READ side exists for `clone`, which materialises a deployed agent from its
+ * stored archive rather than from a git repo the deploy no longer writes to.
  *
  * Scope is deliberately narrow: regular files, no symlinks, no directory
  * entries, no device nodes. That mirrors what the server accepts — it rejects
  * every one of those — so an archive this writer can produce is an archive the
  * server can ingest.
  */
-import { gzipSync } from "node:zlib";
+import { gunzipSync, gzipSync } from "node:zlib";
 
 /** One file in the archive. `path` is a relative POSIX path. */
 export interface TarFile {
@@ -107,4 +109,76 @@ function header(filePath: string, size: number): Buffer {
 /** Zero-padded octal, as every numeric tar field is encoded. */
 function octal(value: number, width: number): string {
   return value.toString(8).padStart(width, "0");
+}
+
+/**
+ * Read a gzipped ustar archive back into a file map.
+ *
+ * The inverse of {@link createTarGz}, and deliberately just as narrow: regular
+ * files only. Anything else in the stream — a symlink, a device node — is a
+ * signal that this did not come from our writer or our server, so it is refused
+ * rather than skipped. Directory entries are the one exception: `tar -czf … .`
+ * emits them, and they carry no content to mishandle.
+ *
+ * Paths are validated here, not by the caller. This output gets written to a
+ * developer's filesystem, so an absolute path or one containing `..` must never
+ * reach `writeFileSync`.
+ */
+export function readTarGz(archive: Uint8Array): TarFile[] {
+  const buffer = Buffer.from(gunzipSync(archive));
+  const files: TarFile[] = [];
+
+  for (let offset = 0; offset + BLOCK_SIZE <= buffer.length; ) {
+    const block = buffer.subarray(offset, offset + BLOCK_SIZE);
+    // A zero block marks end-of-archive; the writer emits two.
+    if (block.every((byte) => byte === 0)) break;
+
+    const name = field(block, 0, NAME_FIELD);
+    const prefix = field(block, 345, PREFIX_FIELD);
+    const size = Number.parseInt(field(block, 124, 12).trim() || "0", 8);
+    const typeFlag = String.fromCharCode(block[156] ?? 0).trim();
+    offset += BLOCK_SIZE;
+
+    if (!Number.isSafeInteger(size) || size < 0) {
+      throw new Error(`readTarGz: entry '${name}' has an unreadable size field.`);
+    }
+
+    const fullPath = prefix ? `${prefix}/${name}` : name;
+    // '0' and '\0' are a regular file; '5' is a directory (no content).
+    const isFile = typeFlag === "0" || typeFlag === "";
+    const isDirectory = typeFlag === "5";
+    if (!isFile && !isDirectory) {
+      throw new Error(`readTarGz: entry '${fullPath}' is not a regular file (type '${typeFlag}').`);
+    }
+
+    if (isFile) {
+      assertSafePath(fullPath);
+      files.push({
+        path: fullPath,
+        content: buffer.subarray(offset, offset + size).toString("utf8"),
+      });
+    }
+    // Content is padded up to a block boundary.
+    offset += Math.ceil(size / BLOCK_SIZE) * BLOCK_SIZE;
+  }
+
+  return files;
+}
+
+/** Read a NUL-terminated ustar header field. */
+function field(block: Buffer, start: number, width: number): string {
+  const raw = block.subarray(start, start + width);
+  const end = raw.indexOf(0);
+  return raw.subarray(0, end === -1 ? raw.length : end).toString("utf8");
+}
+
+/** Refuse any path that would escape the extraction directory. */
+function assertSafePath(entryPath: string): void {
+  if (entryPath.length === 0) throw new Error("readTarGz: an entry has an empty path.");
+  if (entryPath.startsWith("/") || /^[A-Za-z]:/.test(entryPath)) {
+    throw new Error(`readTarGz: entry '${entryPath}' is an absolute path.`);
+  }
+  if (entryPath.split("/").some((segment) => segment === "..")) {
+    throw new Error(`readTarGz: entry '${entryPath}' escapes the archive root.`);
+  }
 }

--- a/packages/agent-core/src/tar.ts
+++ b/packages/agent-core/src/tar.ts
@@ -1,0 +1,110 @@
+/**
+ * Minimal tar+gzip writer for source uploads (AGENT-289).
+ *
+ * WHY HAND-ROLLED rather than a dependency: this is a published SDK, so every
+ * dependency is installed by every consumer of `@sapiom/cli` and
+ * `@sapiom/harness`. Writing a ustar archive of regular files is a small,
+ * well-specified job — and only the WRITE side is needed here, because the
+ * server reads archives with a vetted library. Shelling out to the `tar` binary
+ * was the other option and was rejected: it does not exist on a default Windows
+ * install, which would make `sapiom deploy` platform-dependent.
+ *
+ * Scope is deliberately narrow: regular files, no symlinks, no directory
+ * entries, no device nodes. That mirrors what the server accepts — it rejects
+ * every one of those — so an archive this writer can produce is an archive the
+ * server can ingest.
+ */
+import { gzipSync } from "node:zlib";
+
+/** One file in the archive. `path` is a relative POSIX path. */
+export interface TarFile {
+  path: string;
+  content: string;
+}
+
+const BLOCK_SIZE = 512;
+/** ustar `name` field width. Longer paths use the `prefix` field. */
+const NAME_FIELD = 100;
+/** ustar `prefix` field width — with `name`, allows 255 characters total. */
+const PREFIX_FIELD = 155;
+
+/**
+ * Build a gzipped tar containing `files`.
+ *
+ * `mtime` is fixed rather than read from the clock so the archive is
+ * REPRODUCIBLE: identical source must produce an identical digest, or
+ * content-addressing buys nothing and every deploy re-uploads and rebuilds
+ * source that has not changed.
+ */
+export function createTarGz(files: readonly TarFile[]): Buffer {
+  const blocks: Buffer[] = [];
+  for (const file of [...files].sort((a, b) => (a.path < b.path ? -1 : 1))) {
+    const content = Buffer.from(file.content, "utf8");
+    blocks.push(header(file.path, content.length), content, padding(content.length));
+  }
+  // Two zero blocks mark end-of-archive.
+  blocks.push(Buffer.alloc(BLOCK_SIZE * 2));
+  return gzipSync(Buffer.concat(blocks), { level: 9 });
+}
+
+/** Zero-fill so each file's data ends on a 512-byte boundary. */
+function padding(size: number): Buffer {
+  const remainder = size % BLOCK_SIZE;
+  return remainder === 0 ? Buffer.alloc(0) : Buffer.alloc(BLOCK_SIZE - remainder);
+}
+
+/**
+ * Split an over-long path across ustar `prefix` + `name`.
+ *
+ * The split must fall on a `/`, because the reader rejoins them with one. A path
+ * that cannot be split that way is refused rather than silently truncated — a
+ * truncated path would deploy a file to the wrong place.
+ */
+function splitPath(filePath: string): { name: string; prefix: string } {
+  if (Buffer.byteLength(filePath, "utf8") <= NAME_FIELD) {
+    return { name: filePath, prefix: "" };
+  }
+  for (let i = filePath.length - NAME_FIELD; i < filePath.length; i++) {
+    if (filePath[i] !== "/") continue;
+    const prefix = filePath.slice(0, i);
+    const name = filePath.slice(i + 1);
+    if (
+      Buffer.byteLength(name, "utf8") <= NAME_FIELD &&
+      Buffer.byteLength(prefix, "utf8") <= PREFIX_FIELD
+    ) {
+      return { name, prefix };
+    }
+  }
+  throw new Error(
+    `Path too long for a tar archive (max ${NAME_FIELD + PREFIX_FIELD} characters, split on a '/'): ${filePath}`,
+  );
+}
+
+function header(filePath: string, size: number): Buffer {
+  const block = Buffer.alloc(BLOCK_SIZE);
+  const { name, prefix } = splitPath(filePath);
+
+  block.write(name, 0, NAME_FIELD, "utf8");
+  block.write("000644 \0", 100, 8, "utf8"); // mode: rw-r--r--
+  block.write("000000 \0", 108, 8, "utf8"); // uid
+  block.write("000000 \0", 116, 8, "utf8"); // gid
+  block.write(octal(size, 11) + "\0", 124, 12, "utf8");
+  block.write(octal(0, 11) + "\0", 136, 12, "utf8"); // mtime — fixed, see createTarGz
+  // chksum is spaces while the checksum is computed over the header.
+  block.write("        ", 148, 8, "utf8");
+  block.write("0", 156, 1, "utf8"); // typeflag: regular file
+  block.write("ustar\0", 257, 6, "utf8");
+  block.write("00", 263, 2, "utf8");
+  if (prefix) block.write(prefix, 345, PREFIX_FIELD, "utf8");
+
+  let checksum = 0;
+  for (const byte of block) checksum += byte;
+  block.write(octal(checksum, 6) + "\0 ", 148, 8, "utf8");
+
+  return block;
+}
+
+/** Zero-padded octal, as every numeric tar field is encoded. */
+function octal(value: number, width: number): string {
+  return value.toString(8).padStart(width, "0");
+}

--- a/packages/cli/src/commands/agents/deploy.ts
+++ b/packages/cli/src/commands/agents/deploy.ts
@@ -5,20 +5,44 @@ import { requireConfig } from '../../lib/config.js';
 import { CliError, isJsonMode, ok } from '../../lib/output.js';
 
 /**
- * `sapiom agents deploy` — mint push credentials, push the current
- * commit, trigger a build, and wait for it to finish.
+ * `sapiom agents deploy` — package the current local source, build it, and wait
+ * for the build to finish.
  *
- * Note: the backend tenant deploy routes (POST definitions, push-credentials,
- * builds) are being added in a parallel effort and are not yet merged. Until
- * those land, deploy end-to-end will return 404 from the backend.
+ * No git repository is required. The source is uploaded as an archive; a server
+ * that has archives switched off falls back to the old push transparently, so
+ * this command behaves the same either way (AGENT-289).
  */
-export async function runDeploy(opts: { branch?: string; host?: string; target?: CliTarget }): Promise<void> {
+export async function runDeploy(opts: {
+  branch?: string;
+  message?: string;
+  transport?: string;
+  host?: string;
+  target?: CliTarget;
+}): Promise<void> {
   try {
     const dir = process.cwd();
     const cfg = requireConfig(dir);
     const client = makeClient({ projectHost: cfg.host, flagHost: opts.host, flagTarget: opts.target });
 
-    const result = await deploy({ projectDir: dir, definitionId: cfg.definitionId, branch: opts.branch }, client);
+    if (opts.transport !== undefined && opts.transport !== "archive" && opts.transport !== "git") {
+      // Rejected here rather than passed through: an unrecognised value would
+      // silently take the default path, which is the opposite of pinning one.
+      throw new CliError({
+        code: "BAD_TRANSPORT",
+        message: `--transport must be 'archive' or 'git' (got '${opts.transport}').`,
+      });
+    }
+
+    const result = await deploy(
+      {
+        projectDir: dir,
+        definitionId: cfg.definitionId,
+        branch: opts.branch,
+        ...(opts.message ? { message: opts.message } : {}),
+        ...(opts.transport ? { transport: opts.transport as "archive" | "git" } : {}),
+      },
+      client,
+    );
 
     if (isJsonMode()) {
       ok({ definitionId: result.definitionId, buildRunId: result.buildRunId, status: result.status });

--- a/packages/cli/src/commands/agents/index.ts
+++ b/packages/cli/src/commands/agents/index.ts
@@ -62,7 +62,11 @@ export function registerAgentsCommands(program: Command): void {
         ),
     ),
   )
-    .option("-b, --branch <branch>", "branch to push to", "main")
+    .option("-b, --branch <branch>", "branch to push to (git transport only)", "main")
+    .option("-m, --message <message>", "label this version in the history")
+    // Escape hatch, not a routine choice: the transport is normally decided by
+    // the server, so this exists for a rollback or for reproducing an issue.
+    .option("--transport <transport>", "force 'archive' or 'git'")
     .action(action(runDeploy));
 
   withHostFlags(

--- a/packages/harness/docs/agent-versions.md
+++ b/packages/harness/docs/agent-versions.md
@@ -1,0 +1,103 @@
+# Agent Studio — version management
+
+Video: `agent289-full-loop-v2-trimmed.mp4` · 4m33s · no audio.
+
+## Why this matters
+
+Studio could build and deploy an agent. After that it went quiet.
+
+It could not tell you which version was live. Or what a label pointed at. Or
+whether the code in front of you was the code running in the cloud.
+
+All of that lived in the web dashboard and the API. Now it is in Studio.
+
+## Walkthrough
+
+**0:00 — Where we start.**
+The new Versions tab. Five releases, newest first.
+The header says `LIVE ON CLOUD 1.0.2 9b3b387`. That is the version serving
+traffic, and its label.
+It also says `YOUR FILES 1.0.2`. The code on disk is that exact version.
+
+**0:30 — The agent as it stands.**
+The Steps tab reads `5 steps · 1 exit`.
+
+**1:05 — A step is added.**
+A new `salute` step goes into the agent.
+Steps now reads `6 steps · 1 exit`.
+The edit happens in an editor. Studio has no code editor.
+
+**1:13 — Studio notices on its own.**
+Back on Versions, `YOUR FILES` now reads **`not deployed`**.
+Nothing told it about the edit. It re-read the project and found no deployed
+version matching.
+This question had no answer anywhere in the old UI.
+
+**1:33 — Deploy.**
+One click, from the header.
+Studio switches to Steps and confirms: *Deployed to Sapiom*.
+The build runs and goes live.
+
+**2:26 — The new release is there.**
+Back on Versions: six entries now, not five.
+The new build carries `latest` and is live.
+`YOUR FILES` matches it again.
+
+**2:40 — Naming it.**
+`1.0.3` is typed straight onto the row. No dialog.
+The header switches from the raw sha to `LIVE ON CLOUD 1.0.3 ec80f40`.
+
+**2:59 — Run it locally.**
+The run sheet opens, asking for input.
+Local means: your code on disk, Sapiom calls stubbed.
+
+**3:06 — Local run finishes.**
+`local run completed`. The output contains the new step's contribution.
+
+**3:37 — Run it on the cloud.**
+Cloud means: the deployed version, real capabilities.
+`prod run completed`.
+Both runs agree, because the local copy and the live version are the same code.
+
+**4:07 — Ending state.**
+Six versions. Newest is labelled and live. Working copy matches.
+
+## What is new
+
+**The Versions tab.** Recent releases, with sha, labels, age and build status.
+
+**`latest` is always the top row.** It is the build a deploy just produced. It is
+the row people look for.
+
+**Labelled releases come next.** A tagged release never gets buried under a few
+untagged deploys.
+
+**`LIVE ON CLOUD` and `YOUR FILES`, side by side.** When they differ you see it
+at a glance.
+
+**A version chip beside the agent name.** Shows cloud and local together, from
+anywhere in Studio. Switches version without opening the tab.
+
+**Labels on the row.** Create one or move one inline.
+
+**`latest` cannot be set by hand.** It is computed from the newest ready build,
+so it never goes stale. Trying to set it returns the server's own refusal.
+
+**Roll back to any ready build.** The confirm appears *only* when pinning
+backwards — the case that has a consequence. It says outright that later deploys
+will not go live.
+
+**A pinned agent says so.** A banner, with one-click *Resume following latest*.
+Otherwise a deploy that "did nothing" is a confusing afternoon.
+
+**Cloud run status now appears.** It used to report `execution not found` for
+runs that had completed perfectly well.
+
+## Two things to know
+
+Studio has no code editor. The Code tab generates a snippet for calling the
+agent — it is not a source view.
+
+For agents built from git, Studio says nothing about your working copy. It knows
+which commit is live. It cannot know whether your checkout matches. So it stays
+quiet rather than guess.

--- a/packages/harness/src/core/definition-slug-resolver.test.ts
+++ b/packages/harness/src/core/definition-slug-resolver.test.ts
@@ -205,14 +205,18 @@ describe("createDefinitionSlugResolver", () => {
   });
 
   it("does not cache a null resolution (allows retry after transient failure)", async () => {
-    let calls = 0;
-    const fetchImpl = vi.fn().mockImplementation(async () => {
-      calls++;
-      if (calls === 1) throw new Error("transient");
-      return {
-        ok: true,
-        json: async () => ({ slug: "recovered" }),
-      } as Response;
+    // A lookup now tries the gateway and then falls back to Core, so the mock
+    // has to fail BOTH for the first attempt to be a genuine null — otherwise
+    // the fallback rescues it and this stops testing what it is named for.
+    let gatewayCalls = 0;
+    const fetchImpl = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("/agents/v1/")) {
+        gatewayCalls++;
+        if (gatewayCalls === 1) throw new Error("transient");
+        return { ok: true, json: async () => ({ slug: "recovered" }) } as Response;
+      }
+      // Core: unavailable for this test, so the first attempt has no rescue.
+      return { ok: false, status: 404, json: async () => ({}) } as Response;
     });
 
     const resolver = createDefinitionSlugResolver({
@@ -225,7 +229,9 @@ describe("createDefinitionSlugResolver", () => {
 
     expect(first).toBeNull();
     expect(second).toBe("recovered");
-    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    // gateway(throw) → core(404) → gateway(200). The retry short-circuits on
+    // the gateway, so no second Core call.
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
   });
 
   it("returns null when slug field is not a string (wrong type in body)", async () => {
@@ -253,7 +259,10 @@ describe("createDefinitionSlugResolver", () => {
     await resolver.resolve("777");
     await resolver.resolve("777");
 
-    expect(fetchImpl).toHaveBeenCalledTimes(3);
+    // Two requests per lookup: the gateway, then the Core fallback. The point
+    // of this test is the LOG count, which must stay at one however many
+    // requests a lookup costs.
+    expect(fetchImpl).toHaveBeenCalledTimes(6);
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(String(errorSpy.mock.calls[0][0])).toContain("definitionId=777");
     expect(String(errorSpy.mock.calls[0][0])).toContain("HTTP 404");
@@ -268,5 +277,103 @@ describe("createDefinitionSlugResolver", () => {
     await resolver.resolve("188");
 
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Core fallback when the gateway surface is absent
+// ---------------------------------------------------------------------------
+
+describe("resolveMetadata — Core fallback", () => {
+  const CORE = "http://localhost:3000";
+  const AGENTS = "http://tools.localhost:3100";
+
+  beforeEach(() => {
+    process.env.SAPIOM_CORE_URL = CORE;
+  });
+  afterEach(() => {
+    delete process.env.SAPIOM_CORE_URL;
+  });
+
+  /**
+   * A local stack runs Core without the gateway, so every `agents/v1` route
+   * 404s. Before the fallback that left `activeBuildRunStatus` null and an
+   * agent that IS deployed read as "no runnable build" in Studio.
+   */
+  it("falls back to Core when the gateway 404s, and uses x-api-key there", async () => {
+    const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({
+        url,
+        headers: (init?.headers ?? {}) as Record<string, string>,
+      });
+      if (url.startsWith(AGENTS)) {
+        return new Response("not found", { status: 404 });
+      }
+      return new Response(
+        JSON.stringify({
+          slug: "fresh-demo",
+          activeBuildRunId: "57",
+          activeBuildRunStatus: "ready",
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "sk-key",
+      baseUrl: AGENTS,
+      fetchImpl,
+    });
+
+    expect(await resolver.resolveMetadata("46")).toEqual({
+      slug: "fresh-demo",
+      activeBuildRunId: "57",
+      activeBuildRunStatus: "ready",
+    });
+
+    expect(calls).toHaveLength(2);
+    // Gateway first — it stays the primary surface.
+    expect(calls[0].url).toBe(`${AGENTS}/agents/v1/definitions/46`);
+    expect(calls[0].headers["x-sapiom-api-key"]).toBe("sk-key");
+    // Then Core, whose auth header is different. Sending the gateway's header
+    // here returns 401, which is how this was silently failing.
+    expect(calls[1].url).toBe(`${CORE}/v1/workflows/definitions/46`);
+    expect(calls[1].headers["x-api-key"]).toBe("sk-key");
+    expect(calls[1].headers["x-sapiom-api-key"]).toBeUndefined();
+  });
+
+  it("does not call Core when the gateway answers", async () => {
+    const urls: string[] = [];
+    const fetchImpl = vi.fn(async (url: string) => {
+      urls.push(url);
+      return new Response(
+        JSON.stringify({ slug: "from-gateway", activeBuildRunStatus: "ready" }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "sk-key",
+      baseUrl: AGENTS,
+      fetchImpl,
+    });
+
+    expect((await resolver.resolveMetadata("46"))?.slug).toBe("from-gateway");
+    expect(urls).toEqual([`${AGENTS}/agents/v1/definitions/46`]);
+  });
+
+  it("returns null when neither surface has it", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response("nope", { status: 404 }),
+    ) as unknown as typeof fetch;
+
+    const resolver = createDefinitionSlugResolver({
+      apiKey: "sk-key",
+      baseUrl: AGENTS,
+      fetchImpl,
+    });
+
+    expect(await resolver.resolveMetadata("46")).toBeNull();
   });
 });

--- a/packages/harness/src/core/definition-slug-resolver.ts
+++ b/packages/harness/src/core/definition-slug-resolver.ts
@@ -97,6 +97,60 @@ export function createDefinitionSlugResolver(opts: {
     );
   };
 
+  /** Shape the two surfaces agree on, so either response reads the same. */
+  const readMetadata = (
+    definitionId: string,
+    body: Record<string, unknown>,
+    warnOnMissingSlug: boolean,
+  ): DefinitionMetadata => {
+    const slug = typeof body.slug === "string" ? body.slug : null;
+    const activeBuildRunId =
+      typeof body.activeBuildRunId === "string" ? body.activeBuildRunId : null;
+    const activeBuildRunStatus =
+      typeof body.activeBuildRunStatus === "string"
+        ? body.activeBuildRunStatus
+        : null;
+    if (slug !== null) {
+      cache.set(definitionId, slug);
+    } else if (warnOnMissingSlug) {
+      warnOnce(definitionId, "response had no string `slug` field");
+    }
+    return { slug, activeBuildRunId, activeBuildRunStatus };
+  };
+
+  /**
+   * Core serves the same definition projection at a different path, with a
+   * different auth header.
+   *
+   * The gateway's `agents/v1` surface is the primary and stays so: in prod it is
+   * what answers. But it is a SEPARATE service from Core, and a local stack runs
+   * Core without it — every `agents/v1` route 404s there while
+   * `tools.localhost/health` is happily 200. The visible symptom was ugly and
+   * misleading: an agent that is genuinely deployed (`activeBuildRunStatus:
+   * "ready"` in Core) shows no runnable build in Studio, so Run stays dark and
+   * the agent reads as "never deployed".
+   *
+   * Returns null (not a throw) on anything unexpected: this is a fallback, and a
+   * fallback that throws is worse than no fallback.
+   */
+  const resolveViaCore = async (
+    definitionId: string,
+    currentApiKey: string,
+  ): Promise<DefinitionMetadata | null> => {
+    try {
+      const url = `${resolveCoreBaseUrl()}/v1/workflows/definitions/${encodeURIComponent(definitionId)}`;
+      // Core authenticates `x-api-key`; it rejects `x-sapiom-api-key` with 401.
+      const response = await fetchImpl(url, {
+        headers: { "x-api-key": currentApiKey },
+      });
+      if (!response.ok) return null;
+      const body = (await response.json()) as Record<string, unknown>;
+      return readMetadata(definitionId, body, false);
+    } catch {
+      return null;
+    }
+  };
+
   const resolveMetadata = async (
     definitionId: string,
   ): Promise<DefinitionMetadata | null> => {
@@ -112,27 +166,19 @@ export function createDefinitionSlugResolver(opts: {
       });
 
       if (!response.ok) {
+        // The gateway may simply not be part of this deployment (local stacks
+        // run Core alone). Ask Core before giving up.
+        const viaCore = await resolveViaCore(definitionId, currentApiKey);
+        if (viaCore) return viaCore;
         warnOnce(definitionId, `HTTP ${response.status}`);
         return null;
       }
 
       const body = (await response.json()) as Record<string, unknown>;
-      const slug = typeof body.slug === "string" ? body.slug : null;
-      const activeBuildRunId =
-        typeof body.activeBuildRunId === "string"
-          ? body.activeBuildRunId
-          : null;
-      const activeBuildRunStatus =
-        typeof body.activeBuildRunStatus === "string"
-          ? body.activeBuildRunStatus
-          : null;
-      if (slug !== null) {
-        cache.set(definitionId, slug);
-      } else {
-        warnOnce(definitionId, "response had no string `slug` field");
-      }
-      return { slug, activeBuildRunId, activeBuildRunStatus };
+      return readMetadata(definitionId, body, true);
     } catch (err) {
+      const viaCore = await resolveViaCore(definitionId, currentApiKey);
+      if (viaCore) return viaCore;
       warnOnce(definitionId, err instanceof Error ? err.message : String(err));
       return null;
     }

--- a/packages/harness/src/core/run-state.test.ts
+++ b/packages/harness/src/core/run-state.test.ts
@@ -465,3 +465,161 @@ describe("createRunStateFetcher — refresh-on-401", () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Core fallback: a gateway 404 is ambiguous — route missing, or execution missing
+// ---------------------------------------------------------------------------
+
+describe("createRunStateFetcher — Core fallback on a gateway 404", () => {
+  /**
+   * The case this exists for. On a local stack `GET /agents/v1/executions/:id`
+   * is not mounted, so the gateway answers 404 for a cloud run that completed
+   * perfectly well — and Studio reported "execution not found" for a run whose
+   * output was sitting in Core the whole time.
+   */
+  it("renders the execution from Core when the gateway has no such route", async () => {
+    const mockFetch = makeSequencedFetch([
+      response(404, { message: "Cannot GET /agents/v1/executions/58" }),
+      response(200, RAW_SUCCESS_DOC),
+    ]);
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test-key",
+      baseUrl: "https://agents.test",
+      coreBaseUrl: "https://core.test",
+      fetchImpl: mockFetch,
+    });
+
+    const result = await fetcher.fetch("58");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.runView.status).toBe("completed");
+  });
+
+  it("asks Core with Core's header, not the gateway's", async () => {
+    const calls: Array<{ url: string; headers: Record<string, string> }> = [];
+    const mockFetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      calls.push({
+        url,
+        headers: (init?.headers ?? {}) as Record<string, string>,
+      });
+      return Promise.resolve(
+        calls.length === 1 ? response(404, {}) : response(200, RAW_SUCCESS_DOC),
+      );
+    }) as unknown as typeof fetch;
+
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test-key",
+      baseUrl: "https://agents.test",
+      coreBaseUrl: "https://core.test",
+      fetchImpl: mockFetch,
+    });
+    await fetcher.fetch("58");
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0].url).toBe("https://agents.test/agents/v1/executions/58");
+    expect(calls[0].headers["x-sapiom-api-key"]).toBe("sk-test-key");
+    // Core rejects the gateway's header with a 401, so it must not be reused.
+    expect(calls[1].url).toBe("https://core.test/v1/workflows/executions/58");
+    expect(calls[1].headers["x-api-key"]).toBe("sk-test-key");
+    expect(calls[1].headers["x-sapiom-api-key"]).toBeUndefined();
+  });
+
+  /** Both surfaces disclaim it: now "not found" is the honest answer. */
+  it("keeps the 404 when Core has not heard of it either", async () => {
+    const mockFetch = makeFetch(404, { error: "not found" });
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test-key",
+      baseUrl: "https://agents.test",
+      coreBaseUrl: "https://core.test",
+      fetchImpl: mockFetch,
+    });
+
+    const result = await fetcher.fetch("nope");
+
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: "execution not found",
+    });
+  });
+
+  it("keeps the 404 when Core itself is unreachable", async () => {
+    let call = 0;
+    const mockFetch = vi.fn().mockImplementation(() => {
+      call += 1;
+      if (call === 1) return Promise.resolve(response(404, {}));
+      return Promise.reject(new Error("ECONNREFUSED"));
+    }) as unknown as typeof fetch;
+
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test-key",
+      baseUrl: "https://agents.test",
+      coreBaseUrl: "https://core.test",
+      fetchImpl: mockFetch,
+    });
+
+    const result = await fetcher.fetch("58");
+    expect(result).toEqual({
+      ok: false,
+      status: 404,
+      error: "execution not found",
+    });
+  });
+
+  /**
+   * `decodeExecutionProjection` is lenient — it accepts an unfamiliar object
+   * rather than throwing — so the only way this path is reached is a body that
+   * will not parse at all. A truncated response, say.
+   */
+  it("reports a decode failure rather than claiming the run is missing", async () => {
+    const unparseable = {
+      status: 200,
+      ok: true,
+      json: () => Promise.reject(new SyntaxError("Unexpected end of JSON input")),
+    } as Response;
+    const mockFetch = makeSequencedFetch([response(404, {}), unparseable]);
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test-key",
+      baseUrl: "https://agents.test",
+      coreBaseUrl: "https://core.test",
+      fetchImpl: mockFetch,
+    });
+
+    const result = await fetcher.fetch("58");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.status).toBe(502);
+  });
+
+  /**
+   * The gateway remains the owner of deployed runs in production: a 200 there
+   * must never trigger a second call.
+   */
+  it("does not touch Core when the gateway answers", async () => {
+    const mockFetch = makeFetch(200, RAW_SUCCESS_DOC);
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test-key",
+      baseUrl: "https://agents.test",
+      coreBaseUrl: "https://core.test",
+      fetchImpl: mockFetch,
+    });
+
+    await fetcher.fetch("58");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not touch Core for a non-404 gateway failure", async () => {
+    const mockFetch = makeFetch(500, { error: "boom" });
+    const fetcher = createRunStateFetcher({
+      apiKey: "sk-test-key",
+      baseUrl: "https://agents.test",
+      coreBaseUrl: "https://core.test",
+      fetchImpl: mockFetch,
+    });
+
+    const result = await fetcher.fetch("58");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/harness/src/core/run-state.ts
+++ b/packages/harness/src/core/run-state.ts
@@ -19,6 +19,7 @@
 import { decodeExecutionProjection } from "@sapiom/agent-core";
 
 import type { RunView } from "../shared/types.js";
+import { resolveCoreBaseUrl } from "./definition-slug-resolver.js";
 import { renderRunState } from "./render-run-state.js";
 import {
   type ApiKeyProvider,
@@ -60,12 +61,51 @@ export interface RunStateFetcherOpts {
    */
   apiKey: string | null | ApiKeyProvider;
   baseUrl?: string;
+  /** Override Core's base URL (resolved from env by default). Test seam. */
+  coreBaseUrl?: string;
   /** Injectable fetch implementation — defaults to global fetch. Test seam. */
   fetchImpl?: typeof fetch;
 }
 
 export interface RunStateFetcher {
   fetch(executionId: string): Promise<RunStateResult>;
+}
+
+/**
+ * Core's own view of the same execution, used when the agents surface 404s.
+ *
+ * A 404 from the gateway is ambiguous in a way that matters: it means either
+ * "no such execution" or "no such ROUTE". On a local stack it is the latter —
+ * `GET /agents/v1/executions/:id` is not mounted there, so a cloud run that
+ * completed fine reported "execution not found" and Studio could never show its
+ * status. Asking Core resolves the ambiguity: if Core has the execution it is
+ * rendered, and if Core has not heard of it either then it genuinely does not
+ * exist.
+ *
+ * Core returns the same projection shape, so the SAME decoder renders it —
+ * verified against a real completed execution rather than assumed.
+ *
+ * Note the header: Core authenticates `x-api-key`; the gateway's
+ * `x-sapiom-api-key` is rejected there with a 401.
+ *
+ * The gateway stays primary. It owns deployed agent runs in production, and
+ * this is a fallback rather than a replacement so prod behaviour is unchanged.
+ */
+async function fetchFromCore(
+  executionId: string,
+  apiKey: string,
+  fetchImpl: typeof fetch,
+  coreBaseUrl: string,
+): Promise<Response | null> {
+  try {
+    return await fetchImpl(
+      `${coreBaseUrl}/v1/workflows/executions/${encodeURIComponent(executionId)}`,
+      { headers: { "x-api-key": apiKey } },
+    );
+  } catch {
+    // Core unreachable too — the caller keeps the gateway's verdict.
+    return null;
+  }
 }
 
 /** Upstream statuses that mean "the API key was rejected" — worth one refresh
@@ -90,6 +130,9 @@ export function createRunStateFetcher(
   opts: RunStateFetcherOpts,
 ): RunStateFetcher {
   const { baseUrl = resolveAgentsBaseUrl(), fetchImpl = fetch } = opts;
+  // Resolved lazily: `resolveCoreBaseUrl()` reads the environment, and reading
+  // it at construction would freeze whatever was set at boot.
+  const coreBase = (): string => opts.coreBaseUrl ?? resolveCoreBaseUrl();
   const provider = toApiKeyProvider(opts.apiKey);
 
   const requestOnce = async (
@@ -112,8 +155,13 @@ export function createRunStateFetcher(
     }
   };
 
-  const decode = async (res: Response): Promise<RunStateResult> => {
+  const decode = async (
+    res: Response,
+    onNotFound?: () => Promise<RunStateResult>,
+  ): Promise<RunStateResult> => {
     if (res.status === 404) {
+      // Ask Core before declaring it missing — see fetchFromCore.
+      if (onNotFound) return onNotFound();
       return { ok: false, status: 404, error: "execution not found" };
     }
     if (!res.ok) {
@@ -127,6 +175,23 @@ export function createRunStateFetcher(
       const raw = (await res.json()) as Record<string, unknown>;
       const runView = renderRunState(decodeExecutionProjection(raw));
       return { ok: true, runView };
+    } catch {
+      return { ok: false, status: 502, error: "could not decode execution" };
+    }
+  };
+
+  /** Second opinion from Core, keeping the gateway's 404 if Core has none. */
+  const viaCore = async (
+    executionId: string,
+    apiKey: string,
+  ): Promise<RunStateResult> => {
+    const res = await fetchFromCore(executionId, apiKey, fetchImpl, coreBase());
+    if (!res || !res.ok) {
+      return { ok: false, status: 404, error: "execution not found" };
+    }
+    try {
+      const raw = (await res.json()) as Record<string, unknown>;
+      return { ok: true, runView: renderRunState(decodeExecutionProjection(raw)) };
     } catch {
       return { ok: false, status: 502, error: "could not decode execution" };
     }
@@ -157,11 +222,11 @@ export function createRunStateFetcher(
           apiKey = refreshed;
           const second = await requestOnce(executionId, apiKey);
           if (second.kind === "err") return second.result;
-          return decode(second.res);
+          return decode(second.res, () => viaCore(executionId, apiKey!));
         }
       }
 
-      return decode(first.res);
+      return decode(first.res, () => viaCore(executionId, apiKey));
     },
   };
 }

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -153,6 +153,7 @@ import {
 import { createMacrosRouter } from "./macros.js";
 import { createFsRouter } from "./fs.js";
 import { createRunsRouter } from "./runs.js";
+import { createVersionsRouter } from "./versions.js";
 import { createTemplatesRouter } from "./templates.js";
 import { createAccountRouter } from "./account.js";
 import { createActionsRouter } from "./actions.js";
@@ -1619,6 +1620,14 @@ export const startServer = async (
   // baseUrl omitted: the router self-defaults via resolveCoreBaseUrl().
   app.use(
     createTemplatesRouter({
+      apiKey: apiKeyProvider,
+    }),
+  );
+  // Release history + the writes that change what runs. Core-relayed for the
+  // same reason as the gallery, and because the gateway's agents/v1 surface has
+  // no version projection at all.
+  app.use(
+    createVersionsRouter({
       apiKey: apiKeyProvider,
     }),
   );

--- a/packages/harness/src/server/versions.test.ts
+++ b/packages/harness/src/server/versions.test.ts
@@ -1,0 +1,485 @@
+import type { AddressInfo } from "node:net";
+import type { Server } from "node:http";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import express from "express";
+
+import {
+  createVersionsRouter,
+  orderVersions,
+  isNewestReady,
+  humanError,
+  type AgentVersion,
+} from "./versions.js";
+
+const CORE = "http://core.test";
+
+function version(over: Partial<AgentVersion> & { sha: string }): AgentVersion {
+  return {
+    subject: "",
+    author: "",
+    committedAt: "2026-01-01T00:00:00.000Z",
+    buildStatus: "ready",
+    deployedAt: "2026-01-01T00:00:00.000Z",
+    tags: [],
+    isActive: false,
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Ordering: labelled releases first, then recent unlabelled
+// ---------------------------------------------------------------------------
+
+describe("orderVersions", () => {
+  it("puts labelled releases above unlabelled ones", () => {
+    const rows = [
+      version({ sha: "new-untagged", deployedAt: "2026-03-01T00:00:00.000Z" }),
+      version({
+        sha: "old-tagged",
+        tags: ["0.0.1"],
+        deployedAt: "2026-01-01T00:00:00.000Z",
+      }),
+    ];
+    expect(orderVersions(rows).map((v) => v.sha)).toEqual([
+      "old-tagged",
+      "new-untagged",
+    ]);
+  });
+
+  it("orders within each group by recency", () => {
+    const rows = [
+      version({ sha: "t-old", tags: ["0.0.1"], deployedAt: "2026-01-01T00:00:00.000Z" }),
+      version({ sha: "t-new", tags: ["0.0.2"], deployedAt: "2026-02-01T00:00:00.000Z" }),
+      version({ sha: "u-old", deployedAt: "2026-01-15T00:00:00.000Z" }),
+      version({ sha: "u-new", deployedAt: "2026-02-15T00:00:00.000Z" }),
+    ];
+    expect(orderVersions(rows).map((v) => v.sha)).toEqual([
+      "t-new",
+      "t-old",
+      "u-new",
+      "u-old",
+    ]);
+  });
+
+  /**
+   * `latest` outranks everything, even a labelled release — it is the row
+   * people look for first, and it used to sink below an older tagged version
+   * whenever the newest build carried no label of its own.
+   */
+  it("pins the `latest` row to the top, above a labelled release", () => {
+    const rows = [
+      version({ sha: "real-label", tags: ["0.0.1"], deployedAt: "2026-01-01T00:00:00.000Z" }),
+      version({ sha: "only-latest", tags: ["latest"], deployedAt: "2026-03-01T00:00:00.000Z" }),
+    ];
+    expect(orderVersions(rows).map((v) => v.sha)).toEqual([
+      "only-latest",
+      "real-label",
+    ]);
+  });
+
+  /** Even when `latest` is the OLDEST build — position beats recency here. */
+  it("keeps `latest` on top even if it is not the most recent row", () => {
+    const rows = [
+      version({ sha: "newer-tagged", tags: ["0.0.9"], deployedAt: "2026-05-01T00:00:00.000Z" }),
+      version({ sha: "older-latest", tags: ["latest"], deployedAt: "2026-01-01T00:00:00.000Z" }),
+    ];
+    expect(orderVersions(rows).map((v) => v.sha)).toEqual([
+      "older-latest",
+      "newer-tagged",
+    ]);
+  });
+
+  /**
+   * `latest` still does not make a build count as "labelled" for the second
+   * group — otherwise the labelled/unlabelled split would be meaningless.
+   */
+  it("does not let `latest` promote unlabelled builds into the labelled group", () => {
+    const rows = [
+      version({ sha: "has-latest", tags: ["latest"], deployedAt: "2026-05-01T00:00:00.000Z" }),
+      version({ sha: "plain-new", deployedAt: "2026-04-01T00:00:00.000Z" }),
+      version({ sha: "tagged-old", tags: ["0.0.1"], deployedAt: "2026-01-01T00:00:00.000Z" }),
+    ];
+    expect(orderVersions(rows).map((v) => v.sha)).toEqual([
+      "has-latest",
+      "tagged-old",
+      "plain-new",
+    ]);
+  });
+
+  it("puts a version carrying latest AND a label first", () => {
+    const rows = [
+      version({ sha: "plain", deployedAt: "2026-04-01T00:00:00.000Z" }),
+      version({ sha: "both", tags: ["latest", "0.0.2"], deployedAt: "2026-03-01T00:00:00.000Z" }),
+    ];
+    expect(orderVersions(rows).map((v) => v.sha)).toEqual(["both", "plain"]);
+  });
+
+  it("caps the list at the page size", () => {
+    const rows = Array.from({ length: 25 }, (_, i) =>
+      version({ sha: `v${i}`, deployedAt: `2026-01-${String((i % 28) + 1).padStart(2, "0")}T00:00:00.000Z` }),
+    );
+    expect(orderVersions(rows)).toHaveLength(10);
+  });
+
+  it("falls back to committedAt when a build was never deployed", () => {
+    const rows = [
+      version({ sha: "a", deployedAt: null, committedAt: "2026-05-01T00:00:00.000Z" }),
+      version({ sha: "b", deployedAt: null, committedAt: "2026-04-01T00:00:00.000Z" }),
+    ];
+    expect(orderVersions(rows).map((v) => v.sha)).toEqual(["a", "b"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Confirm gating: pinning older has consequences, returning to newest does not
+// ---------------------------------------------------------------------------
+
+describe("isNewestReady", () => {
+  const rows = [
+    version({ sha: "newest", deployedAt: "2026-03-01T00:00:00.000Z" }),
+    version({ sha: "older", deployedAt: "2026-01-01T00:00:00.000Z" }),
+  ];
+
+  it("is true for the newest ready build (activating it resumes latest)", () => {
+    expect(isNewestReady(rows, "newest")).toBe(true);
+  });
+
+  it("is false for an older build (activating it pins, so confirm)", () => {
+    expect(isNewestReady(rows, "older")).toBe(false);
+  });
+
+  /** A failed build is not a candidate, so the newest READY one still wins. */
+  it("ignores builds that are not ready", () => {
+    const withFailed = [
+      version({ sha: "broken", buildStatus: "failed", deployedAt: "2026-04-01T00:00:00.000Z" }),
+      ...rows,
+    ];
+    expect(isNewestReady(withFailed, "newest")).toBe(true);
+    expect(isNewestReady(withFailed, "broken")).toBe(false);
+  });
+
+  it("is false when there are no ready builds at all", () => {
+    expect(isNewestReady([version({ sha: "x", buildStatus: "building" })], "x")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Routes
+// ---------------------------------------------------------------------------
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+/**
+ * A real express server on an ephemeral port, driven with `fetch` — the same
+ * shape runs.test.ts uses, so these routes are exercised through express's
+ * routing and body parsing rather than a stubbed request object.
+ */
+let server: Server | undefined;
+let origin = "";
+
+function start(fetchImpl: typeof fetch, apiKey: string | null = "sk-test"): void {
+  const a = express();
+  a.use(express.json());
+  a.use(createVersionsRouter({ apiKey, baseUrl: CORE, fetchImpl }));
+  server = a.listen(0);
+  origin = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+}
+
+afterEach(async () => {
+  if (!server) return;
+  const s = server;
+  server = undefined;
+  await new Promise<void>((resolve) => s.close(() => resolve()));
+});
+
+describe("GET /api/versions/:definitionId", () => {
+  it("returns ordered versions plus the active sha and pin state", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse([
+        version({ sha: "aaa", tags: ["latest", "0.0.2"], deployedAt: "2026-03-01T00:00:00.000Z" }),
+        version({
+          sha: "bbb",
+          tags: ["0.0.1"],
+          isActive: true,
+          source: "pinned",
+          deployedAt: "2026-01-01T00:00:00.000Z",
+        }),
+      ]),
+    ) as unknown as typeof fetch;
+
+    start(fetchImpl);
+    const res = await fetch(`${origin}/api/versions/45`);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.versions.map((v: AgentVersion) => v.sha)).toEqual(["aaa", "bbb"]);
+    expect(body.activeSha).toBe("bbb");
+    expect(body.pinned).toBe(true);
+    expect(body.total).toBe(2);
+  });
+
+  it("reports pinned=false when the active version is just following latest", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse([version({ sha: "aaa", tags: ["latest"], isActive: true })]),
+    ) as unknown as typeof fetch;
+
+    start(fetchImpl);
+    const res = await fetch(`${origin}/api/versions/45`);
+    const body = await res.json();
+    expect(body.pinned).toBe(false);
+  });
+
+  it("sends Core's header, not the gateway's", async () => {
+    const seen: Array<Record<string, string>> = [];
+    const fetchImpl = vi.fn(async (_url: string, init?: RequestInit) => {
+      seen.push((init?.headers ?? {}) as Record<string, string>);
+      return jsonResponse([]);
+    }) as unknown as typeof fetch;
+
+    start(fetchImpl);
+    await fetch(`${origin}/api/versions/45`);
+
+    expect(seen[0]["x-api-key"]).toBe("sk-test");
+    expect(seen[0]["x-sapiom-api-key"]).toBeUndefined();
+  });
+
+  it("503s when the harness is not signed in", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    start(fetchImpl, null);
+    const res = await fetch(`${origin}/api/versions/45`);
+    expect(res.status).toBe(503);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("passes Core's status through on failure", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ error: "nope" }, 404),
+    ) as unknown as typeof fetch;
+    start(fetchImpl);
+    const res = await fetch(`${origin}/api/versions/45`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("writes", () => {
+  it("activates a version", async () => {
+    const calls: Array<{ url: string; method?: string }> = [];
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method });
+      return jsonResponse({ buildRunId: "55" });
+    }) as unknown as typeof fetch;
+
+    start(fetchImpl);
+    const res = await fetch(`${origin}/api/versions/45/activate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sha: "abc" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(calls[0].method).toBe("POST");
+    expect(calls[0].url).toBe(`${CORE}/v1/workflows/definitions/45/versions/abc/activate`);
+  });
+
+  it("rejects an activate with no sha", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    start(fetchImpl);
+    const res = await fetch(`${origin}/api/versions/45/activate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("resumes following latest by deleting the pin", async () => {
+    const calls: Array<{ url: string; method?: string }> = [];
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method });
+      return jsonResponse({});
+    }) as unknown as typeof fetch;
+
+    start(fetchImpl);
+    const res = await fetch(`${origin}/api/versions/45/pin`, { method: "DELETE" });
+
+    expect(res.status).toBe(200);
+    expect(calls[0].method).toBe("DELETE");
+    expect(calls[0].url).toBe(`${CORE}/v1/workflows/definitions/45/version-pin`);
+  });
+
+  it("sets or moves a label onto a version", async () => {
+    const calls: Array<{ url: string; method?: string; body?: unknown }> = [];
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method, body: init?.body });
+      return jsonResponse({});
+    }) as unknown as typeof fetch;
+
+    start(fetchImpl);
+    const res = await fetch(`${origin}/api/versions/45/labels/0.0.3`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sha: "abc" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(calls[0].method).toBe("PUT");
+    expect(calls[0].url).toBe(`${CORE}/v1/workflows/definitions/45/tags/0.0.3`);
+    expect(JSON.parse(String(calls[0].body))).toEqual({ sha: "abc" });
+  });
+
+  /**
+   * Core owns the rules — 1–64 chars, and `latest` is refused by a DB CHECK.
+   * The router must relay that verdict rather than pre-judging names, so the
+   * two layers can never disagree about what is legal.
+   */
+  it("relays Core's rejection of a reserved label", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ message: "'latest' is reserved" }, 400),
+    ) as unknown as typeof fetch;
+
+    start(fetchImpl);
+    const res = await fetch(`${origin}/api/versions/45/labels/latest`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sha: "abc" }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    // Relayed as `{error}` — the one error shape this router speaks, so the
+    // panel's banner shows Core's sentence and not its envelope.
+    expect(body.error).toContain("reserved");
+  });
+
+  it("removes a label", async () => {
+    const calls: Array<{ url: string; method?: string }> = [];
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method });
+      return jsonResponse({});
+    }) as unknown as typeof fetch;
+
+    start(fetchImpl);
+    const res = await fetch(`${origin}/api/versions/45/labels/0.0.3`, { method: "DELETE" });
+
+    expect(res.status).toBe(200);
+    expect(calls[0].method).toBe("DELETE");
+    expect(calls[0].url).toBe(`${CORE}/v1/workflows/definitions/45/tags/0.0.3`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error normalisation: Core's sentence, not its envelope
+// ---------------------------------------------------------------------------
+
+describe("humanError", () => {
+  /**
+   * The exact body Core returned when the panel tried to set `latest` — the
+   * useful sentence is in `message`, while `error` is the bare HTTP phrase.
+   * Reading `error` first put "Bad Request" on screen; forwarding the whole
+   * object put a request id there.
+   */
+  it("prefers Core's message over its HTTP phrase", () => {
+    expect(
+      humanError(
+        {
+          statusCode: 400,
+          code: "bad_request",
+          message:
+            "'latest' is computed from the newest ready build and cannot be set.",
+          error: "Bad Request",
+          requestId: "0d543081-8184-4760-814f-1c319555918c",
+        },
+        400,
+      ),
+    ).toBe("'latest' is computed from the newest ready build and cannot be set.");
+  });
+
+  it("joins Nest's validation array", () => {
+    expect(humanError({ message: ["sha must be a string", "sha is required"] }, 400)).toBe(
+      "sha must be a string; sha is required",
+    );
+  });
+
+  it("falls back to `error` when there is no message", () => {
+    expect(humanError({ error: "not signed in to Sapiom" }, 503)).toBe(
+      "not signed in to Sapiom",
+    );
+  });
+
+  it("passes a plain-text body through", () => {
+    expect(humanError("upstream exploded", 502)).toBe("upstream exploded");
+  });
+
+  it("names the status when the body says nothing usable", () => {
+    expect(humanError({}, 404)).toBe("request failed (404)");
+    expect(humanError(null, 500)).toBe("request failed (500)");
+    expect(humanError({ message: "   " }, 400)).toBe("request failed (400)");
+  });
+});
+
+describe("error bodies reaching the browser", () => {
+  /**
+   * End to end through express: what the panel's error banner actually shows.
+   * The client reads `{error}` and nothing else, so a route that forwards
+   * Core's envelope leaves a JSON blob on screen.
+   */
+  it("forwards Core's sentence as {error} from a label write", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(
+        {
+          statusCode: 400,
+          message:
+            "'latest' is computed from the newest ready build and cannot be set.",
+          error: "Bad Request",
+          requestId: "abc",
+        },
+        400,
+      ),
+    ) as unknown as typeof fetch;
+
+    start(fetchImpl);
+    const res = await fetch(`${origin}/api/versions/46/labels/latest`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sha: "aaa" }),
+    });
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toEqual({
+      error: "'latest' is computed from the newest ready build and cannot be set.",
+    });
+    // No envelope leftovers on screen.
+    expect(body.requestId).toBeUndefined();
+    expect(body.statusCode).toBeUndefined();
+  });
+
+  it("normalises an activate failure the same way", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ message: "build is not ready", error: "Conflict" }, 409),
+    ) as unknown as typeof fetch;
+
+    start(fetchImpl);
+    const res = await fetch(`${origin}/api/versions/46/activate`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ sha: "aaa" }),
+    });
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "build is not ready" });
+  });
+
+  it("leaves a successful body untouched", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse([version({ sha: "aaa", tags: ["latest"], isActive: true })]),
+    ) as unknown as typeof fetch;
+
+    start(fetchImpl);
+    const body = await (await fetch(`${origin}/api/versions/45`)).json();
+    expect(body.versions[0].sha).toBe("aaa");
+  });
+});

--- a/packages/harness/src/server/versions.ts
+++ b/packages/harness/src/server/versions.ts
@@ -1,0 +1,380 @@
+/**
+ * Versions router — the deployed agent's release history, and the two writes
+ * that change what runs: activating a version and moving a label.
+ *
+ * Studio could build and deploy, but had no idea what versions existed or which
+ * one was live — that lived only in the web dashboard and the API. This is the
+ * surface behind the Versions tab and the version dropdown beside the agent
+ * name.
+ *
+ * Served by CORE (`/v1/workflows/definitions/...`), not the gateway's
+ * `agents/v1`. That is deliberate: Core owns the version projection and answers
+ * on every deployment including a local stack, where the gateway is not present
+ * at all. Note Core authenticates `x-api-key` — the gateway's
+ * `x-sapiom-api-key` is rejected there with a 401.
+ *
+ * The API key stays server-side, exactly as in the runs router: the browser
+ * calls these routes, never Core directly.
+ */
+
+import { createHash } from "node:crypto";
+
+import { Router } from "express";
+import { packSource } from "@sapiom/agent-core";
+
+import {
+  type ApiKeyProvider,
+  staticApiKeyProvider,
+} from "../core/api-key-provider.js";
+import { resolveCoreBaseUrl } from "../core/definition-slug-resolver.js";
+
+/** One row of release history, as Core projects it. */
+export interface AgentVersion {
+  readonly sha: string;
+  readonly subject: string;
+  readonly author: string;
+  readonly committedAt: string;
+  readonly buildStatus: string;
+  readonly deployedAt: string | null;
+  /**
+   * Movable labels pointing at this version. `latest` appears here too and is
+   * COMPUTED from the newest ready build rather than stored, so it cannot go
+   * stale — and Core refuses to store it (a DB CHECK), so it can never be moved
+   * by hand either.
+   */
+  readonly tags: readonly string[];
+  readonly isActive: boolean;
+  /** `"pinned"` when the active version is an explicit pin rather than latest. */
+  readonly source?: string;
+}
+
+export interface VersionsRouterOpts {
+  apiKey: string | null | ApiKeyProvider;
+  /** Override the Core base URL (resolved from env by default). Test seam. */
+  baseUrl?: string;
+  /** Injectable fetch. Test seam only, mirroring the runs router. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * What the local working copy would deploy as, and whether that is already a
+ * deployed version.
+ *
+ * The digest is not guessed: `postArchive` returns the digest the engine
+ * computes over exactly the bytes it received, and the engine's digest is
+ * `sha256` of the archive. Packing is reproducible (sorted entries, fixed
+ * mtimes), so hashing a local pack here yields the SAME value a deploy would —
+ * which is what makes "your local copy is 0.0.2" a fact rather than a guess.
+ *
+ * A git-built version can never match: its `commit_sha` is a git sha, not a
+ * content digest. So `matchesSha` finding nothing means "not deployed as an
+ * archive", not "you have changes" — the UI must not overclaim.
+ *
+ * Returns null rather than throwing: a project with no `index.ts` is a normal
+ * state (never linked, mid-scaffold), and the version list must still render.
+ */
+export interface LocalSourceView {
+  /** sha256 of the archive this directory would upload. */
+  readonly digest: string;
+  /** The deployed version carrying that digest, when there is one. */
+  readonly matchesSha: string | null;
+}
+
+export async function readLocalSource(
+  projectDir: string,
+  versions: readonly AgentVersion[],
+): Promise<LocalSourceView | null> {
+  try {
+    const { archive } = await packSource(projectDir);
+    const digest = createHash("sha256").update(archive).digest("hex");
+    const match = versions.find((v) => v.sha === digest);
+    return { digest, matchesSha: match?.sha ?? null };
+  } catch {
+    return null;
+  }
+}
+
+/** How many rows the panel shows. */
+export const VERSION_PAGE_SIZE = 10;
+
+/**
+ * `latest` first, always. Then labelled releases, then the rest by recency.
+ *
+ * Three rules, each earning its place:
+ *
+ * 1. **`latest` pinned to the top.** It is the build a plain deploy just
+ *    produced and the one "follow latest" returns to, so it is the row people
+ *    look for first. Grouping by label alone sank it below an older tagged
+ *    release whenever the newest build had no label of its own — burying the
+ *    most-asked-about row.
+ * 2. **Labelled releases next.** A plain chronological list buries a tagged
+ *    release as soon as a few untagged deploys land on top of it.
+ * 3. **`latest` never counts as "labelled" for rule 2.** Every newest build
+ *    carries it, so counting it would collapse the two groups into one.
+ */
+export function orderVersions(
+  versions: readonly AgentVersion[],
+  limit: number = VERSION_PAGE_SIZE,
+): AgentVersion[] {
+  const carriesLatest = (v: AgentVersion): boolean => v.tags.includes("latest");
+  const isLabelled = (v: AgentVersion): boolean =>
+    v.tags.some((t) => t !== "latest");
+  const byRecency = (a: AgentVersion, b: AgentVersion): number =>
+    Date.parse(b.deployedAt ?? b.committedAt) -
+    Date.parse(a.deployedAt ?? a.committedAt);
+
+  // Filtered rather than assumed-single: `latest` should point at exactly one
+  // build, and sorting the group keeps the order defined if it ever does not.
+  const latest = versions.filter(carriesLatest).sort(byRecency);
+  const rest = versions.filter((v) => !carriesLatest(v));
+  const labelled = rest.filter(isLabelled).sort(byRecency);
+  const plain = rest.filter((v) => !isLabelled(v)).sort(byRecency);
+  return [...latest, ...labelled, ...plain].slice(0, limit);
+}
+
+/**
+ * True when `sha` is the newest ready build — i.e. activating it returns the
+ * agent to following latest rather than pinning it back.
+ *
+ * Drives the confirm: pinning to an older version has consequences worth a
+ * second look (later deploys stop going live), returning to the newest does not.
+ */
+export function isNewestReady(
+  versions: readonly AgentVersion[],
+  sha: string,
+): boolean {
+  const ready = versions
+    .filter((v) => v.buildStatus === "ready")
+    .sort(
+      (a, b) =>
+        Date.parse(b.deployedAt ?? b.committedAt) -
+        Date.parse(a.deployedAt ?? a.committedAt),
+    );
+  return ready.length > 0 && ready[0].sha === sha;
+}
+
+/**
+ * Core's own sentence, not its envelope.
+ *
+ * Core answers errors as `{statusCode, code, message, error, requestId, ...}`,
+ * where `message` is written for a human — "'latest' is computed from the
+ * newest ready build and cannot be set." — and `error` is the bare HTTP phrase,
+ * "Bad Request". Forwarding the envelope untouched put that entire JSON blob,
+ * request id and all, into the Versions panel's error banner.
+ *
+ * Normalising to `{error: <sentence>}` here gives every route in this router
+ * the one shape its own 400s already use, so the browser has a single thing to
+ * read. Nest also reports validation failures as a `message` ARRAY, hence the
+ * join rather than a bare string check.
+ */
+export function humanError(body: unknown, status: number): string {
+  if (typeof body === "string" && body.trim()) return body;
+  if (body && typeof body === "object") {
+    const b = body as { message?: unknown; error?: unknown };
+    if (typeof b.message === "string" && b.message.trim()) return b.message;
+    if (Array.isArray(b.message)) {
+      const parts = b.message.filter((m): m is string => typeof m === "string");
+      if (parts.length > 0) return parts.join("; ");
+    }
+    if (typeof b.error === "string" && b.error.trim()) return b.error;
+  }
+  return `request failed (${status})`;
+}
+
+export function createVersionsRouter(opts: VersionsRouterOpts): Router {
+  const router = Router();
+  const provider: ApiKeyProvider =
+    opts.apiKey !== null && typeof opts.apiKey === "object"
+      ? opts.apiKey
+      : staticApiKeyProvider(opts.apiKey);
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const base = (): string => opts.baseUrl ?? resolveCoreBaseUrl();
+
+  /** Core call with the server-held key. Never leaks the key to the caller. */
+  const core = async (
+    path: string,
+    init: RequestInit = {},
+  ): Promise<{ status: number; body: unknown }> => {
+    const key = provider.getKey();
+    if (!key) return { status: 503, body: { error: "not signed in to Sapiom" } };
+    const response = await fetchImpl(`${base()}/v1/workflows${path}`, {
+      ...init,
+      headers: {
+        ...(init.headers ?? {}),
+        // Core's header. `x-sapiom-api-key` (the gateway's) 401s here.
+        "x-api-key": key,
+        ...(init.body ? { "content-type": "application/json" } : {}),
+      },
+    });
+    const text = await response.text();
+    let body: unknown = null;
+    if (text) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = { error: text };
+      }
+    }
+    // One error shape for every route here, carrying Core's sentence rather
+    // than its envelope. Success bodies pass through untouched.
+    if (!response.ok) {
+      return {
+        status: response.status,
+        body: { error: humanError(body, response.status) },
+      };
+    }
+    return { status: response.status, body };
+  };
+
+  const definitionIdOf = (raw: unknown): string | null =>
+    typeof raw === "string" && raw.trim() !== "" ? raw.trim() : null;
+
+  /**
+   * GET /api/versions/:definitionId
+   *
+   * 200 { versions, activeSha, pinned } — ordered, capped at VERSION_PAGE_SIZE
+   * 400 definitionId missing
+   * 503 not signed in
+   */
+  router.get("/api/versions/:definitionId", async (req, res) => {
+    const definitionId = definitionIdOf(req.params.definitionId);
+    if (!definitionId) {
+      res.status(400).json({ error: "definitionId is required" });
+      return;
+    }
+    try {
+      const { status, body } = await core(
+        `/definitions/${encodeURIComponent(definitionId)}/versions`,
+      );
+      if (status !== 200 || !Array.isArray(body)) {
+        res.status(status === 200 ? 502 : status).json(
+          body ?? { error: "could not load versions" },
+        );
+        return;
+      }
+      const all = body as AgentVersion[];
+      const active = all.find((v) => v.isActive) ?? null;
+      // `dir` is optional: without it the list still renders, just with no
+      // statement about the working copy.
+      const dir = typeof req.query.dir === "string" ? req.query.dir : null;
+      const local = dir ? await readLocalSource(dir, all) : null;
+      res.json({
+        versions: orderVersions(all),
+        activeSha: active?.sha ?? null,
+        // An explicit pin means later deploys will NOT go live — the state the
+        // panel has to surface, or a pinned agent looks merely up to date.
+        pinned: active?.source === "pinned",
+        total: all.length,
+        local,
+      });
+    } catch (err) {
+      res
+        .status(502)
+        .json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  /**
+   * POST /api/versions/:definitionId/activate  { sha }
+   *
+   * Makes `sha` the live version. The confirm decision lives in the UI (only
+   * when pinning to an older build); this route always performs it.
+   */
+  router.post("/api/versions/:definitionId/activate", async (req, res) => {
+    const definitionId = definitionIdOf(req.params.definitionId);
+    const sha = definitionIdOf((req.body ?? {}).sha);
+    if (!definitionId || !sha) {
+      res.status(400).json({ error: "definitionId and sha are required" });
+      return;
+    }
+    try {
+      const { status, body } = await core(
+        `/definitions/${encodeURIComponent(definitionId)}/versions/${encodeURIComponent(sha)}/activate`,
+        { method: "POST", body: JSON.stringify({}) },
+      );
+      res.status(status === 200 ? 200 : status).json(body ?? {});
+    } catch (err) {
+      res
+        .status(502)
+        .json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  /**
+   * DELETE /api/versions/:definitionId/pin — resume following latest.
+   *
+   * The counterpart to activating an older version: without this the only way
+   * out of a pin is to activate the newest build by hand.
+   */
+  router.delete("/api/versions/:definitionId/pin", async (req, res) => {
+    const definitionId = definitionIdOf(req.params.definitionId);
+    if (!definitionId) {
+      res.status(400).json({ error: "definitionId is required" });
+      return;
+    }
+    try {
+      const { status, body } = await core(
+        `/definitions/${encodeURIComponent(definitionId)}/version-pin`,
+        { method: "DELETE" },
+      );
+      res.status(status).json(body ?? {});
+    } catch (err) {
+      res
+        .status(502)
+        .json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  /**
+   * PUT /api/versions/:definitionId/labels/:name  { sha }
+   *
+   * Create a label, or move an existing one onto `sha`. Core enforces the rules
+   * (1–64 chars, and `latest` is reserved by a DB CHECK), so a bad name comes
+   * back as its 4xx rather than being guessed at here.
+   */
+  router.put("/api/versions/:definitionId/labels/:name", async (req, res) => {
+    const definitionId = definitionIdOf(req.params.definitionId);
+    const name = definitionIdOf(req.params.name);
+    const sha = definitionIdOf((req.body ?? {}).sha);
+    if (!definitionId || !name || !sha) {
+      res
+        .status(400)
+        .json({ error: "definitionId, label name and sha are required" });
+      return;
+    }
+    try {
+      const { status, body } = await core(
+        `/definitions/${encodeURIComponent(definitionId)}/tags/${encodeURIComponent(name)}`,
+        { method: "PUT", body: JSON.stringify({ sha }) },
+      );
+      res.status(status).json(body ?? {});
+    } catch (err) {
+      res
+        .status(502)
+        .json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  /** DELETE /api/versions/:definitionId/labels/:name — remove a label. */
+  router.delete("/api/versions/:definitionId/labels/:name", async (req, res) => {
+    const definitionId = definitionIdOf(req.params.definitionId);
+    const name = definitionIdOf(req.params.name);
+    if (!definitionId || !name) {
+      res.status(400).json({ error: "definitionId and label name are required" });
+      return;
+    }
+    try {
+      const { status, body } = await core(
+        `/definitions/${encodeURIComponent(definitionId)}/tags/${encodeURIComponent(name)}`,
+        { method: "DELETE" },
+      );
+      res.status(status).json(body ?? {});
+    } catch (err) {
+      res
+        .status(502)
+        .json({ error: err instanceof Error ? err.message : String(err) });
+    }
+  });
+
+  return router;
+}

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -1640,3 +1640,58 @@ export interface StudioRailLaunchEdge {
 export interface StudioRailLaunchEdgesResponse {
   edges: StudioRailLaunchEdge[];
 }
+
+// ---------------------------------------------------------------------------
+// Version history (the Versions tab + the picker beside the agent name)
+// ---------------------------------------------------------------------------
+
+/** One row of an agent's release history, as Core projects it. */
+export interface AgentVersionView {
+  readonly sha: string;
+  readonly subject: string;
+  readonly author: string;
+  readonly committedAt: string;
+  readonly buildStatus: string;
+  readonly deployedAt: string | null;
+  /**
+   * Movable labels pointing at this version. `latest` appears here and is
+   * COMPUTED from the newest ready build — Core refuses to store it, so it can
+   * never be moved by hand and cannot go stale.
+   */
+  readonly tags: readonly string[];
+  readonly isActive: boolean;
+  /** `"pinned"` when the live version is an explicit pin, not just latest. */
+  readonly source?: string;
+}
+
+/**
+ * What the local working copy would deploy as.
+ *
+ * `matchesSha` is how Studio can say "your local copy IS 0.0.2" as a fact: the
+ * digest is content-addressed and packing is reproducible, so a local pack
+ * hashes to the same value a deploy would upload. Null means the working copy
+ * is not deployed AS AN ARCHIVE — which includes the case where the deployed
+ * version came from git (its sha is a commit, not a digest), so the UI must not
+ * report it as "you have changes".
+ */
+export interface LocalSourceStateView {
+  readonly digest: string;
+  readonly matchesSha: string | null;
+}
+
+/** `GET /api/versions/:definitionId`. */
+export interface AgentVersionsView {
+  /** Labelled releases first, then recent unlabelled builds. Capped at 10. */
+  readonly versions: readonly AgentVersionView[];
+  readonly activeSha: string | null;
+  /**
+   * True when the live version is pinned — later deploys will NOT go live until
+   * the pin is released. The panel has to say so, or a pinned agent reads as
+   * merely up to date.
+   */
+  readonly pinned: boolean;
+  /** Total versions upstream, so the panel can say "10 of 23". */
+  readonly total: number;
+  /** Null when no project directory was supplied, or it has no `index.ts`. */
+  readonly local: LocalSourceStateView | null;
+}

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -51,6 +51,7 @@ import type { WorkspaceKey } from "@shared/system-graph";
 
 import { CanvasPane } from "./components/CanvasPane";
 import { CodePanel } from "./components/CodePanel";
+import { VersionsPanel } from "./components/VersionsPanel";
 import { CommandPalette } from "./components/CommandPalette";
 import {
   ConnectivityBanner,
@@ -103,7 +104,8 @@ import {
   type DeepLinkAgentTarget,
   type DeepLinkTarget,
 } from "./lib/desktop";
-import { deepLinkFromSearch } from "./lib/deep-link";
+import { deepLinkFromSearch, tabFromSearch } from "./lib/deep-link";
+import type { RightPaneTab } from "./lib/deep-link";
 import { editorLabel, editorUrl, resolveEditor } from "./lib/editors";
 import { CloneAgentConfirm } from "./components/CloneAgentConfirm";
 import {
@@ -153,7 +155,7 @@ import {
   workflowDeploymentState,
 } from "./lib/workflow-deployment";
 
-type RightTab = "canvas" | "steps" | "code";
+type RightTab = RightPaneTab;
 
 /**
  * How long a held initial prompt waits for the coding agent to become ready
@@ -267,8 +269,15 @@ export const App = (): JSX.Element => {
   // Right tab is part of the held arrangement: restored on reload.
   // Guard against a stored "skills" value (tab removed) — fall back to canvas.
   const [rightTab, setRightTab] = useState<RightTab>(() => {
+    // `?tab=` wins over the stored preference: an explicit link is a deliberate
+    // instruction, and it is what makes a pane linkable and demonstrable.
+    const fromUrl = tabFromSearch();
+    if (fromUrl) return fromUrl;
     const stored = loadUiPrefs().rightTab;
-    return stored === "canvas" || stored === "steps" || stored === "code"
+    return stored === "canvas" ||
+      stored === "steps" ||
+      stored === "code" ||
+      stored === "versions"
       ? stored
       : "canvas";
   });
@@ -2283,6 +2292,19 @@ export const App = (): JSX.Element => {
                 <Icon name="Code" size={14} />
                 Code
               </button>
+              <button
+                role="tab"
+                aria-selected={rightTab === "versions"}
+                className={
+                  "right-pane-tab" +
+                  (rightTab === "versions" ? " is-active" : "")
+                }
+                onClick={() => setRightTab("versions")}
+                data-testid="right-tab-versions"
+              >
+                <Icon name="History" size={14} />
+                Versions
+              </button>
               <div className="right-pane-corner">
                 {/* Cloud-status pill → dashboard. The board has no subheader,
                     so the link/build state lives here in the tab bar. */}
@@ -2453,6 +2475,25 @@ export const App = (): JSX.Element => {
                 onDescribeWorkflow={handleDescribeWithAI}
               />
             </div>
+
+            {/* Mounted only once opened, and unmounted when closed: the panel
+                fetches on mount, so keeping it alive behind `is-hidden` (the
+                Code tab's trick) would hold a stale history for an agent the
+                user has since switched away from. */}
+            {rightTab === "versions" && (
+              <div
+                className="right-pane-panel"
+                data-testid="right-panel-versions"
+              >
+                <VersionsPanel
+                  /* Follows the board's selection, like the Code tab: which
+                     version is live is a property of the agent, not of
+                     whichever session happens to be running. */
+                  boundWorkflow={rightPaneWorkflow}
+                  noSessionAgent={null}
+                />
+              </div>
+            )}
 
             {(rightTab === "code" || codePanelEverShown) && (
               <div

--- a/packages/harness/web/src/components/VersionPicker.tsx
+++ b/packages/harness/web/src/components/VersionPicker.tsx
@@ -1,0 +1,168 @@
+/**
+ * The live-version chip beside the agent name: shows what is running now, and
+ * drops down the recent versions so switching is one click from anywhere in
+ * Studio rather than a trip to the Versions tab.
+ *
+ * Mirrors the run picker two elements over — same `AnchoredPopover`, same
+ * chip-as-trigger shape — so the header keeps one idiom.
+ *
+ * Deliberately reuses {@link PinConfirm} from the Versions tab instead of
+ * writing a second dialog: the guard is the same decision (pinning backwards
+ * stops later deploys going live), and two copies would drift apart in wording.
+ */
+import { useRef, useState } from "react";
+import type { JSX } from "react";
+
+import { AnchoredPopover } from "./AnchoredPopover";
+import { Icon } from "./Icon";
+import { PinConfirm } from "./VersionsPanel";
+import { useVersions } from "../lib/use-versions";
+import { trackingAttrs } from "../lib/analytics/tracking-attrs";
+import {
+  localStateLabel,
+  needsPinConfirm,
+  realLabels,
+  shortSha,
+  versionLabel,
+} from "../lib/versions";
+import type { AgentVersionView } from "@shared/types";
+
+export function VersionPicker({
+  definitionId,
+  projectDir = null,
+}: {
+  /** Null for a project that is linked but never deployed — renders nothing. */
+  definitionId: string | null;
+  /** Absolute project dir, so the chip can also state the LOCAL copy. */
+  projectDir?: string | null;
+}): JSX.Element | null {
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
+  const [confirming, setConfirming] = useState<AgentVersionView | null>(null);
+  const { view, pendingSha, activate } = useVersions(definitionId, projectDir);
+
+  // Nothing deployed, or history not loaded: the header stays as it was rather
+  // than showing an empty control that implies a missing version.
+  if (!definitionId || !view || view.versions.length === 0) return null;
+
+  const versions = view.versions;
+  const active = versions.find((v) => v.sha === view.activeSha) ?? null;
+  const localLabel = localStateLabel(view.local, versions);
+  // "Matches live" is stricter than "is deployed": the local copy can be a
+  // deployed version that is NOT the one currently serving traffic.
+  const localMatchesLive =
+    view.local?.matchesSha != null && view.local.matchesSha === view.activeSha;
+
+  const choose = (v: AgentVersionView): void => {
+    setOpen(false);
+    if (v.sha === view.activeSha) return;
+    // Same shared predicate the Versions tab uses, so the guard cannot differ
+    // between the two places a version can be switched.
+    if (!needsPinConfirm(versions, v.sha)) {
+      void activate(v.sha);
+      return;
+    }
+    setConfirming(v);
+  };
+
+  return (
+    <>
+      <button
+        ref={triggerRef}
+        /* The trigger's aria-label carries a user-authored version label, so
+           this click is marked as touching a user-named entity. The redaction
+           gate's regex does not catch a ternary-formatted label — the leak is
+           the same, so it is tagged deliberately rather than by detection. */
+        {...trackingAttrs({ surface: "version_picker", object: "agent" })}
+        className="btn-ghost version-picker"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={
+          active
+            ? `Live version ${versionLabel(active)} — pick another`
+            : "Pick a version"
+        }
+        data-tooltip="Pick the live version"
+        data-testid="version-picker"
+        disabled={pendingSha !== null}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {/* Both halves, named. The cloud version is what a triggered run
+            executes; the local one is what a Deploy would upload — and they
+            drift apart the moment you edit a file, so showing only one of them
+            makes "which am I looking at?" unanswerable. */}
+        <span className="version-picker-part">
+          <span className="version-picker-key">cloud</span>
+          {active ? versionLabel(active) : "none"}
+          {view.pinned ? (
+            <span title="Pinned — later deploys will not go live">·&nbsp;pinned</span>
+          ) : null}
+        </span>
+        {localLabel ? (
+          <span
+            className={
+              "version-picker-part" +
+              (localMatchesLive ? "" : " is-diverged")
+            }
+            title={
+              localMatchesLive
+                ? "Your working copy is the version running in the cloud"
+                : "Your working copy differs from what is live — Deploy to publish it"
+            }
+          >
+            <span className="version-picker-key">local</span>
+            {localLabel}
+          </span>
+        ) : null}
+        <Icon name="ChevronDown" size={11} />
+      </button>
+      <AnchoredPopover
+        open={open}
+        anchorRef={triggerRef}
+        onDismiss={() => setOpen(false)}
+        placement="down-end"
+        className="version-picker-menu"
+        role="menu"
+        testid="version-picker-menu"
+      >
+        {versions.map((v) => {
+          const isLive = v.sha === view.activeSha;
+          const ready = v.buildStatus === "ready";
+          return (
+            <button
+              key={v.sha}
+              role="menuitemradio"
+              aria-checked={isLive}
+              aria-current={isLive || undefined}
+              className="version-picker-item"
+              title={v.sha}
+              disabled={!ready && !isLive}
+              data-testid={`version-picker-option-${shortSha(v.sha)}`}
+              onClick={() => choose(v)}
+            >
+              <Icon name={isLive ? "Check" : "History"} size={13} />
+              <span className="versions-sha">{shortSha(v.sha)}</span>
+              <span>{realLabels(v).join(" · ") || (ready ? "unlabelled" : v.buildStatus)}</span>
+              {/* Which row your files currently are — the answer to "what am I
+                  about to overwrite if I deploy?" */}
+              {view.local?.matchesSha === v.sha ? (
+                <span className="version-picker-local-tag">your local copy</span>
+              ) : null}
+            </button>
+          );
+        })}
+      </AnchoredPopover>
+      {confirming ? (
+        <PinConfirm
+          version={confirming}
+          onCancel={() => setConfirming(null)}
+          onConfirm={() => {
+            const sha = confirming.sha;
+            setConfirming(null);
+            void activate(sha);
+          }}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/packages/harness/web/src/components/VersionsPanel.tsx
+++ b/packages/harness/web/src/components/VersionsPanel.tsx
@@ -1,0 +1,447 @@
+/**
+ * Versions tab — an agent's release history, and the two writes that change
+ * what runs: activating a version and moving a label.
+ *
+ * Same anatomy as the sibling tabs (Canvas | Steps | Code): the shared
+ * `workflow-actions-header` subheader with the agent name left and the one
+ * server-provable status right, over a `--pane-pad-x` body.
+ *
+ * Studio could build and deploy but never showed which version was live — that
+ * lived only in the web dashboard and the API. Two rules shape this panel:
+ *
+ * - **Labelled releases first, then recent unlabelled builds.** A plain
+ *   chronological list buries a tagged release under a few untagged deploys;
+ *   a labels-only list hides the build you just pushed. Ordering is the
+ *   server's (`orderVersions`) so both surfaces agree.
+ * - **Confirm only when pinning to an older build.** Returning to the newest
+ *   build is a return to normal and needs no ceremony. Pinning backwards stops
+ *   later deploys going live, which is worth a second look.
+ */
+import { useRef, useState } from "react";
+import type { JSX } from "react";
+import type { AgentVersionView, WorkflowInfo } from "@shared/types";
+
+import { EmptyState } from "./EmptyState";
+import { Icon } from "./Icon";
+import { VersionPicker } from "./VersionPicker";
+import { useVersions } from "../lib/use-versions";
+import {
+  COMPUTED_LABEL,
+  localStateLabel,
+  needsPinConfirm,
+  realLabels,
+  shortSha,
+  versionLabel,
+  whenLabel,
+} from "../lib/versions";
+import { useDismissable } from "../lib/use-dismissable";
+import { trackingAttrs } from "../lib/analytics/tracking-attrs";
+
+/**
+ * The confirm shown only for pinning backwards. Names the version and states
+ * the consequence outright — that later deploys stop going live is the whole
+ * reason this dialog exists.
+ */
+export function PinConfirm({
+  version,
+  onCancel,
+  onConfirm,
+}: {
+  version: AgentVersionView;
+  onCancel: () => void;
+  onConfirm: () => void;
+}): JSX.Element {
+  const ref = useRef<HTMLDivElement>(null);
+  useDismissable(true, { onDismiss: onCancel, containerRef: ref });
+  const labels = realLabels(version);
+  return (
+    <div className="modal-backdrop" onClick={onCancel}>
+      <div
+        ref={ref}
+        className="modal modal-confirm"
+        role="alertdialog"
+        aria-label="Activate an older version"
+        data-testid="version-pin-confirm"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="modal-header">
+          Activate {labels[0] ?? shortSha(version.sha)}?
+          <button
+            className="theme-toggle modal-close"
+            aria-label="Close"
+            title="Close"
+            onClick={onCancel}
+          >
+            <Icon name="X" size={14} />
+          </button>
+        </div>
+        <div className="modal-body">
+          <p className="modal-copy">
+            This makes {shortSha(version.sha)} the live version now. It also
+            pins the agent: later deploys will not go live until you activate
+            another version or resume following latest.
+          </p>
+        </div>
+        {/* `modal-actions` is the app's dialog footer — it supplies the row
+            layout and the gap between the two buttons. An earlier pass used
+            `modal-footer`, which this stylesheet does not define, so the
+            buttons sat flush against each other with no spacing at all. */}
+        <div className="modal-actions">
+          {/* Initial focus lands on the SAFE action, matching EndSessionConfirm:
+              Enter keeps the current version, and pinning an older build takes
+              a deliberate Tab or click. */}
+          <button className="btn-ghost" autoFocus onClick={onCancel}>
+            Keep current
+          </button>
+          <button
+            className="btn-primary"
+            onClick={onConfirm}
+            data-testid="version-pin-confirm-go"
+          >
+            Activate
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** Inline label editor on a row: `+ label`, then a one-field commit. */
+function LabelAdderInline({
+  onCommit,
+  disabled,
+}: {
+  onCommit: (name: string) => void;
+  disabled: boolean;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState("");
+
+  if (!open) {
+    return (
+      <button
+        className="version-label-add"
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        aria-label="Add a label to this version"
+        data-testid="version-label-add"
+      >
+        <Icon name="Plus" size={11} />
+        label
+      </button>
+    );
+  }
+
+  const commit = (): void => {
+    const name = value.trim();
+    setOpen(false);
+    setValue("");
+    // Core owns the rules (1–64 chars, `latest` reserved), so an empty string
+    // is the only thing worth stopping here — everything else is its verdict.
+    if (name) onCommit(name);
+  };
+
+  return (
+    <input
+      className="version-label-input"
+      autoFocus
+      value={value}
+      placeholder="0.0.3"
+      aria-label="New label"
+      data-testid="version-label-input"
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={commit}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") commit();
+        if (e.key === "Escape") {
+          setOpen(false);
+          setValue("");
+        }
+      }}
+    />
+  );
+}
+
+interface VersionsPanelProps {
+  /** The workflow bound to the active session, if any. */
+  boundWorkflow: WorkflowInfo | null;
+  /** Named in the empty state when an agent is open with no live session. */
+  noSessionAgent?: string | null;
+}
+
+export function VersionsPanel({
+  boundWorkflow,
+  noSessionAgent = null,
+}: VersionsPanelProps): JSX.Element {
+  // `WorkflowInfo.definitionId` is a number; these routes take it as a path
+  // segment. Convert once here so the hook and the api client stay string-typed.
+  const definitionId =
+    boundWorkflow?.definitionId != null
+      ? String(boundWorkflow.definitionId)
+      : null;
+  const {
+    view,
+    loading,
+    error,
+    pendingSha,
+    activate,
+    resumeLatest,
+    setLabel,
+    removeLabel,
+  } = useVersions(definitionId, boundWorkflow?.path ?? null);
+  const [confirming, setConfirming] = useState<AgentVersionView | null>(null);
+
+  if (!boundWorkflow) {
+    return (
+      <EmptyState
+        className="versions-panel-empty"
+        icon="GitBranch"
+        title={
+          noSessionAgent
+            ? `No running session for ${noSessionAgent}`
+            : "No agent bound"
+        }
+        body={
+          noSessionAgent
+            ? "Start a session to see this agent's version history here."
+            : "Open an agent to see which version is live and roll back."
+        }
+      />
+    );
+  }
+
+  // Linked but never deployed: there is genuinely no history, and saying so
+  // beats an empty table that reads like a failed load.
+  if (!definitionId) {
+    return (
+      <EmptyState
+        className="versions-panel-empty"
+        icon="GitBranch"
+        title="Not deployed yet"
+        body={`${boundWorkflow.name} has no cloud versions. Deploy it and its releases appear here.`}
+      />
+    );
+  }
+
+  const versions = view?.versions ?? [];
+  const activeVersion =
+    versions.find((v) => v.sha === view?.activeSha) ?? null;
+  const localLabel = localStateLabel(view?.local ?? null, versions);
+  const localMatchesLive =
+    view?.local?.matchesSha != null && view.local.matchesSha === view.activeSha;
+
+  const onRowActivate = (v: AgentVersionView): void => {
+    if (v.isActive) return;
+    // Forward to the newest build is a return to normal — no ceremony. One
+    // shared predicate so this tab and the header picker guard identically.
+    if (!needsPinConfirm(versions, v.sha)) {
+      void activate(v.sha);
+      return;
+    }
+    setConfirming(v);
+  };
+
+  return (
+    <div
+      className="versions-panel"
+      /* `object: "agent"` is not decoration: the remove-label control builds
+         its aria-label from a user-authored label name (anything up to 64
+         chars), and before-send only redacts labels on clicks marked as
+         touching a user-named entity. */
+      {...trackingAttrs({ surface: "versions_panel", object: "agent" })}
+    >
+      <div
+        className="workflow-actions-header versions-panel-header"
+        data-testid="versions-panel-header"
+      >
+        <span className="workflow-actions-name">{boundWorkflow.name}</span>
+        {/* The question this tab exists to answer — WHICH version is serving
+            traffic, and under which label — stated here rather than left to be
+            inferred from a `Live` marker somewhere down the list. */}
+        {activeVersion ? (
+          <span className="versions-live-summary" data-testid="versions-live-summary">
+            <span className="version-picker-key">live on cloud</span>
+            <strong>{versionLabel(activeVersion)}</strong>
+            <span className="versions-sha">{shortSha(activeVersion.sha)}</span>
+            {realLabels(activeVersion).length > 1 ? (
+              // A version can carry several labels; naming only the first would
+              // hide that `production` and `0.0.2` are the same build.
+              <span className="versions-live-aka">
+                also {realLabels(activeVersion).slice(1).join(", ")}
+              </span>
+            ) : null}
+            {view?.pinned ? <span className="versions-live-pin">pinned</span> : null}
+          </span>
+        ) : view ? (
+          <span className="versions-live-summary" data-testid="versions-live-summary">
+            <span className="version-picker-key">live on cloud</span>
+            <strong>nothing active</strong>
+          </span>
+        ) : null}
+        {localLabel ? (
+          <span
+            className={
+              "versions-live-summary" + (localMatchesLive ? "" : " is-diverged")
+            }
+            data-testid="versions-local-summary"
+            title={
+              localMatchesLive
+                ? "Your working copy is the version running in the cloud"
+                : "Your working copy differs from what is live — Deploy to publish it"
+            }
+          >
+            <span className="version-picker-key">your files</span>
+            <strong>{localLabel}</strong>
+          </span>
+        ) : null}
+        <VersionPicker definitionId={definitionId} projectDir={boundWorkflow.path} />
+        {view ? (
+          <span className="status-tag" data-testid="versions-count">
+            {view.total > view.versions.length
+              ? `${view.versions.length} of ${view.total}`
+              : `${view.total} version${view.total === 1 ? "" : "s"}`}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="versions-panel-body">
+        {/* A pin means later deploys will NOT go live. Without this the agent
+            reads as merely up to date, and a deploy that "did nothing" is a
+            genuinely confusing afternoon. */}
+        {view?.pinned ? (
+          <div className="versions-pin-banner" data-testid="versions-pin-banner">
+            <Icon name="Info" size={12} />
+            <span>
+              Pinned — later deploys will not go live until you activate another
+              version or resume following latest.
+            </span>
+            <button
+              className="btn-ghost versions-banner-action"
+              onClick={() => void resumeLatest()}
+              data-testid="versions-resume-latest"
+            >
+              Resume following latest
+            </button>
+          </div>
+        ) : null}
+
+        {/* A 401 here is almost always a STALE BOOT TOKEN: the harness mints a
+            new one every start, so a tab left open across a restart keeps
+            sending the old one. Printing the raw status made that read like the
+            versions feature was broken. Name the actual remedy. */}
+        {error ? (
+          <div className="versions-error" role="alert" data-testid="versions-error">
+            {/401|unauthor/i.test(error)
+              ? "This Studio tab is using an expired token — reload the page (Studio mints a new one each time it starts)."
+              : error}
+          </div>
+        ) : null}
+
+        {loading && versions.length === 0 ? (
+          <div className="versions-loading">Loading versions…</div>
+        ) : null}
+
+        {!loading && versions.length === 0 && !error ? (
+          <EmptyState
+            className="versions-panel-empty"
+            icon="GitBranch"
+            title="No versions yet"
+            body={`${boundWorkflow.name} is linked but has no ready build. Deploy it to create the first version.`}
+          />
+        ) : null}
+
+        {versions.length > 0 ? (
+          <ul className="versions-list" data-testid="versions-list">
+            {versions.map((v) => {
+              const labels = realLabels(v);
+              const busy = pendingSha === v.sha;
+              return (
+                <li
+                  key={v.sha}
+                  className={
+                    "versions-row" +
+                    (v.isActive ? " is-active" : "") +
+                    (busy ? " is-busy" : "")
+                  }
+                  data-testid={`version-row-${shortSha(v.sha)}`}
+                  data-active={v.isActive || undefined}
+                >
+                  <span className="versions-sha" title={v.sha}>
+                    {shortSha(v.sha)}
+                  </span>
+
+                  <span className="versions-labels">
+                    {v.tags.includes(COMPUTED_LABEL) ? (
+                      // Computed, never stored — so it has no remove control.
+                      <span
+                        className="version-chip is-computed"
+                        title="Computed from the newest ready build — cannot be moved or stored"
+                      >
+                        latest
+                      </span>
+                    ) : null}
+                    {labels.map((name) => (
+                      <span key={name} className="version-chip">
+                        {name}
+                        <button
+                          className="version-chip-remove"
+                          aria-label={`Remove label ${name}`}
+                          disabled={busy}
+                          onClick={() => void removeLabel(name)}
+                        >
+                          <Icon name="X" size={9} />
+                        </button>
+                      </span>
+                    ))}
+                    <LabelAdderInline
+                      disabled={busy}
+                      onCommit={(name) => void setLabel(name, v.sha)}
+                    />
+                  </span>
+
+                  {/* No commit means no author and no message — an archive
+                      upload has neither, and inventing one would be a lie. */}
+                  <span className="versions-when">{whenLabel(v)}</span>
+                  <span className="versions-subject">{v.subject || "—"}</span>
+
+                  <span className="versions-status">
+                    {v.isActive ? (
+                      <span className="status-tag versions-live">
+                        {view?.pinned ? "Live · pinned" : "Live"}
+                      </span>
+                    ) : v.buildStatus !== "ready" ? (
+                      <span className="status-tag" title={v.buildStatus}>
+                        {v.buildStatus}
+                      </span>
+                    ) : (
+                      <button
+                        className="btn-ghost versions-row-action"
+                        disabled={busy}
+                        onClick={() => onRowActivate(v)}
+                        data-testid={`version-activate-${shortSha(v.sha)}`}
+                      >
+                        {needsPinConfirm(versions, v.sha) ? "Activate" : "Follow latest"}
+                      </button>
+                    )}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+      </div>
+
+      {confirming ? (
+        <PinConfirm
+          version={confirming}
+          onCancel={() => setConfirming(null)}
+          onConfirm={() => {
+            const sha = confirming.sha;
+            setConfirming(null);
+            void activate(sha);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/WorkflowActionsHeader.tsx
+++ b/packages/harness/web/src/components/WorkflowActionsHeader.tsx
@@ -8,6 +8,7 @@ import { displayAgentName } from "../lib/agent-name";
 import { relativeTimeLabel } from "../lib/relative-time";
 import type { ObservedRun, RunTarget } from "../lib/use-harness-state";
 import { AnchoredPopover } from "./AnchoredPopover";
+import { VersionPicker } from "./VersionPicker";
 import { Icon } from "./Icon";
 import { trackingAttrs } from "../lib/analytics/tracking-attrs";
 
@@ -179,6 +180,14 @@ export function WorkflowActionsHeader({
         <span className="workflow-actions-count" data-testid="canvas-steps-count">
           {stepsSummary ?? "no steps"}
         </span>
+        {/* What is running right now, next to the name that identifies it.
+            Renders nothing until there is a deployed history to pick from. */}
+        <VersionPicker
+          definitionId={
+            workflow.definitionId != null ? String(workflow.definitionId) : null
+          }
+          projectDir={workflow.path}
+        />
         {/* One observed run: a plain status chip. Several: the chip is
             the run picker — any past run is one click away. */}
         {run && runs.length <= 1 && (

--- a/packages/harness/web/src/lib/analytics/redaction-gate.test.ts
+++ b/packages/harness/web/src/lib/analytics/redaction-gate.test.ts
@@ -304,7 +304,50 @@ const SAFE_INTERPOLATED_LABELS: Record<string, string> = {
     "Ours, low-cardinality, and the label that makes the on-ramp funnel readable.",
   "CanvasOverviewPanel.tsx": "Static labels only; interpolation is over our own counts.",
   "SchemaInputFields.tsx": "`Remove item ${index + 1}` — a list position, not a name.",
+  "RunTargetMenu.tsx":
+    "`${target.label}: ${disabledReason}` — both ours: `label` is the hardcoded " +
+    "\"Local\"/\"Cloud\" literal in this file, and `disabledReason` is our own copy. " +
+    "No user-authored value reaches this label. Surfaced when the detector was " +
+    "widened to brace matching; it had been invisible to the old regex.",
 };
+
+/**
+ * Every `aria-label={…}` expression in a source file, brace-matched.
+ *
+ * The first version of this check was `/aria-label=\{`[^`]*\$\{/` — a regex
+ * that required a backtick IMMEDIATELY after the brace. That missed three
+ * real components: a ternary (`aria-label={cond ? `…${x}` : y}`), a label
+ * broken across lines, and anything routed through a helper. Two of them had
+ * been interpolating a project name into a label for months with no failing
+ * test, which is precisely the hole this file exists to close.
+ *
+ * Brace matching handles all of those, including `${}` nested inside the
+ * expression, because an interpolation's own braces are balanced.
+ */
+function ariaLabelExpressions(source: string): string[] {
+  const out: string[] = [];
+  const opener = /aria-label=\{/g;
+  let match: RegExpExecArray | null;
+  while ((match = opener.exec(source)) !== null) {
+    let depth = 1;
+    let i = match.index + match[0].length;
+    let expr = "";
+    while (i < source.length && depth > 0) {
+      const ch = source[i];
+      if (ch === "{") depth += 1;
+      else if (ch === "}") depth -= 1;
+      if (depth > 0) expr += ch;
+      i += 1;
+    }
+    out.push(expr);
+  }
+  return out;
+}
+
+/** True when any aria-label on this component is built by interpolation. */
+function interpolatesAriaLabel(source: string): boolean {
+  return ariaLabelExpressions(source).some((expr) => expr.includes("${"));
+}
 
 describe("components that build an aria-label by interpolation must tag their surface", () => {
   const componentsDir = fileURLToPath(new URL("../../components", import.meta.url));
@@ -318,7 +361,7 @@ describe("components that build an aria-label by interpolation must tag their su
       file: file.split(/[\\/]/).pop() ?? file,
       source: readFileSync(`${componentsDir}/${file}`, "utf8"),
     }))
-    .filter(({ source }) => /aria-label=\{`[^`]*\$\{/.test(source));
+    .filter(({ source }) => interpolatesAriaLabel(source));
 
   it("finds the interpolating components at all (guards the regex itself)", () => {
     expect(offenders.length).toBeGreaterThan(0);

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -32,6 +32,8 @@ import type {
   StepView,
   WorkflowInputContractResponse,
   WorkflowInfo,
+  AgentVersionsView,
+  AgentVersionView,
 } from "@shared/types";
 import {
   type SystemGraph,
@@ -435,6 +437,23 @@ export interface HarnessApi {
   /** The rail's plan card view, relayed by the server from core (key stays
    *  server-side). Never rejects on a degraded read — inspect `source`. */
   getAccountPlan(): Promise<AccountPlanView>;
+  /** An agent's release history: labelled versions first, then recent builds.
+   *  Relayed by the server from core, so the key stays server-side. */
+  /** `projectDir` lets the server report what the local copy would deploy as. */
+  getAgentVersions(
+    definitionId: string,
+    projectDir?: string | null,
+  ): Promise<AgentVersionsView>;
+  /** Make `sha` the live version. The caller decides whether to confirm first
+   *  (only pinning to an older build needs it). */
+  activateAgentVersion(definitionId: string, sha: string): Promise<void>;
+  /** Release the pin so the agent follows the newest ready build again. */
+  resumeFollowingLatest(definitionId: string): Promise<void>;
+  /** Create a label or move an existing one onto `sha`. Core owns the rules —
+   *  a reserved or malformed name comes back as its 4xx. */
+  setAgentVersionLabel(definitionId: string, name: string, sha: string): Promise<void>;
+  /** Remove a label from whichever version holds it. */
+  removeAgentVersionLabel(definitionId: string, name: string): Promise<void>;
   /** Live run render state (upstream feat/harness-runtime-analytics):
    *  GET /api/runs/:id/state = inspect -> decode -> renderRunState. Poll
    *  after an execution.started bus message until the run is terminal. */
@@ -756,6 +775,51 @@ class RealApi implements HarnessApi {
 
   getAccountPlan(): Promise<AccountPlanView> {
     return this.request<AccountPlanView>("/api/account/plan");
+  }
+
+  getAgentVersions(
+    definitionId: string,
+    projectDir?: string | null,
+  ): Promise<AgentVersionsView> {
+    const query = projectDir ? `?dir=${encodeURIComponent(projectDir)}` : "";
+    return this.request<AgentVersionsView>(
+      `/api/versions/${encodeURIComponent(definitionId)}${query}`,
+    );
+  }
+
+  async activateAgentVersion(definitionId: string, sha: string): Promise<void> {
+    await this.request<unknown>(
+      `/api/versions/${encodeURIComponent(definitionId)}/activate`,
+      { method: "POST", body: JSON.stringify({ sha }) },
+    );
+  }
+
+  async resumeFollowingLatest(definitionId: string): Promise<void> {
+    await this.request<unknown>(
+      `/api/versions/${encodeURIComponent(definitionId)}/pin`,
+      { method: "DELETE" },
+    );
+  }
+
+  async setAgentVersionLabel(
+    definitionId: string,
+    name: string,
+    sha: string,
+  ): Promise<void> {
+    await this.request<unknown>(
+      `/api/versions/${encodeURIComponent(definitionId)}/labels/${encodeURIComponent(name)}`,
+      { method: "PUT", body: JSON.stringify({ sha }) },
+    );
+  }
+
+  async removeAgentVersionLabel(
+    definitionId: string,
+    name: string,
+  ): Promise<void> {
+    await this.request<unknown>(
+      `/api/versions/${encodeURIComponent(definitionId)}/labels/${encodeURIComponent(name)}`,
+      { method: "DELETE" },
+    );
   }
 
   getRunState(executionId: string): Promise<RunView> {
@@ -1316,6 +1380,107 @@ const MOCK_POLSIA_GRAPH_EDGES: SystemGraph["edges"] = [
     mode: "async",
   },
 ];
+
+/**
+ * Mock version history — mutable so mock mode exercises activate, pin release
+ * and label moves rather than showing a frozen list. Keyed by definitionId so
+ * two agents do not share one history.
+ */
+const MOCK_VERSIONS = new Map<string, AgentVersionView[]>();
+
+function mockVersionsFor(definitionId: string): AgentVersionsView {
+  if (!MOCK_VERSIONS.has(definitionId)) {
+    MOCK_VERSIONS.set(definitionId, [
+      {
+        sha: "7a9e3b7dece9f390bbf712f724117541c5237817",
+        subject: "",
+        author: "",
+        committedAt: "2026-09-02T14:41:59.217Z",
+        deployedAt: "2026-09-02T14:41:59.217Z",
+        buildStatus: "ready",
+        tags: ["latest", "0.0.2"],
+        isActive: false,
+      },
+      {
+        sha: "2f86780534d145719dd7708009ccb1cd440220f2",
+        subject: "deploy",
+        author: "Sapiom Deploy",
+        committedAt: "2026-09-02T14:40:55.000Z",
+        deployedAt: "2026-09-02T14:40:57.163Z",
+        buildStatus: "ready",
+        tags: ["0.0.1"],
+        isActive: true,
+        source: "pinned",
+      },
+    ]);
+  }
+  const rows = MOCK_VERSIONS.get(definitionId) ?? [];
+  const active = rows.find((v) => v.isActive) ?? null;
+  return {
+    versions: rows,
+    activeSha: active?.sha ?? null,
+    pinned: active?.source === "pinned",
+    total: rows.length,
+    // Mock mode has no project on disk to pack, so there is nothing honest to
+    // say about a local copy.
+    local: null,
+  };
+}
+
+function mockActivate(definitionId: string, sha: string): void {
+  const rows = MOCK_VERSIONS.get(definitionId);
+  if (!rows) return;
+  const newest = rows.find((v) => v.tags.includes("latest"))?.sha;
+  MOCK_VERSIONS.set(
+    definitionId,
+    rows.map((v) => ({
+      ...v,
+      isActive: v.sha === sha,
+      // Activating the newest build is a return to following latest, so it
+      // leaves no pin behind; anything older pins.
+      source: v.sha === sha && sha !== newest ? "pinned" : undefined,
+    })),
+  );
+}
+
+function mockResumeLatest(definitionId: string): void {
+  const rows = MOCK_VERSIONS.get(definitionId);
+  if (!rows) return;
+  const newest = rows.find((v) => v.tags.includes("latest"))?.sha;
+  MOCK_VERSIONS.set(
+    definitionId,
+    rows.map((v) => ({
+      ...v,
+      isActive: v.sha === newest,
+      source: undefined,
+    })),
+  );
+}
+
+function mockSetLabel(definitionId: string, name: string, sha: string): void {
+  const rows = MOCK_VERSIONS.get(definitionId);
+  if (!rows) return;
+  MOCK_VERSIONS.set(
+    definitionId,
+    rows.map((v) => ({
+      ...v,
+      // A label points at exactly one version, so setting it elsewhere moves it.
+      tags:
+        v.sha === sha
+          ? Array.from(new Set([...v.tags, name]))
+          : v.tags.filter((t) => t !== name),
+    })),
+  );
+}
+
+function mockRemoveLabel(definitionId: string, name: string): void {
+  const rows = MOCK_VERSIONS.get(definitionId);
+  if (!rows) return;
+  MOCK_VERSIONS.set(
+    definitionId,
+    rows.map((v) => ({ ...v, tags: v.tags.filter((t) => t !== name) })),
+  );
+}
 
 class MockApi implements HarnessApi {
   // Mock auth state: flipped by startAuth() / disconnect() so D7 e2e tests
@@ -2336,6 +2501,48 @@ class MockApi implements HarnessApi {
   async getAccountPlan(): Promise<AccountPlanView> {
     await delay(150);
     return MOCK_ACCOUNT_PLAN;
+  }
+
+  async getAgentVersions(definitionId: string): Promise<AgentVersionsView> {
+    await delay(150);
+    return mockVersionsFor(definitionId);
+  }
+
+  async activateAgentVersion(
+    definitionId: string,
+    sha: string,
+  ): Promise<void> {
+    await delay(120);
+    mockActivate(definitionId, sha);
+  }
+
+  async resumeFollowingLatest(definitionId: string): Promise<void> {
+    await delay(120);
+    mockResumeLatest(definitionId);
+  }
+
+  async setAgentVersionLabel(
+    definitionId: string,
+    name: string,
+    sha: string,
+  ): Promise<void> {
+    await delay(120);
+    if (name === "latest") {
+      throw new ApiError(
+        400,
+        "'latest' is computed from the newest ready build and cannot be set.",
+        undefined,
+      );
+    }
+    mockSetLabel(definitionId, name, sha);
+  }
+
+  async removeAgentVersionLabel(
+    definitionId: string,
+    name: string,
+  ): Promise<void> {
+    await delay(120);
+    mockRemoveLabel(definitionId, name);
   }
 
   async getTemplate(id: string): Promise<TemplateDetailView> {

--- a/packages/harness/web/src/lib/deep-link.test.ts
+++ b/packages/harness/web/src/lib/deep-link.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+
+import { deepLinkFromSearch, tabFromSearch } from "./deep-link";
+
+describe("tabFromSearch", () => {
+  it("reads a known tab", () => {
+    expect(tabFromSearch("?tab=versions")).toBe("versions");
+    expect(tabFromSearch("?tab=canvas")).toBe("canvas");
+  });
+
+  /**
+   * Falls through to the stored preference rather than wedging the pane on a
+   * tab that does not exist — the same failure the stored-value guard already
+   * handles for the removed "skills" tab.
+   */
+  it("ignores an unknown tab", () => {
+    expect(tabFromSearch("?tab=skills")).toBeNull();
+    expect(tabFromSearch("?tab=")).toBeNull();
+  });
+
+  it("is null when the param is absent", () => {
+    expect(tabFromSearch("?agent=46")).toBeNull();
+    expect(tabFromSearch("")).toBeNull();
+  });
+
+  it("coexists with the agent deep link", () => {
+    expect(tabFromSearch("?agent=46&tab=versions")).toBe("versions");
+    expect(deepLinkFromSearch("?agent=46&tab=versions")).toEqual({
+      kind: "agent",
+      definitionId: "46",
+    });
+  });
+});

--- a/packages/harness/web/src/lib/deep-link.ts
+++ b/packages/harness/web/src/lib/deep-link.ts
@@ -30,3 +30,27 @@ export function deepLinkFromSearch(
 
   return null;
 }
+
+/** The right pane's tabs, as persisted and as accepted on the URL. */
+export const RIGHT_TABS = ["canvas", "steps", "code", "versions"] as const;
+export type RightPaneTab = (typeof RIGHT_TABS)[number];
+
+/**
+ * Which right-pane tab to open, read from `?tab=`.
+ *
+ * The tab is React state persisted to local storage, so before this there was
+ * no way to point someone at a particular pane — "open Studio, pick the agent,
+ * then click Versions" instead of a link. It also makes the pane scriptable,
+ * which is how the surface gets demonstrated and screenshotted at all.
+ *
+ * Validated against the known set rather than cast: an unknown value must fall
+ * through to the stored preference, not wedge the pane on a tab that no longer
+ * exists (the same failure the stored-value guard already handles for the
+ * removed "skills" tab).
+ */
+export function tabFromSearch(
+  search = typeof window === "undefined" ? "" : window.location.search,
+): RightPaneTab | null {
+  const raw = new URLSearchParams(search).get("tab");
+  return RIGHT_TABS.includes(raw as RightPaneTab) ? (raw as RightPaneTab) : null;
+}

--- a/packages/harness/web/src/lib/ui-prefs.ts
+++ b/packages/harness/web/src/lib/ui-prefs.ts
@@ -13,7 +13,7 @@ import type { RailAxis, RailSort } from "./project-tree";
 export interface UiPrefs {
   railCollapsed?: boolean;
   rightCollapsed?: boolean;
-  rightTab?: "canvas" | "steps" | "code";
+  rightTab?: "canvas" | "steps" | "code" | "versions";
   /**
    * Rows the user collapsed in the rail tree, as NAMESPACED keys
    * (`project:<abs path>`, `dir:<abs path>`) — see ProjectTreeRows' `dirKey` /

--- a/packages/harness/web/src/lib/use-versions.ts
+++ b/packages/harness/web/src/lib/use-versions.ts
@@ -1,0 +1,116 @@
+/**
+ * An agent's release history, plus the writes that change what runs.
+ *
+ * Studio could build and deploy but had no idea what versions existed or which
+ * one was live — that lived only in the web dashboard and the API. This hook
+ * backs both surfaces that fix it: the Versions tab and the picker beside the
+ * agent name.
+ *
+ * State is NOT held here. It lives in {@link VersionsStore}, keyed by
+ * definition, because those surfaces are mounted at the same time and a
+ * per-component copy let them disagree: resuming "follow latest" in the tab
+ * cleared its pin banner while the header chip still read `· pinned`. This hook
+ * only subscribes and forwards the writes.
+ *
+ * Deliberately NOT polled. History changes only when someone deploys, activates
+ * or moves a label — all of which go through here, so a mutation refetches and a
+ * timer would just add noise. `reload()` is exposed for a deploy finishing
+ * elsewhere in the app.
+ */
+import { useCallback, useEffect, useSyncExternalStore } from "react";
+import type { AgentVersionsView } from "@shared/types";
+
+import { createApi, ApiError } from "./api";
+import { EMPTY_SNAPSHOT, VersionsStore } from "./versions-store";
+
+const api = createApi();
+
+/**
+ * Prefer the server's sentence: Core's own words beat a generic string.
+ *
+ * `reason` is the `{error}` field — the versions router normalises every
+ * failure to that shape, so it is Core's human message. `ApiError.message` is
+ * NOT usable here: it is a `PUT /api/… → 400: {full json body}` trace built for
+ * logs, and putting it in the panel's error banner showed the user a JSON blob
+ * with a request id in it.
+ */
+function messageOf(err: unknown): string {
+  if (err instanceof ApiError) {
+    return err.reason || `request failed (${err.status})`;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** One store for the app, so every surface reads the same rows. */
+const store = new VersionsStore(
+  (definitionId, projectDir) => api.getAgentVersions(definitionId, projectDir),
+  messageOf,
+);
+
+export interface VersionsState {
+  readonly view: AgentVersionsView | null;
+  readonly loading: boolean;
+  /** Human-readable failure for the panel to show inline; null when fine. */
+  readonly error: string | null;
+  /** The sha whose write is in flight, so a row can show its own spinner. */
+  readonly pendingSha: string | null;
+  readonly reload: () => void;
+  readonly activate: (sha: string) => Promise<void>;
+  readonly resumeLatest: () => Promise<void>;
+  readonly setLabel: (name: string, sha: string) => Promise<void>;
+  readonly removeLabel: (name: string) => Promise<void>;
+}
+
+export function useVersions(
+  definitionId: string | null,
+  /** Absolute project dir, so the server can report the local copy's digest. */
+  projectDir: string | null = null,
+): VersionsState {
+  // A null definition still has to return a stable snapshot, so it shares the
+  // store's frozen empty one rather than a fresh object per render.
+  const key = definitionId ?? "";
+  const subscribe = useCallback(
+    (onChange: () => void) => store.subscribe(key, onChange),
+    [key],
+  );
+  const snapshot = useCallback(
+    () => (definitionId ? store.snapshot(key) : EMPTY_SNAPSHOT),
+    [definitionId, key],
+  );
+  const state = useSyncExternalStore(subscribe, snapshot);
+
+  useEffect(() => {
+    // Concurrent mounts collapse onto one request inside the store. Rows
+    // already cached for this agent stay on screen while it refetches, which
+    // beats blanking the list on every remount.
+    if (definitionId) void store.load(definitionId, projectDir);
+  }, [definitionId, projectDir]);
+
+  const reload = useCallback(() => {
+    if (definitionId) void store.load(definitionId, projectDir, { force: true });
+  }, [definitionId, projectDir]);
+
+  const mutate = useCallback(
+    (sha: string | null, op: () => Promise<void>): Promise<void> => {
+      if (!definitionId) return Promise.resolve();
+      return store.mutate(definitionId, projectDir, sha, op);
+    },
+    [definitionId, projectDir],
+  );
+
+  return {
+    view: state.view,
+    loading: state.loading,
+    error: state.error,
+    pendingSha: state.pendingSha,
+    reload,
+    activate: (sha) =>
+      mutate(sha, () => api.activateAgentVersion(definitionId!, sha)),
+    resumeLatest: () =>
+      mutate(null, () => api.resumeFollowingLatest(definitionId!)),
+    setLabel: (name, sha) =>
+      mutate(sha, () => api.setAgentVersionLabel(definitionId!, name, sha)),
+    removeLabel: (name) =>
+      mutate(null, () => api.removeAgentVersionLabel(definitionId!, name)),
+  };
+}

--- a/packages/harness/web/src/lib/versions-store.test.ts
+++ b/packages/harness/web/src/lib/versions-store.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi } from "vitest";
+import type { AgentVersionsView } from "@shared/types";
+
+import { EMPTY_SNAPSHOT, VersionsStore } from "./versions-store";
+
+function view(over: Partial<AgentVersionsView> = {}): AgentVersionsView {
+  return {
+    versions: [],
+    activeSha: null,
+    pinned: false,
+    total: 0,
+    local: null,
+    ...over,
+  };
+}
+
+/** A fetcher whose responses are controlled per call. */
+function fetcherOf(...responses: AgentVersionsView[]) {
+  let i = 0;
+  return vi.fn(async () => responses[Math.min(i++, responses.length - 1)]);
+}
+
+describe("VersionsStore — one copy for every surface", () => {
+  /**
+   * The bug this store exists for. The Versions tab and the header chip are
+   * mounted together; with a per-component copy, resuming "follow latest" in
+   * the tab cleared its banner while the chip went on reading `· pinned`.
+   */
+  it("notifies every subscriber after a write, so no surface stays stale", async () => {
+    const store = new VersionsStore(
+      fetcherOf(
+        view({ activeSha: "old", pinned: true }),
+        view({ activeSha: "new", pinned: false }),
+      ),
+    );
+    // Nullable: listeners also fire for the `loading` flip, before any view.
+    const seenByTab: (boolean | undefined)[] = [];
+    const seenByChip: (boolean | undefined)[] = [];
+    store.subscribe("46", () => seenByTab.push(store.snapshot("46").view?.pinned));
+    store.subscribe("46", () => seenByChip.push(store.snapshot("46").view?.pinned));
+
+    await store.load("46", null);
+    expect(store.snapshot("46").view?.pinned).toBe(true);
+
+    await store.mutate("46", null, null, async () => {});
+
+    expect(store.snapshot("46").view?.pinned).toBe(false);
+    // Both surfaces saw the flip, not just the one that issued the write.
+    expect(seenByTab.at(-1)).toBe(false);
+    expect(seenByChip.at(-1)).toBe(false);
+  });
+
+  it("stops notifying once unsubscribed", async () => {
+    const store = new VersionsStore(fetcherOf(view()));
+    const listener = vi.fn();
+    const off = store.subscribe("46", listener);
+    off();
+    await store.load("46", null);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("survives a listener that unsubscribes while being notified", async () => {
+    const store = new VersionsStore(fetcherOf(view()));
+    const off = store.subscribe("46", () => off());
+    await expect(store.load("46", null)).resolves.toBeUndefined();
+  });
+});
+
+describe("VersionsStore — snapshots", () => {
+  it("reports the shared frozen snapshot for a key never loaded", () => {
+    const store = new VersionsStore(fetcherOf(view()));
+    expect(store.snapshot("nope")).toBe(EMPTY_SNAPSHOT);
+  });
+
+  /**
+   * `useSyncExternalStore` re-renders whenever the snapshot identity changes,
+   * so a fresh object per call would loop forever.
+   */
+  it("returns the same object while nothing changes", async () => {
+    const store = new VersionsStore(fetcherOf(view()));
+    await store.load("46", null);
+    expect(store.snapshot("46")).toBe(store.snapshot("46"));
+  });
+
+  it("keeps agents apart", async () => {
+    const store = new VersionsStore(
+      vi.fn(async (id: string) => view({ activeSha: `sha-${id}` })),
+    );
+    await Promise.all([store.load("46", null), store.load("49", null)]);
+    expect(store.snapshot("46").view?.activeSha).toBe("sha-46");
+    expect(store.snapshot("49").view?.activeSha).toBe("sha-49");
+  });
+});
+
+describe("VersionsStore — request sharing", () => {
+  /**
+   * Three surfaces mount together. Each duplicate GET re-packs and re-hashes
+   * the project directory server-side to report the local copy, so collapsing
+   * them is worth the bookkeeping.
+   */
+  it("collapses concurrent loads onto one request", async () => {
+    const fetcher = fetcherOf(view());
+    const store = new VersionsStore(fetcher);
+    await Promise.all([
+      store.load("46", null),
+      store.load("46", null),
+      store.load("46", null),
+    ]);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("still refetches when forced, which is the point after a write", async () => {
+    const fetcher = fetcherOf(view());
+    const store = new VersionsStore(fetcher);
+    await store.load("46", null);
+    await store.load("46", null, { force: true });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not leave a stale in-flight entry behind after a forced overlap", async () => {
+    const fetcher = fetcherOf(view());
+    const store = new VersionsStore(fetcher);
+    // Overlap deliberately: the first request must not clear the second's slot.
+    await Promise.all([
+      store.load("46", null),
+      store.load("46", null, { force: true }),
+    ]);
+    // A later load is a fresh request rather than a resolved leftover promise.
+    await store.load("46", null);
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
+  it("clears loading only once every overlapping request has finished", async () => {
+    const store = new VersionsStore(fetcherOf(view()));
+    const both = Promise.all([
+      store.load("46", null),
+      store.load("46", null, { force: true }),
+    ]);
+    expect(store.snapshot("46").loading).toBe(true);
+    await both;
+    expect(store.snapshot("46").loading).toBe(false);
+  });
+});
+
+describe("VersionsStore — failures", () => {
+  it("drops the view and reports the message when a load fails", async () => {
+    const store = new VersionsStore(async () => {
+      throw new Error("not signed in to Sapiom");
+    });
+    await store.load("46", null);
+    expect(store.snapshot("46")).toMatchObject({
+      view: null,
+      error: "not signed in to Sapiom",
+      loading: false,
+    });
+  });
+
+  /**
+   * The refetch that follows a failed write succeeds and clears `error` on its
+   * way past, which would leave the user staring at an unchanged list with no
+   * explanation. The message is restated afterwards.
+   */
+  it("keeps a failed write's message after the refetch that follows it", async () => {
+    const store = new VersionsStore(fetcherOf(view({ activeSha: "unchanged" })));
+    await store.load("46", null);
+    await store.mutate("46", null, "abc", async () => {
+      throw new Error("label `latest` is reserved");
+    });
+    expect(store.snapshot("46").error).toBe("label `latest` is reserved");
+    // ...and the list still shows what the server actually holds.
+    expect(store.snapshot("46").view?.activeSha).toBe("unchanged");
+  });
+
+  it("uses the injected describer, so Core's own wording reaches the panel", async () => {
+    const store = new VersionsStore(
+      async () => {
+        throw { status: 409, body: "conflict" };
+      },
+      (err) => `core says ${(err as { status: number }).status}`,
+    );
+    await store.load("46", null);
+    expect(store.snapshot("46").error).toBe("core says 409");
+  });
+});
+
+describe("VersionsStore — pendingSha", () => {
+  it("marks the row being written, then clears it", async () => {
+    const store = new VersionsStore(fetcherOf(view()));
+    const seen: (string | null)[] = [];
+    store.subscribe("46", () => seen.push(store.snapshot("46").pendingSha));
+    await store.mutate("46", null, "abc123", async () => {});
+    expect(seen).toContain("abc123");
+    expect(store.snapshot("46").pendingSha).toBeNull();
+  });
+
+  it("clears the row marker even when the write throws", async () => {
+    const store = new VersionsStore(fetcherOf(view()));
+    await store.mutate("46", null, "abc123", async () => {
+      throw new Error("nope");
+    });
+    expect(store.snapshot("46").pendingSha).toBeNull();
+  });
+
+  it("passes the project dir through to the refetch", async () => {
+    const fetcher = vi.fn(async () => view());
+    const store = new VersionsStore(fetcher);
+    await store.mutate("46", "/home/a/agent289-demo2/fresh", null, async () => {});
+    expect(fetcher).toHaveBeenCalledWith("46", "/home/a/agent289-demo2/fresh");
+  });
+});

--- a/packages/harness/web/src/lib/versions-store.ts
+++ b/packages/harness/web/src/lib/versions-store.ts
@@ -1,0 +1,181 @@
+/**
+ * One copy of an agent's version state, shared by every surface that shows it.
+ *
+ * Three surfaces read this at once: the Versions tab, the picker in that tab's
+ * subheader, and the picker beside the agent name above the canvas. When each
+ * held its own `useState` copy, a write in one left the others stale — resuming
+ * "follow latest" from the tab cleared the tab's pin banner while the header
+ * chip went on reading `· pinned`. Two surfaces disagreeing about whether
+ * deploys go live is worse than either one being wrong alone, because there is
+ * no way to tell which to believe.
+ *
+ * So the state lives here, keyed by definition, and every subscriber is
+ * notified together. Kept as a plain class rather than a React hook so it is
+ * unit-testable in the Node runner (the web tier only runs `lib/**.test.ts`).
+ *
+ * Snapshots are immutable and returned unchanged when nothing moved: that
+ * identity stability is what `useSyncExternalStore` requires, and returning a
+ * fresh object each call would re-render forever.
+ *
+ * Keyed by definition id ALONE, deliberately. `projectDir` only decides whether
+ * the response can also describe the local working copy, and every caller
+ * derives it from the same workflow — keying on it too would split the cache
+ * back into the per-surface copies this exists to merge.
+ */
+import type { AgentVersionsView } from "@shared/types";
+
+export interface VersionsSnapshot {
+  readonly view: AgentVersionsView | null;
+  readonly loading: boolean;
+  /** Human-readable failure for the panel to show inline; null when fine. */
+  readonly error: string | null;
+  /** The sha whose write is in flight, so a row can show its own spinner. */
+  readonly pendingSha: string | null;
+}
+
+/**
+ * What every key reports before anything is loaded. A single frozen instance
+ * because `useSyncExternalStore` compares snapshots by identity.
+ */
+export const EMPTY_SNAPSHOT: VersionsSnapshot = Object.freeze({
+  view: null,
+  loading: false,
+  error: null,
+  pendingSha: null,
+});
+
+export type VersionsFetcher = (
+  definitionId: string,
+  projectDir: string | null,
+) => Promise<AgentVersionsView>;
+
+export class VersionsStore {
+  private readonly snapshots = new Map<string, VersionsSnapshot>();
+  private readonly listeners = new Map<string, Set<() => void>>();
+  /** Live request per key, so simultaneous mounts share one fetch. */
+  private readonly inFlight = new Map<string, Promise<void>>();
+  /** Outstanding request count per key — `loading` must not clear early when a
+   *  forced refetch overlaps the initial load. */
+  private readonly running = new Map<string, number>();
+
+  constructor(
+    private readonly fetcher: VersionsFetcher,
+    /** Turns a thrown value into the message surfaces show. */
+    private readonly describeError: (err: unknown) => string = (err) =>
+      err instanceof Error ? err.message : String(err),
+  ) {}
+
+  snapshot(definitionId: string): VersionsSnapshot {
+    return this.snapshots.get(definitionId) ?? EMPTY_SNAPSHOT;
+  }
+
+  subscribe(definitionId: string, listener: () => void): () => void {
+    let set = this.listeners.get(definitionId);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(definitionId, set);
+    }
+    set.add(listener);
+    return () => {
+      set.delete(listener);
+      if (set.size === 0) this.listeners.delete(definitionId);
+    };
+  }
+
+  private patch(definitionId: string, next: Partial<VersionsSnapshot>): void {
+    this.snapshots.set(definitionId, { ...this.snapshot(definitionId), ...next });
+    // Copied before iterating: a listener may unsubscribe as it runs.
+    for (const listener of [...(this.listeners.get(definitionId) ?? [])]) {
+      listener();
+    }
+  }
+
+  /**
+   * Fetch this agent's versions.
+   *
+   * Collapses concurrent callers onto one request: three surfaces mounting
+   * together would otherwise fire three identical GETs, and each one re-packs
+   * and re-hashes the project directory server-side to report the local copy.
+   *
+   * `force` is for after a write, where the whole point is to see new state.
+   */
+  load(
+    definitionId: string,
+    projectDir: string | null,
+    opts: { force?: boolean } = {},
+  ): Promise<void> {
+    const running = this.inFlight.get(definitionId);
+    if (running && !opts.force) return running;
+    const task = this.run(definitionId, projectDir).finally(() => {
+      // Identity-guarded: a forced refetch may already have replaced this
+      // entry, and clearing it would let the next caller start a duplicate.
+      if (this.inFlight.get(definitionId) === task) {
+        this.inFlight.delete(definitionId);
+      }
+    });
+    this.inFlight.set(definitionId, task);
+    return task;
+  }
+
+  private async run(
+    definitionId: string,
+    projectDir: string | null,
+  ): Promise<void> {
+    this.begin(definitionId);
+    try {
+      const view = await this.fetcher(definitionId, projectDir);
+      this.patch(definitionId, { view, error: null });
+    } catch (err) {
+      this.patch(definitionId, {
+        view: null,
+        error: this.describeError(err),
+      });
+    } finally {
+      this.end(definitionId);
+    }
+  }
+
+  private begin(definitionId: string): void {
+    this.running.set(definitionId, (this.running.get(definitionId) ?? 0) + 1);
+    this.patch(definitionId, { loading: true });
+  }
+
+  private end(definitionId: string): void {
+    const left = (this.running.get(definitionId) ?? 1) - 1;
+    if (left > 0) {
+      this.running.set(definitionId, left);
+      return;
+    }
+    this.running.delete(definitionId);
+    this.patch(definitionId, { loading: false });
+  }
+
+  /**
+   * Run a write, then refetch.
+   *
+   * The server is the source of truth for what a write did — activating the
+   * newest build releases the pin as a side effect, and moving a label changes
+   * two rows — so an optimistic local edit would drift from reality.
+   */
+  async mutate(
+    definitionId: string,
+    projectDir: string | null,
+    sha: string | null,
+    op: () => Promise<void>,
+  ): Promise<void> {
+    this.patch(definitionId, { pendingSha: sha, error: null });
+    try {
+      await op();
+      await this.load(definitionId, projectDir, { force: true });
+    } catch (err) {
+      const message = this.describeError(err);
+      // Refetch first, so a partial failure never leaves state on screen that
+      // the server did not accept — then restate the write's own error, which
+      // a successful refetch clears on its way past.
+      await this.load(definitionId, projectDir, { force: true });
+      this.patch(definitionId, { error: message });
+    } finally {
+      this.patch(definitionId, { pendingSha: null });
+    }
+  }
+}

--- a/packages/harness/web/src/lib/versions.test.ts
+++ b/packages/harness/web/src/lib/versions.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import type { AgentVersionView } from "@shared/types";
+
+import {
+  isContentDigest,
+  localStateLabel,
+  needsPinConfirm,
+  newestReadySha,
+  realLabels,
+  shortSha,
+  versionLabel,
+  whenLabel,
+} from "./versions";
+
+function version(
+  over: Partial<AgentVersionView> & { sha: string },
+): AgentVersionView {
+  return {
+    subject: "",
+    author: "",
+    committedAt: "2026-01-01T00:00:00.000Z",
+    deployedAt: "2026-01-01T00:00:00.000Z",
+    buildStatus: "ready",
+    tags: [],
+    isActive: false,
+    ...over,
+  };
+}
+
+describe("realLabels", () => {
+  it("drops `latest`, which is computed and cannot be moved", () => {
+    expect(realLabels(version({ sha: "a", tags: ["latest", "0.0.2"] }))).toEqual([
+      "0.0.2",
+    ]);
+  });
+
+  it("is empty for a build carrying only the computed label", () => {
+    expect(realLabels(version({ sha: "a", tags: ["latest"] }))).toEqual([]);
+  });
+});
+
+describe("versionLabel", () => {
+  it("prefers a real label over the sha", () => {
+    expect(
+      versionLabel(version({ sha: "abcdef1234", tags: ["latest", "0.0.2"] })),
+    ).toBe("0.0.2");
+  });
+
+  it("falls back to the short sha when nothing is labelled", () => {
+    expect(versionLabel(version({ sha: "abcdef1234", tags: ["latest"] }))).toBe(
+      "abcdef1",
+    );
+  });
+});
+
+describe("newestReadySha", () => {
+  it("picks the most recently deployed ready build", () => {
+    const rows = [
+      version({ sha: "old", deployedAt: "2026-01-01T00:00:00.000Z" }),
+      version({ sha: "new", deployedAt: "2026-03-01T00:00:00.000Z" }),
+    ];
+    expect(newestReadySha(rows)).toBe("new");
+  });
+
+  /**
+   * Offering a building or failed build as "latest" would point the agent at
+   * something that cannot run.
+   */
+  it("ignores builds that are not ready, however recent", () => {
+    const rows = [
+      version({ sha: "building", buildStatus: "building", deployedAt: "2026-05-01T00:00:00.000Z" }),
+      version({ sha: "failed", buildStatus: "failed", deployedAt: "2026-04-01T00:00:00.000Z" }),
+      version({ sha: "ready", deployedAt: "2026-03-01T00:00:00.000Z" }),
+    ];
+    expect(newestReadySha(rows)).toBe("ready");
+  });
+
+  it("returns null when nothing is ready", () => {
+    expect(
+      newestReadySha([version({ sha: "a", buildStatus: "building" })]),
+    ).toBeNull();
+  });
+
+  it("falls back to committedAt for a build that was never deployed", () => {
+    const rows = [
+      version({ sha: "a", deployedAt: null, committedAt: "2026-06-01T00:00:00.000Z" }),
+      version({ sha: "b", deployedAt: null, committedAt: "2026-05-01T00:00:00.000Z" }),
+    ];
+    expect(newestReadySha(rows)).toBe("a");
+  });
+});
+
+describe("needsPinConfirm", () => {
+  const rows = [
+    version({ sha: "newest", deployedAt: "2026-03-01T00:00:00.000Z" }),
+    version({ sha: "older", deployedAt: "2026-01-01T00:00:00.000Z" }),
+  ];
+
+  it("does not confirm when returning to the newest build", () => {
+    // Going forward resumes following latest — a return to normal.
+    expect(needsPinConfirm(rows, "newest")).toBe(false);
+  });
+
+  it("confirms when pinning back to an older build", () => {
+    // Pinning stops later deploys going live, which deserves a second look.
+    expect(needsPinConfirm(rows, "older")).toBe(true);
+  });
+
+  it("confirms for a sha that is not in the list at all", () => {
+    expect(needsPinConfirm(rows, "unknown")).toBe(true);
+  });
+});
+
+describe("whenLabel", () => {
+  const now = Date.parse("2026-03-01T12:00:00.000Z");
+
+  it("reads `just now` under a minute", () => {
+    expect(
+      whenLabel(version({ sha: "a", deployedAt: "2026-03-01T11:59:40.000Z" }), now),
+    ).toBe("just now");
+  });
+
+  it("counts minutes, then hours, then days", () => {
+    expect(
+      whenLabel(version({ sha: "a", deployedAt: "2026-03-01T11:30:00.000Z" }), now),
+    ).toBe("30m ago");
+    expect(
+      whenLabel(version({ sha: "a", deployedAt: "2026-03-01T06:00:00.000Z" }), now),
+    ).toBe("6h ago");
+    expect(
+      whenLabel(version({ sha: "a", deployedAt: "2026-02-25T12:00:00.000Z" }), now),
+    ).toBe("4d ago");
+  });
+
+  it("dashes rather than inventing a date when the stamp is unusable", () => {
+    expect(
+      whenLabel(version({ sha: "a", deployedAt: "not-a-date", committedAt: "also-bad" }), now),
+    ).toBe("—");
+  });
+});
+
+describe("shortSha", () => {
+  it("takes seven characters", () => {
+    expect(shortSha("2f86780534d145719dd7708009ccb1cd440220f2")).toBe("2f86780");
+  });
+});
+
+describe("localStateLabel", () => {
+  const deployed = version({ sha: "a".repeat(64), tags: ["latest", "0.0.2"] });
+  const gitBuilt = version({ sha: "b".repeat(40), tags: ["0.0.1"] });
+
+  it("names the deployed version the local copy matches", () => {
+    expect(
+      localStateLabel({ digest: "a".repeat(64), matchesSha: "a".repeat(64) }, [
+        deployed,
+        gitBuilt,
+      ]),
+    ).toBe("0.0.2");
+  });
+
+  /**
+   * Never "you have unsaved changes". The local copy failing to match proves
+   * only that these bytes are not a deployed ARCHIVE — and with an archive
+   * version present to compare against, "not deployed" is the honest phrasing.
+   * (The git-only case, where even that would overclaim, is covered below.)
+   */
+  it("says `not deployed`, not `modified`, when an archive version exists", () => {
+    const withArchive = [deployed, gitBuilt];
+    expect(
+      localStateLabel({ digest: "f".repeat(64), matchesSha: null }, withArchive),
+    ).toBe("not deployed");
+  });
+
+  it("says nothing when there is nothing to pack", () => {
+    expect(localStateLabel(null, [deployed])).toBeNull();
+  });
+
+  it("falls back to the short digest when the match is off the page", () => {
+    // matchesSha can point at a version beyond the 10 the panel shows.
+    expect(
+      localStateLabel({ digest: "x", matchesSha: "0123456789abcdef" }, []),
+    ).toBe("0123456");
+  });
+});
+
+describe("localStateLabel — nothing comparable", () => {
+  /**
+   * An agent whose only versions came from git. A commit sha can never equal a
+   * content digest, so "not deployed" would be a false accusation against a
+   * pristine checkout. Say nothing instead.
+   */
+  it("stays silent when every version is a git build", () => {
+    const gitOnly = [version({ sha: "a".repeat(40), tags: ["0.0.1"] })];
+    expect(
+      localStateLabel({ digest: "b".repeat(64), matchesSha: null }, gitOnly),
+    ).toBeNull();
+  });
+
+  it("still says `not deployed` once an archive version exists to compare against", () => {
+    const mixed = [
+      version({ sha: "a".repeat(40), tags: ["0.0.1"] }),
+      version({ sha: "c".repeat(64), tags: ["0.0.2"] }),
+    ];
+    expect(
+      localStateLabel({ digest: "b".repeat(64), matchesSha: null }, mixed),
+    ).toBe("not deployed");
+  });
+});
+
+describe("isContentDigest", () => {
+  it("tells a sha256 digest from a git commit sha", () => {
+    expect(isContentDigest("a".repeat(64))).toBe(true);
+    expect(isContentDigest("a".repeat(40))).toBe(false);
+  });
+});

--- a/packages/harness/web/src/lib/versions.ts
+++ b/packages/harness/web/src/lib/versions.ts
@@ -1,0 +1,124 @@
+/**
+ * Version-history logic, kept out of the components so it is unit-testable in
+ * the Node runner (the web tier tests `lib/`; components are covered by the
+ * Playwright e2e tier).
+ *
+ * Shared by the Versions tab and the picker beside the agent name, so the two
+ * surfaces cannot disagree about which version is newest or what to call it.
+ */
+import type { AgentVersionView } from "@shared/types";
+
+/**
+ * `latest` is attached to every newest ready build and is COMPUTED, not stored
+ * — Core refuses to store it (a DB CHECK). So it is never a real label: it
+ * cannot be moved, and counting it would make "labelled" mean "newest".
+ */
+export const COMPUTED_LABEL = "latest";
+
+/** The labels a human actually set on this version. */
+export function realLabels(v: AgentVersionView): string[] {
+  return v.tags.filter((t) => t !== COMPUTED_LABEL);
+}
+
+/** First 7 characters — enough to identify, short enough to align. */
+export function shortSha(sha: string): string {
+  return sha.slice(0, 7);
+}
+
+/** What to call a version in one word: its first real label, else the sha. */
+export function versionLabel(v: AgentVersionView): string {
+  return realLabels(v)[0] ?? shortSha(v.sha);
+}
+
+/**
+ * The newest READY build.
+ *
+ * Activating it means "follow latest again", which is why it drives whether the
+ * confirm appears: going forward to the newest build is a return to normal;
+ * pinning backwards stops later deploys going live.
+ *
+ * A build that is still building or has failed is not a candidate — offering it
+ * as "latest" would point the agent at something that cannot run.
+ */
+export function newestReadySha(
+  versions: readonly AgentVersionView[],
+): string | null {
+  const ready = versions
+    .filter((v) => v.buildStatus === "ready")
+    .sort((a, b) => whenMs(b) - whenMs(a));
+  return ready[0]?.sha ?? null;
+}
+
+/** Deploy time when known, else the commit time. */
+function whenMs(v: AgentVersionView): number {
+  const ms = Date.parse(v.deployedAt ?? v.committedAt);
+  return Number.isNaN(ms) ? 0 : ms;
+}
+
+/**
+ * Coarse relative age. Coarse on purpose: the exact instant is in the `title`,
+ * and a row that re-renders every second draws the eye for no reason.
+ *
+ * `now` is injectable so this is testable without freezing the clock.
+ */
+export function whenLabel(v: AgentVersionView, now: number = Date.now()): string {
+  const ms = Date.parse(v.deployedAt ?? v.committedAt);
+  if (Number.isNaN(ms)) return "—";
+  const mins = Math.round((now - ms) / 60_000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
+}
+
+/**
+ * Whether activating `sha` needs a confirm.
+ *
+ * The single place this decision lives, so the tab and the picker guard
+ * identically — two copies of "is this the newest one?" would drift.
+ */
+export function needsPinConfirm(
+  versions: readonly AgentVersionView[],
+  sha: string,
+): boolean {
+  return sha !== newestReadySha(versions);
+}
+
+/**
+ * What to say about the working copy, in one short phrase.
+ *
+ * Three genuinely different states, and the wording matters because two of them
+ * are easy to conflate:
+ *
+ * - `deployed as X` — the local bytes hash to a deployed archive version. A
+ *   fact, not an inference: packing is reproducible and the digest is the
+ *   version's identity.
+ * - `not deployed` — the local bytes match no archive version. That includes a
+ *   perfectly clean checkout of a GIT-built version, whose sha is a commit and
+ *   can never equal a content digest. So this says "not deployed", NOT "you
+ *   have unsaved changes" — claiming the latter would be wrong half the time.
+ * - `null` — nothing to pack (no `index.ts`, or no directory given). Say
+ *   nothing rather than guess.
+ */
+export function localStateLabel(
+  local: { digest: string; matchesSha: string | null } | null,
+  versions: readonly AgentVersionView[],
+): string | null {
+  if (!local) return null;
+  if (local.matchesSha) {
+    const match = versions.find((v) => v.sha === local.matchesSha);
+    return match ? versionLabel(match) : shortSha(local.matchesSha);
+  }
+  // Nothing comparable: every version came from git, so a content digest could
+  // not have matched whatever the working copy contains. Saying "not deployed"
+  // here would be a false accusation against a pristine checkout — stay quiet
+  // instead. (A 64-hex sha is a sha256 digest; a 40-hex one is a git commit.)
+  if (!versions.some((v) => isContentDigest(v.sha))) return null;
+  return "not deployed";
+}
+
+/** A sha256 digest, as opposed to a 40-hex git commit sha. */
+export function isContentDigest(sha: string): boolean {
+  return /^[0-9a-f]{64}$/i.test(sha);
+}

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -3758,7 +3758,7 @@ button.rail-footer-card:hover {
   overflow: auto;
   padding: var(--sp2);
   border: 1px solid var(--ui-line);
-  border-radius: var(--radius-sm, 6px);
+  border-radius: var(--radius-sm);
   background: var(--surface-raised);
   color: var(--text);
   font-family: var(--font-mono);
@@ -10661,4 +10661,414 @@ button.system-graph-node.is-navigable:focus-visible {
 .tree-row-note svg {
   flex: 0 0 auto;
   opacity: 0.7;
+}
+
+/* ---------------------------------------------------------------------------
+   Versions tab — release history, activation and labels.
+
+   Same anatomy as the sibling right-pane tabs: flex column, the shared
+   .workflow-actions-header subheader, then a --pane-pad-x body. Rows are a
+   grid so the sha, labels, age, message and action align down the pane
+   regardless of how many labels a version carries.
+   -------------------------------------------------------------------------- */
+.versions-panel {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.versions-panel-empty {
+  flex: 1;
+}
+
+.versions-panel-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--sp3) var(--pane-pad-x) var(--sp4);
+}
+
+/* A pin blocks later deploys from going live — stated, not implied, because an
+   agent that silently ignores a deploy is a genuinely confusing afternoon. */
+.versions-pin-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  padding: var(--sp2) var(--sp3);
+  margin-bottom: var(--sp3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-inset);
+  color: var(--text-dim);
+  font-size: var(--type-meta);
+}
+
+.versions-pin-banner > span {
+  flex: 1;
+  min-width: 0;
+}
+
+.versions-pin-banner svg {
+  flex: 0 0 auto;
+}
+
+.versions-error {
+  padding: var(--sp2) var(--sp3);
+  margin-bottom: var(--sp3);
+  border: 1px solid var(--border-warning);
+  border-radius: var(--radius-md);
+  color: var(--red-text);
+  font-size: var(--type-meta);
+}
+
+.versions-loading {
+  padding: var(--sp3) 0;
+  color: var(--text-dim);
+  font-size: var(--type-meta);
+}
+
+.versions-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* sha · labels (flexible) · age · message · action */
+.versions-row {
+  display: grid;
+  grid-template-columns: 4.5rem minmax(8rem, 1fr) 4.5rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--sp2);
+  padding: var(--sp2) 0;
+  border-bottom: 1px solid var(--border);
+  font-size: var(--type-meta);
+}
+
+.versions-row:last-child {
+  border-bottom: 0;
+}
+
+.versions-row.is-busy {
+  opacity: 0.6;
+}
+
+.versions-row.is-active {
+  /* The live row is the one the eye should land on first. */
+  color: var(--text);
+}
+
+.versions-sha {
+  font-family: var(--mono);
+  color: var(--text);
+}
+
+/* Wraps: a version can carry several labels, and the row grows rather than
+   letting them escape the cell (the dashboard had exactly that bug). */
+.versions-labels {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--sp1);
+  min-width: 0;
+}
+
+.version-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: var(--surface-raised);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 11px;
+  max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* `latest` is computed from the newest ready build and cannot be stored, so it
+   gets no remove control and reads as ambient rather than editable. */
+.version-chip.is-computed {
+  background: none;
+  border: 1px dashed var(--border);
+  color: var(--text-dim);
+}
+
+.version-chip-remove {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--text-dim);
+  cursor: pointer;
+}
+
+.version-chip-remove:hover:not(:disabled) {
+  color: var(--red-text);
+}
+
+.version-chip-remove:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.version-label-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 1px 6px;
+  border: 1px dashed var(--border);
+  border-radius: 999px;
+  background: none;
+  color: var(--text-dim);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.version-label-add:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.version-label-add:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.version-label-input {
+  width: 6rem;
+  padding: 1px 6px;
+  border: 1px solid var(--text-dim);
+  border-radius: 999px;
+  background: var(--surface-base);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+.versions-when,
+.versions-subject {
+  color: var(--text-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.versions-status {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.versions-live {
+  color: var(--green-text);
+}
+
+/* Version picker beside the agent name in the actions header. */
+.version-picker {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp1);
+  padding: 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: none;
+  color: var(--text-dim);
+  font-family: var(--mono);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.version-picker:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.version-picker-menu {
+  min-width: 15rem;
+  padding: var(--sp1);
+}
+
+.version-picker-item {
+  display: flex;
+  align-items: center;
+  gap: var(--sp2);
+  width: 100%;
+  padding: var(--sp1) var(--sp2);
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: none;
+  color: var(--text);
+  font-size: var(--type-meta);
+  text-align: left;
+  cursor: pointer;
+}
+
+.version-picker-item:hover:not(:disabled) {
+  background: var(--surface-inset);
+}
+
+.version-picker-item[aria-current="true"] {
+  color: var(--green-text);
+}
+
+.version-picker-item .versions-sha {
+  font-size: 11px;
+}
+
+/* The picker states BOTH halves — cloud and local — because they drift apart
+   the moment a file is edited, and "which one am I looking at?" has to be
+   answerable without opening a tab. */
+.version-picker-part {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.version-picker-key {
+  color: var(--text-faint);
+  font-family: var(--font-sans);
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+/* Local differs from what is live: worth noticing, not worth alarming. */
+.version-picker-part.is-diverged {
+  color: var(--amber-text);
+}
+
+.version-picker-local-tag {
+  margin-left: auto;
+  color: var(--text-dim);
+  font-family: var(--font-sans);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+/* The Versions header answers "which version is live, under which label?"
+   outright. Before this it showed only a count, leaving the answer to be
+   inferred from a `Live` marker somewhere down the list — which is precisely
+   the question the tab exists to answer. */
+.versions-live-summary {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--sp1);
+  font-size: var(--type-meta);
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.versions-live-summary strong {
+  color: var(--text);
+  font-weight: 560;
+}
+
+.versions-live-summary .versions-sha {
+  font-size: 11px;
+}
+
+.versions-live-aka,
+.versions-live-pin {
+  color: var(--text-faint);
+  font-size: 10px;
+}
+
+.versions-live-pin::before {
+  content: "· ";
+}
+
+/* Working copy differs from what is live: notable, not alarming. */
+.versions-live-summary.is-diverged strong {
+  color: var(--amber-text);
+}
+
+/* ---------------------------------------------------------------------------
+   Versions: button spacing.
+
+   The buttons themselves are the app's own `.btn-ghost` / `.btn-primary` —
+   these rules only position them. An earlier pass invented `.btn` and
+   `.btn-sm`, neither of which exists in this stylesheet, so those controls
+   rendered with no padding, border or hover at all.
+   -------------------------------------------------------------------------- */
+
+/* Banner action sits at the end of the pinned notice, clear of the text. */
+.versions-banner-action {
+  margin-left: var(--sp2);
+  flex: 0 0 auto;
+}
+
+/* Row action is the last grid cell: keep it off the pane's right edge and
+   stop it stretching to the column width. */
+.versions-row-action {
+  margin-left: var(--sp2);
+  justify-self: end;
+}
+
+/* The picker inherits .btn-ghost; it only needs a tighter type scale and gap
+   for the cloud/local pair it carries. */
+.version-picker {
+  gap: var(--sp2);
+  padding: 3px 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+}
+
+/* Give the header's summaries room from the name and from each other. */
+.versions-panel-header .versions-live-summary {
+  margin-left: var(--sp3);
+}
+
+/* Stop the agent name being squeezed out of existence.
+ *
+ * This subheader packs four items beside the name — two live summaries, the
+ * picker chip and the count — and every one of them defaulted to
+ * `flex: 0 1 auto` with `min-width: auto`, so none could shrink. The name is
+ * the only flexible item (`flex: 1; min-width: 0` from
+ * `.workflow-actions-name`), which means it absorbed the ENTIRE deficit:
+ * measured at a 776px header, the siblings claimed 676px and the name was left
+ * 12px for text needing 33px, rendering "hello" as "h.".
+ *
+ * Fixed by scope, not by touching `.workflow-actions-name` itself — the canvas
+ * header uses that rule too and is not crowded the same way. Here the name
+ * gets a floor and the two widest items yield space instead. */
+.versions-panel-header .workflow-actions-name {
+  flex: 0 1 auto;
+  min-width: 3.5rem;
+}
+
+.versions-panel-header .versions-live-summary,
+.versions-panel-header .version-picker {
+  min-width: 0;
+}
+
+/* In THIS header the chip's local half is pure duplication — the `YOUR FILES`
+ * summary immediately to its left states the same thing. Dropping it frees
+ * ~115px, which is what stops both halves being clipped mid-word ("· pinne",
+ * "not deploye") once the name has its floor. The chip keeps both halves
+ * everywhere else: in the canvas header it is the only thing saying either.
+ *
+ * Targeted as an adjacent sibling rather than `:nth-child`, because the local
+ * part is conditional — it is absent entirely when there is nothing to say
+ * about the working copy, and an index would then point at the wrong element.
+ * No information is lost to assistive tech either: the visible summary carries
+ * it. */
+.versions-panel-header .version-picker-part + .version-picker-part {
+  display: none;
+}
+
+/* Backstop: if the header is still over-subscribed at a narrow width, the chip
+ * clips rather than shoving the agent name back out of existence. */
+.versions-panel-header .version-picker > * {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+/* The label controls are chips, not buttons — keep them clear of the sha. */
+.versions-labels {
+  margin-left: var(--sp1);
 }

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -338,7 +338,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
   registerTool(
     server,
     "sapiom_dev_agents_deploy",
-    "Deploy the linked agent: bundle the current local source (including uncommitted source), push a synthesized build tree, trigger a metered cloud build, and wait for it to finish. The project must be linked (sapiom.json) and a git repo with at least one commit.",
+    "Deploy the linked agent: package the current local source (including uncommitted source), upload it, trigger a metered cloud build, and wait for it to finish. The project must be linked (sapiom.json). No git repository is required.",
     {
       dir: z
         .string()
@@ -349,9 +349,15 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
       branch: z
         .string()
         .optional()
-        .describe("Branch to push to (default 'main')."),
+        .describe("Branch to push to (default 'main'). Only used if the server falls back to the git transport."),
+      message: z
+        .string()
+        .optional()
+        .describe(
+          "Label this version in the agent's history. Without it the version shows no description.",
+        ),
     },
-    async ({ dir, branch }) => {
+    async ({ dir, branch, message }) => {
       const client = await gatewayClient(env);
       if (!client) return NOT_AUTHED;
       try {
@@ -359,7 +365,12 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
         const cfg = requireConfig(projectDir);
         return ok(
           await deploy(
-            { projectDir, definitionId: cfg.definitionId, branch },
+            {
+              projectDir,
+              definitionId: cfg.definitionId,
+              branch,
+              ...(message ? { message } : {}),
+            },
             client,
           ),
         );


### PR DESCRIPTION
## Summary

Studio could build and deploy an agent, then went quiet. It could not say which
version was live, what a label pointed at, or whether the code in front of you
was the code running in the cloud. This adds that, plus deploy-by-upload in
`agent-core`, the CLI and the MCP server.

## Changes

**`agent-core`**
- Deploy by uploading source instead of pushing git
- Clone from stored source instead of git
- Shared code is archived rather than fetched via git
- Falls back to git when archives are switched off, when the engine predates
  `/source`, and for layouts that cannot be archived

**CLI / MCP** — `--message` on a deploy; the git-repo requirement dropped.

**Harness server**
- Routes behind the Versions tab: list, activate, resume-following-latest, and
  label writes. Served by Core, which owns the version projection and answers on
  every deployment including a local stack. The API key stays server-side.
- Fix: a cloud run's status now appears on a local stack. A gateway 404 is
  ambiguous — no such execution, or no such route — so Core gets asked before we
  believe it. The gateway stays primary; a 200 there never triggers a second call.

**Studio UI**
- A Versions tab: `latest` always the top row, then labelled releases, then
  recent builds
- `LIVE ON CLOUD` and `YOUR FILES` side by side, so divergence is visible
- A version chip beside the agent name showing cloud against local, switching
  version from anywhere
- Labels created and moved inline on the row
- Activate any ready build; the confirm appears only when pinning backwards,
  because that is the case that stops later deploys going live
- A pinned agent shows a banner with one-click resume

State lives in one store keyed by definition. Both surfaces mount at once, so a
per-component copy let them disagree — resuming "follow latest" in the tab
cleared its banner while the chip still read `pinned`.

## Testing

- [x] 166 files, 2667 tests passing
- [x] Typecheck clean
- [x] New: 23 route tests, 16 store tests, 19 label/ordering tests, 7 run-state
      fallback tests
- [x] Walked end to end in Studio against a local stack: add a step → deploy →
      label → run locally → run on the cloud

## Screenshots/Demos

A 4m33s recording of the full loop is attached to the Slack thread. The
walkthrough it follows is in `packages/harness/docs/agent-versions.md`.

## Related

Refs: AGENT-289

Pairs with sapiom/Sapiom#4842 — the engine side. That one carries the flag, so
this can merge first without changing behaviour.

## Checklist

- [x] Commits follow conventions
- [x] No hardcoded secrets
- [x] Self-reviewed
- [ ] Reviewed by a second pair of eyes