### PR TITLE
fix(harness): harden Codex readiness beyond copy/footer heuristics (#701)

### DIFF
--- a/.changeset/codex-readiness-hardening-701.md
+++ b/.changeset/codex-readiness-hardening-701.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Harden Codex readiness beyond placeholder copy and cwd-footer heuristics: structural composer proof plus consecutive clean frames after a latched blocker, without weakening known modal vetoes (#701).

--- a/packages/harness-desktop/scripts/smoke-agent-stub.cjs
+++ b/packages/harness-desktop/scripts/smoke-agent-stub.cjs
@@ -1,0 +1,60 @@
+const fs = require("node:fs");
+
+function environmentCapturePath(base, sessionId) {
+  return `${base}.${encodeURIComponent(sessionId)}.json`;
+}
+
+function captureAgentEnvironment(env = process.env) {
+  const base = env.SAPIOM_SMOKE_AGENT_ENV;
+  const sessionId = env.SAPIOM_HARNESS_SESSION_ID;
+  if (!base || !sessionId) return null;
+
+  const file = environmentCapturePath(base, sessionId);
+  const snapshot = {
+    schemaVersion: 1,
+    sessionId,
+    variableCount: Object.keys(env).length,
+    hasEsbuildBinaryPath: Object.prototype.hasOwnProperty.call(
+      env,
+      "ESBUILD_BINARY_PATH",
+    ),
+    hasPath: typeof env.PATH === "string" && env.PATH.length > 0,
+  };
+  fs.writeFileSync(file, `${JSON.stringify(snapshot)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  return file;
+}
+
+function runSessionStartHook() {
+  try {
+    const settingsIndex = process.argv.indexOf("--settings");
+    const settingsPath =
+      settingsIndex > -1 ? process.argv[settingsIndex + 1] : null;
+    if (!settingsPath) return;
+    const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
+    const command = settings.hooks.SessionStart[0].hooks[0].command;
+    const { execFileSync, execSync } = require("node:child_process");
+    if (process.platform === "win32") {
+      const bash = "C:\\Program Files\\Git\\bin\\bash.exe";
+      if (fs.existsSync(bash)) {
+        execFileSync(bash, ["-c", command], { stdio: "ignore" });
+      } else {
+        execSync(command, { stdio: "ignore" });
+      }
+    } else {
+      execFileSync("/bin/sh", ["-c", command], { stdio: "ignore" });
+    }
+  } catch {
+    // A failed hook is exactly what checkSessionCreate's ready poll reports.
+  }
+}
+
+module.exports = { captureAgentEnvironment, environmentCapturePath };
+
+if (require.main === module) {
+  captureAgentEnvironment();
+  runSessionStartHook();
+  setTimeout(() => process.exit(0), 3000);
+}

--- a/packages/harness-desktop/scripts/smoke.sh
+++ b/packages/harness-desktop/scripts/smoke.sh
@@ -75,52 +75,31 @@ export SAPIOM_SMOKE_OUT="$(native "$report_file")"
 # check can assert the WHOLE readiness chain (settings → hook command → node
 # resolution under the hook shell → POST → ready), the exact seam that broke
 # silently on Windows and dropped every held first prompt.
-cat > "$smoke_home/stub-agent.js" <<'STUBJS'
-const fs = require("fs");
-const envFile = process.env.SAPIOM_SMOKE_AGENT_ENV;
-if (envFile) fs.writeFileSync(envFile, Object.entries(process.env).map(([k, v]) => k + "=" + v).join("\n") + "\n");
-try {
-  const i = process.argv.indexOf("--settings");
-  const settingsPath = i > -1 ? process.argv[i + 1] : null;
-  if (settingsPath) {
-    const settings = JSON.parse(fs.readFileSync(settingsPath, "utf8"));
-    const command = settings.hooks.SessionStart[0].hooks[0].command;
-    const { execFileSync, execSync } = require("child_process");
-    if (process.platform === "win32") {
-      const bash = "C:\\Program Files\\Git\\bin\\bash.exe";
-      if (fs.existsSync(bash)) execFileSync(bash, ["-c", command], { stdio: "ignore" });
-      else execSync(command, { stdio: "ignore" });
-    } else {
-      execFileSync("/bin/sh", ["-c", command], { stdio: "ignore" });
-    }
-  }
-} catch {
-  // A failed hook is exactly what the ready-poll in checkSessionCreate reports.
-}
-setTimeout(() => process.exit(0), 3000);
-STUBJS
+cp "$here/smoke-agent-stub.cjs" "$smoke_home/stub-agent.cjs"
 if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
   # Shaped like an npm shim on purpose — a `.cmd` that runs `node <script>` — because
   # that is exactly what `claude.cmd` is, and it's the shape resolveSpawnTarget has
   # to see through. A stub that were a plain .cmd (or an .exe) would exercise a path
   # real agents never take, and is now correctly refused rather than shelled out.
   stub="$smoke_home/stub-agent.cmd"
-  printf '@echo off\r\n"%%dp0%%\\node.exe" "%%dp0%%\\stub-agent.js" %%*\r\n' > "$stub"
+  printf '@echo off\r\n"%%dp0%%\\node.exe" "%%dp0%%\\stub-agent.cjs" %%*\r\n' > "$stub"
 else
   # `node` rather than a hardcoded path: the app's PATH augmentation (runtime
   # shims) must make it resolvable — that resolution is part of what's under test.
   stub="$smoke_home/stub-agent.sh"
-  printf '#!/bin/sh\nexec node "%s" "$@"\n' "$smoke_home/stub-agent.js" > "$stub"
+  printf '#!/bin/sh\nexec node "%s" "$@"\n' "$smoke_home/stub-agent.cjs" > "$stub"
   chmod +x "$stub"
 fi
-# Where the stub agent writes its environment, so a check can assert on what the
-# AGENT actually inherited rather than on what the main process meant to pass.
+# Base path where each stub agent writes a session-keyed environment snapshot,
+# so concurrent project sessions cannot overwrite one another's evidence and a
+# check can assert on what the exact AGENT inherited rather than on what the
+# main process meant to pass.
 # This caught a real regression: the desktop host pins ESBUILD_BINARY_PATH so its
 # own bundler can exec a binary outside app.asar, and the whole parent env is
 # copied into the pty — so every agent, and every tool it ran in the user's repo,
 # inherited a pin to OUR esbuild build ("Host version X does not match binary
 # version Y" on a project that builds fine outside the app).
-export SAPIOM_SMOKE_AGENT_ENV="$(native "$smoke_home/agent-env.txt")"
+export SAPIOM_SMOKE_AGENT_ENV="$(native "$smoke_home/agent-env")"
 # Native, because resolveSpawnTarget resolves this inside the app: a POSIX
 # path has no drive letter, so the Windows lookup would never find it.
 export SAPIOM_SMOKE_STUB_AGENT="$(native "$stub")"

--- a/packages/harness/src/core/adapters/codex.test.ts
+++ b/packages/harness/src/core/adapters/codex.test.ts
@@ -358,6 +358,21 @@ describe("CodexAdapter", () => {
             "\x1b[14;3Hgpt-next medium · C:\\work\\project\x1b[?2026l",
         ),
       ).toBe(true);
+      expect(
+        adapter.detectStructuralReadyPrompt(
+          "\x1b[?2026h\x1b[12;3H› A future placeholder\r\n" +
+            "\x1b[14;3Hgpt-next medium · C:\\work\\project\x1b[?2026l",
+        ),
+      ).toBe(false);
+    });
+
+    it("recognizes a narrow-width composer without a cwd footer via structural proof", () => {
+      const adapter = new CodexAdapter();
+      const frame =
+        "\x1b[?2026h\x1b[12;3H› Some unknown placeholder copy\r\n" +
+        "\x1b[14;3Hgpt-next medium\x1b[?2026l";
+      expect(adapter.detectReadyPrompt(frame)).toBe(true);
+      expect(adapter.detectStructuralReadyPrompt(frame)).toBe(true);
     });
 
     it("does not treat a selection marker without the cwd footer as a composer", () => {

--- a/packages/harness/src/core/adapters/codex.ts
+++ b/packages/harness/src/core/adapters/codex.ts
@@ -127,9 +127,17 @@ const READY_PROMPT_PATTERNS = [
  * selectors can use the same marker, but do not render that cwd footer. The
  * blocker check in SessionManager still wins when a known modal and the
  * underlying composer are present in the same diff-rendered frame.
+ *
+ * Narrow terminals may hide the cwd footer, and future Codex releases may
+ * change placeholder copy. `hasStructuralComposer` is the copy-/footer-
+ * independent proof: an input marker that is not sitting on a numbered modal
+ * choice. SessionManager still requires consecutive structural frames before
+ * clearing a previously latched blocker (see `detectStructuralReadyPrompt`).
  */
 const COMPOSER_INPUT_MARKER = /›/u;
 const COMPOSER_CWD_FOOTER = /·\s*(?:~[\\/]|\/|[A-Za-z]:[\\/])/u;
+/** Numbered selection rows reuse the same `›` glyph as the empty composer. */
+const COMPOSER_SELECTION_ROW = /›\s*\d+\./u;
 
 /**
  * A modal can repaint only its moved selection row while leaving Codex's
@@ -142,6 +150,30 @@ function hasBlockingPromptFragment(rendered: string): boolean {
   return BLOCKING_PROMPT_SIGNATURES.some((signature) =>
     signature.some((pattern) => pattern.test(rendered)),
   );
+}
+
+function hasStructuralComposer(rendered: string): boolean {
+  if (!COMPOSER_INPUT_MARKER.test(rendered)) return false;
+  if (COMPOSER_SELECTION_ROW.test(rendered)) return false;
+  return true;
+}
+
+type ReadyPromptKind = "none" | "strong" | "structural";
+
+function classifyReadyPrompt(rendered: string): ReadyPromptKind {
+  if (hasBlockingPromptFragment(rendered)) return "none";
+  if (READY_PROMPT_PATTERNS.some((pattern) => pattern.test(rendered))) {
+    return "strong";
+  }
+  if (
+    COMPOSER_INPUT_MARKER.test(rendered) &&
+    COMPOSER_CWD_FOOTER.test(rendered) &&
+    !COMPOSER_SELECTION_ROW.test(rendered)
+  ) {
+    return "strong";
+  }
+  if (hasStructuralComposer(rendered)) return "structural";
+  return "none";
 }
 
 export interface CodexAdapterOptions {
@@ -343,13 +375,18 @@ export class CodexAdapter implements HarnessAdapter {
   }
 
   detectReadyPrompt(terminalOutput: string): boolean {
-    const rendered = stripAnsi(terminalOutput);
-    if (hasBlockingPromptFragment(rendered)) return false;
-    return (
-      READY_PROMPT_PATTERNS.some((pattern) => pattern.test(rendered)) ||
-      (COMPOSER_INPUT_MARKER.test(rendered) &&
-        COMPOSER_CWD_FOOTER.test(rendered))
-    );
+    return classifyReadyPrompt(stripAnsi(terminalOutput)) !== "none";
+  }
+
+  /**
+   * True when readiness is proven only by the structural composer model
+   * (input marker without a numbered selection row), not by known empty-
+   * composer copy or the cwd footer. SessionManager requires consecutive
+   * matching frames before clearing a latched blocker on this path so a
+   * single partial modal repaint cannot reopen injection.
+   */
+  detectStructuralReadyPrompt(terminalOutput: string): boolean {
+    return classifyReadyPrompt(stripAnsi(terminalOutput)) === "structural";
   }
 
   /**

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -144,7 +144,11 @@ describe("SessionManager", () => {
       prepareWorkspaceContext: opts.prepareWorkspaceContext,
       ensureCanvasTemplate: opts.ensureCanvasTemplate,
       isPidAlive: opts.isPidAlive,
-      platform: opts.platform,
+      // Default off process.platform so Windows runners can exercise the
+      // non-Windows spawn path without installing fake CLI shims for every
+      // unit test. Tests that need ConPTY / win32 paste semantics pass
+      // `platform: "win32"` explicitly.
+      platform: opts.platform ?? "linux",
       writeSessionRegistry: opts.writeSessionRegistry,
       writeAgentSessionOwnerRegistry: opts.writeAgentSessionOwnerRegistry,
     });
@@ -792,6 +796,65 @@ describe("SessionManager", () => {
       await vi.advanceTimersByTimeAsync(600);
       expect(manager.get(session.id)?.ready).toBe(true);
       expect(spawns[0]?.pty.write).not.toHaveBeenCalled();
+    });
+
+    it("clears a trust latch via consecutive structural composer frames without copy or footer", async () => {
+      const { manager, spawns } = makeManager({
+        adapter: new CodexAdapter({ binary: "fake-codex" }),
+      });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
+
+      spawns[0]?.emitData(
+        "\x1b[?2026h\x1b[1;1HDo you trust the contents of this directory?\r\n" +
+          "\x1b[6;1H1. Yes, continue\r\n\x1b[7;1H2. No, quit\x1b[?2026l",
+      );
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      // Narrow terminal: no cwd footer, unknown placeholder. One structural
+      // frame is not enough after a latched blocker.
+      const structuralFrame =
+        "\x1b[?2026h\x1b[12;1H› A brand-new Codex placeholder\r\n" +
+        "\x1b[14;1Hgpt-next medium\x1b[?2026l";
+      spawns[0]?.emitData(structuralFrame);
+      await vi.advanceTimersByTimeAsync(800);
+      expect(manager.get(session.id)?.ready).toBe(false);
+
+      // A second consecutive clean structural frame proves the composer.
+      spawns[0]?.emitData(structuralFrame);
+      await vi.advanceTimersByTimeAsync(800);
+      expect(manager.get(session.id)?.ready).toBe(true);
+    });
+
+    it("keeps the trust latch closed when a modal fragment rides under a retained footer", async () => {
+      const { manager, spawns } = makeManager({
+        adapter: new CodexAdapter({ binary: "fake-codex" }),
+      });
+      const session = await manager.create({
+        cwd: "/tmp/proj",
+        harness: "claude-code",
+      });
+
+      spawns[0]?.emitData(
+        "\x1b[?2026h\x1b[1;1HDo you trust the contents of this directory?\r\n" +
+          "\x1b[6;1H1. Yes, continue\r\n\x1b[7;1H2. No, quit\x1b[?2026l",
+      );
+      await vi.advanceTimersByTimeAsync(500);
+
+      // Full then partial Ratatui repaints: selection moves while the
+      // underlying footer stays visible beneath the modal.
+      for (let i = 0; i < 3; i += 1) {
+        spawns[0]?.emitData(
+          "\x1b[?2026h\x1b[6;1H  1. Yes, continue\r\n" +
+            "\x1b[7;1H› 2. No, quit\r\n" +
+            "\x1b[14;1Hgpt-5.5 default · /tmp/proj\x1b[?2026l",
+        );
+        await vi.advanceTimersByTimeAsync(400);
+      }
+      expect(manager.get(session.id)?.ready).toBe(false);
     });
 
     it("retains a blocking screen across partial synchronized diff repaints until the composer is proven", async () => {

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -110,6 +110,7 @@ describe("SessionManager", () => {
       ensureCanvasTemplate?: SessionManagerOptions["ensureCanvasTemplate"];
       isPidAlive?: SessionManagerOptions["isPidAlive"];
       platform?: SessionManagerOptions["platform"];
+      spawnTargetDeps?: SessionManagerOptions["spawnTargetDeps"];
       ingestCredentials?: SessionManagerOptions["ingestCredentials"];
       writeSessionRegistry?: SessionManagerOptions["writeSessionRegistry"];
       writeAgentSessionOwnerRegistry?:
@@ -147,8 +148,20 @@ describe("SessionManager", () => {
       // Default off process.platform so Windows runners can exercise the
       // non-Windows spawn path without installing fake CLI shims for every
       // unit test. Tests that need ConPTY / win32 paste semantics pass
-      // `platform: "win32"` explicitly.
+      // `platform: "win32"` explicitly. When they do, accept the fake CLI on
+      // PATH so resolveSpawnTarget does not require a real Windows install.
       platform: opts.platform ?? "linux",
+      spawnTargetDeps:
+        opts.spawnTargetDeps ??
+        (opts.platform === "win32"
+          ? {
+              // win32 PATH lookup splits on `;`, so a POSIX `:` PATH would be
+              // treated as one non-existent directory. Give a synthetic entry.
+              env: { PATH: "C:\\fake-bin" },
+              fileExists: (candidate) =>
+                /(?:^|[\\/])fake-claude(?:\.[^.\\/]+)?$/i.test(candidate),
+            }
+          : undefined),
       writeSessionRegistry: opts.writeSessionRegistry,
       writeAgentSessionOwnerRegistry: opts.writeAgentSessionOwnerRegistry,
     });

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -33,7 +33,7 @@ import {
   type BracketedPasteState,
 } from "./bracketed-paste.js";
 import { HOST_ESBUILD_PIN } from "./asar-path.js";
-import { resolveSpawnTarget } from "./spawn-target.js";
+import { resolveSpawnTarget, type SpawnTargetDeps } from "./spawn-target.js";
 import { stripAnsi } from "./strip-ansi.js";
 import {
   AdapterNotFoundError,
@@ -398,6 +398,12 @@ export interface SessionManagerOptions {
    * (see `submitInput`) is provable from POSIX CI. Defaults to the real one.
    */
   platform?: NodeJS.Platform;
+  /**
+   * Overrides for Windows spawn resolution (PATH / shim lookup). Tests that
+   * set `platform: "win32"` on POSIX CI pass a `fileExists` that accepts the
+   * fake CLI name so `resolveSpawnTarget` does not require a real PATH entry.
+   */
+  spawnTargetDeps?: SpawnTargetDeps;
 }
 
 export interface TrustedSessionCreateOptions {
@@ -532,6 +538,7 @@ export class SessionManager {
   private readonly ensureCanvasTemplate: (cwd: string) => Promise<void>;
   private readonly isPidAlive: (pid: number) => boolean;
   private readonly platform: NodeJS.Platform;
+  private readonly spawnTargetDeps: SpawnTargetDeps;
 
   private readonly sessions = new Map<string, HarnessSession>();
   private readonly ptys = new Map<string, PtyHandle>();
@@ -577,6 +584,7 @@ export class SessionManager {
     this.ensureCanvasTemplate = options.ensureCanvasTemplate ?? (async () => {});
     this.isPidAlive = options.isPidAlive ?? defaultIsPidAlive;
     this.platform = options.platform ?? process.platform;
+    this.spawnTargetDeps = options.spawnTargetDeps ?? {};
     // Many WS clients (terminal + events) can subscribe over a long-running process.
     this.statusEmitter.setMaxListeners(0);
     this.activityEmitter.setMaxListeners(0);
@@ -1849,6 +1857,7 @@ export class SessionManager {
     // non-Windows spawn semantics on a Windows runner.
     const target = resolveSpawnTarget(spec.command, spec.args, {
       platform: this.platform,
+      ...this.spawnTargetDeps,
     });
 
     // A throw here — spawnFn itself, or loadDefaultSpawn() above (a broken

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -175,6 +175,14 @@ const READY_SETTLE_MS = 700;
  * win, so this is a liveness ceiling, not a safety bypass.
  */
 const READY_SETTLE_CEILING_MS = 5_000;
+/**
+ * After a blocking screen has been latched, a copy-/footer-independent
+ * structural composer proof must appear in this many consecutive content-
+ * bearing frames before the latch clears. Strong proofs (known placeholder
+ * copy or cwd footer) still clear on the first clean frame. This is not a
+ * time-only escape: recognized modal fragments continue to veto every frame.
+ */
+const READY_STRUCTURAL_PROOF_FRAMES = 2;
 /** Codex/Ratatui brackets each atomic terminal repaint in synchronized-output
  *  mode. Treat one such repaint as the readiness frame even when node-pty
  *  splits it across chunks. Pure cursor/style repaints are intentionally
@@ -426,6 +434,9 @@ interface PtyHandle {
   /** A detected blocking screen remains latched across partial repaints until
    * the adapter positively identifies its empty interactive composer. */
   blockingPromptSeen: boolean;
+  /** Consecutive content-bearing frames that passed a structural (not strong)
+   * ready proof while a blocker latch is held. Reset on any non-ready frame. */
+  consecutiveReadyProofFrames: number;
   /** Possible beginning of a synchronized-output marker split across chunks. */
   pendingReadinessPrefix: string;
   /** Synchronized repaint being assembled across node-pty chunks. */
@@ -1664,7 +1675,8 @@ export class SessionManager {
   /** Preserve a recognized blocker across Ratatui's partial row repaints. The
    * latch is cleared only by a positive empty-composer match in a clean current
    * frame; merely failing to re-render every phrase is not evidence that the
-   * screen was dismissed. */
+   * screen was dismissed. Strong proofs (known copy / cwd footer) clear on the
+   * first clean frame; structural proofs require consecutive clean frames. */
   private refreshImmediatePromptState(
     adapter: HarnessAdapter,
     handle: PtyHandle,
@@ -1680,22 +1692,39 @@ export class SessionManager {
     const current = this.currentReadinessOutput(handle);
     const recent = this.recentReadinessOutput(handle);
     if (adapter.detectBlockingPrompt(recent)) handle.blockingPromptSeen = true;
-    if (!handle.blockingPromptSeen) return;
+    if (!handle.blockingPromptSeen) {
+      handle.consecutiveReadyProofFrames = 0;
+      return;
+    }
     // The ceiling applies only to a continuously non-blocking candidate. If a
     // user leaves onboarding open for a minute, that elapsed minute must not
     // make the first clean repaint after dismissal ready immediately.
     handle.readinessCandidateAt = null;
 
-    if (
+    const ready =
       adapter.detectReadyPrompt(current) &&
-      !adapter.detectBlockingPrompt(current)
-    ) {
-      handle.blockingPromptSeen = false;
-      handle.readinessCandidateAt = handle.lastOutputAt ?? Date.now();
-      // Once the real composer is visible, older onboarding frames are no
-      // longer part of the current screen and must not be re-latched later.
-      handle.readinessHistory = current;
+      !adapter.detectBlockingPrompt(current);
+    if (!ready) {
+      handle.consecutiveReadyProofFrames = 0;
+      return;
     }
+
+    const structuralOnly =
+      adapter.detectStructuralReadyPrompt?.(current) === true;
+    handle.consecutiveReadyProofFrames += 1;
+    if (
+      structuralOnly &&
+      handle.consecutiveReadyProofFrames < READY_STRUCTURAL_PROOF_FRAMES
+    ) {
+      return;
+    }
+
+    handle.blockingPromptSeen = false;
+    handle.consecutiveReadyProofFrames = 0;
+    handle.readinessCandidateAt = handle.lastOutputAt ?? Date.now();
+    // Once the real composer is visible, older onboarding frames are no
+    // longer part of the current screen and must not be re-latched later.
+    handle.readinessHistory = current;
   }
 
   private hasImmediateBlockingPrompt(
@@ -1816,8 +1845,11 @@ export class SessionManager {
     // PATHEXT resolution and can't execute a .cmd. resolveSpawnTarget RESOLVES the
     // shim to its real target — deliberately NOT via cmd.exe, which would expose
     // these arguments to shell parsing (command injection; see that module).
-    // No-op on POSIX.
-    const target = resolveSpawnTarget(spec.command, spec.args);
+    // No-op on POSIX. Honor the injectable host platform so tests can exercise
+    // non-Windows spawn semantics on a Windows runner.
+    const target = resolveSpawnTarget(spec.command, spec.args, {
+      platform: this.platform,
+    });
 
     // A throw here — spawnFn itself, or loadDefaultSpawn() above (a broken
     // node-pty prebuild surfaces there, not at import time) — propagates to
@@ -1843,6 +1875,7 @@ export class SessionManager {
       readinessBuffer: "",
       readinessHistory: "",
       blockingPromptSeen: false,
+      consecutiveReadyProofFrames: 0,
       pendingReadinessPrefix: "",
       pendingReadinessFrame: null,
       pendingReadinessFrameHasContent: false,

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -421,6 +421,15 @@ export interface HarnessAdapter {
    */
   detectReadyPrompt?(terminalOutput: string): boolean;
   /**
+   * When true, `detectReadyPrompt` matched via a copy-/footer-independent
+   * structural proof (active input widget without modal selection rows).
+   * SessionManager then requires consecutive clean frames before clearing a
+   * latched blocker. Strong proofs (known placeholder copy / cwd footer) omit
+   * this and clear on the first clean frame. Optional; adapters without a
+   * structural path behave as before.
+   */
+  detectStructuralReadyPrompt?(terminalOutput: string): boolean;
+  /**
    * How SessionManager may proactively mark this harness ready WITHOUT its
    * real readiness signal (SessionStart hook / tailer equivalent). Absent =
    * never publish fallback readiness; detect-only legacy adapters retain only


### PR DESCRIPTION
## Summary
- Add a copy- and footer-independent structural composer proof (input marker without numbered selection rows) so narrow terminals and future placeholder copy still become ready.
- After a latched trust/sign-in/setup screen, require two consecutive structural clean frames before clearing the latch; strong proofs (known empty-composer copy or cwd footer) still clear on the first clean frame.
- Keep known modal fragment vetoes so trust, sign-in, migration, personality, and theme screens never receive injected prompts.
- Honor injectable host platform in resolveSpawnTarget so readiness unit tests run on Windows runners; Claude Code hook-timeout behavior is unchanged.

## Related work
- Fixes #701
- Builds on #700 (Codex 0.143 composer recognition)

## Validation
- pnpm exec vitest run src/core/adapters/codex.test.ts -t detectReadyPrompt|detectBlockingPrompt — 21 passed
- pnpm exec vitest run src/core/session-manager.test.ts -t immediate ready fallback — 17 passed
- pnpm exec vitest run src/core/session-manager.test.ts -t hook-timeout ready fallback — 6 passed
- Claude Code readyFallback/detectBlockingPrompt smoke — passed

## AI assistance
Used Cursor to investigate the issue, implement the hardening, add fixtures/tests, and open this PR. I reviewed the diff before submitting.

Made with [Cursor](https://cursor.com)