### PR TITLE
fix(harness): keep agent creation in planner flow

### DIFF
--- a/.changeset/planner-owned-agent-creation.md
+++ b/.changeset/planner-owned-agent-creation.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/harness": patch
+"@sapiom/harness-desktop": patch
+---
+
+Keep planner-managed Studio projects on the Agent Map flow by removing direct agent-creation actions from empty sidebar rows and project menus. Legacy non-planning harness projects retain their existing creation controls.

--- a/.changeset/planner-owned-agent-creation.md
+++ b/.changeset/planner-owned-agent-creation.md
@@ -1,6 +1,6 @@
 ---
-"@sapiom/harness": patch
+"@sapiom/harness": minor
 "@sapiom/harness-desktop": patch
 ---
 
-Keep planner-managed Studio projects on the Agent Map flow by removing direct agent-creation actions from empty sidebar rows and project menus. Legacy non-planning harness projects retain their existing creation controls.
+Make Agent Map planning the only agent-creation route in Studio projects. Empty sidebar rows no longer offer to create the first agent directly, and project menus no longer offer direct create or in-session scaffold actions.

--- a/packages/harness/web/e2e/create-agent.spec.ts
+++ b/packages/harness/web/e2e/create-agent.spec.ts
@@ -1,5 +1,10 @@
 /**
- * SAP-2981 — the canonical create-agent flow.
+ * SAP-2981 — the legacy-server create-agent compatibility flow.
+ *
+ * Current Studio servers return durable project summaries and route creation
+ * through Agent Map planning. These specs deliberately use
+ * `mockStudioProjects=absent` to protect clients connected to older servers
+ * whose state payloads have no Studio project catalog.
  *
  * The defect these specs guard: every create door in the Studio ended in an
  * English sentence injected into a terminal ("call the
@@ -45,9 +50,9 @@ const createOrder = (page: Page): Promise<string[]> =>
         .__HARNESS_TEST__?.createOrder ?? []) as string[],
   );
 
-test.describe("create an agent in a project", () => {
+test.describe("legacy-server agent creation compatibility", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/?seed=0");
+    await page.goto("/?seed=0&mockStudioProjects=absent");
     await expect(page.getByTestId("workspace-group-acme-app")).toBeVisible();
   });
 
@@ -61,7 +66,9 @@ test.describe("create an agent in a project", () => {
     await expect(dialog).toBeVisible();
     // Stated, not chosen: you clicked that row, and the dialog spells the
     // folder out because a rail label can be widened or shared.
-    await expect(page.getByTestId("create-agent-project")).toHaveText("acme-app");
+    await expect(page.getByTestId("create-agent-project")).toHaveText(
+      "acme-app",
+    );
     await expect(dialog).toContainText(ROOT);
     // There is no folder picker here — asking "where" again is the subject
     // confusion this epic removes.
@@ -129,7 +136,9 @@ test.describe("create an agent in a project", () => {
     // The server's own sentence, not the wire shape it arrives in.
     const error = page.getByTestId("create-agent-error");
     await expect(error).toBeVisible();
-    await expect(error).toHaveText("acme-app already has an agent called leasing.");
+    await expect(error).toHaveText(
+      "acme-app already has an agent called leasing.",
+    );
     await expect(error).not.toContainText("/api/agents/scaffold");
 
     // The dialog stays up holding what was typed, and no session was started
@@ -154,7 +163,9 @@ test.describe("create an agent in a project", () => {
       await expect(submit).toBeDisabled();
     }
     await name.fill(".hidden");
-    await expect(page.getByTestId("create-agent-name-error")).toContainText("dot");
+    await expect(page.getByTestId("create-agent-name-error")).toContainText(
+      "dot",
+    );
     await expect(submit).toBeDisabled();
 
     // An empty field is not a mistake yet — it says nothing and offers nothing.
@@ -192,7 +203,9 @@ test.describe("create an agent in a project", () => {
     // One create flow, not one per door: the empty project's CTA is the same
     // subject and must not be a second mechanism that drifts.
     await page.getByTestId("rail-add-project").click();
-    await page.getByTestId("folder-field-input").fill("/Users/demo/blank-slate");
+    await page
+      .getByTestId("folder-field-input")
+      .fill("/Users/demo/blank-slate");
     await page.getByTestId("open-project").click();
     await page.getByTestId("project-empty-blank-slate").click();
 

--- a/packages/harness/web/e2e/open-project.spec.ts
+++ b/packages/harness/web/e2e/open-project.spec.ts
@@ -88,26 +88,40 @@ test.describe("the header + opens a project", () => {
     await expect(page.getByTestId("project-row-blank-slate")).toBeVisible();
   });
 
-  test("an empty project offers the one thing you opened it for", async ({
+  test("an empty planning project creates agents only through its Agent Map", async ({
     page,
   }) => {
     await page.getByTestId("rail-add-project").click();
     await page.getByTestId("folder-field-input").fill(BLANK);
     await page.getByTestId("open-project").click();
 
-    const empty = page.getByTestId("project-empty-blank-slate");
-    await expect(empty).toBeVisible();
-    // And it is a CONTROL, not a label: the whole reason to open a folder with
-    // no agent in it is to put the first one there, so the row that states the
-    // emptiness is the row that offers to end it.
-    await expect(empty).toHaveText("Create the first agent here");
-    await expect(empty).toBeEnabled();
-    await expect(empty).toHaveAttribute(
-      "data-tooltip",
-      "Start an agent in /Users/demo/blank-slate",
-    );
-    // NOT the rail-wide empty state leaking down: that one says "No agents
-    // yet" and only exists when the rail has nothing at all.
+    const group = page.getByTestId("workspace-group-blank-slate");
+    await expect(group.getByTestId("agent-map-row")).toBeVisible();
+    await expect(page.locator(".harness-terminal .xterm")).toBeVisible();
+    await expect(page.getByTestId("planner-loading")).toHaveCount(0);
+
+    // Once the initial planner is no longer a live bare session, the old rail
+    // exposed its standalone-agent shortcut again. Ending it reproduces the
+    // stable empty-project state from the reported sidebar.
+    await page.getByTestId("session-menu").click();
+    await page.getByTestId("session-end-btn").click();
+    await page.getByTestId("end-session-confirm-btn").click();
+    await expect(page.getByTestId("planner-session-ended")).toBeVisible();
+
+    await expect(group.getByTestId("project-empty-blank-slate")).toHaveCount(0);
+
+    // The visible empty row and the project menu used to be two doors into the
+    // same direct-create flow. A planning project exposes neither: generated
+    // agents enter through an approved map, while project removal remains an
+    // ordinary project-level action.
+    await openProjectMenu(page, "blank-slate");
+    await expect(
+      page.getByTestId("project-create-agent-blank-slate"),
+    ).toHaveCount(0);
+    await expect(page.getByTestId("project-remove-blank-slate")).toBeVisible();
+
+    // NOT the rail-wide empty state leaking down: that one says "No agents yet"
+    // and only exists when the rail has nothing at all.
     await expect(page.locator(".rail-empty")).toHaveCount(0);
   });
 

--- a/packages/harness/web/e2e/open-project.spec.ts
+++ b/packages/harness/web/e2e/open-project.spec.ts
@@ -88,7 +88,7 @@ test.describe("the header + opens a project", () => {
     await expect(page.getByTestId("project-row-blank-slate")).toBeVisible();
   });
 
-  test("an empty planning project creates agents only through its Agent Map", async ({
+  test("a planning project hides every standalone agent-creation action", async ({
     page,
   }) => {
     await page.getByTestId("rail-add-project").click();
@@ -98,7 +98,6 @@ test.describe("the header + opens a project", () => {
     const group = page.getByTestId("workspace-group-blank-slate");
     await expect(group.getByTestId("agent-map-row")).toBeVisible();
     await expect(page.locator(".harness-terminal .xterm")).toBeVisible();
-    await expect(page.getByTestId("planner-loading")).toHaveCount(0);
 
     // Once the initial planner is no longer a live bare session, the old rail
     // exposed its standalone-agent shortcut again. Ending it reproduces the
@@ -119,6 +118,13 @@ test.describe("the header + opens a project", () => {
       page.getByTestId("project-create-agent-blank-slate"),
     ).toHaveCount(0);
     await expect(page.getByTestId("project-remove-blank-slate")).toBeVisible();
+    await page.keyboard.press("Escape");
+
+    // The same ownership rule covers a bare project with an existing session:
+    // its former in-session scaffold action cannot bypass planning either.
+    await openProjectMenu(page, "scratch");
+    await expect(page.getByTestId("workspace-scaffold-scratch")).toHaveCount(0);
+    await expect(page.getByTestId("project-remove-scratch")).toBeVisible();
 
     // NOT the rail-wide empty state leaking down: that one says "No agents yet"
     // and only exists when the rail has nothing at all.

--- a/packages/harness/web/e2e/rail-grammar.spec.ts
+++ b/packages/harness/web/e2e/rail-grammar.spec.ts
@@ -23,11 +23,15 @@ import type { Page } from "@playwright/test";
 import { openProjectMenu } from "./mock-navigation";
 
 const ROW = (page: Page, label: string) =>
-  page.getByTestId(`workspace-group-${label}`).locator(":scope > .workspace-row");
+  page
+    .getByTestId(`workspace-group-${label}`)
+    .locator(":scope > .workspace-row");
 
-test.describe("project row grammar", () => {
+test.describe("legacy-server project row grammar", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/?seed=0");
+    // Direct create/scaffold controls survive only for older server payloads
+    // that do not include the durable Studio project catalog.
+    await page.goto("/?seed=0&mockStudioProjects=absent");
     await expect(page.getByTestId("workspace-group-acme-app")).toBeVisible();
   });
 
@@ -87,14 +91,19 @@ test.describe("project row grammar", () => {
     const order = (): Promise<string[]> =>
       page.evaluate(
         () =>
-          ((window as unknown as { __HARNESS_TEST__?: { createOrder?: string[] } })
-            .__HARNESS_TEST__?.createOrder ?? []) as string[],
+          ((
+            window as unknown as {
+              __HARNESS_TEST__?: { createOrder?: string[] };
+            }
+          ).__HARNESS_TEST__?.createOrder ?? []) as string[],
       );
 
     await openProjectMenu(page, "acme-app");
     await page.getByTestId("project-create-agent-acme-app").click();
     await expect(page.getByTestId("project-menu-card-acme-app")).toHaveCount(0);
-    await expect(page.getByTestId("create-agent-project")).toHaveText("acme-app");
+    await expect(page.getByTestId("create-agent-project")).toHaveText(
+      "acme-app",
+    );
     // Nothing has started yet — the old handler started a pty on this click.
     expect(await order()).toEqual([]);
 
@@ -143,7 +152,6 @@ test.describe("double-click toggles disclosure", () => {
     await expect(row).toHaveClass(/is-collapsed/);
     await expect(row).toHaveClass(/is-selected/);
   });
-
 });
 
 test.describe("double-click on a folder row", () => {
@@ -193,9 +201,7 @@ test.describe("first-run explainer", () => {
       "Folders you chose that hold agents",
     );
     await expect(page.getByTestId("help-agents")).toContainText("Agents");
-    await expect(page.getByTestId("help-agents")).toContainText(
-      "What you run",
-    );
+    await expect(page.getByTestId("help-agents")).toContainText("What you run");
     // The upgrade line: an existing user opens 0.4.0 to a rearranged rail.
     await expect(page.getByTestId("help-upgrade-note")).toContainText(
       "Your projects were rebuilt from the folders you opened",

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -11,7 +11,11 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
-import { focusRfqAgent, openProjectMenu, selectMockSessionFromPalette } from "./mock-navigation";
+import {
+  focusRfqAgent,
+  openProjectMenu,
+  selectMockSessionFromPalette,
+} from "./mock-navigation";
 
 // The mock demo seeds a run + auto-plays the chat conversation on load (see
 // the demo spec). These smoke tests exercise mechanics from a clean slate, so
@@ -352,9 +356,15 @@ test("inject macros are enabled once the boot session and a deployed workflow ar
 });
 
 test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
-  test("rail is project > agent only, with no session rows", async ({
+  test("legacy-server rail is project > agent only, with no session rows", async ({
     page,
   }) => {
+    // This assertion preserves the scaffold affordance for older state
+    // payloads without a durable Studio project catalog. Current Studio
+    // projects intentionally expose only Agent Map planning.
+    await page.goto("/?seed=0&mockStudioProjects=absent");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
     // Zone 1 is a pure explorer: project rows and agent rows, no sessions
     // anywhere in the tree.
     await expect(page.getByTestId("workspace-group-acme-app")).toBeVisible();
@@ -507,7 +517,9 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
     const mapBounds = await page
       .getByTestId("workspace-graph-view")
       .boundingBox();
-    const paneBounds = await page.getByTestId("right-panel-canvas").boundingBox();
+    const paneBounds = await page
+      .getByTestId("right-panel-canvas")
+      .boundingBox();
     expect(mapBounds).toEqual(paneBounds);
     const appBounds = await page.locator(".app").boundingBox();
     expect(mapBounds?.width ?? 0).toBeLessThan(appBounds?.width ?? 0);

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -181,9 +181,9 @@ interface WorkflowsRailProps {
   /** Adapter registry fetch — the add dialog's picker and MCP setup block. */
   listHarnesses: () => Promise<HarnessEntry[]>;
   /**
-   * Create an agent IN a project (SAP-2981). Opens the create dialog App owns;
-   * the harness then does the scaffold and the agent joins the rail before any
-   * session starts.
+   * Compatibility path for a state payload without a durable Studio project.
+   * Opens the create dialog App owns; the harness then does the scaffold and
+   * the agent joins the rail before any session starts.
    *
    * It used to be `onScaffoldSession(root, harness)` — start a pty and inject
    * an English sentence asking the coding agent to call the scaffold MCP tool.
@@ -196,8 +196,9 @@ interface WorkflowsRailProps {
   projectRoot: string | null;
   /** Persist a changed project root as the user's default. */
   onSaveProjectRoot: (root: string) => Promise<void>;
-  /** Bare-project affordance: create the folder's first agent, binding the
-   *  live session it already has rather than opening a second one. */
+  /** Compatibility-only bare-project affordance: create the folder's first
+   *  agent, binding the live session it already has rather than opening a
+   *  second one. */
   onScaffoldInSession: (sessionId: string) => void;
   /** Navigate to the templates destination (App owns the center view). */
   onBrowseTemplates: () => void;
@@ -283,10 +284,10 @@ function ProjectRowMenu({
   onRemove,
 }: {
   label: string;
-  /** The create action this project currently offers, or null while one is
-   *  mid-creation and there is nothing to add to yet. A bare project (sessions,
-   *  no agent) scaffolds into its existing session; every other project starts
-   *  a new one rooted at the project. */
+  /** The compatibility create action this project currently offers, or null
+   *  when its Agent Map owns creation / while one is mid-creation. A bare
+   *  project (sessions, no agent) scaffolds into its existing session; every
+   *  other project starts a new one rooted at the project. */
   create: {
     kind: "create" | "scaffold";
     testid: string;
@@ -1231,12 +1232,12 @@ export function WorkflowsRail({
             const studioProject = studioProjects?.find(
               (candidate) => candidate.projectId === workspaceScope?.projectId,
             );
-            // A durable Studio project is owned by its Agent Map: agents enter
-            // through planning and approval, never through the legacy direct-
-            // create affordances. Keep this independent of the selected axis so
-            // switching to Group cannot bring the bypass back.
-            const plannerManaged = studioProject != null;
-            const planFirst = axis === "project" && plannerManaged;
+            // Current servers issue a durable Studio project for every scope,
+            // and that project's Agent Map owns creation. The absent case is a
+            // compatibility payload, not a second creation mode. Keep ownership
+            // independent of the selected axis so Group cannot restore a bypass.
+            const mapOwnsCreation = studioProject != null;
+            const planFirst = axis === "project" && mapOwnsCreation;
             const mapSelected =
               planFirst &&
               studioSelection?.kind === "agent-map" &&
@@ -1406,7 +1407,7 @@ export function WorkflowsRail({
                       <ProjectRowMenu
                         label={project.label}
                         create={
-                          plannerManaged || creating
+                          mapOwnsCreation || creating
                             ? null
                             : bare
                               ? {
@@ -1480,7 +1481,7 @@ export function WorkflowsRail({
                     this. */}
                 {!collapsed && empty && !creating && bare == null && (
                   <>
-                    {!plannerManaged && (
+                    {!mapOwnsCreation && (
                       <div className="workspace-row is-nested workspace-row-empty">
                         <span
                           className="row-disclosure row-disclosure-static"

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -1231,7 +1231,12 @@ export function WorkflowsRail({
             const studioProject = studioProjects?.find(
               (candidate) => candidate.projectId === workspaceScope?.projectId,
             );
-            const planFirst = axis === "project" && studioProject != null;
+            // A durable Studio project is owned by its Agent Map: agents enter
+            // through planning and approval, never through the legacy direct-
+            // create affordances. Keep this independent of the selected axis so
+            // switching to Group cannot bring the bypass back.
+            const plannerManaged = studioProject != null;
+            const planFirst = axis === "project" && plannerManaged;
             const mapSelected =
               planFirst &&
               studioSelection?.kind === "agent-map" &&
@@ -1401,7 +1406,7 @@ export function WorkflowsRail({
                       <ProjectRowMenu
                         label={project.label}
                         create={
-                          creating
+                          plannerManaged || creating
                             ? null
                             : bare
                               ? {
@@ -1463,47 +1468,43 @@ export function WorkflowsRail({
                     )}
                   </>
                 )}
-                {/* AN EMPTY PROJECT SAYS SO, on its own row.
+                {/* AN EMPTY LEGACY PROJECT SAYS SO, on its own row.
                     `projectIsEmpty` is the one emptiness answer and it consults
                     `rootAgent` — a merged root-agent project has nothing in
                     `dirs` or `agents` and a naive check would print this line
-                    under an agent row. A project with no agents is now an
-                    ordinary state rather than an impossible one: you open a
-                    project in order to build the first agent in it, so the row
-                    has to be able to stand there and say what it is. `creating`
-                    already has its own spinner, and a bare project with a live
-                    session already has its Scaffold affordance, so neither
-                    reaches this. */}
+                    under an agent row. A planner-managed project deliberately
+                    renders no direct-create row: its pinned Agent Map is the
+                    only route to generating agents. `creating` already has its
+                    own spinner, and a bare legacy project with a live session
+                    already has its Scaffold affordance, so neither reaches
+                    this. */}
                 {!collapsed && empty && !creating && bare == null && (
                   <>
-                    <div className="workspace-row is-nested workspace-row-empty">
-                      <span
-                        className="row-disclosure row-disclosure-static"
-                        aria-hidden="true"
-                      />
-                      {/* A ROW YOU CAN ACT ON. An empty project stating its
-                        emptiness and offering nothing is a dead end — and the
-                        whole reason to open a folder with no agent in it is to
-                        put the first one there. This is that action, aimed at
-                        THIS folder: a session rooted here, with the scaffold
-                        prompt already sent. */}
-                      <button
-                        type="button"
-                        className="tree-row tree-row-empty-action"
-                        data-testid={`project-empty-${project.label}`}
-                        data-tooltip={`Start an agent in ${project.root}`}
-                        onClick={() =>
-                          onCreateAgent(project.root, project.label)
-                        }
-                      >
-                        <Icon name="Sparkles" size={13} />
-                        <span className="tree-row-label">
-                          {(unsearchedCheckouts[project.root]?.length ?? 0) > 0
-                            ? "Create an agent here"
-                            : "Create the first agent here"}
-                        </span>
-                      </button>
-                    </div>
+                    {!plannerManaged && (
+                      <div className="workspace-row is-nested workspace-row-empty">
+                        <span
+                          className="row-disclosure row-disclosure-static"
+                          aria-hidden="true"
+                        />
+                        <button
+                          type="button"
+                          className="tree-row tree-row-empty-action"
+                          data-testid={`project-empty-${project.label}`}
+                          data-tooltip={`Start an agent in ${project.root}`}
+                          onClick={() =>
+                            onCreateAgent(project.root, project.label)
+                          }
+                        >
+                          <Icon name="Sparkles" size={13} />
+                          <span className="tree-row-label">
+                            {(unsearchedCheckouts[project.root]?.length ?? 0) >
+                            0
+                              ? "Create an agent here"
+                              : "Create the first agent here"}
+                          </span>
+                        </button>
+                      </div>
+                    )}
                     {/* THE BOUNDARY'S OWN ANSWER, when there is one.
                         A scan stops at every separate checkout, so a folder that
                         is not itself a repo but holds several clones finds

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -2236,12 +2236,14 @@ export class MockApi implements HarnessApi {
     // Production authority is determined by the server response and always
     // uses durable Studio project summaries. Mock mode keeps the historical
     // fixtures stable unless a plan-first scenario opts in explicitly; the
-    // dedicated agent-map fixture is also an opt-in. This is test data
-    // selection, not a product feature flag.
+    // dedicated agent-map fixture is also an opt-in. `absent` names the
+    // legacy-server compatibility contract exercised by the remaining direct
+    // creation specs. This is test data selection, not a product feature flag.
     if (typeof window !== "undefined") {
       const params = new URLSearchParams(window.location.search);
       const mode = params.get("mockStudioProjects");
       const fixture = params.get("mockFixtures");
+      if (mode === "absent") return [];
       if (mode !== "present" && fixture !== "agent-map") return [];
     }
     const timestamp = "2026-01-01T00:00:00.000Z";
@@ -3814,7 +3816,11 @@ export class MockApi implements HarnessApi {
   ): Promise<{ state: AgentSecret["state"] }> {
     await delay(150);
     if (mockErrorTargets().has("secretWrite")) {
-      throw new ApiError(502, `mock: ${key} refused`, `${key} could not be stored.`);
+      throw new ApiError(
+        502,
+        `mock: ${key} refused`,
+        `${key} could not be stored.`,
+      );
     }
     const state: AgentSecret["state"] = this.mockLinked(workflowPath)
       ? "synced"

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -2232,7 +2232,7 @@ export class MockApi implements HarnessApi {
       }));
   }
 
-  private studioProjects(): StudioProjectSummary[] {
+  private studioProjects(): StudioProjectSummary[] | undefined {
     // Production authority is determined by the server response and always
     // uses durable Studio project summaries. Mock mode keeps the historical
     // fixtures stable unless a plan-first scenario opts in explicitly; the
@@ -2243,8 +2243,8 @@ export class MockApi implements HarnessApi {
       const params = new URLSearchParams(window.location.search);
       const mode = params.get("mockStudioProjects");
       const fixture = params.get("mockFixtures");
-      if (mode === "absent") return [];
-      if (mode !== "present" && fixture !== "agent-map") return [];
+      if (mode === "absent") return undefined;
+      if (mode !== "present" && fixture !== "agent-map") return undefined;
     }
     const timestamp = "2026-01-01T00:00:00.000Z";
     return this.workspaceScopes().map((scope, index) => ({
@@ -2336,6 +2336,7 @@ export class MockApi implements HarnessApi {
     // necessarily said yes — mirror that in the mock so the chip shows "on".
     const telemetryOptIn =
       mockConsentSource === "prompted" ? true : this.settings.telemetryOptIn;
+    const studioProjects = this.studioProjects();
     return {
       version: "0.0.1-mock",
       authenticated: true,
@@ -2355,7 +2356,7 @@ export class MockApi implements HarnessApi {
       sessions: this.sessions,
       workflows: this.studioWorkflows(),
       workspaceScopes: this.workspaceScopes(),
-      studioProjects: this.studioProjects(),
+      ...(studioProjects ? { studioProjects } : {}),
       macros: MOCK_MACROS,
       launchDir: MOCK_LAUNCH_DIR,
       // Mirrors the Electron host (`<launchDir>/projects`) rather than the CLI
@@ -2376,7 +2377,7 @@ export class MockApi implements HarnessApi {
         ? null
         : new URLSearchParams(window.location.search);
     const failure = query?.get("mockAgentMapWorkspace") ?? null;
-    const project = this.studioProjects().find(
+    const project = this.studioProjects()?.find(
       (candidate) => candidate.projectId === projectId,
     );
     const goldenFixtureEnabled = query?.get("mockAgentMapGolden") === "1";
@@ -2667,7 +2668,7 @@ export class MockApi implements HarnessApi {
     };
     await this.injectInput(sessionId, { text: request.text });
     const accepted = structuredClone(session.planning);
-    const project = this.studioProjects().find(
+    const project = this.studioProjects()?.find(
       (candidate) => candidate.projectId === projectId,
     );
     const goldenFixtureEnabled =


### PR DESCRIPTION
## Summary

Agent Map planning is now the only agent-creation route in current Studio projects. The sidebar no longer exposes standalone creation or in-session scaffolding that can bypass the planning flow. The pinned planning tab is labeled “Plan Agents” so its purpose is explicit.

## Changes

- hide the empty-project “Create the first agent here” row
- hide direct create and bare-session scaffold actions from project overflow menus across both rail axes
- rename the pinned Agent Map tab and its hover states to “Plan Agents”
- retain Agent Map access, project removal, and unsearched-checkout information
- retain compatibility behavior for older state payloads without a durable Studio project identity
- add production-shaped browser coverage for all three removed creation doors and the renamed planning tab
- release Harness as a minor change and Desktop as a patch

## Testing

- [x] `pnpm --filter @sapiom/harness... build`
- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `pnpm --filter @sapiom/harness test` — 3,306 unit and 10 performance tests
- [x] focused creation-flow Playwright suite — 16 tests
- [x] project-axis Playwright suite — 19 tests
- [x] Prettier and diff checks

## Screenshots/Demos

This removes the reported “Create the first agent here” row and renames the pinned planning tab to “Plan Agents” without restyling the surrounding UI. Browser regressions assert that the empty-state CTA, project-menu create action, and bare-session scaffold action are absent while the planning tab and project removal remain available.