### PR TITLE
fix(harness): add project session shortcut

### DIFF
--- a/.changeset/project-session-shortcut.md
+++ b/.changeset/project-session-shortcut.md
@@ -3,4 +3,4 @@
 "@sapiom/harness-desktop": patch
 ---
 
-The project-row `+` now starts a coding-agent session at that project root. Previously it created an agent and was removed in favor of the row's `⋮`; Sapiom agent creation remains owned by Plan Agents.
+The project-row `+` now starts a coding-agent session at that project root. Previously it created an agent. Sapiom agent creation remains owned by Plan Agents.

--- a/.changeset/project-session-shortcut.md
+++ b/.changeset/project-session-shortcut.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/harness": patch
+"@sapiom/harness-desktop": patch
+---
+
+Restore the project-row `+` shortcut so users can start a coding-agent session at that project root without opening the overflow menu. Sapiom agent creation remains owned by Plan Agents.

--- a/.changeset/project-session-shortcut.md
+++ b/.changeset/project-session-shortcut.md
@@ -1,6 +1,6 @@
 ---
-"@sapiom/harness": patch
+"@sapiom/harness": minor
 "@sapiom/harness-desktop": patch
 ---
 
-Restore the project-row `+` shortcut so users can start a coding-agent session at that project root without opening the overflow menu. Sapiom agent creation remains owned by Plan Agents.
+The project-row `+` now starts a coding-agent session at that project root. Previously it created an agent and was removed in favor of the row's `⋮`; Sapiom agent creation remains owned by Plan Agents.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -18,7 +18,9 @@ system prompt, in whatever project directory you choose.
 ## What you get
 
 - **Terminal sessions** — your agent, your subscription, your machine; the
-  Agent Studio only configures it. Multiple sessions, resumable chat history.
+  Agent Studio only configures it. The `+` beside a project starts a session at
+  that project root; the tab-strip `+` starts a sibling session. Sessions have
+  resumable chat history.
 - **Agents rail** — agent projects (`sapiom.json`) discovered and
   tracked, with one-click local test run, deploy, production run, and
   open-in-Sapiom actions. How that discovery is rooted and bounded, how a

--- a/packages/harness/web/e2e/accumulation-guard.spec.ts
+++ b/packages/harness/web/e2e/accumulation-guard.spec.ts
@@ -94,7 +94,7 @@ test.describe("Remove project", () => {
     await expect(page.getByTestId("workspace-group-acme-app")).toBeVisible();
   });
 
-  test("the control is hover-revealed on the row, and reachable by keyboard", async ({ page }) => {
+  test("the controls are hover-revealed on the row, and reachable by keyboard", async ({ page }) => {
     // A destructive action standing at full strength on every project row
     // would be the loudest thing in the rail; invisible even to the keyboard
     // would be worse. Both halves are CSS, so both are asserted on screen.
@@ -117,6 +117,12 @@ test.describe("Remove project", () => {
     await expect
       .poll(() =>
         actions.first().evaluate((element) => getComputedStyle(element).opacity),
+      )
+      .toBe("1");
+    await actions.nth(1).focus();
+    await expect
+      .poll(() =>
+        actions.nth(1).evaluate((element) => getComputedStyle(element).opacity),
       )
       .toBe("1");
   });

--- a/packages/harness/web/e2e/accumulation-guard.spec.ts
+++ b/packages/harness/web/e2e/accumulation-guard.spec.ts
@@ -98,21 +98,27 @@ test.describe("Remove project", () => {
     // A destructive action standing at full strength on every project row
     // would be the loudest thing in the rail; invisible even to the keyboard
     // would be worse. Both halves are CSS, so both are asserted on screen.
-    // The control is now the row's ⋮ — Remove lives inside it (SAP-2982) — and
-    // the reveal contract it has to keep is the row's, unchanged.
+    // Remove lives inside the row's ⋮ (SAP-2982); the session shortcut sits
+    // beside that menu and shares the same row-owned reveal contract.
     const row = page.getByTestId("workspace-group-acme-app").locator(":scope > .workspace-row");
-    const menu = page.getByTestId("project-menu-acme-app");
-    const opacity = (): Promise<string> =>
-      menu.evaluate((element) => getComputedStyle(element).opacity);
+    const actions = row.locator(":scope > .workspace-row-action");
+    const opacities = (): Promise<string[]> =>
+      actions.evaluateAll((elements) =>
+        elements.map((element) => getComputedStyle(element).opacity),
+      );
 
-    expect(await opacity()).toBe("0");
+    expect(await opacities()).toEqual(["0", "0"]);
     await row.hover();
-    await expect.poll(opacity).toBe("1");
+    await expect.poll(opacities).toEqual(["1", "1"]);
 
     await page.mouse.move(0, 0);
-    await expect.poll(opacity).toBe("0");
-    await menu.focus();
-    await expect.poll(opacity).toBe("1");
+    await expect.poll(opacities).toEqual(["0", "0"]);
+    await actions.first().focus();
+    await expect
+      .poll(() =>
+        actions.first().evaluate((element) => getComputedStyle(element).opacity),
+      )
+      .toBe("1");
   });
 
   test("an OPEN menu holds its trigger on screen after the pointer leaves", async ({ page }) => {

--- a/packages/harness/web/e2e/open-project.spec.ts
+++ b/packages/harness/web/e2e/open-project.spec.ts
@@ -88,7 +88,7 @@ test.describe("the header + opens a project", () => {
     await expect(page.getByTestId("project-row-blank-slate")).toBeVisible();
   });
 
-  test("a planning project hides every standalone agent-creation action", async ({
+  test("a planning project keeps sessions direct while hiding standalone agent creation", async ({
     page,
   }) => {
     await page.getByTestId("rail-add-project").click();
@@ -108,6 +108,9 @@ test.describe("the header + opens a project", () => {
     await expect(page.getByTestId("planner-session-ended")).toBeVisible();
 
     await expect(group.getByTestId("project-empty-blank-slate")).toHaveCount(0);
+    await expect(
+      group.getByTestId("project-start-session-blank-slate"),
+    ).toHaveAttribute("aria-label", "Start a session in blank-slate");
 
     // The visible empty row and the project menu used to be two doors into the
     // same direct-create flow. A planning project exposes neither: generated

--- a/packages/harness/web/e2e/project-axis.spec.ts
+++ b/packages/harness/web/e2e/project-axis.spec.ts
@@ -165,6 +165,82 @@ test.describe("ordering", () => {
 });
 
 test.describe("the plan-first project children", () => {
+  test("the project plus starts a coding session at its root without creating an agent", async ({
+    page,
+  }) => {
+    const group = page.getByTestId("workspace-group-dashboard-keeper");
+    const row = group.getByTestId("project-row-dashboard-keeper");
+    const start = group.getByTestId("project-start-session-dashboard-keeper");
+
+    await expect(start).toHaveAttribute(
+      "aria-label",
+      "Start a session in dashboard-keeper",
+    );
+    await expect(start).toHaveAttribute("data-tooltip", "Start a session here");
+    expect(
+      await row
+        .locator(":scope > .workspace-row-action")
+        .evaluateAll((actions) =>
+          actions.map((action) => action.getAttribute("data-testid")),
+        ),
+    ).toEqual([
+      "project-start-session-dashboard-keeper",
+      "project-menu-dashboard-keeper",
+    ]);
+
+    // Prove the shortcut also works from map altitude: the new generic session
+    // becomes the visible workbench, while the planner remains resumable from
+    // Plan Agents and no scaffold request is made.
+    await group.getByTestId("agent-map-select").click();
+    await expect(group.getByTestId("agent-map-select")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await start.click();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as unknown as {
+                __HARNESS_TEST__?: {
+                  lastCreateSession?: {
+                    req?: { cwd?: string; harness?: string };
+                  };
+                  createOrder?: string[];
+                };
+              }
+            ).__HARNESS_TEST__,
+        ),
+      )
+      .toMatchObject({
+        lastCreateSession: {
+          req: {
+            cwd: "/Users/demo/dashboard-keeper",
+            harness: "claude-code",
+          },
+        },
+      });
+    await expect(group.getByTestId("agent-map-select")).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    await expect(page.getByTestId("session-context-title")).toContainText(
+      "dashboard-keeper",
+    );
+    await expect(page.locator(".harness-terminal")).toBeVisible();
+    expect(
+      await page.evaluate(
+        () =>
+          (
+            window as unknown as {
+              __HARNESS_TEST__?: { createOrder?: string[] };
+            }
+          ).__HARNESS_TEST__?.createOrder ?? [],
+      ),
+    ).not.toContain("scaffold:/Users/demo/dashboard-keeper");
+  });
+
   test("a root agent is a separate target below the pinned Agent Map", async ({
     page,
   }) => {

--- a/packages/harness/web/e2e/project-axis.spec.ts
+++ b/packages/harness/web/e2e/project-axis.spec.ts
@@ -168,6 +168,17 @@ test.describe("the plan-first project children", () => {
   test("the project plus starts a coding session at its root without creating an agent", async ({
     page,
   }) => {
+    await page.evaluate(() => {
+      const key = "sapiom-harness-ui-prefs";
+      const current = JSON.parse(localStorage.getItem(key) ?? "{}") as Record<
+        string,
+        unknown
+      >;
+      localStorage.setItem(
+        key,
+        JSON.stringify({ ...current, preferredHarness: "codex" }),
+      );
+    });
     const group = page.getByTestId("workspace-group-dashboard-keeper");
     const row = group.getByTestId("project-row-dashboard-keeper");
     const start = group.getByTestId("project-start-session-dashboard-keeper");
@@ -217,7 +228,7 @@ test.describe("the plan-first project children", () => {
         lastCreateSession: {
           req: {
             cwd: "/Users/demo/dashboard-keeper",
-            harness: "claude-code",
+            harness: "codex",
           },
         },
       });
@@ -239,6 +250,28 @@ test.describe("the plan-first project children", () => {
           ).__HARNESS_TEST__?.createOrder ?? [],
       ),
     ).not.toContain("scaffold:/Users/demo/dashboard-keeper");
+  });
+
+  test("a failed project session keeps Plan Agents selected", async ({
+    page,
+  }) => {
+    const group = page.getByTestId("workspace-group-dashboard-keeper");
+    const map = group.getByTestId("agent-map-select");
+    await map.click();
+    await expect(map).toHaveAttribute("aria-pressed", "true");
+    await expect(page.locator(".harness-terminal")).toBeVisible();
+    await page.evaluate(() => {
+      (
+        window as unknown as { __MOCK_CREATE_SESSION_FAIL_ONCE__?: boolean }
+      ).__MOCK_CREATE_SESSION_FAIL_ONCE__ = true;
+    });
+
+    await group.getByTestId("project-start-session-dashboard-keeper").click();
+    await expect(page.getByTestId("toast")).toContainText(
+      "mock: couldn't create session",
+    );
+    await expect(map).toHaveAttribute("aria-pressed", "true");
+    await expect(page.getByTestId("agent-map-frame")).toBeVisible();
   });
 
   test("a root agent is a separate target below the pinned Agent Map", async ({

--- a/packages/harness/web/e2e/rail-grammar.spec.ts
+++ b/packages/harness/web/e2e/rail-grammar.spec.ts
@@ -1,17 +1,16 @@
 /**
  * SAP-2982 — the rail's grammar, and the card that names the two nouns.
  *
- * Three defects, one theme: the rail was built on a Project/Agent distinction
- * that it never said out loud.
+ * The rail must keep four different actions legible:
  *
- *   1. `+` and `×` sat adjacent on a project row — same size, same
- *      hover-reveal — while acting on different nouns. `+` created an AGENT
- *      inside the project; `×` removed the PROJECT. The pair made `+` read as
- *      "add project", and the `×` beside it confirmed the misreading.
- *   2. Only the chevron folded a project. Double-clicking the label, the
+ *   1. The project-row `+` starts a coding-agent SESSION at that root. It is a
+ *      frequent shortcut, not another way to scaffold a Sapiom agent.
+ *   2. The `⋮` holds explicitly named PROJECT management actions and the
+ *      legacy-server create-agent compatibility action.
+ *   3. Only the chevron folded a project. Double-clicking the label, the
  *      platform convention for a disclosure row, did nothing — which reads as
  *      a row that has stopped responding, not as a feature that is absent.
- *   3. The taxonomy itself lived only in commit messages.
+ *   4. The taxonomy itself lived only in commit messages.
  *
  * These specs assert COMPUTED state, not presence: the reveal contract and the
  * fold are both CSS, and a control that renders at opacity 0 forever passes
@@ -35,16 +34,24 @@ test.describe("legacy-server project row grammar", () => {
     await expect(page.getByTestId("workspace-group-acme-app")).toBeVisible();
   });
 
-  test("the row carries ONE action control, not a pair acting on two nouns", async ({
+  test("a session shortcut sits immediately before the named project menu", async ({
     page,
   }) => {
     const row = ROW(page, "acme-app");
-    // Every trailing action button on the row. The defect was never "there is
-    // a `+`" — it was two same-sized adjacent glyphs whose subjects differ, so
-    // the assertion is on the SET of controls the row offers at once.
+    // The frequent session action is one click away. Destructive project
+    // management remains behind the named overflow menu instead of returning
+    // as an adjacent `×`.
     const actions = row.locator(".workspace-row-action");
-    await expect(actions).toHaveCount(1);
-    await expect(actions.first()).toHaveAttribute(
+    await expect(actions).toHaveCount(2);
+    await expect(actions.nth(0)).toHaveAttribute(
+      "data-testid",
+      "project-start-session-acme-app",
+    );
+    await expect(actions.nth(0)).toHaveAttribute(
+      "aria-label",
+      "Start a session in acme-app",
+    );
+    await expect(actions.nth(1)).toHaveAttribute(
       "data-testid",
       "project-menu-acme-app",
     );
@@ -59,14 +66,17 @@ test.describe("legacy-server project row grammar", () => {
     );
   });
 
-  test("a bare project's scaffold action is in the same menu, not beside the ×", async ({
+  test("a bare project's session shortcut stays distinct from scaffolding", async ({
     page,
   }) => {
-    // `scratch` has live sessions and no agent. Its create affordance used to
-    // be a Sparkles glyph on the row — an AGENT action sitting next to the
-    // PROJECT's `×`, which is the same defect in its second costume.
+    // `scratch` has live sessions and no Sapiom agent. The row `+` can start
+    // another coding session; the legacy scaffold operation remains named in
+    // the menu so the two operations do not masquerade as one another.
     const row = ROW(page, "scratch");
-    await expect(row.locator(".workspace-row-action")).toHaveCount(1);
+    await expect(row.locator(".workspace-row-action")).toHaveCount(2);
+    await expect(
+      page.getByTestId("project-start-session-scratch"),
+    ).toBeVisible();
     await openProjectMenu(page, "scratch");
     await expect(page.getByTestId("workspace-scaffold-scratch")).toHaveText(
       "Scaffold an agent in scratch",

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -1644,7 +1644,7 @@ export const App = (): JSX.Element => {
         harness.setActiveSessionId(decision.to.id);
       return;
     }
-    void startProjectSession(root, label);
+    void startProjectSession(root, label, preferredHarness());
   };
   selectProjectRef.current = handleSelectWorkspace;
 
@@ -1659,17 +1659,19 @@ export const App = (): JSX.Element => {
   const startProjectSession = async (
     root: string,
     label: string,
-    agentHarness: HarnessKind = "claude-code",
-  ): Promise<void> => {
-    if (startingProjectRootsRef.current.has(root)) return;
+    agentHarness: HarnessKind,
+  ): Promise<boolean> => {
+    if (startingProjectRootsRef.current.has(root)) return false;
     startingProjectRootsRef.current.add(root);
     setStartingProject({ root, label });
     try {
       await createSessionAt(root, agentHarness);
+      return true;
     } catch (err) {
       harness.showToast(
         (err as Error).message || `Couldn't start a session in ${label}.`,
       );
+      return false;
     } finally {
       startingProjectRootsRef.current.delete(root);
       setStartingProject((current) =>
@@ -1683,8 +1685,11 @@ export const App = (): JSX.Element => {
    * preference the rail used to read before it dispatched. It moved here with
    * the create itself; the rail no longer starts sessions.
    */
-  const preferredHarness = (): HarnessKind =>
-    loadUiPrefs().preferredHarness === "codex" ? "codex" : "claude-code";
+  function preferredHarness(): HarnessKind {
+    return loadUiPrefs().preferredHarness === "codex"
+      ? "codex"
+      : "claude-code";
+  }
 
   /**
    * The ONE answer to "where does a session for this agent boot" (SAP-2927).
@@ -2776,14 +2781,20 @@ export const App = (): JSX.Element => {
             }}
             launchDir={state.launchDir ?? null}
             listDir={harness.listDir}
-            onStartProjectSession={(root, label) => {
+            onStartProjectSession={async (root, label) => {
               // A project-row `+` explicitly asks to see a fresh coding
               // session, even when Plan Agents or a legacy project map is the
-              // current altitude. The planner process stays resumable.
+              // current altitude. Change views only after creation succeeds so
+              // a failed launch leaves the planner in place and resumable.
+              const started = await startProjectSession(
+                root,
+                label,
+                preferredHarness(),
+              );
+              if (!started) return;
               studioRestoreGenerationRef.current += 1;
               setStudioSelection(null);
               setSelectedProject(null);
-              return startProjectSession(root, label, preferredHarness());
             }}
             listHarnesses={harness.listHarnesses}
             onCreateAgent={handleCreateAgentInProject}

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -1659,12 +1659,13 @@ export const App = (): JSX.Element => {
   const startProjectSession = async (
     root: string,
     label: string,
+    agentHarness: HarnessKind = "claude-code",
   ): Promise<void> => {
     if (startingProjectRootsRef.current.has(root)) return;
     startingProjectRootsRef.current.add(root);
     setStartingProject({ root, label });
     try {
-      await createSessionAt(root, "claude-code");
+      await createSessionAt(root, agentHarness);
     } catch (err) {
       harness.showToast(
         (err as Error).message || `Couldn't start a session in ${label}.`,
@@ -2775,7 +2776,15 @@ export const App = (): JSX.Element => {
             }}
             launchDir={state.launchDir ?? null}
             listDir={harness.listDir}
-            onCreateSession={handleCreateSession}
+            onStartProjectSession={(root, label) => {
+              // A project-row `+` explicitly asks to see a fresh coding
+              // session, even when Plan Agents or a legacy project map is the
+              // current altitude. The planner process stays resumable.
+              studioRestoreGenerationRef.current += 1;
+              setStudioSelection(null);
+              setSelectedProject(null);
+              return startProjectSession(root, label, preferredHarness());
+            }}
             listHarnesses={harness.listHarnesses}
             onCreateAgent={handleCreateAgentInProject}
             onScaffoldInSession={handleScaffoldInSession}

--- a/packages/harness/web/src/components/ProjectTreeRows.tsx
+++ b/packages/harness/web/src/components/ProjectTreeRows.tsx
@@ -386,8 +386,8 @@ export function ProjectRow({
   ) => void;
   focusedAgentPath: string | null;
   onFocusAgent: (path: string) => void;
-  /** Row-end slot for state that belongs to the project itself (the
-   *  mid-creation spinner). Never a deploy glyph — see below. */
+  /** Row-end slot for project-owned state and actions: creation progress,
+   *  map/session shortcuts, and the overflow menu. Never a deploy glyph. */
   trailing?: ReactNode;
   /** A project with no agents of its own but a live session in it, or one
    *  mid-creation: the row itself is the focus target so those sessions can

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -177,7 +177,7 @@ interface WorkflowsRailProps {
   onOpenProject: (root: string) => Promise<unknown>;
   launchDir: string | null;
   listDir: (path?: string) => Promise<FsListResponse>;
-  /** Starts a coding-agent session at the selected project root. */
+  /** Starts a coding-agent session and owns its failure feedback. */
   onStartProjectSession: (root: string, label: string) => Promise<void>;
   /** Adapter registry fetch — the add dialog's picker and MCP setup block. */
   listHarnesses: () => Promise<HarnessEntry[]>;
@@ -1395,18 +1395,12 @@ export function WorkflowsRail({
                           data-testid={`project-start-session-${project.label}`}
                           aria-label={`Start a session in ${project.label}`}
                           data-tooltip="Start a session here"
-                          onClick={() => {
+                          onClick={() =>
                             void onStartProjectSession(
                               project.root,
                               project.label,
-                            ).catch((err: unknown) => {
-                              onToast(
-                                err instanceof Error
-                                  ? err.message
-                                  : `Couldn't start a session in ${project.label}.`,
-                              );
-                            });
-                          }}
+                            )
+                          }
                         >
                           <Icon name="Plus" size={13} />
                         </button>

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -177,7 +177,8 @@ interface WorkflowsRailProps {
   onOpenProject: (root: string) => Promise<unknown>;
   launchDir: string | null;
   listDir: (path?: string) => Promise<FsListResponse>;
-  onCreateSession: (cwd: string, harness: HarnessKind) => Promise<void>;
+  /** Starts a coding-agent session at the selected project root. */
+  onStartProjectSession: (root: string, label: string) => Promise<void>;
   /** Adapter registry fetch — the add dialog's picker and MCP setup block. */
   listHarnesses: () => Promise<HarnessEntry[]>;
   /**
@@ -262,13 +263,12 @@ const SORT_LABELS: Record<RailSort, string> = {
 };
 
 /**
- * The project row's ONE trailing action control.
+ * The project row's overflow menu.
  *
- * A `⋮` rather than a row of glyphs, because the actions a project row offers
- * do not share a subject: creating an agent acts on an AGENT inside the
- * project, removing acts on the PROJECT. Two adjacent 13px marks cannot say
- * which noun they take, and side by side they claimed a symmetry that was not
- * there — see the call site for the pair this replaces.
+ * The adjacent `+` has one stable meaning: start a coding-agent session at this
+ * project's root. This menu keeps the lower-frequency, explicitly named
+ * project actions. On legacy servers that includes scaffolding a Sapiom agent;
+ * on current plan-first projects, agent creation remains owned by Plan Agents.
  *
  * Named items say it instead. Each carries the project's own label, so the
  * subject is read rather than inferred, and the destructive one is last and
@@ -488,7 +488,7 @@ export function WorkflowsRail({
   onOpenProject,
   launchDir,
   listDir,
-  onCreateSession,
+  onStartProjectSession,
   listHarnesses,
   onCreateAgent,
   onScaffoldInSession,
@@ -952,9 +952,9 @@ export function WorkflowsRail({
               The label owns the leading edge: putting a control there made the
               header read as one more nav button in the stack above it — same
               icon slot, same indent — rather than as the title of the tree
-              below. FOLDER-with-plus, because what it adds is a folder. One `+`
-              per question: this one opens a project; starting another session
-              is the tab strip's trailing `+`, and project rows carry none. */}
+              below. FOLDER-with-plus, because what it adds is a folder. The
+              project-row `+` starts a session at that root; the tab-strip `+`
+              starts a sibling of the session already in view. */}
           <button
             type="button"
             className="theme-toggle rail-header-btn"
@@ -1382,28 +1382,39 @@ export function WorkflowsRail({
                             <Icon name="Waypoints" size={13} />
                           </button>
                         )}
-                      {/* ONE CONTROL, and it opens a menu of NAMED actions.
-                          `+` and `×` used to sit here side by side: same size,
-                          same hover-reveal, adjacent — so they read as a
-                          matched pair operating on one subject. They never
-                          were. `+` created an AGENT inside the project; `×`
-                          removed the PROJECT from the rail. The pair made `+`
-                          read as "add project", and the `×` next to it
-                          confirmed the misreading rather than correcting it.
-                          The same defect had a second form on a bare project,
-                          where a Sparkles "scaffold an agent" glyph sat beside
-                          the same `×`.
-
-                          A menu fixes the grammar rather than re-tuning the
-                          glyphs, because the ambiguity was never in the icons:
-                          it was in asking a 13px mark to carry a noun. Every
-                          item here states its own subject in words — "Create an
-                          agent in acme-app", "Remove acme-app from the rail"
-                          — so there is nothing left to infer from adjacency.
-
-                          What is left on the row is a `⋮` and, on a merged
-                          root-agent row, the map. Both speak for the project,
-                          so no pair on this row spans two nouns any more. */}
+                      {/* START A SESSION HERE. This is the frequent project-row
+                          action and therefore stays one click away, immediately
+                          before the overflow menu. Its accessible name supplies
+                          the noun the glyph cannot: this starts a coding-agent
+                          SESSION at the project root. It does not scaffold a
+                          Sapiom agent or bypass Plan Agents. */}
+                      {!pending && (
+                        <button
+                          type="button"
+                          className="workspace-row-action"
+                          data-testid={`project-start-session-${project.label}`}
+                          aria-label={`Start a session in ${project.label}`}
+                          data-tooltip="Start a session here"
+                          onClick={() => {
+                            void onStartProjectSession(
+                              project.root,
+                              project.label,
+                            ).catch((err: unknown) => {
+                              onToast(
+                                err instanceof Error
+                                  ? err.message
+                                  : `Couldn't start a session in ${project.label}.`,
+                              );
+                            });
+                          }}
+                        >
+                          <Icon name="Plus" size={13} />
+                        </button>
+                      )}
+                      {/* NAMED PROJECT ACTIONS. The destructive action stays in
+                          this menu instead of masquerading as a peer of the
+                          session shortcut. Legacy-only agent creation also
+                          remains spelled out here rather than sharing the `+`. */}
                       <ProjectRowMenu
                         label={project.label}
                         create={


### PR DESCRIPTION
## Summary

Add a project-row `+` immediately before the overflow menu so a developer can start a coding-agent session at that project root in one click. This is a new session action, distinct from the former agent-creation meaning of the glyph; Sapiom agent creation remains owned by Plan Agents.

## Changes

- Add the hover-revealed project-root session shortcut beside `⋮`
- Use the stored preferred coding harness for both the shortcut and project-start path
- Open the new session in the workbench only after creation succeeds
- Keep an active planning conversation visible on failure and resumable after success
- Keep direct Sapiom agent creation hidden for plan-first projects
- Document the project-row and tab-strip session shortcuts
- Add a minor harness / patch desktop changeset with corrected user-facing copy

### Key Refinements from Code Review

- Seed and assert the Codex preference instead of only exercising the Claude default
- Make the provider argument required so new project-session callers must choose consistently
- Preserve Plan Agents when session creation fails
- Cover keyboard reveal for both `+` and `⋮`
- Remove unreachable duplicate error feedback

## Testing

- [x] `pnpm --filter @sapiom/harness build`
- [x] `pnpm --filter @sapiom/harness typecheck`
- [x] `pnpm --filter @sapiom/harness test` — 3,316 tests passed
- [x] 53 targeted Chromium tests across project axis, rail grammar, project opening, and accumulation guard
- [x] Red/green check: the shortcut test fails with the button removed and passes after restoration

## Screenshots/Demos

- Visually checked the hover state in Chromium at 1440×900 against the supplied reference: `+` is directly before `⋮` and reuses the existing row-action treatment.

## Checklist

- [x] Code follows project guidelines
- [x] Commits follow conventions
- [x] No hardcoded secrets
- [x] Self-reviewed