### PR TITLE
chore(ci): advisory component-hygiene rules in the CI review prompt [SAP-3145]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -284,9 +284,14 @@ jobs:
             components and the sibling you want usually exists. Report **at most 3**, highest signal
             first, from:
 
-            1. **A re-implemented shared primitive.** A hand-rolled modal, popover, menu, confirm, empty
-              state, or icon when the repo already ships one (`SecretDialogShell`, `AnchoredPopover`,
-              `MenuChoice`, `EmptyState`, `Icon`, and neighbours). Name the existing one and its path.
+            1. **A re-implemented shared primitive.** A hand-rolled popover, menu, empty state, or icon
+              when the repo already ships one (`AnchoredPopover`, `MenuChoice`, `EmptyState`, `Icon`,
+              and neighbours). Name the existing one and its path. **Dialogs are the exception and you
+              must know it before flagging one:** the harness has no generic modal component and no
+              Radix. The shared thing is the idiom, a `modal-backdrop` > `modal` wrapper with
+              `useDismissable`, used across roughly a dozen files. `SecretDialogShell` is the secrets
+              dialogs' own shell, not a general one. So the finding on a new dialog is "it dismisses
+              differently from its siblings", never "import the shared Dialog", which does not exist.
             2. **A second recipe for a concept that already has one.** Two ways to render the same
               status, two ways to load the same resource, a new hook beside an existing hook doing that
               job. The cost is that every later change has to be made in both places.
@@ -306,7 +311,10 @@ jobs:
 
             **Do not flag**: naming, file placement, prop ordering, unmeasured memoisation, "consider
             extracting" on a component nobody has had to change twice, a missing test for a purely
-            visual change, or any divergence from a design mock. Hygiene findings never outrank the
+            visual change, or any divergence from a design mock. Do not ask a PR to extract a shared
+            primitive that does not exist yet: introducing one is a design decision with its own
+            ticket, and demanding it in review is how an unrelated change gets blocked on somebody
+            else's refactor. Hygiene findings never outrank the
             confidentiality and published-package findings above; a section that floods the PR with
             nitpicks gets the whole review ignored, which is worse than not writing it.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,6 +11,12 @@ name: Claude Code Review
 # tarballs, so customer names and internal business context must be caught
 # at review time — a static blocklist committed here would itself publish
 # the names it protects.
+#
+# The prompt also carries a frontend component-hygiene section, which is
+# ADVISORY by design. We do not gate a build on design parity, so those
+# findings inform and never block. It exists because `lint` in the harness
+# package is `eslint src`, which does not cover `web/src`, where nearly all
+# Studio UI lives: this review is the only automated read of that code.
 
 on:
   pull_request:
@@ -258,6 +264,52 @@ jobs:
             a released version — beyond what fixing it inherently reveals — flag that the details
             belong in private reporting per SECURITY.md, not in a public PR.
 
+            ## Frontend component hygiene
+
+            **Applies only when the diff touches frontend component code**: `.tsx`/`.css` under
+            `packages/harness/web/src`, `packages/harness-desktop/src/renderer`, or any other `web/` or
+            `renderer/` tree. If the diff has none, skip this section and say nothing about it.
+
+            **You are the only automated eye on this code.** The harness `lint` script is
+            `eslint src --ext .ts`, which does not cover `web/src`, where nearly all Studio UI lives. Do
+            not assume a linter already caught duplication, dead state, or a hand-written token value.
+
+            **This is advisory, not a gate.** We do not fail a build because the UI differs from a
+            design, and nothing in this section is grounds for blocking. Label these findings
+            `HYGIENE (advisory)` and word each one as the concrete next step the author can take: name
+            the existing component, hook, token, or class and give its path. If you cannot point at
+            something that already exists in the repo, it is an opinion, so drop it.
+
+            Grep before claiming something is new: `packages/harness/web/src/components` holds 70+
+            components and the sibling you want usually exists. Report **at most 3**, highest signal
+            first, from:
+
+            1. **A re-implemented shared primitive.** A hand-rolled modal, popover, menu, confirm, empty
+              state, or icon when the repo already ships one (`SecretDialogShell`, `AnchoredPopover`,
+              `MenuChoice`, `EmptyState`, `Icon`, and neighbours). Name the existing one and its path.
+            2. **A second recipe for a concept that already has one.** Two ways to render the same
+              status, two ways to load the same resource, a new hook beside an existing hook doing that
+              job. The cost is that every later change has to be made in both places.
+            3. **Presentation and logic tangled in one component.** Fetching, polling, or business rules
+              inside a component that also owns layout, where a sibling in the same directory keeps them
+              apart. Say which half should move and where it goes.
+            4. **State that should be derived.** A `useState` paired with a `useEffect` that only
+              recomputes a value from props or other state: it can go out of sync, so compute it during
+              render instead.
+            5. **An effect doing an event handler's job.** Work belonging in the click, submit, or change
+              handler placed in a `useEffect` keyed on the value it just wrote. Those also fire on mount
+              and on unrelated re-renders.
+            6. **A redefined token or a one-off style.** A literal colour, radius, font size, or spacing
+              where a `var(--...)` token exists, or a new class where an existing one fits.
+              `packages/harness/CLAUDE.md` rule 6 is the standard: read tokens with `var()`, never
+              snapshot their values, because a local copy drifts the moment the design system moves.
+
+            **Do not flag**: naming, file placement, prop ordering, unmeasured memoisation, "consider
+            extracting" on a component nobody has had to change twice, a missing test for a purely
+            visual change, or any divergence from a design mock. Hygiene findings never outrank the
+            confidentiality and published-package findings above; a section that floods the PR with
+            nitpicks gets the whole review ignored, which is worse than not writing it.
+
             ## General review
 
             Code quality, potential bugs, security concerns, test coverage. Use the repository's
@@ -280,7 +332,10 @@ jobs:
             Length budget: 6,000 characters for a first review, 2,000 for a follow-up — a budget to
             come in under, not a target. Do not add the `claude-review-sha` marker yourself.
 
-          claude_args: '--allowed-tools "Write,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # Read/Glob/Grep are read-only on the PR checkout. The component-hygiene
+          # section requires naming the existing component or token a change
+          # bypasses, which is a claim about the repo, not about the diff.
+          claude_args: '--allowed-tools "Write,Read,Glob,Grep,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 
       - name: Post review comment
         if: steps.pr.outputs.should_run == 'true'


### PR DESCRIPTION
SAP-3145, part 1 of 2. Part 2 is the intake skill, in the Sapiom monorepo:
sapiom/Sapiom#4861.

## What

Adds a **Frontend component hygiene** section to the review prompt in
`.github/workflows/claude-code-review.yml`. No change to the trust gate, the
`MAX_AUTO_REVIEWS = 2` round cap, the concurrency group, or the posting step.

## Why

`pnpm lint` in `packages/harness` is `eslint src --ext .ts`. It does not cover
`web/src`, where nearly all Agent Studio UI lives. That code has no automated
reader of any kind, so this review is the only place component duplication,
tangled presentation and logic, stored-instead-of-derived state, or a
hand-written token value can be caught. The prompt says this to the reviewer so
it does not assume lint handled the basics.

## The six rules

Reuse of an existing shared primitive; one recipe per concept; presentation
separated from logic; state derived rather than stored; work in the event
handler rather than in an effect; tokens read with `var()` rather than
redefined (`packages/harness/CLAUDE.md` rule 6).

## Advisory, not a gate

The standard forbids a CI gate that blocks on design parity: we do not fail
builds because prod differs from a design. The prompt states that in the section
itself, so a future edit keeps the property. Findings are labelled
`HYGIENE (advisory)`, capped at **3**, required to name an existing
component/hook/token with its path (an unpinnable finding is an opinion and gets
dropped), ranked below the confidentiality and published-package findings, and
paired with an explicit **do not flag** list: naming, file placement, prop
ordering, unmeasured memoisation, speculative extraction, missing tests for a
purely visual change, and any divergence from a design mock.

The calibration is deliberate. The workflow already imposes a finding budget,
and a hygiene section that floods every PR with nitpicks gets the whole review
ignored, which is worse than not adding one.

## The dialog rule, and why it changed in dac0e3b2

The first draft named `SecretDialogShell` as a shared primitive to reuse. It is
not one: three importers, all secrets dialogs, and its own docstring says the
harness deliberately has no Radix and no generic modal. Measured in `web/src`:
11 files carry the `modal-backdrop` idiom, 10 use `useDismissable`, 0 reference
Radix, and no `Modal`/`Dialog` component exists. SAP-3141 measures the same
thing from the other side.

As first written, the reviewer would have told the SAP-3142/3143 and SAP-3144
dialog PRs to import a component that does not exist. The rule now names the
idiom instead, so the finding on a new dialog is "it dismisses differently from
its siblings", and the do-not-flag list gained: review does not get to demand a
shared primitive be extracted where none exists, because that blocks an
unrelated change on somebody else's refactor. Those sibling PRs are the first
code this section will judge if it lands first, and it is written to be
something I would be content to be judged by.

## One supporting change

`Read`, `Glob` and `Grep` are added to `claude_args --allowed-tools`. They are
read-only against the PR checkout. Rule 1 asks the reviewer to name the existing
component a change bypasses, which is a claim about the repo rather than about
the diff, and cannot be checked with `gh pr diff` alone.

## Verification

- YAML parses; the workflow still has 6 steps and the rendered prompt is 9,858
  characters, with the new section rendering as intended (`yaml.safe_load` on the
  file, then printing `steps[].with.prompt`).
- All checks green. `test (20.x)` and `test (22.x)` failed once on
  `src/server/record-archive-wiring.test.ts`, a `vi.waitFor` assertion, with zero
  source changes in this diff and `test.yml` green on `main` for the prior 8
  runs. Both passed on re-run. Flake, not root-caused.
- **This PR will not be reviewed by the bot.** The workflow's own
  `touchesWorkflow` guard sets `should_run=false` for any PR editing
  `.github/workflows/claude-code-review.yml`, confirmed in the run log as
  `Skipping Claude review (workflow_file_changed)`, and unlike the round cap that
  guard is not bypassed by a manual `/review`. The first real exercise of this
  section is the next harness UI PR after merge.