### PR TITLE
fix(harness): rename Agent Map tab

### DIFF
--- a/.changeset/plan-agents-label.md
+++ b/.changeset/plan-agents-label.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/harness": patch
+"@sapiom/harness-desktop": patch
+---
+
+Rename the pinned Agent Map tab in the Studio project sidebar to Plan Agents so its purpose is clear. The underlying Agent Map view and behavior are unchanged.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -63,7 +63,7 @@ the coding agent's ordinary provider traffic, and opt-in telemetry.
 - **System prompt, on every session start** — an unauthenticated
   `GET https://api.sapiom.ai/v1/harness/system-prompt`, so the Studio conventions
   your coding agent is told about can improve without you upgrading this package.
-  It sends no session content, no identifiers and no API key, and it is *not*
+  It sends no session content, no identifiers and no API key, and it is _not_
   gated on the telemetry opt-in — it fetches configuration rather than reporting
   usage. It is bounded at 5 seconds and falls back to the prompt bundled in this
   package on any failure, so an offline session behaves exactly as before.
@@ -83,6 +83,10 @@ SPA, a small REST API, terminal WebSocket streams, and the local telemetry
 ingest endpoint. The interface contract lives in `src/shared/types.ts`.
 
 ### Agent Map planner sessions
+
+In Studio, the pinned **Plan Agents** tab opens the project's Agent Map.
+**Plan Agents** names the planning entry point; **Agent Map** remains the name
+of the proposal view and its underlying protocol.
 
 The authenticated local API owns planner identity; a model or generic session
 request cannot assign itself the `map-planner` role. The public planner surface

--- a/packages/harness/web/e2e/agent-map-planning.spec.ts
+++ b/packages/harness/web/e2e/agent-map-planning.spec.ts
@@ -417,6 +417,9 @@ test.describe("SAP-3058 Agent Map planning workspace", () => {
     await expect(page.getByTestId("end-session-confirm")).toContainText(
       "stops the planning conversation",
     );
+    await expect(page.getByTestId("end-session-confirm")).toContainText(
+      "fresh planning session from Plan Agents",
+    );
     await expect(page.getByTestId("end-session-confirm")).not.toContainText(
       "live terminal",
     );

--- a/packages/harness/web/e2e/project-axis.spec.ts
+++ b/packages/harness/web/e2e/project-axis.spec.ts
@@ -174,6 +174,11 @@ test.describe("the plan-first project children", () => {
     const agent = group.getByTestId("workflow-dashboard-keeper");
     await expect(project).toBeVisible();
     await expect(map).toBeVisible();
+    await expect(map.getByTestId("agent-map-select")).toHaveText("Plan Agents");
+    await expect(map.getByTestId("agent-map-select")).toHaveAttribute(
+      "data-tooltip",
+      "Open Plan Agents",
+    );
     await expect(agent).toBeVisible();
     await expect(group.locator(":scope > *")).toHaveCount(3);
 
@@ -186,6 +191,10 @@ test.describe("the plan-first project children", () => {
 
     await group.getByTestId("agent-map-select").click();
     await expect(map).toHaveClass(/is-selected/);
+    await expect(map.getByTestId("agent-map-select")).toHaveAttribute(
+      "data-tooltip",
+      "Plan Agents selected",
+    );
     await expect(page.getByTestId("agent-map-empty")).toBeVisible();
 
     // A selected child expands on selection, but an intentional disclosure

--- a/packages/harness/web/src/components/ProjectTreeRows.tsx
+++ b/packages/harness/web/src/components/ProjectTreeRows.tsx
@@ -142,11 +142,11 @@ export function AgentMapRow({
         className="tree-row"
         data-testid="agent-map-select"
         aria-pressed={selected}
-        data-tooltip={selected ? "Agent Map selected" : "Open Agent Map"}
+        data-tooltip={selected ? "Plan Agents selected" : "Open Plan Agents"}
         onClick={onSelect}
       >
         <Icon name="Waypoints" size={13} />
-        <span className="tree-row-label">Agent Map</span>
+        <span className="tree-row-label">Plan Agents</span>
       </button>
     </div>
   );

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -153,14 +153,20 @@ export function SessionBar({
         {overviewMode ? (
           <div className="session-current session-current-static">
             <Icon name="Radio" size={13} />
-            <span className="session-context-title" data-testid="session-context-title">
+            <span
+              className="session-context-title"
+              data-testid="session-context-title"
+            >
               Overview
             </span>
           </div>
         ) : openedAgentName ? (
           /* An agent is open with no live session in its workspace. */
           <div className="session-current session-current-static">
-            <span className="session-context-title" data-testid="session-context-title">
+            <span
+              className="session-context-title"
+              data-testid="session-context-title"
+            >
               {openedAgentName}
             </span>
             <span
@@ -176,7 +182,10 @@ export function SessionBar({
           /* Past-session review: nothing is running here. */
           <div className="session-current session-current-static">
             <Icon name="History" size={13} />
-            <span className="session-context-title" data-testid="session-context-title">
+            <span
+              className="session-context-title"
+              data-testid="session-context-title"
+            >
               {reviewTitle}
             </span>
             <span
@@ -202,7 +211,10 @@ export function SessionBar({
               onClick={onBack}
             >
               <Icon name="ArrowLeft" size={13} />
-              <span className="session-context-title" data-testid="session-context-title">
+              <span
+                className="session-context-title"
+                data-testid="session-context-title"
+              >
                 Back
               </span>
             </button>
@@ -445,7 +457,7 @@ export function SessionBar({
           triggerRef={menuTriggerRef}
           description={
             planning
-              ? "This stops the planning conversation and any work the planner is doing right now. You can start a fresh planning session from the Agent Map."
+              ? "This stops the planning conversation and any work the planner is doing right now. You can start a fresh planning session from Plan Agents."
               : undefined
           }
           onCancel={() => setConfirmingClose(false)}


### PR DESCRIPTION
## Summary

- rename the pinned Studio project sidebar tab from “Agent Map” to “Plan Agents”
- update the tab hover text for both selected and unselected states
- direct the stop-planning confirmation back to “Plan Agents”
- keep “Agent Map” as the name of the proposal view, artifact, and protocol
- connect the two names in the published Harness README
- add a patch changeset for Harness and the bundled Desktop app

“Plan Agents” is intentionally action-oriented navigation: it tells users what they do from the pinned entry point. Once opened, “Agent Map” continues to identify the artifact they are viewing and the underlying protocol. Internal identifiers are unchanged.

## Testing

- [x] `pnpm --filter @sapiom/harness... build`
- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `pnpm --filter @sapiom/harness exec playwright test --config web/e2e/playwright.config.ts web/e2e/project-axis.spec.ts web/e2e/agent-map-planning.spec.ts` — 31 passed
- [x] Prettier check on all changed files
- [x] `git diff --check`