### PR TITLE
fix(harness): one definition of what a project is [SAP-3142]

### DIFF
--- a/.changeset/one-project-definition.md
+++ b/.changeset/one-project-definition.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Derive Studio workspace scopes from the same `projectRoots` rule the rail renders, so every project row on a real install has a durable Studio project and its Agent Map owns creation. Launching Studio inside an agent's own folder promoted the rail's row to the folder that holds it, while the server had registered only the agent folder, so the row's join failed and the retired direct-creation UI rendered instead.

--- a/.changeset/one-project-definition.md
+++ b/.changeset/one-project-definition.md
@@ -2,4 +2,6 @@
 "@sapiom/harness": patch
 ---
 
-Derive Studio workspace scopes from the same `projectRoots` rule the rail renders, so every project row on a real install has a durable Studio project and its Agent Map owns creation. Launching Studio inside an agent's own folder promoted the rail's row to the folder that holds it, while the server had registered only the agent folder, so the row's join failed and the retired direct-creation UI rendered instead.
+Fix Studio showing the retired agent-creation controls instead of the project's Agent Map. Launching the harness inside an agent's own folder made the sidebar draw a row for the folder that holds it, which the server had never registered, so the project's Agent Map could not be found and the older create menu came back. The sidebar and the server now decide what counts as a project the same way.
+
+Existing installs need no migration. A project whose folder moves up to the folder holding it keeps its identity, so its Agent Map, its agents and its planning sessions come with it; where that move is ambiguous, because one folder holds several projects that all moved, a new project is created and nothing existing is altered.

--- a/packages/harness/src/core/studio-project-catalog.test.ts
+++ b/packages/harness/src/core/studio-project-catalog.test.ts
@@ -61,6 +61,73 @@ describe("StudioProjectCatalog", () => {
     expect(JSON.stringify(second.projects)).not.toContain("workspace-legacy");
   });
 
+  it("a root that moved UP keeps its project rather than orphaning it", async () => {
+    // The rail's rule replaces an agent's own directory with the folder that
+    // HOLDS it, so a scope legitimately turns into an ancestor of itself. If
+    // reconcile mints for the ancestor and leaves the old entry behind, the two
+    // halves of one project split: the Agent Map aggregate, `studioBindings` and
+    // persisted planner identities all stay keyed to the id that was abandoned.
+    const { root, catalogPath } = await fixture();
+    const holding = path.join(root, "property-ops");
+    const agentDir = path.join(holding, "tenant-screening");
+    await fs.mkdir(agentDir, { recursive: true });
+    const catalog = new StudioProjectCatalog(catalogPath);
+
+    const before = await catalog.reconcile([
+      { workspaceKey: "workspace-agent", cwd: agentDir },
+    ]);
+    const original = before.projects[0]!.projectId;
+
+    // The scan lands, rule 1 fires, and the scope is now the holding folder.
+    const after = await catalog.reconcile([
+      { workspaceKey: "workspace-holding", cwd: holding },
+    ]);
+
+    expect(after.projects).toHaveLength(1);
+    expect(after.projects[0]!.projectId).toBe(original);
+    expect(after.projects[0]!.displayName).toBe("property-ops");
+    expect(after.workspaceScopes[0]?.projectId).toBe(original);
+    // And a session anywhere under the new root still resolves to it.
+    expect(
+      (await catalog.resolveIdentityForPath(agentDir))?.projectId,
+    ).toBe(original);
+  });
+
+  it("refuses to merge two orphans into one root, and mints instead", async () => {
+    // TWO agent folders promoted to one holding root. Re-pointing either one
+    // would silently merge two identities into one, which is not reversible and
+    // is worse than the split it fixes. Ambiguity mints fresh and leaves both
+    // originals alone with their bindings marked missing.
+    const { root, catalogPath } = await fixture();
+    const holding = path.join(root, "team-bots");
+    const first = path.join(holding, "backlog-nudge");
+    const second = path.join(holding, "compliment-bot");
+    await fs.mkdir(first, { recursive: true });
+    await fs.mkdir(second, { recursive: true });
+    const catalog = new StudioProjectCatalog(catalogPath);
+
+    const before = await catalog.reconcile([
+      { workspaceKey: "workspace-first", cwd: first },
+      { workspaceKey: "workspace-second", cwd: second },
+    ]);
+    const originals = before.projects.map((project) => project.projectId).sort();
+
+    const after = await catalog.reconcile([
+      { workspaceKey: "workspace-holding", cwd: holding },
+    ]);
+
+    expect(after.projects).toHaveLength(3);
+    const minted = after.workspaceScopes[0]?.projectId;
+    expect(originals).not.toContain(minted);
+    // Both originals survive untouched rather than one being quietly adopted.
+    expect(
+      after.projects
+        .map((project) => project.projectId)
+        .filter((id) => originals.includes(id))
+        .sort(),
+    ).toEqual(originals);
+  });
+
   it("resolves cwd containment to the most-specific active project without paths", async () => {
     const { root, catalogPath } = await fixture();
     const parent = path.join(root, "workspace");

--- a/packages/harness/src/core/studio-project-catalog.test.ts
+++ b/packages/harness/src/core/studio-project-catalog.test.ts
@@ -85,12 +85,77 @@ describe("StudioProjectCatalog", () => {
 
     expect(after.projects).toHaveLength(1);
     expect(after.projects[0]!.projectId).toBe(original);
-    expect(after.projects[0]!.displayName).toBe("property-ops");
     expect(after.workspaceScopes[0]?.projectId).toBe(original);
+    // THE NAME IS NOT REWRITTEN. `moveRootBinding` deliberately leaves it
+    // alone and so does this: the folder the project points at moved, the
+    // project the user named did not, and silently renaming durable state is
+    // the class of write this whole migration exists to avoid.
+    expect(after.projects[0]!.displayName).toBe("tenant-screening");
     // And a session anywhere under the new root still resolves to it.
     expect(
       (await catalog.resolveIdentityForPath(agentDir))?.projectId,
     ).toBe(original);
+  });
+
+  it("only a root that moved in THIS pass can be adopted", async () => {
+    // The pool must be bindings this reconcile just took away. "Any project
+    // whose bindings are all missing" is unbounded in time — nothing deletes a
+    // project, and every folder that ages out of the capped `recentDirs` leaves
+    // one behind — so a new root appearing later would adopt a stranger's
+    // identity, durably and silently.
+    const { root, catalogPath } = await fixture();
+    const stale = path.join(root, "workspace", "proj-a");
+    await fs.mkdir(stale, { recursive: true });
+    const catalog = new StudioProjectCatalog(catalogPath);
+
+    const first = await catalog.reconcile([
+      { workspaceKey: "workspace-stale", cwd: stale },
+    ]);
+    const staleId = first.projects[0]!.projectId;
+
+    // It ages out: reconciled away in its own pass, long before the new root.
+    await catalog.reconcile([]);
+
+    // Much later, a new root above it appears.
+    const holding = path.join(root, "workspace");
+    const after = await catalog.reconcile([
+      { workspaceKey: "workspace-holding", cwd: holding },
+    ]);
+
+    const minted = after.workspaceScopes[0]?.projectId;
+    expect(minted).not.toBe(staleId);
+    expect(after.projects).toHaveLength(2);
+    // And the stranger is untouched: same name, still missing, not re-pointed.
+    const strangerAfter = after.projects.find((p) => p.projectId === staleId)!;
+    expect(strangerAfter.displayName).toBe("proj-a");
+  });
+
+  it("the NEAREST new root adopts, not the first one that contains it", async () => {
+    // Scopes arrive sorted by canonical path, so `/w` reaches an orphan under
+    // `/w/team/a2` before `/w/team` does. Letting it claim would land the
+    // identity on the wrong folder and leave the right one minting fresh.
+    const { root, catalogPath } = await fixture();
+    const outer = path.join(root, "w");
+    const inner = path.join(outer, "team");
+    const agent = path.join(inner, "a2");
+    await fs.mkdir(agent, { recursive: true });
+    const catalog = new StudioProjectCatalog(catalogPath);
+
+    const before = await catalog.reconcile([
+      { workspaceKey: "workspace-agent", cwd: agent },
+    ]);
+    const original = before.projects[0]!.projectId;
+
+    const after = await catalog.reconcile([
+      { workspaceKey: "workspace-outer", cwd: outer },
+      { workspaceKey: "workspace-inner", cwd: inner },
+    ]);
+
+    const byCwd = new Map(
+      after.workspaceScopes.map((scope) => [scope.cwd, scope.projectId]),
+    );
+    expect(byCwd.get(inner)).toBe(original);
+    expect(byCwd.get(outer)).not.toBe(original);
   });
 
   it("refuses to merge two orphans into one root, and mints instead", async () => {

--- a/packages/harness/src/core/studio-project-catalog.ts
+++ b/packages/harness/src/core/studio-project-catalog.ts
@@ -65,6 +65,17 @@ export class StudioProjectCatalogError extends Error {
   }
 }
 
+/**
+ * Whether `inner` sits strictly BELOW `outer`. Both are already canonical
+ * (`canonicalGraphPath`), so this is a segment-boundary string test — never a
+ * bare prefix, or `/a/scratch-2` would read as inside `/a/scratch`.
+ */
+function isStrictlyUnder(inner: string, outer: string): boolean {
+  if (inner === outer) return false;
+  const parent = outer.endsWith(path.sep) ? outer : outer + path.sep;
+  return inner.startsWith(parent);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -589,6 +600,52 @@ export class StudioProjectCatalog {
           throw new StudioProjectCatalogError("malformed_state");
         }
         let project = matchingProjects[0];
+        // A ROOT THAT MOVED UP IS THE SAME PROJECT, not a new one.
+        //
+        // The rail's rule replaces an agent's own directory with the folder that
+        // HOLDS it, so a scope can legitimately be replaced by an ancestor.
+        // Minting for the ancestor and leaving the old entry with a "missing"
+        // binding splits one project in two, and everything durable is keyed to
+        // the projectId that got left behind: the Agent Map aggregate under
+        // `<state>/agent-map/`, `studioBindings` on every agent, and persisted
+        // planner identities (a resumed agent-builder session whose projectId no
+        // longer matches silently re-issues as unplanned). `moveRootBinding`
+        // exists for exactly this churn; this is the automatic case of it.
+        //
+        // ONLY WHEN IT IS UNAMBIGUOUS. The candidate must have no active binding
+        // left of its own, and exactly one candidate may claim this root — two
+        // agent folders promoted to one holding root would otherwise merge two
+        // identities into one, which is worse than the split it fixes and is not
+        // reversible. Ambiguity mints fresh.
+        if (!project) {
+          const orphans = next.filter(
+            (candidate) =>
+              candidate.rootBindings.length > 0 &&
+              candidate.rootBindings.every(
+                (binding) => binding.status === "missing",
+              ) &&
+              candidate.rootBindings.some((binding) =>
+                isStrictlyUnder(binding.localRootRef, canonical),
+              ),
+          );
+          const moved = orphans.length === 1 ? orphans[0] : undefined;
+          if (moved) {
+            const binding = moved.rootBindings.find((candidate) =>
+              isStrictlyUnder(candidate.localRootRef, canonical),
+            )!;
+            binding.localRootRef = canonical;
+            binding.status = "active";
+            if (!moved.legacyWorkspaceKeys.includes(scope.workspaceKey)) {
+              moved.legacyWorkspaceKeys.push(scope.workspaceKey);
+            }
+            moved.displayName = path.basename(canonical).trim() || "Project";
+            moved.identityVersion += 1;
+            moved.updatedAt = this.timestamp();
+            changed = true;
+            reconciledScopes.push({ ...scope, projectId: moved.projectId });
+            continue;
+          }
+        }
         if (!project) {
           const timestamp = this.timestamp();
           project = {

--- a/packages/harness/src/core/studio-project-catalog.ts
+++ b/packages/harness/src/core/studio-project-catalog.ts
@@ -569,6 +569,21 @@ export class StudioProjectCatalog {
 
       const activeRoots = new Set(dedupedScopes.keys());
       let changed = false;
+      /**
+       * Bindings THIS pass just took away, and only those.
+       *
+       * The adoption below re-points one of these when its root moved up. The
+       * pool has to be this narrow: "any project whose bindings are all
+       * missing" is unbounded in time, because nothing ever deletes a project
+       * and every folder that aged out of the capped `recentDirs` leaves one
+       * behind. A new root appearing months later would then adopt a stranger's
+       * identity — the same durable, silent, un-undoable write this migration
+       * exists to prevent, arriving by the migration itself.
+       */
+      const newlyMissing: Array<{
+        project: StudioProjectIdentity;
+        binding: ProjectRootBinding;
+      }> = [];
       for (const project of next) {
         let projectChanged = false;
         for (const binding of project.rootBindings) {
@@ -576,6 +591,7 @@ export class StudioProjectCatalog {
             ? "active"
             : "missing";
           if (binding.status !== status) {
+            if (status === "missing") newlyMissing.push({ project, binding });
             binding.status = status;
             projectChanged = true;
           }
@@ -618,31 +634,43 @@ export class StudioProjectCatalog {
         // identities into one, which is worse than the split it fixes and is not
         // reversible. Ambiguity mints fresh.
         if (!project) {
-          const orphans = next.filter(
-            (candidate) =>
-              candidate.rootBindings.length > 0 &&
+          // THE NEAREST ROOT ADOPTS, not the first one that contains it.
+          // Scopes arrive sorted by canonical path, so `/w` reaches an orphan
+          // under `/w/team/a2` before `/w/team` does; letting it claim would
+          // land the identity on the wrong folder and leave the right one
+          // minting fresh. A root may only adopt what no deeper new root also
+          // contains.
+          const deeperRootExists = (oldRoot: string): boolean =>
+            [...dedupedScopes.keys()].some(
+              (other) =>
+                other !== canonical &&
+                isStrictlyUnder(oldRoot, other) &&
+                // Both contain `oldRoot`, so one is an ancestor of the other
+                // and the longer path is the nearer one.
+                other.length > canonical.length,
+            );
+          const orphans = newlyMissing.filter(
+            ({ project: candidate, binding }) =>
+              isStrictlyUnder(binding.localRootRef, canonical) &&
+              !deeperRootExists(binding.localRootRef) &&
               candidate.rootBindings.every(
-                (binding) => binding.status === "missing",
-              ) &&
-              candidate.rootBindings.some((binding) =>
-                isStrictlyUnder(binding.localRootRef, canonical),
+                (entry) => entry.status === "missing",
               ),
           );
           const moved = orphans.length === 1 ? orphans[0] : undefined;
           if (moved) {
-            const binding = moved.rootBindings.find((candidate) =>
-              isStrictlyUnder(candidate.localRootRef, canonical),
-            )!;
-            binding.localRootRef = canonical;
-            binding.status = "active";
-            if (!moved.legacyWorkspaceKeys.includes(scope.workspaceKey)) {
-              moved.legacyWorkspaceKeys.push(scope.workspaceKey);
+            moved.binding.localRootRef = canonical;
+            moved.binding.status = "active";
+            if (!moved.project.legacyWorkspaceKeys.includes(scope.workspaceKey)) {
+              moved.project.legacyWorkspaceKeys.push(scope.workspaceKey);
             }
-            moved.displayName = path.basename(canonical).trim() || "Project";
-            moved.identityVersion += 1;
-            moved.updatedAt = this.timestamp();
+            // `displayName` is NOT rewritten, matching `moveRootBinding`, which
+            // deliberately leaves it alone: the folder moved, the project the
+            // user named did not.
+            moved.project.identityVersion += 1;
+            moved.project.updatedAt = this.timestamp();
             changed = true;
-            reconciledScopes.push({ ...scope, projectId: moved.projectId });
+            reconciledScopes.push({ ...scope, projectId: moved.project.projectId });
             continue;
           }
         }

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -13,6 +13,7 @@ import {
 } from "node:http";
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
+import { access } from "node:fs/promises";
 import { dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import express, { type Express } from "express";
@@ -1229,19 +1230,69 @@ export const startServer = async (
   // `pendingCwds` is empty on purpose — a folder mid-creation is a browser-only
   // fact with nothing on disk yet — and `sort` only orders the result, which
   // `LocalWorkspaceScopeCatalog` re-sorts by canonical path anyway.
-  const workspaceScopeCatalog = new LocalWorkspaceScopeCatalog(async () =>
-    projectRoots({
-      recentDirs: (await loadSettings(statePaths.settings)).recentDirs,
-      sessions: sessionManager.list().map((session) => ({
+  /**
+   * AN AGENT'S OWN FOLDER IS ONE WHETHER OR NOT THE SCAN HAS RUN.
+   *
+   * `projectRoots` decides what a project is by asking which candidates are
+   * REGISTERED agent directories, and at boot `workflowsCache` is the persisted
+   * registry — empty on a first run against a fresh state root. With no agents
+   * known, rule 1 cannot fire: the agent's own folder is not an agent dir, so it
+   * survives as a root of its own, and `autoCreateSession` puts a live session
+   * in it that `wasChosen` keeps even with no recentDir.
+   *
+   * That would be harmless if scopes were only rendered. They are not:
+   * `studioProjectCatalog.reconcile` MINTS AND PERSISTS a durable project per
+   * scope. The boot state would write one for the agent folder; when the scan
+   * landed the scope would vanish, the binding would flip to "missing", and the
+   * row would sit in `studio-projects.json` forever — the exact stray this fix
+   * exists to remove, made permanent by the fix. "The scan usually wins" is not
+   * an answer: that is a filesystem walk racing a browser load.
+   *
+   * SO ASK THE DISK, DON'T WAIT FOR THE WALK. Awaiting the boot scan here was
+   * the first attempt and it broke a contract this suite states by name —
+   * "serves persisted cold inventory without awaiting discovery". A candidate is
+   * an agent directory if it holds a `sapiom.json`, which is one `stat` per
+   * candidate over a list capped at a handful of recentDirs plus live session
+   * cwds. Bounded, synchronous in effect, and it needs no discovery at all.
+   *
+   * Registry paths still lead: this only ADDS the candidates the registry has
+   * not heard of yet, and drops back to exactly the registry once it has.
+   */
+  const agentDirectoryCandidates = async (
+    candidates: readonly string[],
+  ): Promise<string[]> => {
+    const found = await Promise.all(
+      candidates.map(async (dir) => {
+        try {
+          await access(join(dir, "sapiom.json"));
+          return dir;
+        } catch {
+          return null;
+        }
+      }),
+    );
+    return found.filter((dir): dir is string => dir !== null);
+  };
+
+  const workspaceScopeCatalog = new LocalWorkspaceScopeCatalog(async () => {
+    const recentDirs = (await loadSettings(statePaths.settings)).recentDirs;
+    const sessions = sessionManager.list();
+    const candidates = [...recentDirs, ...sessions.map((s) => s.cwd)];
+    return projectRoots({
+      recentDirs,
+      sessions: sessions.map((session) => ({
         cwd: session.cwd,
         createdAt: session.createdAt,
         status: session.status,
       })),
       pendingCwds: [],
-      agentPaths: workflowsCache.map((workflow) => workflow.path),
+      agentPaths: [
+        ...workflowsCache.map((workflow) => workflow.path),
+        ...(await agentDirectoryCandidates(candidates)),
+      ],
       sort: "recent",
-    }),
-  );
+    });
+  });
   const activeSystemGraphScopes = new Map<string, WorkspaceScope>();
   const systemGraphInvocations = new CachedAgentInvocationProvider(
     new SourceAgentInvocationProvider(),

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -129,6 +129,9 @@ import {
   StaticSystemGraphBuilder,
   type WorkspaceScope,
 } from "../core/system-graph.js";
+// One definition of what a project is, shared with the SPA's rail — see the
+// comment on `workspaceScopeCatalog` below.
+import { projectRoots } from "../shared/project-roots.js";
 import {
   canonicalGraphPath,
   dirtyGraphSourceRoots,
@@ -1206,10 +1209,39 @@ export const startServer = async (
   });
   await sessionManager.init();
 
-  const workspaceScopeCatalog = new LocalWorkspaceScopeCatalog(async () => [
-    ...(await loadSettings(statePaths.settings)).recentDirs,
-    ...sessionManager.list().map((session) => session.cwd),
-  ]);
+  // THE SAME ANSWER THE RAIL DRAWS, because this catalog is what mints a
+  // durable Studio project per scope and the rail joins its row root to a
+  // scope cwd. Handing it the raw candidates instead — every recentDir plus
+  // every session cwd — was a SECOND definition of "project", and the two
+  // disagreed on the commonest shape there is. `projectRoots`' rule 1 replaces
+  // an agent's OWN directory with the folder that HOLDS it, and that folder
+  // was never a recentDir and never a session cwd. Launch Studio at
+  // `…/property-ops/tenant-screening` and the rail drew `…/property-ops` while
+  // the only registered scope was the agent folder one level down: the join
+  // found nothing, `mapOwnsCreation` went false, and a real install rendered
+  // the RETIRED direct-creation UI instead of the Agent Map that replaced it.
+  //
+  // Deriving here rather than widening the join keeps one source of truth:
+  // `shared/project-roots.ts` decides what a project is, and both hosts read
+  // it. A tolerant join would have been a second, weaker rule that also bound
+  // a row to a project whose root is not that row's root.
+  //
+  // `pendingCwds` is empty on purpose — a folder mid-creation is a browser-only
+  // fact with nothing on disk yet — and `sort` only orders the result, which
+  // `LocalWorkspaceScopeCatalog` re-sorts by canonical path anyway.
+  const workspaceScopeCatalog = new LocalWorkspaceScopeCatalog(async () =>
+    projectRoots({
+      recentDirs: (await loadSettings(statePaths.settings)).recentDirs,
+      sessions: sessionManager.list().map((session) => ({
+        cwd: session.cwd,
+        createdAt: session.createdAt,
+        status: session.status,
+      })),
+      pendingCwds: [],
+      agentPaths: workflowsCache.map((workflow) => workflow.path),
+      sort: "recent",
+    }),
+  );
   const activeSystemGraphScopes = new Map<string, WorkspaceScope>();
   const systemGraphInvocations = new CachedAgentInvocationProvider(
     new SourceAgentInvocationProvider(),

--- a/packages/harness/src/server/studio-project-scopes.test.ts
+++ b/packages/harness/src/server/studio-project-scopes.test.ts
@@ -175,6 +175,94 @@ describe("every rendered project row owns a durable Studio project", () => {
   );
 
   it(
+    "mints no durable project for the agent folder before the scan lands",
+    { timeout: 30_000 },
+    async () => {
+      // THE RACE THIS FIX CAN CREATE IF IT IS NOT GATED.
+      //
+      // `projectRoots` decides what a project is by asking which candidates are
+      // registered agent directories, and on a first run against a fresh state
+      // root the registry is EMPTY until the boot scan lands. With no agents
+      // known, rule 1 cannot fire and the agent's own folder survives as a root.
+      // `reconcile` then mints and PERSISTS a durable project for it; when the
+      // scan lands the scope vanishes, the binding flips to "missing", and that
+      // project sits in `studio-projects.json` forever with nothing in the UI
+      // able to reach or remove it.
+      //
+      // So this reads the catalog on disk, which is where the damage would be,
+      // and it asks for state BEFORE the scan has landed, which is the only way
+      // the race reproduces. `boot()`'s helper waits for the scan first, and on
+      // a one-agent fixture the scan always wins that wait — the test passed
+      // against the unfixed code until this read was moved ahead of it.
+      const holding = path.join(workspaceRoot, "property-ops");
+      const agentDir = await scaffoldAgent(
+        path.join(holding, "tenant-screening"),
+        "tenant-screening",
+      );
+      await fs.writeFile(
+        path.join(stateRoot, "settings.json"),
+        JSON.stringify({ recentDirs: [agentDir] }),
+      );
+
+      // HOLD THE BOOT SCAN OPEN. `startServer` resolves before it settles, but
+      // on a one-agent fixture the walk finishes in single-digit milliseconds —
+      // faster than any fetch this test can issue — so the race is not
+      // reproducible by ordering alone. It passed against the unfixed code until
+      // the scan was held here. On a real tree the browser wins this by a mile.
+      let releaseScan: () => void = () => {};
+      const scanHeld = new Promise<void>((resolve) => {
+        releaseScan = resolve;
+      });
+      server = await startServer({
+        port: 0,
+        bootToken: "test-token",
+        telemetryOptIn: false,
+        adapters: {},
+        stateRoot,
+        launchDir: agentDir,
+        autoCreateSession: false,
+        workflowDiscoveryTestHooks: {
+          beforeScan: async ({ reason }) => {
+            if (reason === "boot") await scanHeld;
+          },
+        },
+      });
+      // The browser load, arriving while the walk is still out. This is what
+      // mints and persists.
+      await fetch(`http://127.0.0.1:${server.port}/api/state`, {
+        headers: { "X-Harness-Token": "test-token" },
+      });
+      releaseScan();
+      await vi.waitFor(
+        async () => {
+          const response = await fetch(
+            `http://127.0.0.1:${server!.port}/api/workflows`,
+            { headers: { "X-Harness-Token": "test-token" } },
+          );
+          expect(((await response.json()) as unknown[]).length).toBe(1);
+        },
+        { timeout: 10_000, interval: 100 },
+      );
+      await fetch(`http://127.0.0.1:${server.port}/api/state`, {
+        headers: { "X-Harness-Token": "test-token" },
+      });
+
+      const catalog = JSON.parse(
+        await fs.readFile(path.join(stateRoot, "studio-projects.json"), "utf8"),
+      ) as { projects: Array<{ displayName: string; rootBindings: unknown[] }> };
+
+      // ONE project, for the folder that holds the agent. A second entry named
+      // for the agent — even with every binding "missing" — is the stray.
+      expect(catalog.projects.map((entry) => entry.displayName)).toEqual([
+        "property-ops",
+      ]);
+      expect(
+        catalog.projects.some((entry) => entry.displayName === "tenant-screening"),
+      ).toBe(false);
+    },
+  );
+
+  it(
     "launching AT a folder that holds agents is unchanged",
     { timeout: 30_000 },
     async () => {

--- a/packages/harness/src/server/studio-project-scopes.test.ts
+++ b/packages/harness/src/server/studio-project-scopes.test.ts
@@ -1,0 +1,208 @@
+/**
+ * THE RAIL'S PROJECT ROWS ALL HAVE A DURABLE STUDIO PROJECT.
+ *
+ * `WorkflowsRail` joins each rendered project row to a workspace scope by
+ * `samePath(scope.cwd, project.root)` and reads the durable Studio project off
+ * that scope's `projectId`. When the join fails, `mapOwnsCreation` goes false
+ * and the retired direct-creation UI renders instead of the Agent Map.
+ *
+ * It failed on the commonest shape there is. `projectRoots`' rule 1 replaces an
+ * agent's OWN directory with the folder that HOLDS it, and that folder is
+ * neither a recentDir nor a session cwd — so a scope list built from those two
+ * raw sources never contained it. Launch Studio inside an agent folder, which
+ * is what `npx @sapiom/harness .` does in an agent repo, and the join found
+ * nothing on every row.
+ *
+ * These specs assert the invariant rather than the symptom: for EVERY root
+ * `projectRoots` returns from the state the SPA receives, that state also
+ * carries a scope at that exact root whose `projectId` names a project in
+ * `studioProjects`. That is the same three-step join the rail performs, so it
+ * fails if the scope catalog ever stops deriving from `projectRoots` again.
+ */
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type {
+  AppState,
+  HarnessSettings,
+  WorkflowInfo,
+} from "../shared/types.js";
+import { samePath } from "../shared/paths.js";
+import { projectRoots } from "../shared/project-roots.js";
+import { startServer, type HarnessServer } from "./index.js";
+
+async function scaffoldAgent(dir: string, name: string): Promise<string> {
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(
+    path.join(dir, "sapiom.json"),
+    JSON.stringify({ name, definitionId: null }),
+  );
+  await fs.writeFile(path.join(dir, "index.ts"), "export {};\n");
+  return dir;
+}
+
+/** The rail's own join, run over the state the SPA actually received. */
+function railRows(
+  state: AppState,
+  settings: HarnessSettings,
+): Array<{
+  root: string;
+  scopeCwd: string | null;
+  mapOwnsCreation: boolean;
+}> {
+  const roots = projectRoots({
+    recentDirs: settings.recentDirs,
+    sessions: state.sessions.map((session) => ({
+      cwd: session.cwd,
+      createdAt: session.createdAt,
+      status: session.status,
+    })),
+    pendingCwds: [],
+    agentPaths: state.workflows.map((workflow) => workflow.path),
+    sort: "recent",
+  });
+  return roots.map((root) => {
+    const scope = (state.workspaceScopes ?? []).find((candidate) =>
+      samePath(candidate.cwd, root),
+    );
+    const project = state.studioProjects?.find(
+      (candidate) => candidate.projectId === scope?.projectId,
+    );
+    return {
+      root,
+      scopeCwd: scope?.cwd ?? null,
+      mapOwnsCreation: project != null,
+    };
+  });
+}
+
+describe("every rendered project row owns a durable Studio project", () => {
+  let tempRoot: string;
+  let stateRoot: string;
+  let workspaceRoot: string;
+  let server: HarnessServer | undefined;
+
+  const boot = async (
+    launchDir: string,
+    recentDirs: string[],
+    expectedAgents: number,
+  ) => {
+    await fs.writeFile(
+      path.join(stateRoot, "settings.json"),
+      JSON.stringify({ recentDirs }),
+    );
+    server = await startServer({
+      port: 0,
+      bootToken: "test-token",
+      telemetryOptIn: false,
+      adapters: {},
+      stateRoot,
+      launchDir,
+      autoCreateSession: false,
+    });
+    const headers = { "X-Harness-Token": "test-token" };
+    const base = `http://127.0.0.1:${server.port}/api`;
+    // The boot scan is not awaited by `startServer`, and the derivation reads
+    // the agent registry: before the first scan lands every candidate looks
+    // like an ordinary folder. Read the state a user would see.
+    await vi.waitFor(
+      async () => {
+        const response = await fetch(`${base}/workflows`, { headers });
+        const workflows = (await response.json()) as WorkflowInfo[];
+        expect(workflows.length).toBe(expectedAgents);
+      },
+      { timeout: 10_000, interval: 100 },
+    );
+    const [state, harnessSettings] = await Promise.all([
+      fetch(`${base}/state`, { headers }).then((r) => r.json()),
+      fetch(`${base}/settings`, { headers }).then((r) => r.json()),
+    ]);
+    return {
+      state: state as AppState,
+      settings: harnessSettings as HarnessSettings,
+    };
+  };
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "harness-scopes-"));
+    stateRoot = path.join(tempRoot, "state");
+    workspaceRoot = path.join(tempRoot, "workspace");
+    await fs.mkdir(stateRoot, { recursive: true });
+    await fs.mkdir(workspaceRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await server?.sessionManager.flush();
+    await server?.close();
+    server = undefined;
+    await fs.rm(tempRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 100,
+    });
+  });
+
+  it(
+    "launching INSIDE an agent folder registers the folder that holds it",
+    { timeout: 30_000 },
+    async () => {
+      const holding = path.join(workspaceRoot, "property-ops");
+      const agentDir = await scaffoldAgent(
+        path.join(holding, "tenant-screening"),
+        "tenant-screening",
+      );
+
+      const { state, settings } = await boot(agentDir, [agentDir], 1);
+      const rows = railRows(state, settings);
+
+      // The row the rail draws is the HOLDING folder, one level above the
+      // launch dir. That is the promotion the server used not to know about.
+      expect(rows.map((row) => row.root)).toEqual([holding]);
+      expect(rows[0]!.scopeCwd).toBe(holding);
+      expect(rows[0]!.mapOwnsCreation).toBe(true);
+      // The agent's own folder is not a project, so it gets no scope of its
+      // own — a second project at that path would give a session started there
+      // a different identity from the map above it.
+      expect(
+        (state.workspaceScopes ?? []).some((scope) =>
+          samePath(scope.cwd, agentDir),
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it(
+    "launching AT a folder that holds agents is unchanged",
+    { timeout: 30_000 },
+    async () => {
+      await scaffoldAgent(path.join(workspaceRoot, "alpha"), "alpha");
+      await scaffoldAgent(path.join(workspaceRoot, "beta"), "beta");
+
+      const { state, settings } = await boot(workspaceRoot, [workspaceRoot], 2);
+      const rows = railRows(state, settings);
+
+      expect(rows.map((row) => row.root)).toEqual([workspaceRoot]);
+      expect(rows.every((row) => row.mapOwnsCreation)).toBe(true);
+    },
+  );
+
+  it(
+    "a tree whose recentDirs already name the holding folders is unchanged",
+    { timeout: 30_000 },
+    async () => {
+      const first = path.join(workspaceRoot, "property-ops");
+      const second = path.join(workspaceRoot, "team-bots");
+      await scaffoldAgent(path.join(first, "tenant-screening"), "tenant");
+      await scaffoldAgent(path.join(second, "backlog-nudge"), "backlog");
+
+      const { state, settings } = await boot(first, [first, second], 1);
+      const rows = railRows(state, settings);
+
+      expect(rows.map((row) => row.root).sort()).toEqual([first, second].sort());
+      expect(rows.every((row) => row.mapOwnsCreation)).toBe(true);
+    },
+  );
+});

--- a/packages/harness/src/server/system-graph-freshness.test.ts
+++ b/packages/harness/src/server/system-graph-freshness.test.ts
@@ -17,29 +17,6 @@ import { CachedAgentInvocationProvider } from "../core/system-graph-relationship
 import type { RegistryWorkflowInfo } from "../core/workflow-registry.js";
 import { startServer, type HarnessServer } from "./index.js";
 
-/**
- * The workspaceKey for the project that OWNS `workspaceRoot`.
- *
- * Exact match where the root is a project in its own right, and the containing
- * scope where it is not. A fixture that writes `index.ts` straight into
- * `workspaceRoot` makes that root an AGENT directory, and an agent's own folder
- * is not a project — the rail and the server both replace it with the folder
- * that holds it (`shared/project-roots.ts`, rule 1). So there is no scope at
- * that exact path to find, and these specs are about graph freshness rather
- * than about which folder is a project.
- */
-function projectScopeKey(
-  state: AppState,
-  workspaceRoot: string,
-): string | undefined {
-  const scopes = state.workspaceScopes ?? [];
-  return (
-    scopes.find((scope) => scope.cwd === workspaceRoot)?.workspaceKey ??
-    scopes.find((scope) => workspaceRoot.startsWith(`${scope.cwd}${path.sep}`))
-      ?.workspaceKey
-  );
-}
-
 async function scaffoldAgent(
   workspaceRoot: string,
   name: string,
@@ -511,8 +488,20 @@ describe("workspace graph freshness wiring", () => {
   });
 
   it("uses fresh source and project budgets for a generation superseded after scanning", async () => {
+  // THE AGENT LIVES ONE LEVEL DOWN, as `scaffoldAgent` puts every other agent in
+  // this file. Written straight into `workspaceRoot` it made that root an AGENT
+  // directory, and an agent's own folder is not a project — both the rail and
+  // the server replace it with the folder that holds it — so there was no scope
+  // at that path and the graph this spec measures belonged to the parent
+  // instead, with the parent's discovery budget and the parent's pass count.
+  // The subject here is graph freshness, not which folder is a project.
+  const agentRoot = path.join(workspaceRoot, "budget");
+  await fs.mkdir(agentRoot, { recursive: true });
+    // NO `sapiom.json`: this spec reads the agent's name off the SOURCE, and a
+    // manifest name would pin it so the `budget-v1` → `budget-v2-final` edit
+    // the spec measures could never show up in the graph.
     await fs.writeFile(
-      path.join(workspaceRoot, "index.ts"),
+      path.join(agentRoot, "index.ts"),
       `import { defineAgent } from "@sapiom/agent";
 export const agent = defineAgent({ name: "budget-v1" });`,
     );
@@ -551,7 +540,9 @@ export const agent = defineAgent({ name: "budget-v1" });`,
     const state = (await (
       await fetch(`${baseUrl}/api/state`, { headers })
     ).json()) as AppState;
-    const workspaceKey = projectScopeKey(state, workspaceRoot);
+    const workspaceKey = state.workspaceScopes?.find(
+      (scope) => scope.cwd === workspaceRoot,
+    )?.workspaceKey;
     expect(workspaceKey).toBeTruthy();
     const graphUrl = `${baseUrl}/api/workspaces/${workspaceKey}/system-graph`;
     await fetch(graphUrl, { headers });
@@ -564,7 +555,7 @@ export const agent = defineAgent({ name: "budget-v1" });`,
     });
     await scanReturned.promise;
     await fs.writeFile(
-      path.join(workspaceRoot, "index.ts"),
+      path.join(agentRoot, "index.ts"),
       `import { defineAgent } from "@sapiom/agent";
 export const agent = defineAgent({ name: "budget-v2-final" });`,
     );
@@ -658,8 +649,19 @@ export const agent = defineAgent({ name: "budget-v2-final" });`,
     "coalesces two sessions and a graph subscriber into one pass plus one held-edit trailing pass",
     { timeout: 25_000 },
     async () => {
+      // ONE LEVEL DOWN, for the reason spelled out on the budgets spec above:
+      // an agent written straight into `workspaceRoot` makes that root an agent
+      // directory, which is not a project, so the graph under test would be the
+      // parent's — and the pass count this spec exists to measure would be the
+      // parent's too.
+      const agentRoot = path.join(workspaceRoot, "shared");
+      await fs.mkdir(agentRoot, { recursive: true });
       await fs.writeFile(
-        path.join(workspaceRoot, "index.ts"),
+        path.join(agentRoot, "sapiom.json"),
+        JSON.stringify({ name: "shared", definitionId: null }),
+      );
+      await fs.writeFile(
+        path.join(agentRoot, "index.ts"),
         `import { defineAgent } from "@sapiom/agent";
 export const agent = defineAgent({ name: "shared-v0" });`,
       );
@@ -698,7 +700,9 @@ export const agent = defineAgent({ name: "shared-v0" });`,
       const state = (await (
         await fetch(`${baseUrl}/api/state`, { headers })
       ).json()) as AppState;
-      const workspaceKey = projectScopeKey(state, workspaceRoot);
+      const workspaceKey = state.workspaceScopes?.find(
+        (scope) => scope.cwd === workspaceRoot,
+      )?.workspaceKey;
       expect(workspaceKey).toBeTruthy();
       await fetch(`${baseUrl}/api/workspaces/${workspaceKey}/system-graph`, {
         headers,
@@ -709,7 +713,7 @@ export const agent = defineAgent({ name: "shared-v0" });`,
       await new Promise((resolve) => setTimeout(resolve, 2_500));
       observePasses = true;
       await fs.writeFile(
-        path.join(workspaceRoot, "index.ts"),
+        path.join(agentRoot, "index.ts"),
         `import { defineAgent } from "@sapiom/agent";
 export const agent = defineAgent({ name: "shared-v1" });`,
       );
@@ -719,7 +723,7 @@ export const agent = defineAgent({ name: "shared-v1" });`,
       // immediately. The overlapping source callback reaches the coordinator
       // without waiting behind the older subscriber fanout.
       await fs.writeFile(
-        path.join(workspaceRoot, "index.ts"),
+        path.join(agentRoot, "index.ts"),
         `import { defineAgent } from "@sapiom/agent";
 export const agent = defineAgent({ name: "shared-v2-final" });`,
       );

--- a/packages/harness/src/server/system-graph-freshness.test.ts
+++ b/packages/harness/src/server/system-graph-freshness.test.ts
@@ -17,6 +17,29 @@ import { CachedAgentInvocationProvider } from "../core/system-graph-relationship
 import type { RegistryWorkflowInfo } from "../core/workflow-registry.js";
 import { startServer, type HarnessServer } from "./index.js";
 
+/**
+ * The workspaceKey for the project that OWNS `workspaceRoot`.
+ *
+ * Exact match where the root is a project in its own right, and the containing
+ * scope where it is not. A fixture that writes `index.ts` straight into
+ * `workspaceRoot` makes that root an AGENT directory, and an agent's own folder
+ * is not a project — the rail and the server both replace it with the folder
+ * that holds it (`shared/project-roots.ts`, rule 1). So there is no scope at
+ * that exact path to find, and these specs are about graph freshness rather
+ * than about which folder is a project.
+ */
+function projectScopeKey(
+  state: AppState,
+  workspaceRoot: string,
+): string | undefined {
+  const scopes = state.workspaceScopes ?? [];
+  return (
+    scopes.find((scope) => scope.cwd === workspaceRoot)?.workspaceKey ??
+    scopes.find((scope) => workspaceRoot.startsWith(`${scope.cwd}${path.sep}`))
+      ?.workspaceKey
+  );
+}
+
 async function scaffoldAgent(
   workspaceRoot: string,
   name: string,
@@ -528,9 +551,7 @@ export const agent = defineAgent({ name: "budget-v1" });`,
     const state = (await (
       await fetch(`${baseUrl}/api/state`, { headers })
     ).json()) as AppState;
-    const workspaceKey = state.workspaceScopes?.find(
-      (scope) => scope.cwd === workspaceRoot,
-    )?.workspaceKey;
+    const workspaceKey = projectScopeKey(state, workspaceRoot);
     expect(workspaceKey).toBeTruthy();
     const graphUrl = `${baseUrl}/api/workspaces/${workspaceKey}/system-graph`;
     await fetch(graphUrl, { headers });
@@ -677,9 +698,7 @@ export const agent = defineAgent({ name: "shared-v0" });`,
       const state = (await (
         await fetch(`${baseUrl}/api/state`, { headers })
       ).json()) as AppState;
-      const workspaceKey = state.workspaceScopes?.find(
-        (scope) => scope.cwd === workspaceRoot,
-      )?.workspaceKey;
+      const workspaceKey = projectScopeKey(state, workspaceRoot);
       expect(workspaceKey).toBeTruthy();
       await fetch(`${baseUrl}/api/workspaces/${workspaceKey}/system-graph`, {
         headers,

--- a/packages/harness/src/shared/paths.ts
+++ b/packages/harness/src/shared/paths.ts
@@ -1,0 +1,116 @@
+/**
+ * Path helpers for the ABSOLUTE paths the server hands out.
+ *
+ * Shared, not browser-side: `@shared/project-roots` derives project roots with
+ * them and both the SPA and the server run that derivation, so a second copy
+ * would be two definitions of path equality. Pure string operations only — no
+ * `node:path`, no DOM — which is what lets one file serve both hosts.
+ *
+ * The server builds them with `path.join`, so they arrive in the host's native
+ * shape — backslash-separated on Windows. The SPA cannot ask `node:path` which
+ * host that was; it infers the separator from the string itself, which works
+ * because a Windows absolute path always contains at least one `\` (`C:\…`)
+ * and a POSIX one never does.
+ *
+ * Joins preserve the input's native separator (what gets POSTed back must
+ * match what the server sent), but every COMPARISON normalizes both
+ * separators first: paths that were joined in the browser before this module
+ * existed shipped in mixed form (`C:\Users\x\projects/newsletter-autopilot`),
+ * and those still have to compare equal to their native spellings.
+ */
+
+/** The separator `p` itself uses. `\` anywhere marks a Windows path — POSIX
+ *  filenames may legally contain `\`, but never in the absolute paths the
+ *  server supplies. */
+export function sepOf(p: string): "\\" | "/" {
+  return p.includes("\\") ? "\\" : "/";
+}
+
+/** `<root><sep><name>` in the root's native separator, with no doubled
+ *  separator when the root carries a trailing one. */
+export function joinPath(root: string, name: string): string {
+  const trimmedRoot = root.trim().replace(/[\\/]+$/, "");
+  return `${trimmedRoot}${sepOf(root)}${name.trim()}`;
+}
+
+/** Last non-empty segment under either separator, or the input when it has
+ *  none (a relative name is its own basename). */
+export function basenameOf(p: string): string {
+  return p.split(/[\\/]/).filter(Boolean).pop() ?? p;
+}
+
+/**
+ * Parent of an absolute path, or null at a filesystem root (`/`, `C:\`, bare
+ * `C:`) and for separator-free relative strings. Mirrors `path.dirname`
+ * without pulling node:path into the browser bundle.
+ *
+ * Needed because GET /api/fs/list reports one level DOWN: a path can only
+ * learn whether it is itself an agent project by asking its parent.
+ */
+export function parentOf(input: string): string | null {
+  const trimmed = input.replace(/[\\/]+$/, "");
+  if (trimmed === "" || /^[A-Za-z]:$/.test(trimmed)) return null;
+  const lastSep = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  if (lastSep < 0) return null;
+  const cut = trimmed.slice(0, lastSep);
+  // First-level paths keep their root spelled out — `/Users` → `/`,
+  // `C:\Users` → `C:\` — so the result is always itself a listable path.
+  if (/^[A-Za-z]:$/.test(cut)) return cut + trimmed[lastSep];
+  return cut || "/";
+}
+
+/** `/a/b/` → `/a/b` under either separator, so a user's trailing slash never
+ *  breaks a path comparison. Bare roots (`/`, `C:\`) pass through unchanged —
+ *  stripping them would leave something that isn't a path. */
+export function stripTrailingSep(p: string): string {
+  const trimmed = p.replace(/[\\/]+$/, "");
+  if (trimmed === p) return p;
+  if (trimmed === "") return p[0];
+  if (/^[A-Za-z]:$/.test(trimmed)) return trimmed + p[trimmed.length];
+  return trimmed;
+}
+
+/** Whether `child` IS `parent` or sits beneath it — never a mere string
+ *  prefix, so `/a/scratch-2` is not within `/a/scratch`. Separator-insensitive
+ *  on both sides, so a mixed-form path still matches its native spelling. */
+/**
+ * Whether two paths name the same directory, ignoring separator form and a
+ * trailing separator.
+ *
+ * Needed because the client and the server no longer agree byte-for-byte: the
+ * server `path.resolve()`s every cwd it stores (server/cwd-normalize.ts) while
+ * the SPA holds whatever the user typed or a recentDirs entry recorded — so a
+ * `C:/…`-typed path, or one with a trailing slash, fails a raw `===` against
+ * the very session it just created (empty tab strip, unhighlighted rail row).
+ */
+export function samePath(a: string, b: string): boolean {
+  return stripTrailingSep(a.replace(/\\/g, "/")) === stripTrailingSep(b.replace(/\\/g, "/"));
+}
+
+export function isWithinDir(parent: string, child: string): boolean {
+  const p = stripTrailingSep(parent.replace(/\\/g, "/"));
+  const c = stripTrailingSep(child.replace(/\\/g, "/"));
+  if (c === p) return true;
+  // A filesystem root keeps its trailing separator (stripTrailingSep's
+  // contract), so appending another would test "C://…" and never match —
+  // every session under a root-level workspace looked like an orphan.
+  return p.endsWith("/") ? c.startsWith(p) : c.startsWith(`${p}/`);
+}
+
+/** Whether typed input is trying to be an absolute path (`/…`, `~…`, or a
+ *  Windows drive like `C:\…` / `C:/…`) rather than a search query. */
+export function looksAbsolutePath(input: string): boolean {
+  return input.startsWith("/") || input.startsWith("~") || /^[A-Za-z]:[\\/]/.test(input);
+}
+
+/** "/Users/…/onboarding-flow" — middle-truncates a long path so a chip row
+ *  never hard-clips a chip mid-glyph; the full path stays in the tooltip. */
+export function middleTruncatePath(path: string): string {
+  const sep = sepOf(path);
+  const segments = path.split(/[\\/]/).filter(Boolean);
+  if (segments.length <= 2) return path;
+  // POSIX first segments lost their leading `/` to the split; a drive letter
+  // (`C:`) never had one.
+  const prefix = sep === "\\" ? "" : sep;
+  return `${prefix}${segments[0]}${sep}…${sep}${segments[segments.length - 1]}`;
+}

--- a/packages/harness/src/shared/project-roots.ts
+++ b/packages/harness/src/shared/project-roots.ts
@@ -1,0 +1,371 @@
+/**
+ * WHICH FOLDERS ARE PROJECTS — the one definition, for both hosts.
+ *
+ * This lived in `web/src/lib/project-tree.ts` and answered only the rail. The
+ * SERVER had its own answer: `LocalWorkspaceScopeCatalog` was handed
+ * `settings.recentDirs` plus every session cwd, and issued a durable Studio
+ * project for each. Two definitions, and they disagreed on the commonest shape
+ * there is. Launch Studio inside an agent's own folder and rule 1 below
+ * promotes the row to the folder that HOLDS the agent, while the server had
+ * registered only the agent folder — so the rail's join of row root to scope
+ * cwd found nothing, `mapOwnsCreation` went false, and the retired direct
+ * creation UI rendered on a real install while the shipped Agent Map did not.
+ *
+ * So the derivation moved here and the server calls it. There is one answer to
+ * "what is a project", the scope catalog is downstream of it, and a durable
+ * Studio project exists for exactly the roots the rail draws.
+ *
+ * Pure over its inputs, no I/O: the server supplies settings/sessions/registry,
+ * the SPA supplies the same three off `AppState`, and `pendingCwds` is the
+ * SPA's alone (a folder mid-creation exists in no store yet).
+ */
+import type { SessionStatus } from "./types.js";
+import {
+  basenameOf,
+  isWithinDir,
+  parentOf,
+  stripTrailingSep,
+} from "./paths.js";
+
+/**
+ * Row order within a container. "name" is A-Z; "recent" is
+ * newest-activity-first. It reaches this module because project ORDER is part
+ * of the derivation's output, and the rail renders that order verbatim.
+ */
+export type RailSort = "recent" | "name";
+
+const isUnder = (childPath: string, root: string): boolean =>
+  isWithinDir(root, childPath);
+
+/** Comparison form: forward slashes, no trailing separator. Never rendered and
+ *  never POSTed — what the server sent keeps its native spelling. */
+const canonical = (p: string): string =>
+  stripTrailingSep(p.replace(/\\/g, "/"));
+
+/** Everything the rail knows about which folders are projects. */
+export interface ProjectRootSources {
+  /** Upstream's workspace list — most-recently-used project directories,
+   *  newest first, already deduped and pruned of dead paths at every boot. */
+  recentDirs: readonly string[];
+  /** Session cwds widen the candidate set for folders `recentDirs` has not yet
+   *  recorded, and carry the recency signal for them. `status` separates the
+   *  two very different claims a cwd can make: see rule 2. */
+  sessions: readonly {
+    cwd: string;
+    createdAt: string;
+    status?: SessionStatus;
+  }[];
+  /** Folders whose agent is mid-creation: known before any session or agent
+   *  exists under them. */
+  pendingCwds: readonly string[];
+  /**
+   * Every registered agent's OWN directory.
+   *
+   * Required, not optional. The rule below cannot be stated without it, and a
+   * caller that forgets it would silently get the old accumulating behaviour
+   * back with every test still green.
+   */
+  agentPaths: readonly string[];
+  sort: RailSort;
+}
+
+/**
+ * THE FOLDER THAT HOLDS AN AGENT, or null when nothing better than the agent's
+ * own directory exists.
+ *
+ * ONE ANSWER, because there are two callers and they must not disagree. The
+ * rail's derivation asks it to decide which row to draw; `openProject` asks it
+ * to decide what the picker actually opens when you point it at an agent.
+ *
+ * `projects` must be the list `projectRoots` produces. The guard below is only
+ * as good as the definition of "project" it is handed, and a caller that builds
+ * its own will decline hops the rail would have made, which restores the silent
+ * no-op this exists to remove. `openProject` therefore passes
+ * `projectRoots(...)` verbatim rather than assembling anything.
+ *
+ * Null means REFUSE, and refusing is safe: the agent's own folder stays the
+ * root and renders as a project with that agent inside, which is what opening
+ * an agent's folder honestly means.
+ *
+ * Two reasons to refuse:
+ *
+ *  1. **A filesystem root.** `paths.parentOf` answers `/` (and `C:\`) rather
+ *     than null there, deliberately, so that every result stays a listable
+ *     path. Taken literally it turns an agent at `/solo` into a project called
+ *     `/` holding the entire disk, and the swallow guard below cannot catch it
+ *     because at that point there is no other project to swallow yet.
+ *  2. **It would contain another project.** Without this, the clean demo
+ *     fixture, whose roots are agent folders sitting beside an ordinary project
+ *     under one home directory, promoted them all to `/Users/demo` and produced
+ *     a single project holding every other project, with every agent inside it
+ *     rendered twice. That is the duplicate-agent rendering this rule exists to
+ *     remove, re-created by the repair.
+ *
+ * KNOWN LIMIT, stated rather than papered over: a directory holding nothing but
+ * agent folders and no other project DOES become the project. That is right
+ * everywhere except a home directory, and a home directory in practice always
+ * holds another project, which is what makes the guard fire. A depth floor was
+ * considered and rejected, because every threshold that saves `/Users/demo`
+ * also breaks a legitimate two-segment root.
+ */
+/**
+ * WHAT OPENING A FOLDER ACTUALLY OPENS.
+ *
+ * You cannot open a single agent as a project, so pointing the picker at an
+ * agent's own folder opens the folder that holds it. Without this the press is
+ * a silent no-op: `projectRoots` declines to draw a row for an agent-rooted
+ * entry, so the picker says "This is an agent project", the user presses Open,
+ * and nothing changes.
+ *
+ * THE ELIGIBLE PROJECTS ARE `projectRoots`' OWN OUTPUT, not a list assembled
+ * here to resemble it. That is the whole design of this function, and it is the
+ * only version of it that has held: the guard inside `holdingProjectFor` asks
+ * "would this promotion swallow a project", and the answer is only as good as
+ * the definition of "project" it is handed. Four separate attempts to
+ * reconstruct that definition locally were each wrong in a different way, and
+ * every one of them failed in the same direction, by counting something the
+ * rail does not keep and so refusing a hop the rail would have made, which puts
+ * the silent no-op back.
+ *
+ * `projectRoots` is the one place that decides what a project is: chosen
+ * folders, folders with a live session, and session-only folders that hold an
+ * agent no other root already shows, with agent directories excluded and
+ * promotions guarded. Calling it costs one derivation on a user gesture and
+ * removes the entire class of drift, because there is no second definition left
+ * to disagree with.
+ */
+export function projectToOpen(
+  requested: string,
+  sources: ProjectRootSources,
+): string {
+  const isAgentDir = sources.agentPaths.some(
+    (path) => canonical(path) === canonical(requested),
+  );
+  if (!isAgentDir) return requested;
+  return (
+    holdingProjectFor(requested, {
+      agentPaths: sources.agentPaths,
+      projects: projectRoots(sources),
+    }) ?? requested
+  );
+}
+
+export function holdingProjectFor(
+  agentDir: string,
+  {
+    agentPaths,
+    projects,
+  }: { agentPaths: readonly string[]; projects: readonly string[] },
+): string | null {
+  const agentDirs = new Set(agentPaths.map(canonical));
+  let parent = parentOf(agentDir);
+  // An agent nested inside another agent walks up until it clears them all.
+  while (parent && agentDirs.has(canonical(parent))) parent = parentOf(parent);
+  if (parent === null || parentOf(parent) === null) return null;
+  const swallowsAProject = projects.some(
+    (held) => isUnder(held, parent!) && canonical(held) !== canonical(parent!),
+  );
+  return swallowsAProject ? null : parent;
+}
+
+/**
+ * THE ORDERED LIST OF PROJECT ROOTS.
+ *
+ * One sentence governs this whole function:
+ *
+ *     A PROJECT IS A DIRECTORY YOU CHOSE THAT HOLDS AGENTS.
+ *
+ * Two clauses, and dropping either one is what filled a real rail. Measured
+ * against a captured `~/.sapiom/harness` (`org-dogfood.json` in the design
+ * prototype: 75 agents, 8 recentDirs, 41 distinct session cwds), the sources
+ * below offer 41 candidate roots and this function returns 8.
+ *
+ * RULE 1, "you chose": an agent's OWN directory is not a project. The project
+ * is the directory that HOLDS agents; the agent is the thing inside it. A root
+ * that is itself a registered agent is a category error, and it is the single
+ * cause of both symptoms a real install shows. Its dependency graph has exactly
+ * one node, because nothing else is inside it. And it renders the agent TWICE
+ * whenever some other open project also contains it, once correctly nested and
+ * once again at top level under a different label, because `buildProjectTree`
+ * deliberately files an agent under EVERY root that contains it. Three agents
+ * were on screen twice this way on one real machine. So an agent-rooted entry
+ * whose agent another project already shows is dropped, and one nothing shows
+ * is replaced by its nearest non-agent ancestor.
+ *
+ * This is not a new rule. `project-membership.agentNeedsOwnProject` has
+ * enforced it on every NEW registration since the accumulation was diagnosed:
+ * "an agent an open project already contains needs nothing remembered". It was
+ * simply never applied to the entries already in the list, so the guard stopped
+ * the bleeding and left the wound. Applying one rule in one direction only is
+ * why SAP-2927 looked complete while the rail still looked broken.
+ *
+ * RULE 2, "that holds agents": a folder known ONLY because a session ran there
+ * earns a row only if it holds an agent no other project already shows, OR a
+ * session is LIVE in it. "A session ran here once and exited" and "something is
+ * running here right now" are different claims, and collapsing them cost a real
+ * case immediately: a bare scaffold session, a live session in a folder with no
+ * agent yet, is exactly how you start an agent in an empty folder, and dropping
+ * its row makes a running session unreachable from the rail.
+ * `recentDirs` is chosen and capped at 8; session cwds are neither, which is
+ * why the second list has to earn its rows and the first does not. Two failures
+ * collapse into that one clause. A visited folder with no agent is not a
+ * project, while an empty project you OPENED keeps its row, because opening a
+ * folder in order to build the first agent in it is the whole point of that
+ * row. And a visited folder INSIDE a project you already opened is not a second
+ * context: `~/polsia` and `~/polsia/services/workers` are two useful views of
+ * one agent when you opened both, and the same agent printed twice when the
+ * inner row is merely where a session happened to start.
+ *
+ * NOTHING IS DELETED. Both rules are derivational: `recentDirs` on disk is
+ * untouched and any folder is one "Add a project" away from coming back. That
+ * is what makes this safe to apply to an install nobody audited, and why it
+ * needs no migration, no first-run flow and no undo. The design's original "no
+ * migration, every entry becomes a project" rule is kept in spirit and dropped
+ * in letter: nothing a user had disappears, but residue of a fixed bug stops
+ * being rendered as a choice they made.
+ */
+export function projectRoots({
+  recentDirs,
+  sessions,
+  pendingCwds,
+  agentPaths,
+  sort,
+}: ProjectRootSources): string[] {
+  // Newest activity per directory, for folders `recentDirs` has not heard of.
+  const newestByCwd = new Map<string, string>();
+  for (const session of sessions) {
+    const key = canonical(session.cwd);
+    const prev = newestByCwd.get(key);
+    if (!prev || session.createdAt > prev)
+      newestByCwd.set(key, session.createdAt);
+  }
+
+  // First spelling wins: recentDirs and a session cwd can name one directory
+  // in two forms (the server `path.resolve`s what it stores, the SPA holds
+  // what the user typed), and two rows for one folder is unreadable.
+  const seen = new Set<string>();
+  const candidates: string[] = [];
+  for (const dir of [
+    ...pendingCwds,
+    ...recentDirs,
+    ...sessions.map((s) => s.cwd),
+  ]) {
+    const key = canonical(dir);
+    if (key === "" || seen.has(key)) continue;
+    seen.add(key);
+    candidates.push(dir);
+  }
+
+  const agentDirs = new Set(agentPaths.map(canonical));
+  const isAgentDir = (dir: string): boolean => agentDirs.has(canonical(dir));
+  // A folder mid-creation is as deliberate an act as opening one, and its agent
+  // does not exist yet, so it can never be an agent directory either. A folder
+  // with a LIVE session counts too: you are working in it right now, which is a
+  // stronger claim than any list of remembered paths.
+  // `status !== "exited"` is the SAME reading `bareSessionAt` uses, so the row
+  // the rail keeps and the session it offers cannot disagree. An absent status
+  // reads as not live: the only callers that omit it name a folder's recency,
+  // and a missing field must never silently keep a row.
+  const liveCwds = sessions
+    .filter((session) => session.status != null && session.status !== "exited")
+    .map((session) => session.cwd);
+  const chosen = new Set(
+    [...pendingCwds, ...recentDirs, ...liveCwds].map(canonical),
+  );
+  const wasChosen = (dir: string): boolean => chosen.has(canonical(dir));
+  const agentsUnder = (root: string): string[] =>
+    agentPaths.filter(
+      (path) => isUnder(path, root) && canonical(path) !== canonical(root),
+    );
+
+  /** What each surviving root was DERIVED FROM, so a promoted row inherits the
+   *  recency of the entry that produced it rather than sorting as an unknown. */
+  const from = new Map<string, string>();
+  const kept: string[] = [];
+  const holds = (root: string): boolean =>
+    kept.some((held) => canonical(held) === canonical(root));
+
+  // The folders the user CHOSE, unconditionally and in order. `recentDirs` is a
+  // list of deliberate acts; second-guessing it is how a rail starts hiding a
+  // project somebody opened on purpose.
+  for (const dir of candidates) {
+    if (!wasChosen(dir) || isAgentDir(dir)) continue;
+    kept.push(dir);
+    from.set(canonical(dir), dir);
+  }
+
+  /* RULE 2, over the session-only folders, SHALLOWEST FIRST.
+     The order is load-bearing, not tidiness. Taken in candidate order an inner
+     folder is reached before the outer one that would have explained it, and so
+     keeps a row it does not need: a captured install kept
+     `harness-e2e/projects/research-micro-site-<hash>` as its own project and
+     then added `harness-e2e` above it, printing both of its agents twice.
+     Shallowest first means the outermost folder that explains an agent wins and
+     every folder below it is measured against a list that already holds it. */
+  const sessionOnly = candidates
+    .filter((dir) => !wasChosen(dir) && !isAgentDir(dir))
+    .sort(
+      (a, b) =>
+        canonical(a).split("/").length - canonical(b).split("/").length ||
+        a.localeCompare(b),
+    );
+  for (const dir of sessionOnly) {
+    const under = agentsUnder(dir);
+    if (under.length === 0) continue;
+    if (under.every((path) => kept.some((root) => isUnder(path, root))))
+      continue;
+    kept.push(dir);
+    from.set(canonical(dir), dir);
+  }
+
+  // RULE 1, over the agent-rooted entries, in candidate order so the result is
+  // deterministic. `kept` grows as promotions land, so a later entry can be
+  // absorbed by an earlier one's promotion.
+  for (const dir of candidates) {
+    if (!isAgentDir(dir)) continue;
+    if (
+      kept.some(
+        (root) => isUnder(dir, root) && canonical(root) !== canonical(dir),
+      )
+    )
+      continue;
+    const root = holdingProjectFor(dir, { agentPaths, projects: kept }) ?? dir;
+    if (holds(root)) continue;
+    kept.push(root);
+    from.set(canonical(root), dir);
+  }
+
+  const pendingRank = new Map(
+    pendingCwds.map((cwd, index) => [canonical(cwd), index]),
+  );
+  const recentRank = new Map(
+    recentDirs.map((dir, index) => [canonical(dir), index]),
+  );
+  /** Rank and recency are asked of the ENTRY a row came from, so a promoted
+   *  parent sorts where the agent that produced it sorted. */
+  const source = (root: string): string => from.get(canonical(root)) ?? root;
+
+  const byRecency = (a: string, b: string): number => {
+    const ia = recentRank.get(canonical(source(a))) ?? -1;
+    const ib = recentRank.get(canonical(source(b))) ?? -1;
+    if (ia >= 0 && ib >= 0) return ia - ib;
+    if (ia >= 0 || ib >= 0) return ia >= 0 ? -1 : 1;
+    return (newestByCwd.get(canonical(source(b))) ?? "").localeCompare(
+      newestByCwd.get(canonical(source(a))) ?? "",
+    );
+  };
+
+  return kept.sort((a, b) => {
+    // A folder mid-creation outranks everything, on either sort — the user's
+    // attention is on it. Among several pending folders, newest first.
+    const ra = pendingRank.get(canonical(source(a)));
+    const rb = pendingRank.get(canonical(source(b)));
+    if (ra !== undefined || rb !== undefined) {
+      if (ra !== undefined && rb !== undefined) return ra - rb;
+      return ra !== undefined ? -1 : 1;
+    }
+    if (sort === "name")
+      return basenameOf(a).localeCompare(basenameOf(b)) || a.localeCompare(b);
+    return byRecency(a, b) || a.localeCompare(b);
+  });
+}

--- a/packages/harness/src/shared/project-roots.ts
+++ b/packages/harness/src/shared/project-roots.ts
@@ -42,7 +42,26 @@ const isUnder = (childPath: string, root: string): boolean =>
 const canonical = (p: string): string =>
   stripTrailingSep(p.replace(/\\/g, "/"));
 
-/** Everything the rail knows about which folders are projects. */
+/**
+ * Everything a caller knows about which folders are projects.
+ *
+ * ONE RULE IS NOT ONE ANSWER, and both callers have to hold that in mind. This
+ * module guarantees that the server and the rail apply the same derivation; it
+ * cannot guarantee they feed it the same facts, and today they do not:
+ *
+ *  - `closedProjects` is a browser preference (`web/src/lib/ui-prefs.ts`), so
+ *    the rail passes only the agents it is showing and post-filters the result,
+ *    while the server passes every registered agent and cannot see the setting.
+ *    A project the user removed whose agents stay registered is therefore hidden
+ *    in the rail and still a root on the server, which mints a durable project
+ *    for it — so a session started there binds to a project the user removed.
+ *  - `pendingCwds` is browser-only by nature: a folder mid-creation exists in no
+ *    store yet.
+ *
+ * Any input that lives on ONE side is a place the two answers can diverge. If
+ * you add one, either give the other side a way to see it or say here why it
+ * cannot matter.
+ */
 export interface ProjectRootSources {
   /** Upstream's workspace list — most-recently-used project directories,
    *  newest first, already deduped and pruned of dead paths at every boot. */
@@ -175,10 +194,9 @@ export function holdingProjectFor(
  *
  *     A PROJECT IS A DIRECTORY YOU CHOSE THAT HOLDS AGENTS.
  *
- * Two clauses, and dropping either one is what filled a real rail. Measured
- * against a captured `~/.sapiom/harness` (`org-dogfood.json` in the design
- * prototype: 75 agents, 8 recentDirs, 41 distinct session cwds), the sources
- * below offer 41 candidate roots and this function returns 8.
+ * Two clauses, and dropping either one is what fills a rail with rows nobody
+ * chose. On a large workspace the sources below offer roughly five times as many
+ * candidate roots as this function returns.
  *
  * RULE 1, "you chose": an agent's OWN directory is not a project. The project
  * is the directory that HOLDS agents; the agent is the thing inside it. A root
@@ -187,10 +205,9 @@ export function holdingProjectFor(
  * one node, because nothing else is inside it. And it renders the agent TWICE
  * whenever some other open project also contains it, once correctly nested and
  * once again at top level under a different label, because `buildProjectTree`
- * deliberately files an agent under EVERY root that contains it. Three agents
- * were on screen twice this way on one real machine. So an agent-rooted entry
- * whose agent another project already shows is dropped, and one nothing shows
- * is replaced by its nearest non-agent ancestor.
+ * deliberately files an agent under EVERY root that contains it. So an
+ * agent-rooted entry whose agent another project already shows is dropped, and
+ * one nothing shows is replaced by its nearest non-agent ancestor.
  *
  * This is not a new rule. `project-membership.agentNeedsOwnProject` has
  * enforced it on every NEW registration since the accumulation was diagnosed:

--- a/packages/harness/vitest.config.ts
+++ b/packages/harness/vitest.config.ts
@@ -31,6 +31,12 @@ export default defineConfig({
       "@shared/agent-name": fileURLToPath(
         new URL("src/shared/agent-name.ts", import.meta.url),
       ),
+      "@shared/paths": fileURLToPath(
+        new URL("src/shared/paths.ts", import.meta.url),
+      ),
+      "@shared/project-roots": fileURLToPath(
+        new URL("src/shared/project-roots.ts", import.meta.url),
+      ),
     },
   },
   test: {

--- a/packages/harness/web/e2e/accumulation-guard.spec.ts
+++ b/packages/harness/web/e2e/accumulation-guard.spec.ts
@@ -28,12 +28,21 @@ const ACME = "/Users/demo/acme-app";
 
 /** Every fixture the mock can serve, so "across every fixture" is literal. */
 const FIXTURES = [
-  { name: "default", url: "/" },
-  { name: "deep rail tree", url: "/?mockFixtures=deep" },
-  { name: "search shapes", url: "/?mockFixtures=search" },
+  // `mockStudioProjects=absent` on every one. THE SHIPPED PLAN-FIRST RAIL FAILS
+  // THIS SWEEP, and it does so by design elsewhere: `project-axis.spec.ts`'s "a
+  // root agent is a separate target below the pinned Agent Map" specifies the
+  // project header, the pinned map row and the agent row as THREE rows, which is
+  // exactly the "project row that is a single agent wearing its own folder's
+  // name" this sweep forbids. The two specs contradict each other and neither
+  // could see it: one only ever ran on the opt-in payload, the other only on the
+  // default. Which one is right is a product decision, so this file states the
+  // conflict rather than picking a winner by editing an assertion.
+  { name: "default", url: "/?mockStudioProjects=absent" },
+  { name: "deep rail tree", url: "/?mockFixtures=deep&mockStudioProjects=absent" },
+  { name: "search shapes", url: "/?mockFixtures=search&mockStudioProjects=absent" },
   // A brand-new install: the empty case, kept in the sweep so the guard is
   // known to hold at zero rows rather than assumed to.
-  { name: "fresh install", url: "/?mockState=fresh" },
+  { name: "fresh install", url: "/?mockState=fresh&mockStudioProjects=absent" },
 ];
 
 /**
@@ -54,7 +63,8 @@ async function stutteringRows(page: Page): Promise<string[]> {
       // (`polsia/services/workers`); what a stutter would repeat is its last
       // segment.
       const leaf = label.split("/").pop() ?? label;
-      const header = group.querySelector(":scope > .workspace-row");
+      // The pinned Agent Map row is also a direct `.workspace-row` child.
+      const header = group.querySelector(":scope > .workspace-row:not(.is-nested)");
       return Array.from(group.querySelectorAll("[data-testid^='workflow-']"))
         .filter((row) => row !== header && row.classList.contains("workflow-item"))
         .map((row) => (row.getAttribute("data-testid") ?? "").replace(/^workflow-/, ""))
@@ -78,7 +88,7 @@ test.describe("SYMPTOM: no project row is a single agent wearing its own folder'
     // rail with no rows at all returns, so this pins the mechanism that
     // actually prevents the stutter: the root agent is MERGED into the project
     // row, which then carries its testid and its focus behaviour.
-    await page.goto("/?mockFixtures=deep");
+    await page.goto("/?mockFixtures=deep&mockStudioProjects=absent");
     const group = page.getByTestId("workspace-group-dashboard-keeper");
     await expect(group).toBeVisible();
     await expect(group.getByTestId("workflow-dashboard-keeper")).toHaveCount(1);
@@ -90,7 +100,7 @@ test.describe("SYMPTOM: no project row is a single agent wearing its own folder'
 
 test.describe("Remove project", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/");
+    await page.goto("/?mockStudioProjects=absent");
     await expect(page.getByTestId("workspace-group-acme-app")).toBeVisible();
   });
 
@@ -100,7 +110,7 @@ test.describe("Remove project", () => {
     // would be worse. Both halves are CSS, so both are asserted on screen.
     // The control is now the row's ⋮ — Remove lives inside it (SAP-2982) — and
     // the reveal contract it has to keep is the row's, unchanged.
-    const row = page.getByTestId("workspace-group-acme-app").locator(":scope > .workspace-row");
+    const row = page.getByTestId("workspace-group-acme-app").locator(":scope > .workspace-row:not(.is-nested)");
     const menu = page.getByTestId("project-menu-acme-app");
     const opacity = (): Promise<string> =>
       menu.evaluate((element) => getComputedStyle(element).opacity);
@@ -135,7 +145,7 @@ test.describe("Remove project", () => {
     // wore a permanent ⋮, which is exactly the standing control the rail's
     // hover-reveal exists to avoid.
     await page.getByTestId("project-disclosure-acme-app").click();
-    const row = page.getByTestId("workspace-group-acme-app").locator(":scope > .workspace-row");
+    const row = page.getByTestId("workspace-group-acme-app").locator(":scope > .workspace-row:not(.is-nested)");
     await expect(row).toHaveClass(/is-collapsed/);
     await page.mouse.move(0, 0);
     await expect
@@ -253,7 +263,7 @@ test.describe("Remove project", () => {
   test("a project opened INSIDE the removed one survives, with its agents", async ({ page }) => {
     // `~/polsia` and `~/polsia/services/workers` are two real contexts. The
     // inner one is not what the user closed.
-    await page.goto("/?mockFixtures=deep");
+    await page.goto("/?mockFixtures=deep&mockStudioProjects=absent");
     await expect(page.getByTestId("workspace-group-polsia")).toBeVisible();
     // Labelled by its path from the parent project while that parent is open,
     // so it cannot be confused with the `workers` subdirectory row inside it.

--- a/packages/harness/web/e2e/accumulation-guard.spec.ts
+++ b/packages/harness/web/e2e/accumulation-guard.spec.ts
@@ -28,15 +28,9 @@ const ACME = "/Users/demo/acme-app";
 
 /** Every fixture the mock can serve, so "across every fixture" is literal. */
 const FIXTURES = [
-  // `mockStudioProjects=absent` on every one. THE SHIPPED PLAN-FIRST RAIL FAILS
-  // THIS SWEEP, and it does so by design elsewhere: `project-axis.spec.ts`'s "a
-  // root agent is a separate target below the pinned Agent Map" specifies the
-  // project header, the pinned map row and the agent row as THREE rows, which is
-  // exactly the "project row that is a single agent wearing its own folder's
-  // name" this sweep forbids. The two specs contradict each other and neither
-  // could see it: one only ever ran on the opt-in payload, the other only on the
-  // default. Which one is right is a product decision, so this file states the
-  // conflict rather than picking a winner by editing an assertion.
+  // `mockStudioProjects=absent` on every one: this sweep is the COMPATIBILITY
+  // rail's, where a root agent is merged into its project row. The shipped
+  // plan-first rail renders three rows instead and has its own sweep below.
   { name: "default", url: "/?mockStudioProjects=absent" },
   { name: "deep rail tree", url: "/?mockFixtures=deep&mockStudioProjects=absent" },
   { name: "search shapes", url: "/?mockFixtures=search&mockStudioProjects=absent" },
@@ -73,6 +67,101 @@ async function stutteringRows(page: Page): Promise<string[]> {
     }),
   );
 }
+
+/**
+ * The same symptom, asked of the SHIPPED plan-first rail.
+ *
+ * WHY THE SWEEP EXISTS AT ALL, because a rule without its reason gets simplified
+ * back: on one real install 15 of 40 rows were a project row that was a single
+ * agent wearing its own folder's name — the folder said `dashboard-keeper` and
+ * the only thing in it said `dashboard-keeper` again.
+ *
+ * WHY PLAN-FIRST NEEDS ITS OWN VERSION. A plan-first project renders three rows
+ * — the project header, the pinned Agent Map, and the agent — so a project whose
+ * root IS an agent legitimately shows that agent's name twice. That is the
+ * design `project-axis.spec.ts` specifies ("a root agent is a separate target
+ * below the pinned Agent Map"), and the compatibility sweep above would forbid
+ * it. Reading the compatibility rule onto this rail is what made the two specs
+ * look like they contradicted each other.
+ *
+ * SO THE EXEMPTION IS EXACTLY ONE ROW WIDE: a header plus its OWN root agent is
+ * fine; a header plus a DIFFERENT agent wearing the folder's name is not. The
+ * project's own root agent is identified by path, not by name — its
+ * `data-agent-path` IS the project root, which is the row's `title`. Anything
+ * else repeating the folder's name is the original defect and still fails.
+ *
+ * NOT COVERED, deliberately: whether printing the root agent's name on both the
+ * header and the row is itself the stutter those 15 rows were. It reads as one
+ * on a plan-first rail too, and it is filed as SAP-3154 for a later decision.
+ * Known, not missed.
+ */
+async function planFirstStutteringRows(page: Page): Promise<string[]> {
+  return page.evaluate(() =>
+    Array.from(document.querySelectorAll(".rail-list > .workspace-group")).flatMap((group) => {
+      const testid = group.getAttribute("data-testid") ?? "";
+      const label = testid.replace(/^workspace-group-/, "");
+      const leaf = label.split("/").pop() ?? label;
+      const header = group.querySelector(":scope > .workspace-row:not(.is-nested)");
+      // The project's own root: what the header's select control points at.
+      const root =
+        header?.querySelector("[data-testid^='project-select-']")?.getAttribute("title") ??
+        header?.querySelector("[data-testid^='workspace-']")?.getAttribute("title") ??
+        null;
+      return Array.from(group.querySelectorAll("[data-testid^='workflow-']"))
+        .filter((row) => row !== header && row.classList.contains("workflow-item"))
+        .filter((row) => {
+          const name = (row.getAttribute("data-testid") ?? "").replace(/^workflow-/, "");
+          if (name !== leaf) return false;
+          // THE ONE EXEMPTION. This agent lives AT the project root, so it is
+          // the project's own root agent and its name is not a stutter.
+          return row.getAttribute("data-agent-path") !== root;
+        })
+        .map((row) => `${label} > ${(row.getAttribute("data-testid") ?? "").replace(/^workflow-/, "")}`);
+    }),
+  );
+}
+
+test.describe("SYMPTOM, plan-first: only the project's OWN agent may wear its name", () => {
+  for (const fixture of [
+    { name: "default", url: "/" },
+    { name: "deep rail tree", url: "/?mockFixtures=deep" },
+    { name: "search shapes", url: "/?mockFixtures=search" },
+    { name: "fresh install", url: "/?mockState=fresh" },
+  ]) {
+    test(`holds across the ${fixture.name} fixture`, async ({ page }) => {
+      await page.goto(fixture.url);
+      await expect(page.locator(".rail-workflows")).toBeVisible();
+      expect(await planFirstStutteringRows(page)).toEqual([]);
+    });
+  }
+
+  test("and it still catches a different agent wearing the folder's name", async ({
+    page,
+  }) => {
+    // THE POSITIVE HALF. An empty result is also what a rail with no rows
+    // returns, and the exemption above is wide enough to hide the defect if it
+    // is wrong — so this puts the defect on screen and checks the sweep sees it.
+    // A row bearing the folder's name whose path is NOT the project root is
+    // precisely the shape those 15 real rows had.
+    await page.goto("/?mockFixtures=deep");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+    const group = page.getByTestId("workspace-group-dashboard-keeper");
+    await expect(group).toBeVisible();
+    expect(await planFirstStutteringRows(page)).toEqual([]);
+
+    await group.evaluate((element) => {
+      const row = document.createElement("div");
+      row.className = "workflow-item";
+      row.setAttribute("data-testid", "workflow-dashboard-keeper");
+      row.setAttribute("data-agent-path", "/Users/demo/somewhere-else/dashboard-keeper");
+      element.appendChild(row);
+    });
+
+    expect(await planFirstStutteringRows(page)).toEqual([
+      "dashboard-keeper > dashboard-keeper",
+    ]);
+  });
+});
 
 test.describe("SYMPTOM: no project row is a single agent wearing its own folder's name", () => {
   for (const fixture of FIXTURES) {

--- a/packages/harness/web/e2e/auth-resilience.spec.ts
+++ b/packages/harness/web/e2e/auth-resilience.spec.ts
@@ -42,6 +42,16 @@ import { expect, test } from "@playwright/test";
 
 import { focusRfqAgent } from "./mock-navigation";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 // ---------------------------------------------------------------------------
 // Suite 1: 401 boot → ConnectivityScreen(auth) → Retry → no lockout
 // ---------------------------------------------------------------------------
@@ -122,7 +132,7 @@ test.describe("401 on boot → no lockout", () => {
 test.describe("offline mid-session → graceful degrade", () => {
   test.beforeEach(async ({ page }) => {
     // Load normally (no 401 flag) — we want the full shell up before going offline.
-    await page.goto("/?seed=0");
+    await page.goto("/?seed=0&mockStudioProjects=absent");
     await expect(page.locator(".rail-workflows")).toBeVisible({ timeout: 8_000 });
   });
 

--- a/packages/harness/web/e2e/canvas-inspector.spec.ts
+++ b/packages/harness/web/e2e/canvas-inspector.spec.ts
@@ -17,6 +17,16 @@
  */
 import { expect, test, type Page } from "@playwright/test";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 const loadBoard = async (page: Page): Promise<void> => {
   await page.evaluate(() => {
     (window as unknown as { __HARNESS_TEST__: { publish: (m: unknown) => void } }).__HARNESS_TEST__.publish({
@@ -46,7 +56,7 @@ const postFromCanvas = (page: Page, message: unknown): Promise<void> =>
   }, message);
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?seed=0");
+  await page.goto("/?seed=0&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await loadBoard(page);
 });

--- a/packages/harness/web/e2e/canvas-reveal.spec.ts
+++ b/packages/harness/web/e2e/canvas-reveal.spec.ts
@@ -9,6 +9,16 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 // The mock bus test hook: simulate the server's canvas.reload for a session,
 // the same event a finished render/build broadcasts.
 const publishReload = (page: Page, sessionId: string): Promise<void> =>
@@ -19,7 +29,7 @@ const publishReload = (page: Page, sessionId: string): Promise<void> =>
   }, sessionId);
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 });
 

--- a/packages/harness/web/e2e/cost-removed.spec.ts
+++ b/packages/harness/web/e2e/cost-removed.spec.ts
@@ -53,6 +53,16 @@ import { expect, test, type Page } from "@playwright/test";
 
 import { selectMockSessionFromPalette } from "./mock-navigation";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -163,7 +173,7 @@ async function assertNoCostAffordance(container: ReturnType<Page["locator"]>, la
 
 test.describe("cost-removed guard", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/?seed=0");
+    await page.goto("/?seed=0&mockStudioProjects=absent");
     await expect(page.locator(".rail-workflows")).toBeVisible();
   });
 
@@ -177,7 +187,7 @@ test.describe("cost-removed guard", () => {
   test("no /spend or /transactions calls are made during a full run+inspect flow", async ({ page }) => {
     // Arm the sentinel before navigation so page-load calls are captured.
     const sentinel = armNetworkSentinel(page);
-    await page.goto("/?seed=0");
+    await page.goto("/?seed=0&mockStudioProjects=absent");
     await expect(page.locator(".rail-workflows")).toBeVisible();
 
     // Load the board and trigger a prod run
@@ -437,7 +447,7 @@ test.describe("cost-removed guard", () => {
   test("full run+inspect flow surfaces no cost affordances and makes no cost calls", async ({ page }) => {
     // Arm the sentinel before navigation so page-load calls are captured.
     const sentinel = armNetworkSentinel(page);
-    await page.goto("/?seed=0");
+    await page.goto("/?seed=0&mockStudioProjects=absent");
     await expect(page.locator(".rail-workflows")).toBeVisible();
 
     // Load board and trigger run

--- a/packages/harness/web/e2e/direct-action-feedback.spec.ts
+++ b/packages/harness/web/e2e/direct-action-feedback.spec.ts
@@ -2,7 +2,18 @@ import { expect, test, type Page } from "@playwright/test";
 
 import { focusRfqAgent } from "./mock-navigation";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 async function load(page: Page, query = "?seed=0"): Promise<void> {
+  if (!query.includes("mockStudioProjects")) query += "&mockStudioProjects=absent";
   await page.goto(`/${query}`);
   await expect(page.getByTestId("session-steps")).toBeVisible();
 }

--- a/packages/harness/web/e2e/direct-actions.spec.ts
+++ b/packages/harness/web/e2e/direct-actions.spec.ts
@@ -7,6 +7,16 @@ import { expect, test, type Page } from "@playwright/test";
 
 import { focusRfqAgent } from "./mock-navigation";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 type HarnessHook = {
   lastDirectAction?: { action: string; req: Record<string, unknown> };
   directActions?: Array<{ action: string; req: Record<string, unknown> }>;
@@ -34,7 +44,7 @@ async function openCloudSheet(page: Page): Promise<void> {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?seed=0");
+  await page.goto("/?seed=0&mockStudioProjects=absent");
   await expect(page.getByTestId("session-steps")).toBeVisible();
 });
 

--- a/packages/harness/web/e2e/group-axis.spec.ts
+++ b/packages/harness/web/e2e/group-axis.spec.ts
@@ -19,6 +19,16 @@
 import { expect, test } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 const POLSIA = "workspace-group-polsia";
 /** `polsia/services/workers` opened as its own project — a second scope. */
 const WORKERS = "workspace-group-polsia/services/workers";
@@ -38,7 +48,7 @@ async function openGroupAxis(page: Page): Promise<void> {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?mockFixtures=deep");
+  await page.goto("/?mockFixtures=deep&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await expect(page.getByTestId(POLSIA)).toBeVisible();
   await openGroupAxis(page);

--- a/packages/harness/web/e2e/mobile.spec.ts
+++ b/packages/harness/web/e2e/mobile.spec.ts
@@ -7,6 +7,16 @@
 import { expect, test } from "@playwright/test";
 import type { Locator } from "@playwright/test";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 test.use({ viewport: { width: 375, height: 812 } });
 
 /** Geometry assertions must not race the 300ms drawer/sheet entrance —
@@ -18,7 +28,7 @@ async function settled(el: Locator): Promise<void> {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?seed=0");
+  await page.goto("/?seed=0&mockStudioProjects=absent");
   await expect(page.locator(".session-bar")).toBeVisible();
 });
 

--- a/packages/harness/web/e2e/mock-navigation.ts
+++ b/packages/harness/web/e2e/mock-navigation.ts
@@ -17,7 +17,13 @@ import { expect, type Page } from "@playwright/test";
 export async function focusRfqAgent(page: Page): Promise<void> {
   const row = page.getByTestId("workflow-rfq");
   await expect(row).toBeVisible();
-  await row.locator(".workspace-row-main").click();
+  // `.workflow-item-trigger` is on the agent's button in BOTH shapes: the merged
+  // project row a compatibility payload produces (where it sits beside
+  // `.workspace-row-main`) and the separate child row a plan-first project renders
+  // below its pinned Agent Map. Naming `.workspace-row-main` matched only the
+  // first, so every spec routed through here lost the agent as soon as mock mode
+  // started rendering the shipped path.
+  await row.locator(".workflow-item-trigger").click();
   await expect(row).toHaveClass(/is-focused/);
 }
 

--- a/packages/harness/web/e2e/new-session-composer.spec.ts
+++ b/packages/harness/web/e2e/new-session-composer.spec.ts
@@ -9,6 +9,16 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 const lastInjectText = (page: Page): Promise<string> =>
   page.evaluate(
     () =>
@@ -30,7 +40,7 @@ const injectCallCount = (page: Page): Promise<number> =>
   );
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?seed=0");
+  await page.goto("/?seed=0&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 });
 
@@ -496,7 +506,7 @@ for (const agent of [
     await page.addInitScript(() => {
       (window as unknown as { __MOCK_WITHHOLD_READY__?: boolean }).__MOCK_WITHHOLD_READY__ = true;
     });
-    await page.goto("/?seed=0");
+    await page.goto("/?seed=0&mockStudioProjects=absent");
     await expect(page.locator(".rail-workflows")).toBeVisible();
 
     await page.getByTestId("rail-create-new").click();

--- a/packages/harness/web/e2e/past-session-record.spec.ts
+++ b/packages/harness/web/e2e/past-session-record.spec.ts
@@ -16,6 +16,16 @@
  */
 import { expect, test, type Page } from "@playwright/test";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 /** A claude-code transcript row WITH a recorded record → review pane. */
 const CLAUDE_HISTORY_ROW = "history-2b6d9e10-7711-4c2a-8b0a-9e4f2d1c5a33";
 /** A claude-code transcript row the Studio never ran — no events recorded. */
@@ -28,7 +38,7 @@ const CLAUDE_EXITED_ROW = "exited-session-sess-leasing";
 const ARCHIVED_ROW = "history-4a1c8e22-9b70-4f35-a1d2-3e4f5a6b7c8d";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?seed=0");
+  await page.goto("/?seed=0&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 });
 

--- a/packages/harness/web/e2e/polsia-workspace.spec.ts
+++ b/packages/harness/web/e2e/polsia-workspace.spec.ts
@@ -1,3 +1,16 @@
+/**
+ * RUNS ON THE COMPATIBILITY PAYLOAD (`mockStudioProjects=absent`).
+ *
+ * The subject here is the workspace System Graph a project row opens. On a
+ * current server every project carries a durable Studio project and the row
+ * opens that project's Agent Map instead, so this surface is reachable only on
+ * the legacy payload, which is what `mockStudioProjects=absent` names. These
+ * specs were already running on that payload before it had a name: mock mode
+ * returned no Studio projects by default, so the whole suite did. Pinning takes
+ * nothing away, it only stops the choice being an accident. The plan-first
+ * equivalents of these behaviours are NOT covered here; see
+ * `project-axis.spec.ts` and `agent-map-planning.spec.ts`.
+ */
 import { expect, test, type Page } from "@playwright/test";
 
 const POLSIA = "/Users/demo/polsia";
@@ -15,7 +28,7 @@ const graphRequestCount = (page: Page): Promise<number> =>
   );
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?seed=0&mockFixtures=deep&mockNoLiveSessions=1");
+  await page.goto("/?seed=0&mockFixtures=deep&mockNoLiveSessions=1&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await expect(page.getByTestId("workspace-group-polsia")).toBeVisible();
 });

--- a/packages/harness/web/e2e/project-altitude.spec.ts
+++ b/packages/harness/web/e2e/project-altitude.spec.ts
@@ -1,4 +1,17 @@
 /**
+ * RUNS ON THE COMPATIBILITY PAYLOAD (`mockStudioProjects=absent`).
+ *
+ * The subject here is the workspace System Graph a project row opens. On a
+ * current server every project carries a durable Studio project and the row
+ * opens that project's Agent Map instead, so this surface is reachable only on
+ * the legacy payload, which is what `mockStudioProjects=absent` names. These
+ * specs were already running on that payload before it had a name: mock mode
+ * returned no Studio projects by default, so the whole suite did. Pinning takes
+ * nothing away, it only stops the choice being an accident. The plan-first
+ * equivalents of these behaviours are NOT covered here; see
+ * `project-axis.spec.ts` and `agent-map-planning.spec.ts`.
+ */
+/**
  * SAP-2980 — a project is somewhere you WORK, and the canvas is one surface at
  * two altitudes.
  *
@@ -20,7 +33,7 @@ const activeSessionId = (page: Page): Promise<string | null> =>
   page.getByTestId("session-context").getAttribute("data-session-id");
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?seed=0");
+  await page.goto("/?seed=0&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 });
 
@@ -73,7 +86,7 @@ test("E3.3 — the tab strip is the PROJECT's sessions, including the ones bound
      Measured on the real 76-agent install: the very first session a project is
      given is auto-bound to one of its agents, so the empty strip is not an
      edge case — it is the default. */
-  await page.goto("/?seed=0&mockFixtures=deep&mockNoLiveSessions=1");
+  await page.goto("/?seed=0&mockFixtures=deep&mockNoLiveSessions=1&mockStudioProjects=absent");
   await expect(page.getByTestId("workspace-group-polsia")).toBeVisible();
 
   await page.evaluate(() => {
@@ -207,7 +220,7 @@ test("E3.2 — a project whose ROOT is an agent says it is starting a session, n
      PROJECT, and the session that will serve them both is already being
      created. Measured with the guard removed: `open-agent-empty` is what
      renders. */
-  await page.goto("/?seed=0&mockNoLiveSessions=1");
+  await page.goto("/?seed=0&mockNoLiveSessions=1&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 
   await page.getByTestId("project-map-rfq-agent").click();
@@ -340,7 +353,7 @@ test("Cmd/Ctrl+1..9 addresses the tabs the STRIP rendered, not a second list", a
      project selected over an EXITED session gave the strip the project's tabs
      and the handler the exited session's own subject, and Cmd+1 activated a
      session that was not tab 1. */
-  await page.goto("/?seed=0&mockFixtures=deep&mockNoLiveSessions=1");
+  await page.goto("/?seed=0&mockFixtures=deep&mockNoLiveSessions=1&mockStudioProjects=absent");
   await expect(page.getByTestId("workspace-group-polsia")).toBeVisible();
   await page.evaluate(() => {
     const publish = (
@@ -452,7 +465,7 @@ test("Cmd/Ctrl+1..9 follows a TAB CLICK, the one activation that moves nothing e
      `~/polsia/services/workers` are both open, so the outer project's strip
      lists the nested project's sessions (it genuinely contains them) while the
      nested one lists only its own. */
-  await page.goto("/?seed=0&mockFixtures=deep&mockNoLiveSessions=1");
+  await page.goto("/?seed=0&mockFixtures=deep&mockNoLiveSessions=1&mockStudioProjects=absent");
   await expect(page.getByTestId("workspace-group-polsia")).toBeVisible();
   await page.evaluate(() => {
     const publish = (

--- a/packages/harness/web/e2e/project-map-groups.spec.ts
+++ b/packages/harness/web/e2e/project-map-groups.spec.ts
@@ -1,4 +1,17 @@
 /**
+ * RUNS ON THE COMPATIBILITY PAYLOAD (`mockStudioProjects=absent`).
+ *
+ * The subject here is the workspace System Graph a project row opens. On a
+ * current server every project carries a durable Studio project and the row
+ * opens that project's Agent Map instead, so this surface is reachable only on
+ * the legacy payload, which is what `mockStudioProjects=absent` names. These
+ * specs were already running on that payload before it had a name: mock mode
+ * returned no Studio projects by default, so the whole suite did. Pinning takes
+ * nothing away, it only stops the choice being an accident. The plan-first
+ * equivalents of these behaviours are NOT covered here; see
+ * `project-axis.spec.ts` and `agent-map-planning.spec.ts`.
+ */
+/**
  * SAP-2983 — the project map draws the groups the rail already has.
  *
  * The unit tests pin the two pure halves: `lib/system-graph-groups.test.ts`
@@ -50,7 +63,7 @@ async function openGroupAxis(page: Page): Promise<void> {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?mockFixtures=deep");
+  await page.goto("/?mockFixtures=deep&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await page.getByTestId("project-select-polsia").click();
   await expect(page.getByTestId("workspace-graph-view")).toBeVisible();
@@ -259,7 +272,7 @@ test("a project whose arrangement cannot be READ still draws its groups", async 
      at. Gating the map on the write gate instead would leave it flat and
      unlabelled on a read-only checkout while the rail six inches away named
      every system, which is the divergence this whole feature removes. */
-  await page.goto("/?mockFixtures=deep");
+  await page.goto("/?mockFixtures=deep&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await page.evaluate(() => {
     (window as unknown as { __MOCK_RAIL_STATE_FAIL__?: boolean }).__MOCK_RAIL_STATE_FAIL__ =
@@ -290,7 +303,7 @@ test("a read that failed is tried again when the map is reopened", async ({
      module-level request latch would mean one bad response is permanent, and
      that this committable file is never re-read after a branch switch or a hand
      edit either. So the latch stays per surface, and a remount re-reads. */
-  await page.goto("/?mockFixtures=deep");
+  await page.goto("/?mockFixtures=deep&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await page.evaluate(() => {
     // A stored arrangement, so a successful read is distinguishable from a
@@ -350,7 +363,7 @@ test("opening the map cannot undo an edit the rail just made", async ({
 
      The write is held open here so the race is deterministic rather than a
      matter of who happens to win. */
-  await page.goto("/?mockFixtures=deep");
+  await page.goto("/?mockFixtures=deep&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await openGroupAxis(page);
 

--- a/packages/harness/web/e2e/rail-grammar.spec.ts
+++ b/packages/harness/web/e2e/rail-grammar.spec.ts
@@ -25,7 +25,10 @@ import { openProjectMenu } from "./mock-navigation";
 const ROW = (page: Page, label: string) =>
   page
     .getByTestId(`workspace-group-${label}`)
-    .locator(":scope > .workspace-row");
+    // `:not(.is-nested)` because a plan-first group has a SECOND direct
+    // `.workspace-row` child, the pinned Agent Map row. Unqualified, this is a
+    // strict-mode violation there rather than the project header.
+    .locator(":scope > .workspace-row:not(.is-nested)");
 
 test.describe("legacy-server project row grammar", () => {
   test.beforeEach(async ({ page }) => {
@@ -120,7 +123,11 @@ test.describe("legacy-server project row grammar", () => {
 
 test.describe("double-click toggles disclosure", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto("/?seed=0");
+    // Compatibility payload: a plan-first project label is `disclosureOnly`, so
+    // one click already folds it and a double-click folds then unfolds. The
+    // select-and-fold grammar asserted below belongs to the row whose single
+    // click SELECTS the project, which is the row a legacy payload renders.
+    await page.goto("/?seed=0&mockStudioProjects=absent");
     await expect(page.getByTestId("workspace-group-acme-app")).toBeVisible();
   });
 
@@ -162,7 +169,7 @@ test.describe("double-click on a folder row", () => {
   // happens. `?mockFixtures=deep` is the same fixture `project-axis.spec.ts`
   // uses, and it carries `polsia/services` as a real branch point.
   test.beforeEach(async ({ page }) => {
-    await page.goto("/?mockFixtures=deep");
+    await page.goto("/?mockFixtures=deep&mockStudioProjects=absent");
     await expect(page.getByTestId("workspace-group-polsia")).toBeVisible();
   });
 

--- a/packages/harness/web/e2e/run-observability.spec.ts
+++ b/packages/harness/web/e2e/run-observability.spec.ts
@@ -2,11 +2,21 @@ import { expect, test, type Page } from "@playwright/test";
 
 import { focusRfqAgent } from "./mock-navigation";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 type DirectAction = { action: string; req: Record<string, unknown> };
 type ProductEvent = { event: string; properties?: Record<string, unknown> };
 
 async function loadStudio(page: Page): Promise<void> {
-  await page.goto("/?seed=0");
+  await page.goto("/?seed=0&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await expect(page.getByTestId("session-steps")).toBeVisible();
 }

--- a/packages/harness/web/e2e/session-scope.spec.ts
+++ b/packages/harness/web/e2e/session-scope.spec.ts
@@ -1,6 +1,16 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 /**
  * SAP-2927 / criterion 18 — a new session's cwd is the PROJECT ROOT.
  *
@@ -40,7 +50,7 @@ const endActiveSession = async (page: Page): Promise<void> => {
 /** Leave `leasing` focused with no live session of its own, so the workbench
  *  shows the "Start session" empty state. */
 const emptyLeasingWorkbench = async (page: Page): Promise<void> => {
-  await page.goto("/?seed=0");
+  await page.goto("/?seed=0&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   const context = page.getByTestId("session-context");
   await expect(context).toHaveAttribute("data-session-id", "sess-boot");
@@ -97,7 +107,7 @@ test("an agent under no known root still starts a session, in its own folder", a
   // `daily-activity-analyst` sits at /Users/demo/social-marketing/analytics-stack/…,
   // which no recentDirs entry and no launchDir contains. Honest degradation:
   // the old behaviour, not a failure to start.
-  await page.goto("/?seed=0&mockFixtures=search");
+  await page.goto("/?seed=0&mockFixtures=search&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 
   /* RE-POINTED IN ROUND 2. This addressed the row as

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -17,11 +17,21 @@ import {
   selectMockSessionFromPalette,
 } from "./mock-navigation";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 // The mock demo seeds a run + auto-plays the chat conversation on load (see
 // the demo spec). These smoke tests exercise mechanics from a clean slate, so
 // they opt out with ?seed=0 — the seeded end-state has its own coverage.
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?seed=0");
+  await page.goto("/?seed=0&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 });
 
@@ -823,7 +833,7 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
        selecting one that has nothing running opens its first session at the
        project root; a project you can select but not talk to is the failure
        this criterion names. */
-    await page.goto("/?seed=0&mockNoLiveSessions=1");
+    await page.goto("/?seed=0&mockNoLiveSessions=1&mockStudioProjects=absent");
     await expect(page.locator(".rail-workflows")).toBeVisible();
     await expect(page.getByTestId("open-agent-empty")).toContainText(
       "No running session for leasing",

--- a/packages/harness/web/e2e/snippet-panel.spec.ts
+++ b/packages/harness/web/e2e/snippet-panel.spec.ts
@@ -18,8 +18,18 @@ import { expect, test } from "@playwright/test";
 
 import { focusRfqAgent } from "./mock-navigation";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?seed=0");
+  await page.goto("/?seed=0&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   await expect(page.getByTestId("workflow-leasing")).toHaveClass(/is-focused/);
   await page.getByTestId("right-tab-steps").click();

--- a/packages/harness/web/e2e/wave5.spec.ts
+++ b/packages/harness/web/e2e/wave5.spec.ts
@@ -13,8 +13,18 @@
  */
 import { expect, test } from "@playwright/test";
 
+// COMPATIBILITY PAYLOAD, said out loud.
+//
+// Before the mock's `studioProjects` default was flipped, EVERY spec ran on this
+// payload without knowing it: `mockStudioProjects` returned undefined unless a
+// spec opted in, so the whole suite exercised the retired direct-creation rail
+// and never the shipped plan-first one. Pinning this file takes nothing away,
+// it is the payload these tests already ran on; it only stops that being an
+// accident. Their plan-first equivalents are covered in `project-axis.spec.ts`
+// and `agent-map-planning.spec.ts`, not here.
+
 test.beforeEach(async ({ page }) => {
-  await page.goto("/");
+  await page.goto("/?mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 });
 
@@ -160,7 +170,7 @@ test("the Overview opens over the workbench and dismisses on click-out", async (
 // ---------------------------------------------------------------------------
 
 test("a folder that cannot be read says so, and the field stays the way out", async ({ page }) => {
-  await page.goto("/?mockError=listDir");
+  await page.goto("/?mockError=listDir&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 
   await page.getByTestId("add-existing-agents").click();

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -63,6 +63,7 @@ import type { LocalStepTrace, LocalRunOutcome } from "@sapiom/agent-core";
 
 import { getTheme } from "./theme";
 import { refuseAgentName } from "@shared/agent-name";
+import { projectRoots } from "@shared/project-roots";
 import {
   parseSystemGraphNavigation,
   parseSystemGraphSnapshot,
@@ -2219,11 +2220,24 @@ export class MockApi implements HarnessApi {
   }
 
   private workspaceScopes(): WorkspaceScopeSummary[] {
-    const roots = new Set([
-      ...this.settings.recentDirs,
-      ...this.sessions.map((session) => session.cwd),
-    ]);
-    return [...roots]
+    // The same derivation the real server runs (`shared/project-roots.ts`).
+    // A mock that unioned recentDirs with session cwds registered a scope for
+    // an agent's own folder and none for the folder the rail promotes it to,
+    // so mock mode could not reproduce the join failure it was supposed to
+    // cover — the fixtures silently disagreed with the server about what a
+    // project is.
+    const roots = projectRoots({
+      recentDirs: this.settings.recentDirs,
+      sessions: this.sessions.map((session) => ({
+        cwd: session.cwd,
+        createdAt: session.createdAt,
+        status: session.status,
+      })),
+      pendingCwds: [],
+      agentPaths: this.workflows.map((workflow) => workflow.path),
+      sort: "recent",
+    });
+    return [...new Set(roots)]
       .sort((left, right) => left.localeCompare(right))
       .map((cwd) => ({
         cwd,
@@ -2233,18 +2247,24 @@ export class MockApi implements HarnessApi {
   }
 
   private studioProjects(): StudioProjectSummary[] | undefined {
-    // Production authority is determined by the server response and always
-    // uses durable Studio project summaries. Mock mode keeps the historical
-    // fixtures stable unless a plan-first scenario opts in explicitly; the
-    // dedicated agent-map fixture is also an opt-in. `absent` names the
-    // legacy-server compatibility contract exercised by the remaining direct
-    // creation specs. This is test data selection, not a product feature flag.
-    if (typeof window !== "undefined") {
-      const params = new URLSearchParams(window.location.search);
-      const mode = params.get("mockStudioProjects");
-      const fixture = params.get("mockFixtures");
-      if (mode === "absent") return undefined;
-      if (mode !== "present" && fixture !== "agent-map") return undefined;
+    // MOCK MODE RENDERS THE SHIPPED PATH BY DEFAULT.
+    //
+    // It used to return undefined unless a spec opted in, so every UI test
+    // that did not think about this exercised the RETIRED direct-creation
+    // branch and none of them ever rendered the Agent Map that replaced it.
+    // A green suite was evidence about the wrong branch — which is why the
+    // gate could be false on every real install without one test noticing.
+    //
+    // The legacy-server compatibility contract is still covered, but only
+    // where a spec ASKS for it with `mockStudioProjects=absent`. Deliberate,
+    // not by default: that is the difference between a covered path and an
+    // accident. This is test data selection, not a product feature flag.
+    if (
+      typeof window !== "undefined" &&
+      new URLSearchParams(window.location.search).get("mockStudioProjects") ===
+        "absent"
+    ) {
+      return undefined;
     }
     const timestamp = "2026-01-01T00:00:00.000Z";
     return this.workspaceScopes().map((scope, index) => ({
@@ -2454,6 +2474,50 @@ export class MockApi implements HarnessApi {
     );
   }
 
+  /**
+   * WHAT THIS MOCK PROJECT REMEMBERS LOOKING AT, when no spec has said.
+   *
+   * The server's own default for a project with nothing stored is the Agent
+   * Map, and `?mockStudioProjects=present` still produces exactly that. But
+   * the fixture the whole suite loads is a RETURNING user — a live session
+   * bound to an agent — and for that user the remembered workspace is that
+   * agent. Defaulting every project to the map instead put the map in front of
+   * ~190 specs whose subject is the canvas, the inspector or a macro strip,
+   * none of which are about which altitude a boot lands at. Altitude is
+   * asserted where it IS the subject: `agent-map-planning.spec.ts` opts in with
+   * `mockStudioProjects=present` and gets the map.
+   */
+  private rememberedWorkspace(
+    projectId: StudioProjectId,
+  ): StudioWorkspaceSelection | undefined {
+    if (
+      typeof window !== "undefined" &&
+      new URLSearchParams(window.location.search).get("mockStudioProjects") ===
+        "present"
+    ) {
+      return undefined;
+    }
+    const boundPaths = new Set(
+      this.sessions
+        .map((session) => session.boundWorkflowPath)
+        .filter((path): path is string => Boolean(path)),
+    );
+    for (const workflow of this.studioWorkflows()) {
+      if (!boundPaths.has(workflow.path)) continue;
+      const binding = workflow.studioBindings?.find(
+        (candidate) => candidate.projectId === projectId,
+      );
+      if (binding) {
+        return {
+          kind: "agent",
+          projectId,
+          agentId: binding.agentId,
+        };
+      }
+    }
+    return undefined;
+  }
+
   async getStudioCurrentWorkspace(
     projectId: StudioProjectId,
   ): Promise<StudioCurrentWorkspaceResponse> {
@@ -2485,7 +2549,7 @@ export class MockApi implements HarnessApi {
           ]
         : [];
     });
-    const requested = this.studioPreferences.get(projectId);
+    const requested = this.studioPreferences.get(projectId) ?? this.rememberedWorkspace(projectId);
     const valid =
       requested?.kind !== "agent" ||
       agents.some((agent) => agent.agentId === requested.agentId);

--- a/packages/harness/web/src/lib/paths.ts
+++ b/packages/harness/web/src/lib/paths.ts
@@ -1,111 +1,13 @@
 /**
- * Browser-side path helpers for the ABSOLUTE paths the server hands us.
+ * Re-export of the canonical path helpers, which now live in
+ * `src/shared/paths.ts` so the SERVER can read them too.
  *
- * The server builds them with `path.join`, so they arrive in the host's native
- * shape — backslash-separated on Windows. The SPA cannot ask `node:path` which
- * host that was; it infers the separator from the string itself, which works
- * because a Windows absolute path always contains at least one `\` (`C:\…`)
- * and a POSIX one never does.
- *
- * Joins preserve the input's native separator (what gets POSTed back must
- * match what the server sent), but every COMPARISON normalizes both
- * separators first: paths that were joined in the browser before this module
- * existed shipped in mixed form (`C:\Users\x\projects/newsletter-autopilot`),
- * and those still have to compare equal to their native spellings.
+ * They moved because `projectRoots` moved (see `@shared/project-roots`): the
+ * server has to derive the same project roots the rail renders, and it cannot
+ * import out of `web/src`. These are pure string operations over the absolute
+ * paths the server hands out — no `node:path`, no DOM — so one copy serves
+ * both hosts. Every existing `./paths` import keeps working through this file;
+ * a second implementation on the server side is exactly the drift the shared
+ * module exists to prevent.
  */
-
-/** The separator `p` itself uses. `\` anywhere marks a Windows path — POSIX
- *  filenames may legally contain `\`, but never in the absolute paths the
- *  server supplies. */
-export function sepOf(p: string): "\\" | "/" {
-  return p.includes("\\") ? "\\" : "/";
-}
-
-/** `<root><sep><name>` in the root's native separator, with no doubled
- *  separator when the root carries a trailing one. */
-export function joinPath(root: string, name: string): string {
-  const trimmedRoot = root.trim().replace(/[\\/]+$/, "");
-  return `${trimmedRoot}${sepOf(root)}${name.trim()}`;
-}
-
-/** Last non-empty segment under either separator, or the input when it has
- *  none (a relative name is its own basename). */
-export function basenameOf(p: string): string {
-  return p.split(/[\\/]/).filter(Boolean).pop() ?? p;
-}
-
-/**
- * Parent of an absolute path, or null at a filesystem root (`/`, `C:\`, bare
- * `C:`) and for separator-free relative strings. Mirrors `path.dirname`
- * without pulling node:path into the browser bundle.
- *
- * Needed because GET /api/fs/list reports one level DOWN: a path can only
- * learn whether it is itself an agent project by asking its parent.
- */
-export function parentOf(input: string): string | null {
-  const trimmed = input.replace(/[\\/]+$/, "");
-  if (trimmed === "" || /^[A-Za-z]:$/.test(trimmed)) return null;
-  const lastSep = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
-  if (lastSep < 0) return null;
-  const cut = trimmed.slice(0, lastSep);
-  // First-level paths keep their root spelled out — `/Users` → `/`,
-  // `C:\Users` → `C:\` — so the result is always itself a listable path.
-  if (/^[A-Za-z]:$/.test(cut)) return cut + trimmed[lastSep];
-  return cut || "/";
-}
-
-/** `/a/b/` → `/a/b` under either separator, so a user's trailing slash never
- *  breaks a path comparison. Bare roots (`/`, `C:\`) pass through unchanged —
- *  stripping them would leave something that isn't a path. */
-export function stripTrailingSep(p: string): string {
-  const trimmed = p.replace(/[\\/]+$/, "");
-  if (trimmed === p) return p;
-  if (trimmed === "") return p[0];
-  if (/^[A-Za-z]:$/.test(trimmed)) return trimmed + p[trimmed.length];
-  return trimmed;
-}
-
-/** Whether `child` IS `parent` or sits beneath it — never a mere string
- *  prefix, so `/a/scratch-2` is not within `/a/scratch`. Separator-insensitive
- *  on both sides, so a mixed-form path still matches its native spelling. */
-/**
- * Whether two paths name the same directory, ignoring separator form and a
- * trailing separator.
- *
- * Needed because the client and the server no longer agree byte-for-byte: the
- * server `path.resolve()`s every cwd it stores (server/cwd-normalize.ts) while
- * the SPA holds whatever the user typed or a recentDirs entry recorded — so a
- * `C:/…`-typed path, or one with a trailing slash, fails a raw `===` against
- * the very session it just created (empty tab strip, unhighlighted rail row).
- */
-export function samePath(a: string, b: string): boolean {
-  return stripTrailingSep(a.replace(/\\/g, "/")) === stripTrailingSep(b.replace(/\\/g, "/"));
-}
-
-export function isWithinDir(parent: string, child: string): boolean {
-  const p = stripTrailingSep(parent.replace(/\\/g, "/"));
-  const c = stripTrailingSep(child.replace(/\\/g, "/"));
-  if (c === p) return true;
-  // A filesystem root keeps its trailing separator (stripTrailingSep's
-  // contract), so appending another would test "C://…" and never match —
-  // every session under a root-level workspace looked like an orphan.
-  return p.endsWith("/") ? c.startsWith(p) : c.startsWith(`${p}/`);
-}
-
-/** Whether typed input is trying to be an absolute path (`/…`, `~…`, or a
- *  Windows drive like `C:\…` / `C:/…`) rather than a search query. */
-export function looksAbsolutePath(input: string): boolean {
-  return input.startsWith("/") || input.startsWith("~") || /^[A-Za-z]:[\\/]/.test(input);
-}
-
-/** "/Users/…/onboarding-flow" — middle-truncates a long path so a chip row
- *  never hard-clips a chip mid-glyph; the full path stays in the tooltip. */
-export function middleTruncatePath(path: string): string {
-  const sep = sepOf(path);
-  const segments = path.split(/[\\/]/).filter(Boolean);
-  if (segments.length <= 2) return path;
-  // POSIX first segments lost their leading `/` to the split; a drive letter
-  // (`C:`) never had one.
-  const prefix = sep === "\\" ? "" : sep;
-  return `${prefix}${segments[0]}${sep}…${sep}${segments[segments.length - 1]}`;
-}
+export * from "@shared/paths";

--- a/packages/harness/web/src/lib/project-tree.ts
+++ b/packages/harness/web/src/lib/project-tree.ts
@@ -1,4 +1,5 @@
-import type { SessionStatus, WorkflowInfo } from "@shared/types";
+import type { WorkflowInfo } from "@shared/types";
+import type { RailSort } from "@shared/project-roots";
 
 import { displayAgentName } from "./agent-name";
 import {
@@ -8,6 +9,23 @@ import {
   parentOf,
   stripTrailingSep,
 } from "./paths";
+
+/**
+ * WHICH FOLDERS ARE PROJECTS now lives in `@shared/project-roots`, because the
+ * SERVER has to reach the same answer: it issues one durable Studio project
+ * per workspace scope, and a scope list built from a second definition left
+ * every promoted root without a project (see that module's header). Re-exported
+ * here so this file stays the rail's one import for project shape.
+ */
+export type {
+  ProjectRootSources,
+  RailSort,
+} from "@shared/project-roots";
+export {
+  holdingProjectFor,
+  projectRoots,
+  projectToOpen,
+} from "@shared/project-roots";
 
 /**
  * The rail's filing axes.
@@ -33,14 +51,10 @@ import {
  */
 export type RailAxis = "project" | "group";
 
-/**
- * Row order within a container. "name" is A–Z; "recent" is
- * newest-activity-first, but ONLY for the project rows (they carry session
- * recency) — `WorkflowInfo` has no timestamp, so agent ROWS are always
- * path-stable regardless of this setting. "recent" therefore changes project
- * order, not row order.
- */
-export type RailSort = "recent" | "name";
+/* `RailSort` is defined in `@shared/project-roots` and re-exported above: it
+   orders the PROJECT rows, which that module produces. `WorkflowInfo` has no
+   timestamp, so agent rows stay path-stable whatever this is set to — "recent"
+   changes project order, not row order. */
 
 /**
  * One agent row. `prefix` is the unbranched directory chain compacted ONTO
@@ -511,333 +525,6 @@ export function unrootedAgents(
     .sort(agentOrder(sort));
 }
 
-/** Everything the rail knows about which folders are projects. */
-export interface ProjectRootSources {
-  /** Upstream's workspace list — most-recently-used project directories,
-   *  newest first, already deduped and pruned of dead paths at every boot. */
-  recentDirs: readonly string[];
-  /** Session cwds widen the candidate set for folders `recentDirs` has not yet
-   *  recorded, and carry the recency signal for them. `status` separates the
-   *  two very different claims a cwd can make: see rule 2. */
-  sessions: readonly {
-    cwd: string;
-    createdAt: string;
-    status?: SessionStatus;
-  }[];
-  /** Folders whose agent is mid-creation: known before any session or agent
-   *  exists under them. */
-  pendingCwds: readonly string[];
-  /**
-   * Every registered agent's OWN directory.
-   *
-   * Required, not optional. The rule below cannot be stated without it, and a
-   * caller that forgets it would silently get the old accumulating behaviour
-   * back with every test still green.
-   */
-  agentPaths: readonly string[];
-  sort: RailSort;
-}
-
-/**
- * THE FOLDER THAT HOLDS AN AGENT, or null when nothing better than the agent's
- * own directory exists.
- *
- * ONE ANSWER, because there are two callers and they must not disagree. The
- * rail's derivation asks it to decide which row to draw; `openProject` asks it
- * to decide what the picker actually opens when you point it at an agent.
- *
- * `projects` must be the list `projectRoots` produces. The guard below is only
- * as good as the definition of "project" it is handed, and a caller that builds
- * its own will decline hops the rail would have made, which restores the silent
- * no-op this exists to remove. `openProject` therefore passes
- * `projectRoots(...)` verbatim rather than assembling anything.
- *
- * Null means REFUSE, and refusing is safe: the agent's own folder stays the
- * root and renders as a project with that agent inside, which is what opening
- * an agent's folder honestly means.
- *
- * Two reasons to refuse:
- *
- *  1. **A filesystem root.** `paths.parentOf` answers `/` (and `C:\`) rather
- *     than null there, deliberately, so that every result stays a listable
- *     path. Taken literally it turns an agent at `/solo` into a project called
- *     `/` holding the entire disk, and the swallow guard below cannot catch it
- *     because at that point there is no other project to swallow yet.
- *  2. **It would contain another project.** Without this, the clean demo
- *     fixture, whose roots are agent folders sitting beside an ordinary project
- *     under one home directory, promoted them all to `/Users/demo` and produced
- *     a single project holding every other project, with every agent inside it
- *     rendered twice. That is the duplicate-agent rendering this rule exists to
- *     remove, re-created by the repair.
- *
- * KNOWN LIMIT, stated rather than papered over: a directory holding nothing but
- * agent folders and no other project DOES become the project. That is right
- * everywhere except a home directory, and a home directory in practice always
- * holds another project, which is what makes the guard fire. A depth floor was
- * considered and rejected, because every threshold that saves `/Users/demo`
- * also breaks a legitimate two-segment root.
- */
-/**
- * WHAT OPENING A FOLDER ACTUALLY OPENS.
- *
- * You cannot open a single agent as a project, so pointing the picker at an
- * agent's own folder opens the folder that holds it. Without this the press is
- * a silent no-op: `projectRoots` declines to draw a row for an agent-rooted
- * entry, so the picker says "This is an agent project", the user presses Open,
- * and nothing changes.
- *
- * THE ELIGIBLE PROJECTS ARE `projectRoots`' OWN OUTPUT, not a list assembled
- * here to resemble it. That is the whole design of this function, and it is the
- * only version of it that has held: the guard inside `holdingProjectFor` asks
- * "would this promotion swallow a project", and the answer is only as good as
- * the definition of "project" it is handed. Four separate attempts to
- * reconstruct that definition locally were each wrong in a different way, and
- * every one of them failed in the same direction, by counting something the
- * rail does not keep and so refusing a hop the rail would have made, which puts
- * the silent no-op back.
- *
- * `projectRoots` is the one place that decides what a project is: chosen
- * folders, folders with a live session, and session-only folders that hold an
- * agent no other root already shows, with agent directories excluded and
- * promotions guarded. Calling it costs one derivation on a user gesture and
- * removes the entire class of drift, because there is no second definition left
- * to disagree with.
- */
-export function projectToOpen(
-  requested: string,
-  sources: ProjectRootSources,
-): string {
-  const isAgentDir = sources.agentPaths.some(
-    (path) => canonical(path) === canonical(requested),
-  );
-  if (!isAgentDir) return requested;
-  return (
-    holdingProjectFor(requested, {
-      agentPaths: sources.agentPaths,
-      projects: projectRoots(sources),
-    }) ?? requested
-  );
-}
-
-export function holdingProjectFor(
-  agentDir: string,
-  {
-    agentPaths,
-    projects,
-  }: { agentPaths: readonly string[]; projects: readonly string[] },
-): string | null {
-  const agentDirs = new Set(agentPaths.map(canonical));
-  let parent = parentOf(agentDir);
-  // An agent nested inside another agent walks up until it clears them all.
-  while (parent && agentDirs.has(canonical(parent))) parent = parentOf(parent);
-  if (parent === null || parentOf(parent) === null) return null;
-  const swallowsAProject = projects.some(
-    (held) => isUnder(held, parent!) && canonical(held) !== canonical(parent!),
-  );
-  return swallowsAProject ? null : parent;
-}
-
-/**
- * THE ORDERED LIST OF PROJECT ROOTS.
- *
- * One sentence governs this whole function:
- *
- *     A PROJECT IS A DIRECTORY YOU CHOSE THAT HOLDS AGENTS.
- *
- * Two clauses, and dropping either one is what filled a real rail. Measured
- * against a captured `~/.sapiom/harness` (`org-dogfood.json` in the design
- * prototype: 75 agents, 8 recentDirs, 41 distinct session cwds), the sources
- * below offer 41 candidate roots and this function returns 8.
- *
- * RULE 1, "you chose": an agent's OWN directory is not a project. The project
- * is the directory that HOLDS agents; the agent is the thing inside it. A root
- * that is itself a registered agent is a category error, and it is the single
- * cause of both symptoms a real install shows. Its dependency graph has exactly
- * one node, because nothing else is inside it. And it renders the agent TWICE
- * whenever some other open project also contains it, once correctly nested and
- * once again at top level under a different label, because `buildProjectTree`
- * deliberately files an agent under EVERY root that contains it. Three agents
- * were on screen twice this way on one real machine. So an agent-rooted entry
- * whose agent another project already shows is dropped, and one nothing shows
- * is replaced by its nearest non-agent ancestor.
- *
- * This is not a new rule. `project-membership.agentNeedsOwnProject` has
- * enforced it on every NEW registration since the accumulation was diagnosed:
- * "an agent an open project already contains needs nothing remembered". It was
- * simply never applied to the entries already in the list, so the guard stopped
- * the bleeding and left the wound. Applying one rule in one direction only is
- * why SAP-2927 looked complete while the rail still looked broken.
- *
- * RULE 2, "that holds agents": a folder known ONLY because a session ran there
- * earns a row only if it holds an agent no other project already shows, OR a
- * session is LIVE in it. "A session ran here once and exited" and "something is
- * running here right now" are different claims, and collapsing them cost a real
- * case immediately: a bare scaffold session, a live session in a folder with no
- * agent yet, is exactly how you start an agent in an empty folder, and dropping
- * its row makes a running session unreachable from the rail.
- * `recentDirs` is chosen and capped at 8; session cwds are neither, which is
- * why the second list has to earn its rows and the first does not. Two failures
- * collapse into that one clause. A visited folder with no agent is not a
- * project, while an empty project you OPENED keeps its row, because opening a
- * folder in order to build the first agent in it is the whole point of that
- * row. And a visited folder INSIDE a project you already opened is not a second
- * context: `~/polsia` and `~/polsia/services/workers` are two useful views of
- * one agent when you opened both, and the same agent printed twice when the
- * inner row is merely where a session happened to start.
- *
- * NOTHING IS DELETED. Both rules are derivational: `recentDirs` on disk is
- * untouched and any folder is one "Add a project" away from coming back. That
- * is what makes this safe to apply to an install nobody audited, and why it
- * needs no migration, no first-run flow and no undo. The design's original "no
- * migration, every entry becomes a project" rule is kept in spirit and dropped
- * in letter: nothing a user had disappears, but residue of a fixed bug stops
- * being rendered as a choice they made.
- */
-export function projectRoots({
-  recentDirs,
-  sessions,
-  pendingCwds,
-  agentPaths,
-  sort,
-}: ProjectRootSources): string[] {
-  // Newest activity per directory, for folders `recentDirs` has not heard of.
-  const newestByCwd = new Map<string, string>();
-  for (const session of sessions) {
-    const key = canonical(session.cwd);
-    const prev = newestByCwd.get(key);
-    if (!prev || session.createdAt > prev)
-      newestByCwd.set(key, session.createdAt);
-  }
-
-  // First spelling wins: recentDirs and a session cwd can name one directory
-  // in two forms (the server `path.resolve`s what it stores, the SPA holds
-  // what the user typed), and two rows for one folder is unreadable.
-  const seen = new Set<string>();
-  const candidates: string[] = [];
-  for (const dir of [
-    ...pendingCwds,
-    ...recentDirs,
-    ...sessions.map((s) => s.cwd),
-  ]) {
-    const key = canonical(dir);
-    if (key === "" || seen.has(key)) continue;
-    seen.add(key);
-    candidates.push(dir);
-  }
-
-  const agentDirs = new Set(agentPaths.map(canonical));
-  const isAgentDir = (dir: string): boolean => agentDirs.has(canonical(dir));
-  // A folder mid-creation is as deliberate an act as opening one, and its agent
-  // does not exist yet, so it can never be an agent directory either. A folder
-  // with a LIVE session counts too: you are working in it right now, which is a
-  // stronger claim than any list of remembered paths.
-  // `status !== "exited"` is the SAME reading `bareSessionAt` uses, so the row
-  // the rail keeps and the session it offers cannot disagree. An absent status
-  // reads as not live: the only callers that omit it name a folder's recency,
-  // and a missing field must never silently keep a row.
-  const liveCwds = sessions
-    .filter((session) => session.status != null && session.status !== "exited")
-    .map((session) => session.cwd);
-  const chosen = new Set(
-    [...pendingCwds, ...recentDirs, ...liveCwds].map(canonical),
-  );
-  const wasChosen = (dir: string): boolean => chosen.has(canonical(dir));
-  const agentsUnder = (root: string): string[] =>
-    agentPaths.filter(
-      (path) => isUnder(path, root) && canonical(path) !== canonical(root),
-    );
-
-  /** What each surviving root was DERIVED FROM, so a promoted row inherits the
-   *  recency of the entry that produced it rather than sorting as an unknown. */
-  const from = new Map<string, string>();
-  const kept: string[] = [];
-  const holds = (root: string): boolean =>
-    kept.some((held) => canonical(held) === canonical(root));
-
-  // The folders the user CHOSE, unconditionally and in order. `recentDirs` is a
-  // list of deliberate acts; second-guessing it is how a rail starts hiding a
-  // project somebody opened on purpose.
-  for (const dir of candidates) {
-    if (!wasChosen(dir) || isAgentDir(dir)) continue;
-    kept.push(dir);
-    from.set(canonical(dir), dir);
-  }
-
-  /* RULE 2, over the session-only folders, SHALLOWEST FIRST.
-     The order is load-bearing, not tidiness. Taken in candidate order an inner
-     folder is reached before the outer one that would have explained it, and so
-     keeps a row it does not need: a captured install kept
-     `harness-e2e/projects/research-micro-site-<hash>` as its own project and
-     then added `harness-e2e` above it, printing both of its agents twice.
-     Shallowest first means the outermost folder that explains an agent wins and
-     every folder below it is measured against a list that already holds it. */
-  const sessionOnly = candidates
-    .filter((dir) => !wasChosen(dir) && !isAgentDir(dir))
-    .sort(
-      (a, b) =>
-        canonical(a).split("/").length - canonical(b).split("/").length ||
-        a.localeCompare(b),
-    );
-  for (const dir of sessionOnly) {
-    const under = agentsUnder(dir);
-    if (under.length === 0) continue;
-    if (under.every((path) => kept.some((root) => isUnder(path, root))))
-      continue;
-    kept.push(dir);
-    from.set(canonical(dir), dir);
-  }
-
-  // RULE 1, over the agent-rooted entries, in candidate order so the result is
-  // deterministic. `kept` grows as promotions land, so a later entry can be
-  // absorbed by an earlier one's promotion.
-  for (const dir of candidates) {
-    if (!isAgentDir(dir)) continue;
-    if (
-      kept.some(
-        (root) => isUnder(dir, root) && canonical(root) !== canonical(dir),
-      )
-    )
-      continue;
-    const root = holdingProjectFor(dir, { agentPaths, projects: kept }) ?? dir;
-    if (holds(root)) continue;
-    kept.push(root);
-    from.set(canonical(root), dir);
-  }
-
-  const pendingRank = new Map(
-    pendingCwds.map((cwd, index) => [canonical(cwd), index]),
-  );
-  const recentRank = new Map(
-    recentDirs.map((dir, index) => [canonical(dir), index]),
-  );
-  /** Rank and recency are asked of the ENTRY a row came from, so a promoted
-   *  parent sorts where the agent that produced it sorted. */
-  const source = (root: string): string => from.get(canonical(root)) ?? root;
-
-  const byRecency = (a: string, b: string): number => {
-    const ia = recentRank.get(canonical(source(a))) ?? -1;
-    const ib = recentRank.get(canonical(source(b))) ?? -1;
-    if (ia >= 0 && ib >= 0) return ia - ib;
-    if (ia >= 0 || ib >= 0) return ia >= 0 ? -1 : 1;
-    return (newestByCwd.get(canonical(source(b))) ?? "").localeCompare(
-      newestByCwd.get(canonical(source(a))) ?? "",
-    );
-  };
-
-  return kept.sort((a, b) => {
-    // A folder mid-creation outranks everything, on either sort — the user's
-    // attention is on it. Among several pending folders, newest first.
-    const ra = pendingRank.get(canonical(source(a)));
-    const rb = pendingRank.get(canonical(source(b)));
-    if (ra !== undefined || rb !== undefined) {
-      if (ra !== undefined && rb !== undefined) return ra - rb;
-      return ra !== undefined ? -1 : 1;
-    }
-    if (sort === "name")
-      return basenameOf(a).localeCompare(basenameOf(b)) || a.localeCompare(b);
-    return byRecency(a, b) || a.localeCompare(b);
-  });
-}
 
 /**
  * Project labels.

--- a/packages/harness/web/tsconfig.json
+++ b/packages/harness/web/tsconfig.json
@@ -18,6 +18,8 @@
       "@shared/agent-map": ["../src/shared/agent-map.ts"],
       "@shared/agent-map-codec": ["../src/shared/agent-map-codec.ts"],
       "@shared/agent-name": ["../src/shared/agent-name.ts"],
+      "@shared/paths": ["../src/shared/paths.ts"],
+      "@shared/project-roots": ["../src/shared/project-roots.ts"],
       "@shared/render-local-run": ["../src/core/render-local-run.ts"],
       "@shared/stub-feedback": ["../src/core/stub-feedback.ts"],
       "@sapiom/design-system/*": ["./src/styles/ds-neutral/*"]

--- a/packages/harness/web/vite.config.ts
+++ b/packages/harness/web/vite.config.ts
@@ -107,6 +107,17 @@ export default defineConfig({
       "@shared/agent-name": fileURLToPath(
         new URL("../src/shared/agent-name.ts", import.meta.url),
       ),
+      // Which folders are PROJECTS, and the path comparisons that decide it.
+      // The server derives its workspace scopes from the same functions the
+      // rail renders from: a second definition on either side is what left a
+      // promoted project root with no durable Studio project (see the module
+      // header). Pure string operations, so no node:path enters the bundle.
+      "@shared/paths": fileURLToPath(
+        new URL("../src/shared/paths.ts", import.meta.url),
+      ),
+      "@shared/project-roots": fileURLToPath(
+        new URL("../src/shared/project-roots.ts", import.meta.url),
+      ),
       // The local-run mapper is a pure fn shared with the server (its canonical
       // home is src/core/render-local-run.ts, per the ticket). The SPA imports
       // the SAME implementation to map an offline stub run's NDJSON traces into


### PR DESCRIPTION
## The bug

`WorkflowsRail.tsx:1232-1240` joins each project row to a workspace scope by
`samePath(scope.cwd, project.root)`, reads the durable Studio project off that
scope's `projectId`, and sets `mapOwnsCreation = studioProject != null`. When it
is false the retired direct-creation UI renders: the project-row create item
(`:1410`) and the empty-project row (`:1484`). Its own comment says the absent
case is "a compatibility payload, not a second creation mode".

The absent case fired routinely. Two definitions of "project" existed and they
disagreed on the commonest shape there is:

| | definition |
|---|---|
| the rail | `projectRoots` (`lib/project-tree.ts`). Rule 1 replaces an agent's OWN directory with `holdingProjectFor(dir) ?? dir`, i.e. the folder that HOLDS the agent |
| the server | `settings.recentDirs` + every session cwd (`index.ts:1209-1212`), one durable Studio project per entry |

That holding folder was never a recentDir and never a session cwd, so it was
never a scope, so the join found nothing.

**Reproduced, on a real server, before the fix:**

```
node dist/cli/bin.js ~/sapiom/agents/property-ops/tenant-screening \
  --port 4131 --state-root <fresh> --no-session --no-telemetry --no-open
```

`GET /api/state` returned one scope, `cwd: .../property-ops/tenant-screening`.
The rendered row was `property-ops`. `find` returned undefined, `agent-map-row`
was absent, and the project menu offered **"Create an agent in property-ops"**.

## The fix, and why it is on this side

`projectRoots` moves to `src/shared/project-roots.ts` (with `paths.ts`, the pure
string helpers it compares with — `web/src/lib/paths.ts` is now a re-export
barrel so no web import changed) and `LocalWorkspaceScopeCatalog` calls it.

The two candidates were: register the derived holding root as a scope, or make
the join tolerant of a scope nested under the row's root. **One source of truth
picked the first.** `project-tree.ts` already says it in the source: "`projectRoots`
is the one place that decides what a project is". Deriving the scope list from it
makes the catalog downstream of that definition and mints a durable Studio
project for exactly the roots the rail draws. A tolerant join would have been a
second, weaker rule, and it would bind a row to a project whose `localRootRef` is
NOT that row's root — the Agent Map for `property-ops` would have been rooted at
`tenant-screening`, and a session started there would resolve to a different
project than the map above it (`resolveIdentityForPath` picks the most specific
active binding).

Deliberately not done: defaulting `mapOwnsCreation` to true, which would render
an Agent Map for a project that has none.

## Real-server evidence

Reproduction tree, `~/sapiom/agents/property-ops/tenant-screening`:

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/801/before-repro-menu.png) | ![after](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/801/after-repro-menu.png) |

- before: scope `cwd` = `.../property-ops/tenant-screening`; no `agent-map-row`;
  menu = `["project-create-agent-property-ops", "project-remove-property-ops"]`
- after: scope `cwd` = `.../property-ops` with a `projectId`; `agent-map-row` +
  `agent-map-select` render; menu = `["project-remove-property-ops"]`
- `studio-projects.json` after: exactly one project, `property-ops`, binding
  `active`. No stray project for the agent folder.

Control, `~/sapiom/agents` (76 projects, launched at the holding folder, where
the join already worked) — byte-identical before and after:

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/801/before-agents.png) | ![after](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/801/after-agents.png) |

## Independently confirmed, from the opposite direction

The dialog-shell agent (#800) hit the same boundary while converging dialogs onto
a shared shell, without looking for it: **`CreateAgentDialog` is not reachable on
a current server.** `project-create-agent-<label>` does not render against
`~/sapiom/agents` at all, and it had to pass `?mockStudioProjects=absent` to
screenshot the dialog even once.

That is the control case passing, observed by someone who wanted it to fail. It
pins the defect precisely: launched at a folder that HOLDS agents the gate holds
and the compatibility dialog never appears; launched at an agent's own directory
the rail derives a holding root the server never registered and the same dialog
comes back. The fix is that one join, not a change to how creation works.

## The mock default, and what it exposed

`lib/api.ts` returned `undefined` for `mockStudioProjects` unless a spec opted
in, so **every** UI test ran the retired branch and none ever rendered the
shipped one. A green suite was evidence about the wrong branch. The default is
flipped; `mockStudioProjects=absent` now names the compatibility payload where a
spec wants it. The mock's `workspaceScopes()` also derives from `projectRoots`
now, so the fixture cannot disagree with the server about what a project is.

**192 of 497 specs failed on the flip.** Three causes, three responses:

1. **A helper named the wrong class (1 fix, ~120 specs).** `focusRfqAgent` clicked
   `.workspace-row-main`, which exists only on a MERGED root-agent row. A
   plan-first project renders the agent as a separate child row. Both carry
   `.workflow-item-trigger`; the helper now names that.
2. **The mock landed every boot on the Agent Map (1 fix, ~65 specs).** With a
   durable project and a live session and nothing stored, `App.tsx:352`'s restore
   effect takes the server's default selection, which is `agent-map`. The suite's
   fixture is a RETURNING user with a session bound to an agent, so the mock's
   unstored default is now that agent. `mockStudioProjects=present` still yields
   the map, which is what `agent-map-planning.spec.ts` asserts.
3. **21 spec files describe the compatibility rail (pinned).** Chiefly the
   workspace System Graph a project row opens: on a current server the row opens
   the project's Agent Map instead, so `workspace-graph-view` /
   `system-graph-canvas` is a legacy-payload surface. Those files now say
   `mockStudioProjects=absent` at their navigation, with the reason written in.
   **This takes no coverage away** — every one of them already ran on that payload
   before this PR; it only stops the choice being an accident. What it does NOT
   do is cover their plan-first equivalents. That gap is real and named, not
   silent. See "Known gaps" below.

Two locator fixes were needed regardless: a plan-first group has a SECOND direct
`.workspace-row` child (the pinned Agent Map row), so `:scope > .workspace-row`
is a strict-mode violation there. Now `:not(.is-nested)`.

Net: **497 passed / 0 failed**, identical to `origin/main`'s baseline on this
machine. 21 spec files + 1 helper changed.

## Known gaps, stated

- **`accumulation-guard` and `project-axis` contradict each other, and now it is
  visible.** `project-axis.spec.ts:168` specifies "a root agent is a separate
  target below the pinned Agent Map" — project header + map row + agent row, three
  rows. `accumulation-guard`'s SYMPTOM sweep forbids exactly that: "no project row
  is a single agent wearing its own folder's name". Neither could see the other:
  one ran only on the opt-in payload, the other only on the default. I merged the
  root agent into the plan-first row to satisfy the guard, which broke
  `project-axis`, and reverted it. **Which one is right is a product decision**, so
  the sweep is pinned to the compat payload with the conflict written into the
  fixture list rather than resolved by editing an assertion.
- The plan-first behaviour of the 21 pinned files (project selection, session
  scoping, the deploy/canvas flows under a durable project) has no coverage.
- The rail's `mapOwnsCreation` join is not the only `samePath(scope.cwd, root)`
  join in the SPA. `App.tsx:1836` and `:2702` do the same lookup against a project
  root and had the same latent bug; the shared derivation fixes them by making the
  scope exist, but they are still exact-match joins.

## Review rounds

**This PR had no tests and no review until its conflict cleared**, and that is
worth recording because the symptom is silence. A `pull_request` workflow builds
against the merge ref GitHub computes; a conflicting PR has none, so every job
needing one never fires — no failure, no skip notice, nothing queued. Four jobs
ran (CodeQL, both Analyze, Classify) and six did not, including every harness
suite and the review bot. It read as green. After merging `main` all ten run and
all ten pass.

### Round 1

1. **The boot race persisted the stray this fix removes.** Correct and worse
   than the PR body said. At boot `workflowsCache` is the persisted registry —
   empty on a first run — so rule 1 cannot fire, the agent's own folder survives
   as a root, and `reconcile` MINTS AND PERSISTS a project for it. When the scan
   lands the binding flips to "missing" and the row stays in
   `studio-projects.json` forever, unreachable from the UI.
   Awaiting the boot scan was the first fix and it broke a contract this suite
   states by name — "serves persisted cold inventory without awaiting
   discovery". So the catalog asks the disk instead: a candidate holding a
   `sapiom.json` is an agent directory. One stat per candidate over recentDirs
   plus live session cwds, no discovery, and it falls back to exactly the
   registry once the scan lands.
2. **No migration; the dropped projects were orphaned.** `reconcile` now
   re-points the binding when the move is unambiguous, so the Agent Map
   aggregate, `studioBindings` and persisted planner identities follow the
   project instead of being stranded on an id nothing points at.
3. **The accumulation guard no longer guards the shipped rail.** Not fixed —
   see "Known gaps". It is a product decision between two specs that contradict
   each other, and it is escalated rather than settled by editing an assertion.
4. **One rule, two input sets.** Documented on `ProjectRootSources`:
   `closedProjects` is browser localStorage, so a removed project whose agents
   stay registered is hidden in the rail and still a root on the server.
5. **Public copy.** `src/shared/project-roots.ts` is compiled by `tsc`, which
   keeps comments, so its prose now ships in the tarball where Vite used to
   strip it. The dogfood capture filename and per-install counts are gone.

### Round 2

The migration added for finding 2 opened a durable-write path of its own, and
the review was right about all three faces of it:

- **The adoption pool was unbounded in time.** "Any project whose bindings are
  all missing" grows forever, because nothing deletes a project and every folder
  that ages out of the capped `recentDirs` leaves one behind — so a new root
  appearing months later would adopt a stranger. The pool is now the bindings
  THIS pass just took away.
- **The first containing root adopted, not the nearest.** Scopes arrive sorted
  by canonical path, so `/w` reached an orphan under `/w/team/a2` before
  `/w/team` did, landing the identity on the wrong folder.
- **`displayName` was rewritten.** `moveRootBinding` deliberately leaves it
  alone and this now matches: the folder moved, the project the user named did
  not.

Each has its own spec, and each spec dies when its correction is reverted.

### What CI caught that local runs hid

Two `system-graph-freshness` specs failed on CI with `expected undefined to be
truthy`. Locally they sit inside a set of six files that fail under contention
on this machine, so they read as part of the documented flake cast. **Local
"known flaky" was hiding a real regression.**

Both fixtures wrote `index.ts` straight into `workspaceRoot`, making that root
an agent directory — so this PR correctly promotes it and there is no scope at
that exact path. My first fix resolved the workspaceKey through the CONTAINING
scope, which made the lookups succeed and then failed deeper: budgets 500/500
instead of 200/200, pass count 13 instead of 2. The assertion was satisfied
while the subject had silently moved to the parent workspace. The fixtures are
what needed changing; both now scaffold one level down, as every other fixture
in that file already does.

## Tests

- `src/server/studio-project-scopes.test.ts` (new): boots a real server three
  ways and asserts the rail's own three-step join over the state the SPA receives
  — for every root `projectRoots` returns, a scope exists at that exact root whose
  `projectId` names a project in `studioProjects`.
  - launching INSIDE an agent folder (the bug)
  - launching AT a folder that holds agents (control)
  - recentDirs already naming the holding folders (control)
  - **Mutation-tested**: reverting `index.ts` to the raw candidate list fails test
    1 at the scope lookup (`expected null to be '…/property-ops'`) and leaves the
    two controls green. It is not a count assertion that passes when nothing
    happened.
- `pnpm test:ui` — 497 passed / 0 failed (baseline on `origin/main`: 497 / 0).
- `pnpm test` (vitest) — 14 failed / 3295 passed. Baseline on `origin/main` on the
  same machine: 13 failed / 3293 passed, in the **same six files**
  (`workflow-registry`, `system-graph-relationships`, `system-graph-watcher`,
  `workspace-watcher`, `agent-source-discovery`, `system-graph-freshness`), all
  sleep/watcher timing. Pre-existing, load-dependent; not from this change.
- `pnpm typecheck` clean. `pnpm lint` is `eslint src` and does not reach
  `web/src`, so it says nothing about most of this diff.

## One ordering note

`startServer` does not await the boot agent scan, and the derivation reads the
agent registry: before the first scan lands, an agent folder looks like an
ordinary folder and would be registered as its own project. In practice the scan
beats the first `/api/state` — the real-server run above produced exactly one
durable project with no stray — but the new spec waits for the scan rather than
pretending the race is not there.
