### PR TITLE
fix(tools): guard missing run_local capabilities (#155)

### DIFF
--- a/.changeset/run-local-capability-stubs-155.md
+++ b/.changeset/run-local-capability-stubs-155.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/tools": patch
+"@sapiom/agent-core": patch
+---
+
+run_local stub client documents and guards memory/database/email/domains availability: missing top-level capabilities throw `CapabilityNotAvailableError` instead of an opaque TypeError (#155).

--- a/packages/agent-core/src/local/run-local.spec.ts
+++ b/packages/agent-core/src/local/run-local.spec.ts
@@ -945,3 +945,41 @@ describe("runLocal", () => {
     expect(result.output).toEqual({ trimmed: "(none)" });
   });
 });
+
+describe("runLocal — issue #155 memory/database/email/domains stubs", () => {
+  it("runs a step that calls memory, database, email, and domains without TypeError", async () => {
+    const persist = defineStep({
+      name: "persist",
+      next: [],
+      terminal: true,
+      async run(_input, ctx: AgentExecutionContext) {
+        await ctx.sapiom.memory.append({ content: "hello", namespace: "demo" });
+        await ctx.sapiom.database.create({ duration: "1h" });
+        await ctx.sapiom.email.inboxes.create();
+        await ctx.sapiom.domains.check({ domainNames: ["example.com"] });
+        return terminate({ ok: true });
+      },
+    });
+    const def = defineAgent({
+      name: "capability-stubs",
+      entry: "persist",
+      steps: { persist },
+    });
+
+    const result = await runLocal({
+      definition: def,
+      manifest: manifestFor(def),
+    });
+
+    expect(result.outcome).toBe("completed");
+    expect(result.output).toEqual({ ok: true });
+    expect(result.steps[0]?.calls?.map((c) => c.capability)).toEqual(
+      expect.arrayContaining([
+        "memory.append",
+        "database.create",
+        "email.inboxes.create",
+        "domains.check",
+      ]),
+    );
+  });
+});

--- a/packages/tools/src/stub/capability-availability.test.ts
+++ b/packages/tools/src/stub/capability-availability.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Regression coverage for issue #155: run_local must expose memory / database /
+ * email / domains on the stub client, and any missing top-level capability must
+ * throw a legible CapabilityNotAvailableError instead of an opaque TypeError.
+ */
+import {
+  CapabilityNotAvailableError,
+  createStubClient,
+} from "./index.js";
+
+describe("createStubClient — issue #155 capability availability", () => {
+  it("stubs memory, database, email, and domains (not undefined)", async () => {
+    const client = createStubClient();
+
+    expect(client.memory).toBeDefined();
+    expect(client.database).toBeDefined();
+    expect(client.email).toBeDefined();
+    expect(client.domains).toBeDefined();
+
+    const appended = await client.memory.append({
+      content: "hello",
+      namespace: "demo",
+    });
+    expect(appended).toMatchObject({ content: "hello" });
+
+    const db = await client.database.create({ duration: "1h" });
+    expect(db).toMatchObject({ id: expect.any(String) });
+
+    const inbox = await client.email.inboxes.create();
+    expect(inbox).toMatchObject({ email: expect.any(String) });
+
+    const availability = await client.domains.check({
+      domainNames: ["example.com"],
+    });
+    expect(Array.isArray(availability)).toBe(true);
+  });
+
+  it("throws CapabilityNotAvailableError for a missing top-level capability", () => {
+    const client = createStubClient() as unknown as Record<string, unknown>;
+
+    expect(() => client.notARealCapability).toThrow(CapabilityNotAvailableError);
+    try {
+      void client.notARealCapability;
+    } catch (err) {
+      expect(err).toBeInstanceOf(CapabilityNotAvailableError);
+      expect((err as CapabilityNotAvailableError).capability).toBe(
+        "notARealCapability",
+      );
+      expect((err as Error).message).toMatch(/not available under run_local/i);
+    }
+  });
+});

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -6,6 +6,12 @@
  * locally with zero setup) plus optional per-capability overrides (when a step's
  * logic branches on a result). No network, no credentials.
  *
+ * Stubbed namespaces include the full client surface: sandboxes, repositories,
+ * models, agents, llm, fileStorage, contentGeneration, search, database, email,
+ * domains, memory, vault, keys, speech, and browserAutomation. A missing
+ * top-level capability (typo or future gap) throws `CapabilityNotAvailableError`
+ * instead of an opaque `TypeError` on `undefined`.
+ *
  * It is shape-faithful: namespace methods return the real handle types
  * (`Repository`, `Sandbox`, `RunHandle`), and a handle's instance methods
  * (`repo.pushFromSandbox(...)`, `sandbox.exec(...)`) work too — so a step never
@@ -823,6 +829,43 @@ function stubMemoryFilterMatches(
     }
   }
   return true;
+}
+
+/**
+ * Thrown when author code reads a top-level `ctx.sapiom.<capability>` that the
+ * stub client does not implement. Prefer this over an opaque
+ * `TypeError: Cannot read properties of undefined` under `run_local`.
+ */
+export class CapabilityNotAvailableError extends Error {
+  readonly capability: string;
+
+  constructor(capability: string) {
+    super(
+      `Capability '${capability}' is not available under run_local ` +
+        `(not stubbed by createStubClient)`,
+    );
+    this.name = "CapabilityNotAvailableError";
+    this.capability = capability;
+  }
+}
+
+/**
+ * Replace missing top-level capability reads with a legible error. Existing
+ * namespaces (including memory / database / email / domains) are returned as-is.
+ */
+function guardMissingCapabilities(client: Sapiom): Sapiom {
+  return new Proxy(client, {
+    get(target, prop, receiver) {
+      if (typeof prop === "symbol") {
+        return Reflect.get(target, prop, receiver);
+      }
+      const value = Reflect.get(target, prop, receiver);
+      if (value !== undefined || prop in target) {
+        return value;
+      }
+      throw new CapabilityNotAvailableError(String(prop));
+    },
+  });
 }
 
 export function createStubClient(opts: StubClientOptions = {}): Sapiom {
@@ -2013,11 +2056,13 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
           ),
       },
     },
-    withAttribution: () => client,
+    withAttribution: () => guarded,
     // The stub makes no HTTP calls and creates no analytics emitter — nothing
     // to release, so shutdown matches the real client's "resolve immediately".
     shutdown: () => Promise.resolve(),
   };
 
-  return client;
+  let guarded!: Sapiom;
+  guarded = guardMissingCapabilities(client);
+  return guarded;
 }

--- a/packages/tools/src/stub/index.ts
+++ b/packages/tools/src/stub/index.ts
@@ -2056,13 +2056,13 @@ export function createStubClient(opts: StubClientOptions = {}): Sapiom {
           ),
       },
     },
-    withAttribution: () => guarded,
+    withAttribution: () => guarded.value!,
     // The stub makes no HTTP calls and creates no analytics emitter — nothing
     // to release, so shutdown matches the real client's "resolve immediately".
     shutdown: () => Promise.resolve(),
   };
 
-  let guarded!: Sapiom;
-  guarded = guardMissingCapabilities(client);
-  return guarded;
+  const guarded: { value?: Sapiom } = {};
+  guarded.value = guardMissingCapabilities(client);
+  return guarded.value;
 }


### PR DESCRIPTION
## Summary
- Document that createStubClient() stubs memory, database, email, and domains (among the full client surface).
- Throw CapabilityNotAvailableError for missing top-level ctx.sapiom.* reads under run_local instead of an opaque TypeError.
- Add stub + runLocal regression tests covering the issue #155 repro shape.

## Related work
- Fixes #155
- Complements #581 (tests-only) with production hardening for the opaque-TypeError failure mode

## Validation
- pnpm --filter @sapiom/tools test -- src/stub/capability-availability.test.ts — pass
- pnpm --filter @sapiom/agent-core test -- src/local/run-local.spec.ts — pass (24/24)

## AI assistance
Used Cursor to investigate the issue, implement the guard, add tests, and open this PR. I reviewed the diff before submitting.

Made with [Cursor](https://cursor.com)