### PR TITLE
fix(harness): keep new-agent prompts in builder sessions

### DIFF
--- a/.changeset/manual-builder-session.md
+++ b/.changeset/manual-builder-session.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/harness": patch
+"@sapiom/harness-desktop": patch
+---
+
+Keep new-agent composer submissions in their standalone coding session instead of automatically switching to Plan Agents.

--- a/packages/harness/web/e2e/new-session-composer.spec.ts
+++ b/packages/harness/web/e2e/new-session-composer.spec.ts
@@ -9,6 +9,8 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
+import { selectMockSessionFromPalette } from "./mock-navigation";
+
 const lastInjectText = (page: Page): Promise<string> =>
   page.evaluate(
     () =>
@@ -108,9 +110,7 @@ test("describing an outcome starts a session and hands the agent that outcome", 
 test("Enter keeps a new-agent prompt in its standalone builder until Plan Agents is explicitly selected", async ({
   page,
 }) => {
-  await page.goto(
-    "/?seed=0&mockNoLiveSessions=1&mockStudioProjects=present",
-  );
+  await page.goto("/?seed=0&mockNoLiveSessions=1&mockStudioProjects=present");
   await expect(page.locator(".rail-workflows")).toBeVisible();
   // The parent project exists, but with no live session it has never restored
   // its default Plan Agents workspace. Creating beneath it must not give that
@@ -150,6 +150,68 @@ test("Enter keeps a new-agent prompt in its standalone builder until Plan Agents
     .poll(async () => (await sessionEvidence(page)).openPlannerSessionCalls)
     .toBe(before.openPlannerSessionCalls + 1);
   await expect(planAgents).toHaveAttribute("aria-pressed", "true");
+});
+
+test("returning to an in-progress standalone builder does not restore Plan Agents", async ({
+  page,
+}) => {
+  await page.goto("/?seed=0&mockStudioProjects=present");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+  await expect
+    .poll(async () => (await sessionEvidence(page)).openPlannerSessionCalls)
+    .toBeGreaterThan(0);
+  await expect
+    .poll(async () => {
+      const evidence = await sessionEvidence(page);
+      return evidence.createSessionCalls - evidence.openPlannerSessionCalls;
+    })
+    .toBe(0);
+  const before = await sessionEvidence(page);
+
+  await page.getByTestId("rail-create-new").click();
+  const idea = "Build a revisit guard agent.";
+  await page.getByTestId("composer-input").fill(idea);
+  await page.getByTestId("composer-input").press("Enter");
+
+  const pendingBuilder = page.locator('[data-testid^="workspace-pending-"]');
+  await expect(pendingBuilder).toBeVisible();
+  await expect
+    .poll(async () => (await sessionEvidence(page)).createSessionCalls)
+    .toBe(before.createSessionCalls + 1);
+  await expect(pendingBuilder).toHaveCount(0);
+  // createSession() has selected the builder but has not finished the catalog
+  // refresh yet, so moving now exercises the intent's bounded lifetime.
+  await expect(page.getByTestId("new-session-composer")).toBeVisible();
+  await selectMockSessionFromPalette(page, "scratch");
+  await expect(page.getByTestId("session-context")).toHaveAttribute(
+    "data-session-id",
+    /.+/,
+  );
+  const awaySessionId = (await sessionEvidence(page)).activeSessionId!;
+  await expect
+    .poll(async () => (await sessionEvidence(page)).injectedText)
+    .toContain(idea);
+  // Let the session we deliberately visited finish its own normal restore;
+  // only planner work caused by returning to the builder is under test.
+  await page.waitForTimeout(500);
+  const beforeReturn = await sessionEvidence(page);
+
+  await selectMockSessionFromPalette(page, "build-revisit-guard");
+  await expect(page.getByTestId("session-context")).toHaveAttribute(
+    "data-session-id",
+    /.+/,
+  );
+  expect((await sessionEvidence(page)).activeSessionId).not.toBe(awaySessionId);
+  await page.waitForTimeout(500);
+  const afterReturn = await sessionEvidence(page);
+  expect(afterReturn.openPlannerSessionCalls).toBe(
+    beforeReturn.openPlannerSessionCalls,
+  );
+  await expect(
+    page
+      .getByTestId("workspace-group-acme-app/projects/build-revisit-guard")
+      .getByTestId("agent-map-select"),
+  ).toHaveAttribute("aria-pressed", "false");
 });
 
 test("a picked file reaches the first request without naming the project", async ({

--- a/packages/harness/web/e2e/new-session-composer.spec.ts
+++ b/packages/harness/web/e2e/new-session-composer.spec.ts
@@ -54,7 +54,7 @@ const sessionEvidence = (
       activeSessionId:
         document
           .querySelector('[data-testid="session-context"]')
-          ?.getAttribute("data-session-id") ?? null,
+          ?.getAttribute("data-session-id") || null,
       createSessionCalls: testState?.createSessionCalls?.length ?? 0,
       injectInputCalls: testState?.injectInputCalls?.length ?? 0,
       injectedSessionId: testState?.lastInjectInput?.id ?? null,
@@ -108,20 +108,18 @@ test("describing an outcome starts a session and hands the agent that outcome", 
 test("Enter keeps a new-agent prompt in its standalone builder until Plan Agents is explicitly selected", async ({
   page,
 }) => {
-  await page.goto("/?seed=0&mockStudioProjects=present");
+  await page.goto(
+    "/?seed=0&mockNoLiveSessions=1&mockStudioProjects=present",
+  );
   await expect(page.locator(".rail-workflows")).toBeVisible();
-  // Let the existing project's default Plan Agents workspace settle first.
-  // The regression was a SECOND planner opened for the new builder's root.
-  await expect
-    .poll(async () => (await sessionEvidence(page)).openPlannerSessionCalls)
-    .toBeGreaterThan(0);
-  await expect
-    .poll(async () => {
-      const evidence = await sessionEvidence(page);
-      return evidence.createSessionCalls - evidence.openPlannerSessionCalls;
-    })
-    .toBe(0);
+  // The parent project exists, but with no live session it has never restored
+  // its default Plan Agents workspace. Creating beneath it must not give that
+  // parent restore a head start over the explicit standalone builder intent.
+  await expect(page.getByTestId("workspace-group-acme-app")).toBeVisible();
   const before = await sessionEvidence(page);
+  expect(before.activeSessionId).toBeNull();
+  expect(before.createSessionCalls).toBe(0);
+  expect(before.openPlannerSessionCalls).toBe(0);
 
   await page.getByTestId("rail-create-new").click();
   const idea = "Build a sales outreach agent.";

--- a/packages/harness/web/e2e/new-session-composer.spec.ts
+++ b/packages/harness/web/e2e/new-session-composer.spec.ts
@@ -29,6 +29,40 @@ const injectCallCount = (page: Page): Promise<number> =>
       ).__HARNESS_TEST__?.injectInputCalls?.length ?? 0,
   );
 
+const sessionEvidence = (
+  page: Page,
+): Promise<{
+  activeSessionId: string | null;
+  createSessionCalls: number;
+  injectInputCalls: number;
+  injectedSessionId: string | null;
+  injectedText: string;
+  openPlannerSessionCalls: number;
+}> =>
+  page.evaluate(() => {
+    const testState = (
+      window as unknown as {
+        __HARNESS_TEST__?: {
+          createSessionCalls?: unknown[];
+          injectInputCalls?: unknown[];
+          lastInjectInput?: { id?: string; req?: { text?: string } };
+          openPlannerSessionCalls?: unknown[];
+        };
+      }
+    ).__HARNESS_TEST__;
+    return {
+      activeSessionId:
+        document
+          .querySelector('[data-testid="session-context"]')
+          ?.getAttribute("data-session-id") ?? null,
+      createSessionCalls: testState?.createSessionCalls?.length ?? 0,
+      injectInputCalls: testState?.injectInputCalls?.length ?? 0,
+      injectedSessionId: testState?.lastInjectInput?.id ?? null,
+      injectedText: testState?.lastInjectInput?.req?.text ?? "",
+      openPlannerSessionCalls: testState?.openPlannerSessionCalls?.length ?? 0,
+    };
+  });
+
 test.beforeEach(async ({ page }) => {
   await page.goto("/?seed=0");
   await expect(page.locator(".rail-workflows")).toBeVisible();
@@ -69,6 +103,55 @@ test("describing an outcome starts a session and hands the agent that outcome", 
   await expect
     .poll(() => lastInjectText(page))
     .toContain("Diff our competitors' pricing pages");
+});
+
+test("Enter keeps a new-agent prompt in its standalone builder until Plan Agents is explicitly selected", async ({
+  page,
+}) => {
+  await page.goto("/?seed=0&mockStudioProjects=present");
+  await expect(page.locator(".rail-workflows")).toBeVisible();
+  // Let the existing project's default Plan Agents workspace settle first.
+  // The regression was a SECOND planner opened for the new builder's root.
+  await expect
+    .poll(async () => (await sessionEvidence(page)).openPlannerSessionCalls)
+    .toBeGreaterThan(0);
+  await expect
+    .poll(async () => {
+      const evidence = await sessionEvidence(page);
+      return evidence.createSessionCalls - evidence.openPlannerSessionCalls;
+    })
+    .toBe(0);
+  const before = await sessionEvidence(page);
+
+  await page.getByTestId("rail-create-new").click();
+  const idea = "Build a sales outreach agent.";
+  await page.getByTestId("composer-input").fill(idea);
+  await page.getByTestId("composer-input").press("Enter");
+
+  await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
+  await expect
+    .poll(async () => (await sessionEvidence(page)).injectedText)
+    .toContain(idea);
+
+  const evidence = await sessionEvidence(page);
+  expect(evidence.createSessionCalls).toBe(before.createSessionCalls + 1);
+  expect(evidence.openPlannerSessionCalls).toBe(before.openPlannerSessionCalls);
+  expect(evidence.injectedSessionId).not.toBeNull();
+  expect(evidence.activeSessionId).toBe(evidence.injectedSessionId);
+  expect(evidence.activeSessionId).not.toBe(before.activeSessionId);
+  expect(evidence.injectInputCalls).toBe(before.injectInputCalls + 1);
+
+  const project = page.getByTestId(
+    "workspace-group-acme-app/projects/build-sales-outreach",
+  );
+  const planAgents = project.getByTestId("agent-map-select");
+  await expect(planAgents).toHaveAttribute("aria-pressed", "false");
+
+  await planAgents.click();
+  await expect
+    .poll(async () => (await sessionEvidence(page)).openPlannerSessionCalls)
+    .toBe(before.openPlannerSessionCalls + 1);
+  await expect(planAgents).toHaveAttribute("aria-pressed", "true");
 });
 
 test("a picked file reaches the first request without naming the project", async ({

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -227,6 +227,8 @@ const HELD_PROMPT_HINT_DELAY_MS = 4_000;
 interface CreateSessionAtOptions {
   /** Keep the create-new queue mounted while inline files are materialized. */
   keepComposerOpen?: boolean;
+  /** Keep an explicit new-agent builder active when its root joins Studio. */
+  standaloneBuilder?: boolean;
 }
 
 /**
@@ -293,6 +295,11 @@ export const App = (): JSX.Element => {
   );
   const [studioSelection, setStudioSelection] =
     useState<StudioWorkspaceSelection | null>(null);
+  // A global create-new submit is a request to BUILD in a generic session,
+  // not a project visit whose saved/default workspace should be restored.
+  // Key by root because createSession() refreshes Studio's project catalog
+  // before it returns the session to this component.
+  const pendingStandaloneBuilderRootsRef = useRef(new Set<string>());
   const restoredStudioProjectsRef = useRef(new Set<string>());
   const studioRestoreGenerationRef = useRef(0);
   const plannerProjectId =
@@ -368,6 +375,19 @@ export const App = (): JSX.Element => {
       restoredStudioProjectsRef.current.has(project.projectId)
     )
       return;
+    // Only consume the intent once Studio has issued an identity for the
+    // exact new root. A parent project can temporarily be the best scope while
+    // createSession() is still refreshing the catalog; consuming it there
+    // would let the later exact project fall through to its Agent Map default.
+    const standaloneBuilderRoot = [
+      ...pendingStandaloneBuilderRootsRef.current,
+    ].find((root) => samePath(root, active.cwd) && samePath(root, scope.cwd));
+    if (standaloneBuilderRoot) {
+      pendingStandaloneBuilderRootsRef.current.delete(standaloneBuilderRoot);
+      restoredStudioProjectsRef.current.add(project.projectId);
+      studioRestoreGenerationRef.current += 1;
+      return;
+    }
     restoredStudioProjectsRef.current.add(project.projectId);
     const generation = ++studioRestoreGenerationRef.current;
     void harness.api
@@ -1730,6 +1750,9 @@ export const App = (): JSX.Element => {
     // the real session/agent lands (see the store's pruning effect).
     harness.addPendingWorkspace(cwd);
     closeMobileDrawer();
+    if (options.standaloneBuilder) {
+      pendingStandaloneBuilderRootsRef.current.add(cwd);
+    }
     try {
       const session = await harness.createSession({
         cwd,
@@ -1742,6 +1765,9 @@ export const App = (): JSX.Element => {
       });
       return session;
     } catch (err) {
+      if (options.standaloneBuilder) {
+        pendingStandaloneBuilderRootsRef.current.delete(cwd);
+      }
       harness.removePendingWorkspace(cwd);
       throw err;
     }
@@ -2102,6 +2128,7 @@ export const App = (): JSX.Element => {
     setRightCollapsed(true);
     const session = await createSessionAt(cwd, agentHarness, {
       keepComposerOpen: true,
+      standaloneBuilder: true,
     });
     try {
       const resolved = await materializeAttachments(
@@ -2122,6 +2149,7 @@ export const App = (): JSX.Element => {
       await harness.closeSession(session.id).catch((rollbackError: unknown) => {
         console.error("[harness] attachment rollback failed:", rollbackError);
       });
+      pendingStandaloneBuilderRootsRef.current.delete(cwd);
       harness.removePendingWorkspace(cwd);
       throw error;
     }

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -296,10 +296,13 @@ export const App = (): JSX.Element => {
   const [studioSelection, setStudioSelection] =
     useState<StudioWorkspaceSelection | null>(null);
   // A global create-new submit is a request to BUILD in a generic session,
-  // not a project visit whose saved/default workspace should be restored.
-  // Key by root because createSession() refreshes Studio's project catalog
-  // before it returns the session to this component.
-  const pendingStandaloneBuilderRootsRef = useRef(new Set<string>());
+  // not a project visit whose saved/default workspace should be restored. The
+  // session id is null until createSession() selects the new session; binding
+  // it then prevents a later, unrelated visit to the same root from consuming
+  // stale intent when catalog refresh fails or the user switches away.
+  const pendingStandaloneBuilderSessionsRef = useRef(
+    new Map<string, string | null>(),
+  );
   const restoredStudioProjectsRef = useRef(new Set<string>());
   const studioRestoreGenerationRef = useRef(0);
   const plannerProjectId =
@@ -360,6 +363,36 @@ export const App = (): JSX.Element => {
     const active = state?.sessions.find(
       (session) => session.id === harness.activeSessionId,
     );
+
+    // Bind the intent as soon as createSession() selects its session — before
+    // that call's slower recent-directory/catalog refresh finishes. Once
+    // bound, leaving or exiting that session expires the one-shot intent.
+    for (const [
+      root,
+      sessionId,
+    ] of pendingStandaloneBuilderSessionsRef.current) {
+      if (sessionId === null) {
+        if (
+          active &&
+          active.status !== "exited" &&
+          samePath(root, active.cwd)
+        ) {
+          pendingStandaloneBuilderSessionsRef.current.set(root, active.id);
+        }
+        continue;
+      }
+      const builder = state?.sessions.find(
+        (session) => session.id === sessionId,
+      );
+      if (
+        !builder ||
+        builder.status === "exited" ||
+        harness.activeSessionId !== sessionId
+      ) {
+        pendingStandaloneBuilderSessionsRef.current.delete(root);
+      }
+    }
+
     if (!state?.studioProjects || !active) return;
     const scope = mostSpecificStudioScope(
       active.boundWorkflowPath ?? active.cwd,
@@ -369,25 +402,27 @@ export const App = (): JSX.Element => {
     const project = state.studioProjects.find(
       (candidate) => candidate.projectId === scope?.projectId,
     );
-    if (
-      !scope?.projectId ||
-      !project ||
-      restoredStudioProjectsRef.current.has(project.projectId)
-    )
-      return;
-    // Only consume the intent once Studio has issued an identity for the
-    // exact new root. A parent project can temporarily be the best scope while
-    // createSession() is still refreshing the catalog; consuming it there
-    // would let the later exact project fall through to its Agent Map default.
+    if (!scope?.projectId || !project) return;
     const standaloneBuilderRoot = [
-      ...pendingStandaloneBuilderRootsRef.current,
-    ].find((root) => samePath(root, active.cwd) && samePath(root, scope.cwd));
+      ...pendingStandaloneBuilderSessionsRef.current,
+    ].find(
+      ([root, sessionId]) =>
+        sessionId === active.id && isWithinDir(scope.cwd, root),
+    )?.[0];
     if (standaloneBuilderRoot) {
-      pendingStandaloneBuilderRootsRef.current.delete(standaloneBuilderRoot);
-      restoredStudioProjectsRef.current.add(project.projectId);
-      studioRestoreGenerationRef.current += 1;
+      // Before the new root has a durable Studio identity, its containing
+      // parent is the most-specific scope. Suppress that restore without
+      // consuming the intent; only the exact-root identity completes it.
+      if (samePath(standaloneBuilderRoot, scope.cwd)) {
+        pendingStandaloneBuilderSessionsRef.current.delete(
+          standaloneBuilderRoot,
+        );
+        restoredStudioProjectsRef.current.add(project.projectId);
+        studioRestoreGenerationRef.current += 1;
+      }
       return;
     }
+    if (restoredStudioProjectsRef.current.has(project.projectId)) return;
     restoredStudioProjectsRef.current.add(project.projectId);
     const generation = ++studioRestoreGenerationRef.current;
     void harness.api
@@ -1751,13 +1786,22 @@ export const App = (): JSX.Element => {
     harness.addPendingWorkspace(cwd);
     closeMobileDrawer();
     if (options.standaloneBuilder) {
-      pendingStandaloneBuilderRootsRef.current.add(cwd);
+      pendingStandaloneBuilderSessionsRef.current.set(cwd, null);
+      // Explicit create-new intent supersedes any preference read still in
+      // flight for the session/project the user just left.
+      studioRestoreGenerationRef.current += 1;
     }
     try {
       const session = await harness.createSession({
         cwd,
         harness: agentHarness,
       });
+      if (
+        options.standaloneBuilder &&
+        pendingStandaloneBuilderSessionsRef.current.get(cwd) === null
+      ) {
+        pendingStandaloneBuilderSessionsRef.current.set(cwd, session.id);
+      }
       track("session.created");
       trackProduct("session.started", {
         harness_kind: agentHarness,
@@ -1766,7 +1810,7 @@ export const App = (): JSX.Element => {
       return session;
     } catch (err) {
       if (options.standaloneBuilder) {
-        pendingStandaloneBuilderRootsRef.current.delete(cwd);
+        pendingStandaloneBuilderSessionsRef.current.delete(cwd);
       }
       harness.removePendingWorkspace(cwd);
       throw err;
@@ -2149,7 +2193,7 @@ export const App = (): JSX.Element => {
       await harness.closeSession(session.id).catch((rollbackError: unknown) => {
         console.error("[harness] attachment rollback failed:", rollbackError);
       });
-      pendingStandaloneBuilderRootsRef.current.delete(cwd);
+      pendingStandaloneBuilderSessionsRef.current.delete(cwd);
       harness.removePendingWorkspace(cwd);
       throw error;
     }

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -366,7 +366,8 @@ export const App = (): JSX.Element => {
 
     // Bind the intent as soon as createSession() selects its session — before
     // that call's slower recent-directory/catalog refresh finishes. Once
-    // bound, leaving or exiting that session expires the one-shot intent.
+    // bound, the session id makes the intent safe to retain across focus
+    // changes; only that session disappearing or exiting expires it.
     for (const [
       root,
       sessionId,
@@ -384,11 +385,7 @@ export const App = (): JSX.Element => {
       const builder = state?.sessions.find(
         (session) => session.id === sessionId,
       );
-      if (
-        !builder ||
-        builder.status === "exited" ||
-        harness.activeSessionId !== sessionId
-      ) {
+      if (!builder || builder.status === "exited") {
         pendingStandaloneBuilderSessionsRef.current.delete(root);
       }
     }


### PR DESCRIPTION
## Summary
Keep Create new agent submissions in the standalone coding session that receives the submitted prompt. Prevent project preference restoration from replacing it with a Plan Agents session.

## Changes
- Record standalone-builder intent before the generic session and project catalog refresh begin.
- Suppress containing parent-project restores until Studio resolves the exact new project root.
- Bind the one-shot intent to the created session, retain it across focus changes, and expire it only when that session exits or disappears.
- Preserve normal explicit Plan Agents entry and clean up failed creation attempts.
- Add regression coverage for an unrestored parent project and for leaving and returning before catalog refresh completes.
- Add patch changesets for the harness and desktop app.

## Testing
- [x] pnpm --filter @sapiom/harness typecheck
- [x] pnpm --filter @sapiom/harness build
- [x] Composer Playwright suite: 18 passed
- [x] Parent-race regression repeated 5 times: 5 passed
- [x] Revisit regression repeated 5 times: 5 passed
- [x] Regressions verified red before their fixes and green afterward

## Screenshots
Not applicable; this changes session selection behavior without changing visuals.

## Checklist
- [x] Code follows project guidelines
- [x] No hardcoded secrets
- [x] Self-reviewed