### PR TITLE
feat(harness): one create verb, and the folder step comes first [SAP-3143]

### DIFF
--- a/.changeset/one-create-verb.md
+++ b/.changeset/one-create-verb.md
@@ -2,4 +2,4 @@
 "@sapiom/harness": minor
 ---
 
-Collapse the rail's three folder-or-create controls into ONE create verb on the Projects header, whose first step is where the agent lives: a project you already have, or a folder you pick. On desktop that folder step opens the OS folder browser directly instead of a dialog wrapping a text field. Creation then goes to that project's Agent Map, the same route project rows already take, so the rail's most prominent control no longer reaches the English scaffold prompt injected into the agent terminal. Registering a folder that already holds agents moves into the rail's settings menu.
+One `+` on the rail's Projects header creates an agent, and its first step asks which project or folder it belongs to. It replaces the "Create new agent" button and the header's separate "add a project" control. On the desktop app that folder step opens the system folder browser instead of a dialog with a path field. Registering a folder that already holds agents moved into the rail's ⋮ menu.

--- a/.changeset/one-create-verb.md
+++ b/.changeset/one-create-verb.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": minor
+---
+
+Collapse the rail's three folder-or-create controls into ONE create verb on the Projects header, whose first step is where the agent lives: a project you already have, or a folder you pick. On desktop that folder step opens the OS folder browser directly instead of a dialog wrapping a text field. Creation then goes to that project's Agent Map, the same route project rows already take, so the rail's most prominent control no longer reaches the English scaffold prompt injected into the agent terminal. Registering a folder that already holds agents moves into the rail's settings menu.

--- a/.changeset/palette-over-dialog.md
+++ b/.changeset/palette-over-dialog.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+The command palette no longer opens on top of an open dialog. Pressing its shortcut while a dialog is up used to stack the palette over it, and pressing Tab then walked out of the palette into the dialog behind. The shortcut now does nothing while a dialog is open, and is not handed to the browser. It still opens the palette over the Overview, which is unchanged.

--- a/packages/harness/web/e2e/accumulation-guard.spec.ts
+++ b/packages/harness/web/e2e/accumulation-guard.spec.ts
@@ -22,7 +22,7 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
-import { openProjectMenu } from "./mock-navigation";
+import { openProjectMenu, openAddExistingAgents } from "./mock-navigation";
 
 const ACME = "/Users/demo/acme-app";
 
@@ -250,7 +250,7 @@ test.describe("Remove project", () => {
     await page.getByTestId("remove-project-confirm-btn").click();
     await expect(page.getByTestId("workspace-group-acme-app")).toHaveCount(0);
 
-    await page.getByTestId("add-existing-agents").click();
+    await openAddExistingAgents(page);
     await page.getByTestId("folder-field-input").fill(`${ACME}/leasing`);
     await page.getByTestId("aw-add").click();
 

--- a/packages/harness/web/e2e/consent.spec.ts
+++ b/packages/harness/web/e2e/consent.spec.ts
@@ -196,8 +196,10 @@ test.describe("UI event tracking (track() calls)", () => {
   });
 
   test("new session creation emits track('session.created')", async ({ page }) => {
-    // Creating a new agent starts a session from the composer.
-    await page.getByTestId("rail-create-new").click();
+    // The composer is the app's home screen — what it shows with no session, no
+    // agent and nothing selected — rather than something the rail opens. The
+    // rail's create verb goes to a project's Agent Map instead.
+    await page.goto("/?mockState=fresh&mockStudioProjects=absent");
     await expect(page.getByTestId("new-session-composer")).toBeVisible();
     await page.getByTestId("composer-input").fill("Summarize new issues each morning.");
     await page.getByTestId("composer-send").click();

--- a/packages/harness/web/e2e/create-agent.spec.ts
+++ b/packages/harness/web/e2e/create-agent.spec.ts
@@ -26,7 +26,7 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
-import { openProjectMenu } from "./mock-navigation";
+import { openAddExistingAgents, openProjectMenu } from "./mock-navigation";
 
 const ROOT = "/Users/demo/acme-app";
 
@@ -202,7 +202,11 @@ test.describe("legacy-server agent creation compatibility", () => {
   test("the empty-project row opens the same dialog", async ({ page }) => {
     // One create flow, not one per door: the empty project's CTA is the same
     // subject and must not be a second mechanism that drifts.
-    await page.getByTestId("rail-add-project").click();
+    // Through the ⋮, not the create verb: the verb's folder step CONTINUES
+    // into creation once the folder is named, which is the whole point of it
+    // asking where first. This test needs the folder registered and nothing
+    // else, so it asks the other question.
+    await openAddExistingAgents(page);
     await page
       .getByTestId("folder-field-input")
       .fill("/Users/demo/blank-slate");

--- a/packages/harness/web/e2e/create-verb.spec.ts
+++ b/packages/harness/web/e2e/create-verb.spec.ts
@@ -191,4 +191,54 @@ test.describe("⌘K over an open dialog", () => {
     await page.keyboard.press("ControlOrMeta+k");
     await expect(page.getByTestId("command-palette-input")).toBeVisible();
   });
+
+  test("⌘P over a dialog is swallowed, not handed to the browser", async ({
+    page,
+  }) => {
+    // THE SAME HANDLER OWNS ⌘P, and ⌘P is the browser's PRINT shortcut. A guard
+    // that returns early WITHOUT preventing the event stops the palette and
+    // hands ⌘P to the browser, which opens a native print preview over the
+    // dialog — worse than the stacking it was added to stop, and invisible to a
+    // spec that only presses ⌘K.
+    //
+    // `defaultPrevented` IS THE ASSERTION, not `beforeprint`. Headless Chromium
+    // never fires `beforeprint` for an unhandled Ctrl+P, so a spec written that
+    // way passes whether or not the event was prevented — measured: it survived
+    // its own mutation. This listener is registered after the app's (same
+    // target, `window`, so registration order decides), and reads what the app
+    // left behind.
+    await page.goto("/?seed=0&mockStudioProjects=absent");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+    await page.evaluate(() => {
+      const win = window as unknown as { __printKey?: boolean | null };
+      win.__printKey = null;
+      window.addEventListener("keydown", (event) => {
+        if (!(event.metaKey || event.ctrlKey)) return;
+        if (event.key.toLowerCase() !== "p") return;
+        // READ AFTER DISPATCH, not during. The app re-subscribes its handler on
+        // re-render, so a listener added from a spec is not reliably last and
+        // reading `defaultPrevented` inline can sample before the app has acted.
+        // The flag stays set on the event object once dispatch completes.
+        setTimeout(() => {
+          win.__printKey = event.defaultPrevented;
+        }, 0);
+      });
+    });
+
+    await page.getByTestId("rail-create-new").click();
+    await page.getByTestId("new-agent-in-acme-app").click();
+    await expect(page.getByTestId("create-agent-dialog")).toBeVisible();
+
+    await page.keyboard.press("ControlOrMeta+p");
+    await expect(page.getByTestId("command-palette-input")).toHaveCount(0);
+    await expect(page.getByTestId("create-agent-dialog")).toBeVisible();
+    // Seen by the listener, and prevented by the app during dispatch.
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __printKey?: boolean | null }).__printKey,
+        ),
+      )
+      .toBe(true);
+  });
 });

--- a/packages/harness/web/e2e/create-verb.spec.ts
+++ b/packages/harness/web/e2e/create-verb.spec.ts
@@ -47,6 +47,79 @@ const lastInjectText = (page: Page): Promise<string> =>
   );
 
 test.describe("the create verb lands somewhere", () => {
+  test("both entrances land on the new agent screen, scoped to the project", async ({
+    page,
+  }) => {
+    // THE SWAP THIS PR EXISTS FOR, asserted on both entrances.
+    //
+    // The screen with the good surface had the wrong plumbing (it invented a
+    // folder from a slug and typed English at the coding agent); the path with
+    // the right plumbing had no surface. One screen now, two ways in.
+    await page.goto("/?seed=0");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    // ENTRANCE ONE: a project you already have.
+    await page.getByTestId("rail-create-new").click();
+    await page.getByTestId("new-agent-in-acme-app").click();
+    await expect(page.getByTestId("new-session-composer")).toBeVisible();
+    // It NAMES the project, so the second entrance cannot leave you guessing
+    // where the agent will live.
+    await expect(page.getByTestId("composer-greeting")).toContainText(
+      "in acme-app",
+    );
+
+    // ENTRANCE TWO: a folder that is not a project yet. On the browser host the
+    // folder step falls back to the dialog; on desktop it is the OS picker and
+    // no dialog opens (`folder-step.test.ts` covers that half).
+    await page.goto("/?seed=0");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+    await page.getByTestId("rail-create-new").click();
+    await page.getByTestId("new-agent-choose-folder").click();
+    await page
+      .getByTestId("folder-field-input")
+      .fill("/Users/demo/blank-slate");
+    await page.getByTestId("open-project").click();
+    await expect(page.getByTestId("new-session-composer")).toBeVisible();
+    await expect(page.getByTestId("composer-greeting")).toContainText(
+      "in blank-slate",
+    );
+  });
+
+  test("submitting in a project dispatches the planner and types no English", async ({
+    page,
+  }) => {
+    await page.goto("/?seed=0");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+    await page.getByTestId("rail-create-new").click();
+    await page.getByTestId("new-agent-in-acme-app").click();
+    await expect(page.getByTestId("new-session-composer")).toBeVisible();
+
+    const before = await page.evaluate(
+      () =>
+        ((window as unknown as { __HARNESS_TEST__?: { openPlannerSessionCalls?: unknown[] } })
+          .__HARNESS_TEST__?.openPlannerSessionCalls ?? []).length,
+    );
+    const idea = "Diff our competitors' pricing pages weekly.";
+    await page.getByTestId("composer-input").fill(idea);
+    await page.getByTestId("composer-send").click();
+
+    // The planner opened for this project...
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            ((window as unknown as { __HARNESS_TEST__?: { openPlannerSessionCalls?: unknown[] } })
+              .__HARNESS_TEST__?.openPlannerSessionCalls ?? []).length,
+        ),
+      )
+      .toBeGreaterThan(before);
+    // ...and what reached it is the user's own sentence, not a request that the
+    // coding agent please call a scaffold tool. `composerScaffoldPrompt` names
+    // the tool explicitly, so its absence is checkable rather than inferred.
+    await expect.poll(() => lastInjectText(page)).toContain(idea);
+    expect(await lastInjectText(page)).not.toContain("sapiom_dev_agents");
+  });
+
   test("a project with an Agent Map: the verb opens that map", async ({
     page,
   }) => {

--- a/packages/harness/web/e2e/create-verb.spec.ts
+++ b/packages/harness/web/e2e/create-verb.spec.ts
@@ -1,0 +1,194 @@
+/**
+ * THE ONE CREATE VERB, and where each of its branches actually lands.
+ *
+ * `handleNewAgentIn` (App.tsx) is this PR's whole payload and nothing asserted
+ * it. Every spec the change touched was updated to assert the MENU OPENING,
+ * which is the step before the one that matters — a handler that resolved the
+ * wrong scope and fell through to the compatibility dialog with the wrong
+ * project's name would have left the whole suite green.
+ *
+ * So these assert the destination, on both branches and on the folder step:
+ *
+ *  1. a project WITH a durable Studio project → its Agent Map, which is what
+ *     owns creation inside a project (#790). `agent-map-select` is pressed and
+ *     the map frame is the right pane's subject.
+ *  2. a project WITHOUT one (`mockStudioProjects=absent`, the legacy payload) →
+ *     the create dialog, NAMING THAT PROJECT. The name is asserted because the
+ *     documented failure is falling through silently with the wrong one.
+ *  3. the web folder step continues into 1 rather than merely registering the
+ *     folder, which is the difference between the verb and the ⋮'s "Add
+ *     existing agents".
+ *  4. a failure anywhere in it is reported. Both call sites are
+ *     `void onNewAgentIn(...)` from a control that has already closed its
+ *     popover, so an unhandled rejection is a dead end with no symptom.
+ */
+import { expect, test } from "@playwright/test";
+import type { Page } from "@playwright/test";
+
+/** Everything the app has done to create things, in order — the same probe
+ *  `create-agent.spec.ts` reads, so "and it created nothing" is checkable. */
+const createOrder = (page: Page): Promise<string[]> =>
+  page.evaluate(
+    () =>
+      ((window as unknown as { __HARNESS_TEST__?: { createOrder?: string[] } })
+        .__HARNESS_TEST__?.createOrder ?? []) as string[],
+  );
+
+/** The prompt text last injected into a session, if any. The verb must never
+ *  produce one: that is the mechanism SAP-2981 exists to remove. */
+const lastInjectText = (page: Page): Promise<string> =>
+  page.evaluate(
+    () =>
+      (
+        window as unknown as {
+          __HARNESS_TEST__?: { lastInjectInput?: { req?: { text?: string } } };
+        }
+      ).__HARNESS_TEST__?.lastInjectInput?.req?.text ?? "",
+  );
+
+test.describe("the create verb lands somewhere", () => {
+  test("a project with an Agent Map: the verb opens that map", async ({
+    page,
+  }) => {
+    await page.goto("/?seed=0");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await page.getByTestId("rail-create-new").click();
+    await page.getByTestId("new-agent-in-acme-app").click();
+
+    // THE DESTINATION, not the menu.
+    const group = page.getByTestId("workspace-group-acme-app");
+    await expect(group.getByTestId("agent-map-select")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(page.getByTestId("agent-map-frame")).toBeVisible();
+
+    // AND THE DIALOG NEVER APPEARS, held for a window rather than sampled once.
+    // This is the assertion that separates the two branches, and it has to be
+    // the patient one: on the fall-through the map ALSO ends up selected (the
+    // project-restore effect gets there on its own once the folder is open), so
+    // the map assertions above are true either way and only this one is not.
+    // A single `toHaveCount(0)` raced the dialog's first paint and passed while
+    // the branch was broken — measured, not assumed.
+    await expect
+      .poll(() => page.getByTestId("create-agent-dialog").count(), {
+        timeout: 2_000,
+        intervals: [200, 200, 200, 200, 200, 200, 200, 200, 200, 200],
+      })
+      .toBe(0);
+    await expect(page.getByTestId("create-agent-dialog")).toHaveCount(0);
+
+    // NO AGENT WAS SCAFFOLDED BEHIND IT, and no English was typed at anybody.
+    // Not "nothing happened": landing on the map starts its planner session
+    // (`use-agent-map-entry.ts:400-423` calls `loadPlanner(…, "resume-or-create")`
+    // off the selection), so `createOrder` legitimately carries a `session:`
+    // entry. That session IS the creation surface. What must never appear is a
+    // `scaffold:` — the harness making an agent behind the user's back — or the
+    // prompt injection this verb was rewired to stop reaching.
+    // The planner session is started by an effect off the selection, so it can
+    // land after the map paints. Waited for, not sampled.
+    await expect
+      .poll(() => createOrder(page), { timeout: 10_000 })
+      .toContain("session:/Users/demo/acme-app");
+    const order = await createOrder(page);
+    expect(order.filter((entry) => entry.startsWith("scaffold:"))).toEqual([]);
+    expect(await lastInjectText(page)).not.toContain("sapiom_dev_agents");
+  });
+
+  test("a legacy payload: the verb opens the create dialog, naming that project", async ({
+    page,
+  }) => {
+    await page.goto("/?seed=0&mockStudioProjects=absent");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await page.getByTestId("rail-create-new").click();
+    await page.getByTestId("new-agent-in-acme-app").click();
+
+    await expect(page.getByTestId("create-agent-dialog")).toBeVisible();
+    // THE NAME IS THE ASSERTION. Resolving the wrong scope falls through to
+    // this same dialog carrying the wrong folder's basename, and a spec that
+    // only checked the dialog was visible would pass on exactly that bug.
+    await expect(page.getByTestId("create-agent-project")).toHaveText(
+      "acme-app",
+    );
+    expect(await createOrder(page)).toEqual([]);
+  });
+
+  test("the folder step continues into the flow, it does not just register", async ({
+    page,
+  }) => {
+    // The browser host, which is what Playwright is: the folder step falls back
+    // to the dialog here. On desktop it is the OS picker and no dialog opens —
+    // `folder-step.test.ts` covers that branch, since Electron cannot run here.
+    await page.goto("/?seed=0");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await page.getByTestId("rail-create-new").click();
+    await page.getByTestId("new-agent-choose-folder").click();
+    await expect(page.locator(".modal-start")).toBeVisible();
+    await page
+      .getByTestId("folder-field-input")
+      .fill("/Users/demo/blank-slate");
+    await page.getByTestId("open-project").click();
+
+    // Registering the folder is the ⋮'s job and it stops there. The VERB keeps
+    // going: the new project is open AND its map is the subject.
+    const group = page.getByTestId("workspace-group-blank-slate");
+    await expect(group).toBeVisible();
+    await expect(group.getByTestId("agent-map-select")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(page.getByTestId("agent-map-frame")).toBeVisible();
+  });
+
+  test("a failure is reported, not swallowed", async ({ page }) => {
+    // The verb opens the folder and then RE-READS the workspace to find the
+    // project it just made. The popover has already closed by then, so without
+    // a catch the only trace of a 500 on that read is an unhandled rejection in
+    // a console nobody has open: the control simply does nothing.
+    //
+    // The read, not the settings write, because `rememberProjectDir` swallows
+    // its own 500 by design (`use-harness-state.ts:1503-1513`) and `openProject`
+    // therefore does not reject. Injecting there would have tested nothing.
+    await page.goto("/?seed=0&mockError=stateRefresh");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await page.getByTestId("rail-create-new").click();
+    await page.getByTestId("new-agent-in-acme-app").click();
+
+    await expect(page.getByTestId("toast")).toContainText(
+      /Couldn't open .* to create an agent in/i,
+    );
+    await expect(page.getByTestId("create-agent-dialog")).toHaveCount(0);
+  });
+});
+
+test.describe("⌘K over an open dialog", () => {
+  test("the palette does not stack on top of a dialog", async ({ page }) => {
+    // Found by the dialog-shell work (#800), which stopped at `App.tsx` rather
+    // than reaching into it. The pane-collapse hotkey directly above the ⌘K
+    // handler already bails when a layer is open; ⌘K did not, so the palette
+    // opened over the dialog and native Tab then walked out of the palette into
+    // the dialog behind it. `CommandPalette` carries no `role`, so the guard has
+    // to match `.modal-backdrop` — a role-only selector cannot see it.
+    await page.goto("/?seed=0&mockStudioProjects=absent");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    await page.getByTestId("rail-create-new").click();
+    await page.getByTestId("new-agent-in-acme-app").click();
+    await expect(page.getByTestId("create-agent-dialog")).toBeVisible();
+
+    await page.keyboard.press("ControlOrMeta+k");
+    await expect(page.getByTestId("command-palette-input")).toHaveCount(0);
+    // The dialog is still the top layer and still the thing that has focus.
+    await expect(page.getByTestId("create-agent-dialog")).toBeVisible();
+
+    // And the shortcut is not broken — it works again once the layer is gone.
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("create-agent-dialog")).toHaveCount(0);
+    await page.keyboard.press("ControlOrMeta+k");
+    await expect(page.getByTestId("command-palette-input")).toBeVisible();
+  });
+});

--- a/packages/harness/web/e2e/dismiss.spec.ts
+++ b/packages/harness/web/e2e/dismiss.spec.ts
@@ -5,6 +5,7 @@
  * smoke.spec.ts.
  */
 import { expect, test } from "@playwright/test";
+import { openAddExistingAgents } from "./mock-navigation";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
@@ -81,18 +82,22 @@ test.describe("Start dialog", () => {
   test("closes on Escape and returns focus to the button that spawned it", async ({
     page,
   }) => {
-    await page.getByTestId("add-existing-agents").click();
+    await openAddExistingAgents(page);
     await expect(page.locator(".modal-start")).toBeVisible();
 
     await page.keyboard.press("Escape");
     await expect(page.locator(".modal-start")).toBeHidden();
-    await expect(page.getByTestId("add-existing-agents")).toBeFocused();
+    // The ⋮, because that is the control still on screen. "Add existing agents"
+    // is an item INSIDE that menu now, and the menu closed when the item was
+    // chosen — a `triggerRef` pointing at a detached node restores focus to
+    // <body>, which is the bug this spec exists to catch.
+    await expect(page.getByTestId("history-trigger")).toBeFocused();
   });
 
   test("still closes on a backdrop click, but not on clicks inside the panel", async ({
     page,
   }) => {
-    await page.getByTestId("add-existing-agents").click();
+    await openAddExistingAgents(page);
     await expect(page.locator(".modal-start")).toBeVisible();
 
     await page.getByTestId("folder-field-input").click();

--- a/packages/harness/web/e2e/folder-field.spec.ts
+++ b/packages/harness/web/e2e/folder-field.spec.ts
@@ -12,6 +12,7 @@
  * reaches — the one that now carries the whole picker.
  */
 import { expect, test } from "@playwright/test";
+import { openAddExistingAgents, openFolderStep } from "./mock-navigation";
 
 /** Mirrors the preload's bridge, recording what the SPA asked for. */
 const installDesktopBridge = async (
@@ -42,7 +43,7 @@ test.describe("browser host (npx)", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
     await expect(page.locator(".rail-workflows")).toBeVisible();
-    await page.getByTestId("rail-add-project").click();
+    await openFolderStep(page);
     await expect(page.locator(".modal-start")).toBeVisible();
   });
 
@@ -71,13 +72,19 @@ test.describe("browser host (npx)", () => {
 });
 
 test.describe("desktop host", () => {
+  /* REACHED THROUGH THE ⋮, not the create verb. The verb's folder step now
+     goes STRAIGHT to the OS folder browser when the bridge is there and opens
+     no dialog at all (`lib/folder-step.ts`, unit-tested — Electron cannot run
+     here). The detection dialog behind "Add existing agents" is a different
+     question and still asks it in a panel, which is where `FolderField`'s own
+     desktop behaviour — a Choose button and no datalist — still shows. */
   test("Choose opens the OS folder browser at the current folder, and takes its answer", async ({
     page,
   }) => {
     await installDesktopBridge(page, "/Users/demo/blank-slate");
     await page.goto("/");
     await expect(page.locator(".rail-workflows")).toBeVisible();
-    await page.getByTestId("rail-add-project").click();
+    await openAddExistingAgents(page);
 
     const input = page.getByTestId("folder-field-input");
     await expect(input).toHaveValue("/Users/demo/acme-app/projects");
@@ -102,7 +109,7 @@ test.describe("desktop host", () => {
     await installDesktopBridge(page, null);
     await page.goto("/");
     await expect(page.locator(".rail-workflows")).toBeVisible();
-    await page.getByTestId("rail-add-project").click();
+    await openAddExistingAgents(page);
 
     const input = page.getByTestId("folder-field-input");
     await page.getByTestId("folder-field-choose").click();

--- a/packages/harness/web/e2e/mock-navigation.ts
+++ b/packages/harness/web/e2e/mock-navigation.ts
@@ -56,3 +56,31 @@ export async function openProjectMenu(page: Page, label: string): Promise<void> 
   await page.getByTestId(`project-menu-${label}`).click();
   await expect(page.getByTestId(`project-menu-card-${label}`)).toBeVisible();
 }
+
+/**
+ * Open "Add existing agents".
+ *
+ * It used to be a row in the rail's nav, beside Search and Templates. There is
+ * ONE create verb now — the rail header's `+` — and a nav row that also took a
+ * folder read as a second one, so registering what a folder already holds moved
+ * into the rail's own ⋮ settings menu. Same dialog, same question, one level
+ * deeper and no longer competing with the verb.
+ */
+export async function openAddExistingAgents(page: Page): Promise<void> {
+  await page.getByTestId("history-trigger").click();
+  await page.getByTestId("add-existing-agents").click();
+}
+
+/**
+ * Open the create verb's FOLDER step on a browser host.
+ *
+ * The header `+` no longer opens a folder dialog directly: its first step asks
+ * WHERE the agent lives, offering the projects that already exist plus a way
+ * out to a folder that does not. On desktop that way out is the OS folder
+ * browser and no dialog opens at all (`lib/folder-step.ts`); in Playwright,
+ * which is the browser host by definition, it is this dialog.
+ */
+export async function openFolderStep(page: Page): Promise<void> {
+  await page.getByTestId("rail-create-new").click();
+  await page.getByTestId("new-agent-choose-folder").click();
+}

--- a/packages/harness/web/e2e/new-session-composer.spec.ts
+++ b/packages/harness/web/e2e/new-session-composer.spec.ts
@@ -39,15 +39,29 @@ const injectCallCount = (page: Page): Promise<number> =>
       ).__HARNESS_TEST__?.injectInputCalls?.length ?? 0,
   );
 
+/**
+ * THE COMPOSER IS THE HOME SCREEN, not a create door.
+ *
+ * These specs used to open it by clicking the rail's "Create new agent" CTA.
+ * That control is gone: the rail now has ONE create verb, its first step names
+ * the project, and creation goes to that project's Agent Map — the real path —
+ * rather than to a composer that invents a folder from a slug and then asks the
+ * coding agent, in English, to please scaffold something in it.
+ *
+ * What the composer still is: what the app shows when there is no session, no
+ * agent and nothing selected. `mockState=fresh` is that state, so it is how
+ * these specs reach it now. Every assertion below is unchanged — the subject
+ * was always the composer's own behaviour (attachments, prompt ordering, the
+ * agent picker), never the control that opened it.
+ */
 test.beforeEach(async ({ page }) => {
-  await page.goto("/?seed=0&mockStudioProjects=absent");
-  await expect(page.locator(".rail-workflows")).toBeVisible();
+  await page.goto("/?mockState=fresh&mockStudioProjects=absent");
+  await expect(page.getByTestId("new-session-composer")).toBeVisible();
 });
 
 test("Create new opens the composer with no terminal or canvas, and a chip prefills the box", async ({
   page,
 }) => {
-  await page.getByTestId("rail-create-new").click();
   await expect(page.getByTestId("new-session-composer")).toBeVisible();
 
   // No terminal, no canvas while composing.
@@ -65,7 +79,6 @@ test("Create new opens the composer with no terminal or canvas, and a chip prefi
 test("describing an outcome starts a session and hands the agent that outcome", async ({
   page,
 }) => {
-  await page.getByTestId("rail-create-new").click();
   await page
     .getByTestId("composer-input")
     .fill("Diff our competitors' pricing pages every morning.");
@@ -84,7 +97,6 @@ test("describing an outcome starts a session and hands the agent that outcome", 
 test("a picked file reaches the first request without naming the project", async ({
   page,
 }) => {
-  await page.getByTestId("rail-create-new").click();
   await page.evaluate(() => {
     window.sapiomDesktop = {
       appVersion: "test",
@@ -123,7 +135,6 @@ test("a picked file reaches the first request without naming the project", async
 test("picker, drop, and pathless clipboard files reach one ordered first request", async ({
   page,
 }) => {
-  await page.getByTestId("rail-create-new").click();
   await page.evaluate(() => {
     window.sapiomDesktop = {
       appVersion: "test",
@@ -237,7 +248,6 @@ test("ordinary clipboard text pastes natively without creating an attachment", a
   page,
 }) => {
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
-  await page.getByTestId("rail-create-new").click();
   await page.evaluate(() => navigator.clipboard.writeText("pasted plain text"));
 
   const input = page.getByTestId("composer-input");
@@ -251,7 +261,6 @@ test("ordinary clipboard text pastes natively without creating an attachment", a
 test("attachment controls expose names, live status, and keyboard removal", async ({
   page,
 }) => {
-  await page.getByTestId("rail-create-new").click();
   await page.evaluate(() => {
     window.sapiomDesktop = {
       appVersion: "test",
@@ -289,7 +298,6 @@ test("attachment controls expose names, live status, and keyboard removal", asyn
 test("attachment rows stay contained with touch-sized removal at a narrow viewport", async ({
   page,
 }) => {
-  await page.getByTestId("rail-create-new").click();
   await page.setViewportSize({ width: 360, height: 800 });
   await page.evaluate(() => {
     window.sapiomDesktop = {
@@ -337,7 +345,6 @@ test("attachment rows stay contained with touch-sized removal at a narrow viewpo
 test("re-adding and removing files keeps only the intended first-request paths", async ({
   page,
 }) => {
-  await page.getByTestId("rail-create-new").click();
   await page.evaluate(() => {
     window.sapiomDesktop = {
       appVersion: "test",
@@ -377,7 +384,6 @@ test("re-adding and removing files keeps only the intended first-request paths",
 test("an attachment-only start uses the fallback project and sends the file", async ({
   page,
 }) => {
-  await page.getByTestId("rail-create-new").click();
   await page.evaluate(() => {
     window.sapiomDesktop = {
       appVersion: "test",
@@ -409,7 +415,6 @@ test("an attachment-only start uses the fallback project and sends the file", as
 test("an upload failure rolls back, retains the queue, sends nothing, and retries once", async ({
   page,
 }) => {
-  await page.getByTestId("rail-create-new").click();
   await page.evaluate(() => {
     window.sapiomDesktop = {
       appVersion: "test",
@@ -506,11 +511,10 @@ for (const agent of [
     await page.addInitScript(() => {
       (window as unknown as { __MOCK_WITHHOLD_READY__?: boolean }).__MOCK_WITHHOLD_READY__ = true;
     });
-    await page.goto("/?seed=0&mockStudioProjects=absent");
-    await expect(page.locator(".rail-workflows")).toBeVisible();
+    await page.goto("/?mockState=fresh&mockStudioProjects=absent");
+    await expect(page.getByTestId("new-session-composer")).toBeVisible();
 
-    await page.getByTestId("rail-create-new").click();
-    if (agent.id === "codex") {
+      if (agent.id === "codex") {
       await page.getByTestId("composer-harness-select").click();
       await page.getByTestId("composer-harness-option-codex").click();
       await expect(page.getByTestId("composer-harness-select")).toContainText("Codex");
@@ -565,7 +569,6 @@ for (const agent of [
 test("a new session opens terminal-only; the canvas stays hidden until it has content", async ({
   page,
 }) => {
-  await page.getByTestId("rail-create-new").click();
   await page.getByTestId("composer-input").fill("Build a small thing.");
   await page.getByTestId("composer-send").click();
   await expect(page.getByTestId("agent-view")).toBeVisible();
@@ -600,7 +603,6 @@ test("the new agent's folder appears in the rail at once and is never lost mid-c
   const groups = page.locator(".rail-list .workspace-group");
   const before = await groups.count();
 
-  await page.getByTestId("rail-create-new").click();
   await page
     .getByTestId("composer-input")
     .fill("Diff competitor pricing pages every morning.");
@@ -619,26 +621,18 @@ test("the new agent's folder appears in the rail at once and is never lost mid-c
   await expect(groups).toHaveCount(before + 1);
 });
 
-test("Back returns to the session the composer was opened over", async ({
-  page,
-}) => {
-  await expect(page.getByTestId("session-context")).toHaveAttribute(
-    "data-session-id",
-    "sess-boot",
-  );
-  await page.getByTestId("rail-create-new").click();
+test("the home screen has nothing to go Back to", async ({ page }) => {
+  // This asserted the inverse: the composer was something you OPENED over a
+  // running session, and Back put that session back. It is not opened over
+  // anything any more — the rail's create verb goes to a project's Agent Map,
+  // and the composer is what the app shows when there is no session, no agent
+  // and nothing selected. With nothing underneath, a Back control would be a
+  // door onto an empty room, so there isn't one.
   await expect(page.getByTestId("new-session-composer")).toBeVisible();
-
-  await page.getByTestId("composer-back").click();
-  await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
-  await expect(page.getByTestId("session-context")).toHaveAttribute(
-    "data-session-id",
-    "sess-boot",
-  );
+  await expect(page.getByTestId("composer-back")).toHaveCount(0);
 });
 
 test("the agent selector lists the coding agents", async ({ page }) => {
-  await page.getByTestId("rail-create-new").click();
   const select = page.getByTestId("composer-harness-select");
   await expect(select).toContainText("Claude Code");
 

--- a/packages/harness/web/e2e/new-session-composer.spec.ts
+++ b/packages/harness/web/e2e/new-session-composer.spec.ts
@@ -131,39 +131,36 @@ test("describing an outcome starts a session and hands the agent that outcome", 
     .toContain("Diff our competitors' pricing pages");
 });
 
-/* HELD: these two reach the composer through a door this branch removes.
+/* THE STANDALONE BUILDER, on the branch that still creates one.
  *
- * #802 shipped the standalone-builder intent — a create-new submit is a request
- * to BUILD in a generic session, not a project visit whose saved workspace
- * should be restored — and both specs open the composer with `rail-create-new`
- * on a fixture that HAS projects (`seed=0`). On this branch that control is the
- * create verb: it opens the "where does it live" step, and creation goes to the
- * project's Agent Map. The composer survives only as the home screen, which by
- * definition is the state with no session, no agent and nothing selected, so it
- * is not reachable in a fixture whose whole point is that a parent project
- * already exists. Measured: the composer renders 0 times at both of their URLs.
+ * #802 shipped this: an explicit create-new submit is a request to BUILD in a
+ * generic session, not a project visit whose saved workspace should be restored.
+ * Both specs reached it by pressing the rail's create control on a fixture that
+ * HAS projects. That control is the create verb now, and on a project it lands
+ * on the new agent screen scoped to that project, where submitting dispatches
+ * the planner — so the in-project half of the original scenario is not merely
+ * unreachable, it is deliberately the opposite of what this PR now does there.
  *
- * The BEHAVIOUR they cover is untouched — #802's `App.tsx` changes merged
- * cleanly and are still here. What is gone is the door, and choosing whether
- * the composer keeps one is a product decision on top of two PRs that landed
- * hours apart, not a test edit. Escalated; held rather than deleted so the
- * question is visible in the run rather than absent from it.
+ * WHAT STILL HOLDS, and it is the half these specs are really about: with NO
+ * project there is nothing to dispatch to, so the home screen still creates a
+ * standalone builder, and it still must not be replaced by a Plan Agents
+ * restore when its folder later joins Studio. `mockState=fresh` is that state.
+ * Every assertion below is #802's, unchanged; what moved is the fixture and the
+ * door. The parent-project precondition went with it, because a fixture whose
+ * premise is an existing parent is the in-project case by definition.
+ *
+ * #802's `App.tsx` changes are untouched and still carry this.
  */
-test.fixme("Enter keeps a new-agent prompt in its standalone builder until Plan Agents is explicitly selected", async ({
+test("Enter keeps a new-agent prompt in its standalone builder until Plan Agents is explicitly selected", async ({
   page,
 }) => {
-  await page.goto("/?seed=0&mockNoLiveSessions=1&mockStudioProjects=present");
-  await expect(page.locator(".rail-workflows")).toBeVisible();
-  // The parent project exists, but with no live session it has never restored
-  // its default Plan Agents workspace. Creating beneath it must not give that
-  // parent restore a head start over the explicit standalone builder intent.
-  await expect(page.getByTestId("workspace-group-acme-app")).toBeVisible();
+  await page.goto("/?mockState=fresh&mockStudioProjects=present");
+  await expect(page.getByTestId("new-session-composer")).toBeVisible();
   const before = await sessionEvidence(page);
   expect(before.activeSessionId).toBeNull();
   expect(before.createSessionCalls).toBe(0);
   expect(before.openPlannerSessionCalls).toBe(0);
 
-  await page.getByTestId("rail-create-new").click();
   const idea = "Build a sales outreach agent.";
   await page.getByTestId("composer-input").fill(idea);
   await page.getByTestId("composer-input").press("Enter");
@@ -181,10 +178,15 @@ test.fixme("Enter keeps a new-agent prompt in its standalone builder until Plan 
   expect(evidence.activeSessionId).not.toBe(before.activeSessionId);
   expect(evidence.injectInputCalls).toBe(before.injectInputCalls + 1);
 
-  const project = page.getByTestId(
-    "workspace-group-acme-app/projects/build-sales-outreach",
-  );
-  const planAgents = project.getByTestId("agent-map-select");
+  // The builder's own folder joined the rail and its Plan Agents is NOT
+  // pressed: #802's claim, that an explicit create-new is a request to build
+  // rather than a project visit whose workspace should be restored. Located by
+  // "the one project that just appeared" instead of by the seeded fixture's
+  // folder path, which the no-project home does not produce.
+  const planAgents = page
+    .locator('[data-testid^="workspace-group-"]')
+    .last()
+    .getByTestId("agent-map-select");
   await expect(planAgents).toHaveAttribute("aria-pressed", "false");
 
   await planAgents.click();
@@ -194,23 +196,27 @@ test.fixme("Enter keeps a new-agent prompt in its standalone builder until Plan 
   await expect(planAgents).toHaveAttribute("aria-pressed", "true");
 });
 
+/* STILL HELD, and this one cannot be adjusted without lying.
+ *
+ * It needs BOTH a parent project and the composer as the home screen, and those
+ * two states are mutually exclusive in the product: `App.tsx`'s initial-focus
+ * effect always focuses an agent when any project has one, so the composer is
+ * the home only when there is nothing to focus. It then navigates AWAY to a
+ * second session (`scratch`) to prove the builder's intent survives, which the
+ * no-project fixture has none of.
+ *
+ * Making it pass would mean inventing a mock flag for a state users never
+ * reach — projects present, nothing focused — which would be a spec that is
+ * green against something that cannot happen. Left held with the reason instead,
+ * for Yash to re-aim at the flow that replaced it.
+ */
 test.fixme("returning to an in-progress standalone builder does not restore Plan Agents", async ({
   page,
 }) => {
-  await page.goto("/?seed=0&mockStudioProjects=present");
-  await expect(page.locator(".rail-workflows")).toBeVisible();
-  await expect
-    .poll(async () => (await sessionEvidence(page)).openPlannerSessionCalls)
-    .toBeGreaterThan(0);
-  await expect
-    .poll(async () => {
-      const evidence = await sessionEvidence(page);
-      return evidence.createSessionCalls - evidence.openPlannerSessionCalls;
-    })
-    .toBe(0);
+  await page.goto("/?mockState=fresh&mockStudioProjects=present");
+  await expect(page.getByTestId("new-session-composer")).toBeVisible();
   const before = await sessionEvidence(page);
 
-  await page.getByTestId("rail-create-new").click();
   const idea = "Build a revisit guard agent.";
   await page.getByTestId("composer-input").fill(idea);
   await page.getByTestId("composer-input").press("Enter");

--- a/packages/harness/web/e2e/open-project.spec.ts
+++ b/packages/harness/web/e2e/open-project.spec.ts
@@ -21,7 +21,7 @@
  */
 import { expect, test } from "@playwright/test";
 
-import { openProjectMenu } from "./mock-navigation";
+import { openProjectMenu, openAddExistingAgents, openFolderStep } from "./mock-navigation";
 
 /* A folder that is NOTHING yet: no agent, no session, no recentDirs entry.
    `scratch` cannot play this part — it is the fixture's bare-session project,
@@ -48,7 +48,7 @@ test.describe("the header + opens a project", () => {
   }) => {
     await expect(page.getByTestId("project-row-blank-slate")).toHaveCount(0);
 
-    await page.getByTestId("rail-add-project").click();
+    await openFolderStep(page);
     await expect(page.locator(".modal-start-title")).toHaveText(
       "Add a project",
     );
@@ -91,7 +91,7 @@ test.describe("the header + opens a project", () => {
   test("a planning project hides every standalone agent-creation action", async ({
     page,
   }) => {
-    await page.getByTestId("rail-add-project").click();
+    await openFolderStep(page);
     await page.getByTestId("folder-field-input").fill(BLANK);
     await page.getByTestId("open-project").click();
 
@@ -146,7 +146,7 @@ test.describe("the header + opens a project", () => {
   }) => {
     // One press, because "open this folder" and "show me what's in it" is not
     // a decision worth asking twice.
-    await page.getByTestId("rail-add-project").click();
+    await openFolderStep(page);
     await page
       .getByTestId("folder-field-input")
       .fill("/Users/demo/acme-app/leasing");
@@ -175,7 +175,7 @@ test.describe("the two questions stay two controls", () => {
   test("the nav row still asks the DETECTION question, with its own primary", async ({
     page,
   }) => {
-    await page.getByTestId("add-existing-agents").click();
+    await openAddExistingAgents(page);
     await expect(page.locator(".modal-start-title")).toHaveText(
       "Add existing agents",
     );
@@ -188,7 +188,7 @@ test.describe("the two questions stay two controls", () => {
   test("a no-agent folder in the detection flow is no longer a dead end", async ({
     page,
   }) => {
-    await page.getByTestId("add-existing-agents").click();
+    await openAddExistingAgents(page);
     await page.getByTestId("folder-field-input").fill(BLANK);
     // The immediate-child probe has nothing to register, so its button is gone
     // rather than sitting there disabled.
@@ -213,7 +213,7 @@ test.describe("the two questions stay two controls", () => {
   test("Add a project offers ONE action, and it still brings the agents", async ({
     page,
   }) => {
-    await page.getByTestId("rail-add-project").click();
+    await openFolderStep(page);
     await page.getByTestId("folder-field-input").fill("/Users/demo/acme-app");
     await expect(page.getByTestId("aw-add-all")).toHaveCount(0);
     await expect(page.getByTestId("aw-add")).toHaveCount(0);
@@ -247,7 +247,7 @@ test.describe("round trip: removed, then back", () => {
     // Removal takes the SUBTREE, agents included — it is not a relocation.
     await expect(page.getByTestId("workflow-leasing")).toHaveCount(0);
 
-    await page.getByTestId("rail-add-project").click();
+    await openFolderStep(page);
     await page.getByTestId("folder-field-input").fill("/Users/demo/acme-app");
     await page.getByTestId("open-project").click();
 
@@ -287,7 +287,7 @@ test.describe("round trip: removed, then back", () => {
     await page.getByTestId("remove-project-confirm-btn").click();
     await expect(page.getByTestId("workflow-leasing")).toHaveCount(0);
 
-    await page.getByTestId("rail-add-project").click();
+    await openFolderStep(page);
     await page.getByTestId("folder-field-input").fill("/Users/demo");
     await page.getByTestId("open-project").click();
 

--- a/packages/harness/web/e2e/open-project.spec.ts
+++ b/packages/harness/web/e2e/open-project.spec.ts
@@ -91,7 +91,11 @@ test.describe("the header + opens a project", () => {
   test("a planning project keeps sessions direct while hiding standalone agent creation", async ({
     page,
   }) => {
-    await openFolderStep(page);
+    // Through the ⋮, not the create verb. The verb's folder step CONTINUES into
+    // the new agent screen once the folder is named — that is the flow it
+    // exists for — and this spec's subject is what a planning project offers
+    // afterwards, which needs the folder registered and nothing else.
+    await openAddExistingAgents(page);
     await page.getByTestId("folder-field-input").fill(BLANK);
     await page.getByTestId("open-project").click();
 

--- a/packages/harness/web/e2e/project-axis.spec.ts
+++ b/packages/harness/web/e2e/project-axis.spec.ts
@@ -375,19 +375,28 @@ test.describe("row chrome", () => {
     // Folding it hid the only thing the rail is for and left a header sitting
     // on nothing.
     await expect(page.locator(".rail-header-label")).toHaveText("Projects");
-    await expect(page.locator(".rail-header [aria-expanded]")).toHaveCount(1); // the sliders popover
+    // Two now: the create verb's own menu and the settings popover. Both are
+    // menus the header OWNS; neither folds the tree, which is the claim.
+    await expect(page.locator(".rail-header [aria-expanded]")).toHaveCount(2);
     await expect(page.locator(".rail-header .row-disclosure")).toHaveCount(0);
-    await expect(
-      page.locator(".rail-header button[aria-expanded]"),
-    ).toHaveAttribute("data-testid", "history-trigger");
+    const expandables = await page
+      .locator(".rail-header button[aria-expanded]")
+      .evaluateAll((els) => els.map((el) => el.getAttribute("data-testid")));
+    expect(expandables).toEqual(["rail-create-new", "history-trigger"]);
   });
 
-  test("the header's + sits LEFT OF the settings ellipsis, and adds a PROJECT", async ({
+  test("the header's + sits LEFT OF the settings ellipsis, and is THE create verb", async ({
     page,
   }) => {
-    await expect(page.getByTestId("rail-add-project")).toHaveAttribute(
+    // It used to be "Add a project" and it opened a folder dialog. It is the
+    // one create verb now: IA-REVIEW's rule is "One create verb, `New agent`,
+    // as the rail header's `+`. Not a row among places" — so the black CTA that
+    // sat in the nav above, and the nav's own "Add existing agents" row, are
+    // both gone from that list. A folder is something this verb's first step
+    // collects, not the thing it makes.
+    await expect(page.getByTestId("rail-create-new")).toHaveAttribute(
       "aria-label",
-      "Add a project",
+      "New agent",
     );
 
     // ORDER, asserted from the live DOM rather than from CSS: the LABEL owns the
@@ -403,7 +412,7 @@ test.describe("row chrome", () => {
       );
     expect(headerOrder).toEqual([
       "label",
-      "rail-add-project",
+      "rail-create-new",
       "history-trigger",
     ]);
 
@@ -414,16 +423,19 @@ test.describe("row chrome", () => {
         document.querySelector(".rail-header-label")!.getBoundingClientRect()
           .left,
       ),
+      // Any surviving nav row does; they all share the one icon slot. Search is
+      // the one that cannot be removed by an IA change, so it is the measure.
       navRow: Math.round(
         document
-          .querySelector('[data-testid="add-existing-agents"] span')!
+          .querySelector('[data-testid="palette-trigger"] span')!
           .getBoundingClientRect().left,
       ),
     }));
     expect(indents.header).toBeLessThan(indents.navRow);
 
-    await page.getByTestId("rail-add-project").click();
-    await expect(page.locator(".modal-start")).toBeVisible();
+    // The verb's first step is a choice of place, not a folder dialog.
+    await page.getByTestId("rail-create-new").click();
+    await expect(page.getByTestId("new-agent-menu")).toBeVisible();
     await page.keyboard.press("Escape");
 
     // AN ELLIPSIS, reversing the design doc's "sliders, not an ellipsis". That

--- a/packages/harness/web/e2e/smoke.spec.ts
+++ b/packages/harness/web/e2e/smoke.spec.ts
@@ -14,8 +14,7 @@ import type { Page } from "@playwright/test";
 import {
   focusRfqAgent,
   openProjectMenu,
-  selectMockSessionFromPalette,
-} from "./mock-navigation";
+  selectMockSessionFromPalette, openAddExistingAgents } from "./mock-navigation";
 
 // COMPATIBILITY PAYLOAD, said out loud.
 //
@@ -131,20 +130,25 @@ test.describe("theme — defaults to light until the user chooses", () => {
   });
 });
 
-test("rail: the Create-new CTA sits below Search and opens the composer", async ({
+test("rail: the create verb is the header's +, and it asks WHERE first", async ({
   page,
 }) => {
+  // It used to be a row IN the nav, above Search, reading "Create new agent" —
+  // a verb in a list of destinations, which is the confusion IA-REVIEW names.
+  // It is the Projects header's `+` now, and the nav holds only places.
+  await expect(page.locator(".rail-nav").getByTestId("rail-create-new")).toHaveCount(0);
   const cta = page.getByTestId("rail-create-new");
   await expect(cta).toBeVisible();
-  // Says WHAT it creates. Bare "Create new" named nothing, and "project" would
-  // be false — this opens the composer, which scaffolds an agent.
-  await expect(cta).toContainText("Create new agent");
+  await expect(cta).toHaveAttribute("aria-label", "New agent");
 
-  // It opens the composer-first "new session" home — the primary creative
-  // action, reachable straight from the nav.
   await cta.click();
-  await expect(page.getByTestId("new-session-composer")).toBeVisible();
-  await expect(page.getByTestId("composer-input")).toBeVisible();
+  // The first step is WHERE it lives: the projects the rail already shows, plus
+  // a way out to a folder it does not. Nothing is created until that is
+  // answered, which is the whole change — the old CTA went straight to a
+  // composer that invented a folder from whatever you typed into it.
+  await expect(page.getByTestId("new-agent-menu")).toBeVisible();
+  await expect(page.getByTestId("new-agent-in-acme-app")).toBeVisible();
+  await expect(page.getByTestId("new-agent-choose-folder")).toBeVisible();
 });
 
 test("brand header shows the Sapiom wordmark and the demo-workspace identity", async ({
@@ -198,7 +202,7 @@ test("session header: compact identity (name only; path in the tooltip); New ses
 
   await page.screenshot({ path: "web/e2e/screenshots/session-header.png" });
 
-  await page.getByTestId("add-existing-agents").click();
+  await openAddExistingAgents(page);
   await expect(page.locator(".modal-start")).toBeVisible();
   await page.getByRole("button", { name: "Cancel" }).click();
 });
@@ -288,7 +292,7 @@ test("creation IA: Add existing agents opens detection; the tab + starts a sibli
 }) => {
   // Adding what already exists is ONE detection-driven dialog — no doors, no
   // modes, no agent picker.
-  await page.getByTestId("add-existing-agents").click();
+  await openAddExistingAgents(page);
   const modal = page.locator(".modal-start");
   await expect(modal).toBeVisible();
   await expect(page.getByTestId("add-menu")).toHaveCount(0);
@@ -1363,7 +1367,7 @@ test.describe("three-zone IA (rail explorer, tab strip, right pane)", () => {
 test("Add existing agents: the folder field seeds itself and drives the action", async ({
   page,
 }) => {
-  await page.getByTestId("add-existing-agents").click();
+  await openAddExistingAgents(page);
   const modal = page.locator(".modal-start");
   await expect(modal).toBeVisible();
 
@@ -1405,7 +1409,7 @@ test("Add existing agents: a failed directory read is reported, not swallowed", 
   await page.goto("/?mockError=listDir&seed=0");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 
-  await page.getByTestId("add-existing-agents").click();
+  await openAddExistingAgents(page);
   const modal = page.locator(".modal-start");
   await expect(modal).toBeVisible();
 
@@ -2857,7 +2861,7 @@ test("folder field: Enter fires the dialog's primary action", async ({
   // The in-app listing's arrow-key navigation went with the listing; Enter is
   // no longer "drill into the highlighted row", it is "do the one thing this
   // dialog is for".
-  await page.getByTestId("add-existing-agents").click();
+  await openAddExistingAgents(page);
   const input = page.getByTestId("folder-field-input");
   await input.fill("/Users/demo/rfq-agent");
   await expect(page.getByTestId("aw-add")).toBeEnabled();

--- a/packages/harness/web/e2e/start-dialog.spec.ts
+++ b/packages/harness/web/e2e/start-dialog.spec.ts
@@ -12,11 +12,12 @@
  * `scratch` is a plain folder.
  */
 import { expect, test } from "@playwright/test";
+import { openAddExistingAgents } from "./mock-navigation";
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
   await expect(page.locator(".rail-workflows")).toBeVisible();
-  await page.getByTestId("add-existing-agents").click();
+  await openAddExistingAgents(page);
   await expect(page.locator(".modal-start")).toBeVisible();
 });
 
@@ -30,12 +31,19 @@ test.describe("opening", () => {
     await expect(page.locator(".folder-field")).toBeVisible();
   });
 
-  test("Create new opens the composer, not this dialog", async ({ page }) => {
-    // Adding what exists and creating something new are different surfaces now.
+  test("the create verb asks WHERE first, and it is not this dialog", async ({
+    page,
+  }) => {
+    // Adding what exists and creating something new are still different
+    // surfaces. What changed is the second one: "Create new agent" used to open
+    // a composer that invented a folder from whatever you typed. The verb's
+    // first step now names the place — the projects that exist, plus a way out
+    // to a folder that does not — and this detection dialog is not it.
     await page.keyboard.press("Escape");
     await expect(page.locator(".modal-start")).toHaveCount(0);
     await page.getByTestId("rail-create-new").click();
-    await expect(page.getByTestId("new-session-composer")).toBeVisible();
+    await expect(page.getByTestId("new-agent-menu")).toBeVisible();
+    await expect(page.getByTestId("new-agent-choose-folder")).toBeVisible();
     await expect(page.locator(".modal-start")).toHaveCount(0);
   });
 });

--- a/packages/harness/web/e2e/templates.spec.ts
+++ b/packages/harness/web/e2e/templates.spec.ts
@@ -424,7 +424,10 @@ test("the rail navigates away from templates: another nav row dismisses the brow
   await expect(page.getByTestId("templates-panel")).toBeVisible();
   await expect(page.locator(".center-pane")).toBeHidden();
 
+  // The create verb's first step is a choice of PLACE, so leaving the templates
+  // destination happens when that choice is made, not when the verb is pressed.
   await page.getByTestId("rail-create-new").click();
+  await page.getByTestId("new-agent-in-acme-app").click();
 
   // The template destination is gone and the workbench is back — you actually
   // navigated, rather than staying stranded on the browser.

--- a/packages/harness/web/e2e/unrooted-agents.spec.ts
+++ b/packages/harness/web/e2e/unrooted-agents.spec.ts
@@ -21,7 +21,7 @@
 import { expect, test } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
-import { openProjectMenu } from "./mock-navigation";
+import { openProjectMenu, openFolderStep } from "./mock-navigation";
 
 const ORCHESTRATION = "/Users/demo/design-eng/ari/orchestration";
 const FIX_ORCHESTRATION = "/Users/demo/design-eng-fix/ari/orchestration";
@@ -439,7 +439,7 @@ test.describe("(c) there is a way OUT", () => {
     // This is the assertion that matters most: `hiddenByClosedProject` refuses
     // to let an EQUAL open entry un-close a root, so without a deliberate
     // reopen path the project could never come back at all.
-    await page.getByTestId("rail-add-project").click();
+    await openFolderStep(page);
     await page.getByTestId("folder-field-input").fill("/Users/demo/design-eng");
     await page.getByTestId("open-project").click();
     await expect(page.getByTestId("project-row-design-eng")).toBeVisible();

--- a/packages/harness/web/e2e/wave5.spec.ts
+++ b/packages/harness/web/e2e/wave5.spec.ts
@@ -12,6 +12,7 @@
  *   - overview mode shows the fresh-install canvas state
  */
 import { expect, test } from "@playwright/test";
+import { openAddExistingAgents } from "./mock-navigation";
 
 // COMPATIBILITY PAYLOAD, said out loud.
 //
@@ -79,7 +80,7 @@ test.describe("command palette sections and highlighting", () => {
 
 test.describe("add existing agents (detection-driven)", () => {
   test("a root holding several projects offers to add them all, and toasts the count", async ({ page }) => {
-    await page.getByTestId("add-existing-agents").click();
+    await openAddExistingAgents(page);
     const modal = page.locator(".modal-start");
     await modal.getByTestId("folder-field-input").fill("/Users/demo");
 
@@ -173,7 +174,7 @@ test("a folder that cannot be read says so, and the field stays the way out", as
   await page.goto("/?mockError=listDir&mockStudioProjects=absent");
   await expect(page.locator(".rail-workflows")).toBeVisible();
 
-  await page.getByTestId("add-existing-agents").click();
+  await openAddExistingAgents(page);
   const modal = page.locator(".modal-start");
 
   const err = modal.locator(".modal-error");

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -307,6 +307,19 @@ export const App = (): JSX.Element => {
   // Create-new intent; the workbench tab + starts a sibling directly instead.
   // The home also shows whenever nothing else claims the centre pane.
   const [composing, setComposing] = useState(false);
+  /**
+   * THE PROJECT THE NEW AGENT SCREEN IS SCOPED TO, or null for the home screen.
+   *
+   * Creating an agent leads to one screen whichever entrance you came through —
+   * a folder you just picked, or a project you already have — and this is what
+   * makes the second entrance possible. It is deliberately NOT `studioSelection`:
+   * the Agent Map row still opens the map, and only the create verb lands here,
+   * so the two must be able to differ.
+   */
+  const [composingProject, setComposingProject] = useState<{
+    projectId: StudioProjectId;
+    label: string;
+  } | null>(null);
   // The tab + is a one-at-a-time create/bind transaction. State renders the
   // pending affordance; the ref closes React's same-frame double-click window.
   const [siblingSessionPending, setSiblingSessionPending] = useState(false);
@@ -1544,9 +1557,14 @@ export const App = (): JSX.Element => {
   const showComposer =
     !showReview &&
     !showDead &&
-    !planningWorkspace &&
+    // A SCOPED COMPOSER OUTRANKS THE MAP. Landing on a project's map is what
+    // selecting the project does; landing on this screen is what CREATING in it
+    // does, and the create verb sets both (the map so the rail reads right, the
+    // scope so the screen knows where it is building). Without this the map's
+    // chat pane would win and the entrance would go nowhere.
+    (composingProject !== null || !planningWorkspace) &&
     !showProjectStarting &&
-    (composing || (!showAgentEmpty && !showWorkbench));
+    (composing || composingProject !== null || (!showAgentEmpty && !showWorkbench));
   /** The project a board can cut UP to — derived, so the way back is the same
    *  door whether the agent was reached from the rail or from the map. */
   const upToProject = atMapAltitude
@@ -3479,7 +3497,8 @@ export const App = (): JSX.Element => {
                    screen gives way to the terminal (createSessionAt clears
                    `composing`), and the canvas reveals itself once populated. */
                 <NewSessionComposer
-                  firstRun={state.firstRun === true}
+                  project={composingProject}
+                  firstRun={composingProject === null && state.firstRun === true}
                   onSubmitIdea={handleComposerSubmitIdea}
                   onAttachmentError={harness.showToast}
                   onUseTemplate={handleComposerUseTemplate}

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -1808,6 +1808,76 @@ export const App = (): JSX.Element => {
     setCreatingAgent({ root, label });
   };
 
+  /**
+   * THE ONE CREATE VERB'S SECOND STEP — and it never types English at anyone.
+   *
+   * The rail's create control used to call `onNewSession`, which set
+   * `composing` and ended at `sendScaffoldPrompt`: a session at a folder
+   * invented from a slug of the user's sentence, then an English request that
+   * the coding agent please call `sapiom_dev_agents_scaffold`. That is the
+   * mechanism SAP-2981 set out to remove, still wired to the most prominent
+   * control in the product, and it failed the way a prompt fails — a create
+   * that did not happen arrived as a confused model rather than an error.
+   *
+   * `aaf721bb` (#790) had already fixed the project-row doors, and the fix is
+   * the same one: WHEN A PROJECT HAS A DURABLE STUDIO PROJECT, ITS AGENT MAP
+   * OWNS CREATION. So this resolves the folder to a project and hands over to
+   * the map, exactly as selecting the project does — `handleSelectWorkspace`'s
+   * map branch, run against the state that comes back from opening the folder
+   * rather than the render's own copy of it, which is one refresh stale here.
+   *
+   * The folder does not have to be a project yet. `openProject` is what makes
+   * it one (and resolves an agent's own folder to the folder that HOLDS it),
+   * and after PR "one definition of what a project is" the server issues a
+   * durable Studio project for exactly that root, so the map is there when we
+   * ask for it.
+   *
+   * A payload with no Studio project catalog is the one case the map cannot
+   * serve. That is not a reason to keep the injection: it falls through to
+   * `handleCreateAgentInProject`, the dialog whose endpoint creates the agent
+   * on disk and rescans before any session starts. Still the harness creating
+   * the agent; still no sentence sent to a model.
+   */
+  const handleNewAgentIn = async (
+    root: string,
+    label?: string,
+  ): Promise<void> => {
+    const openedRoot = await harness.openProject(root);
+    const refreshed = await harness.api.getState();
+    const scope = refreshed.workspaceScopes?.find((candidate) =>
+      samePath(candidate.cwd, openedRoot),
+    );
+    const project = refreshed.studioProjects?.find(
+      (candidate) => candidate.projectId === scope?.projectId,
+    );
+    const name = label ?? basenameOf(openedRoot);
+    if (!scope || !project) {
+      handleCreateAgentInProject(openedRoot, name);
+      return;
+    }
+    studioRestoreGenerationRef.current += 1;
+    restoredStudioProjectsRef.current.add(project.projectId);
+    const selection: StudioWorkspaceSelection = {
+      kind: "agent-map",
+      projectId: project.projectId,
+    };
+    setStudioSelection(selection);
+    setSelectedProject(null);
+    setFocusedAgentPath(scope.cwd);
+    setComposing(false);
+    setReviewSummary(null);
+    setTemplatesOpen(false);
+    setOverviewOpen(false);
+    closeMobileDrawer();
+    if (isMobile) setRightCollapsed(true);
+    await harness.api
+      .putStudioCurrentWorkspace(project.projectId, selection)
+      .catch(() => {
+        // The map is already selected. Remembering it is best effort and must
+        // not turn a completed navigation into a failure.
+      });
+  };
+
   const createAgentInProject = async (input: {
     name: string;
     template: string;
@@ -2092,6 +2162,14 @@ export const App = (): JSX.Element => {
     if (!cwd) {
       throw new Error("Set a project folder first — use the + to open one.");
     }
+    // SAY IT, don't infer it. `composing` used to be set by the rail control
+    // that opened this, and holding it true is what keeps the composer MOUNTED
+    // across the session that is about to be created and, on a failed upload,
+    // closed again. The composer is now the home screen — shown because
+    // nothing else is — so without this the workbench appears for the life of
+    // that provisional session, the composer unmounts, and the attachment queue
+    // a rollback is supposed to retain goes with it.
+    setComposing(true);
     // Terminal-first: the new session's canvas slides in once it paints.
     setRightCollapsed(true);
     const session = await createSessionAt(cwd, agentHarness, {
@@ -2677,14 +2755,7 @@ export const App = (): JSX.Element => {
               setTemplatesOpen(false);
               closeMobileDrawer();
             }}
-            onNewSession={() => {
-              studioRestoreGenerationRef.current += 1;
-              setStudioSelection(null);
-              setSelectedProject(null);
-              setComposing(true);
-              setTemplatesOpen(false);
-              setOverviewOpen(false);
-            }}
+            onNewAgentIn={handleNewAgentIn}
             onReviewSummary={reviewPastSession}
             history={harness.history}
             historyLoading={harness.historyLoading}

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -212,13 +212,6 @@ const knownRootsOf = (
 ): string[] => [...(recentDirs ?? []), ...(launchDir ? [launchDir] : [])];
 
 /**
- * How long a held initial prompt waits for the coding agent to become ready
- * (i.e. the user to finish any sign-in, trust, or onboarding step) before we
- * give up and surface the failure. The normal end of a hold is the session
- * going ready (prompt sent) or exiting — this is only a leak-guard for setup
- * the user walks away from.
- */
-/**
  * A layer the COMMAND PALETTE must not open on top of.
  *
  * `.modal-backdrop` leads because it is the one thing every overlay in this app
@@ -245,6 +238,14 @@ const PALETTE_BLOCKING_LAYER_SELECTOR = [
   '[role="alertdialog"]:not(.overview-modal)',
   '[aria-modal="true"]:not(.overview-modal)',
 ].join(",");
+
+/**
+ * How long a held initial prompt waits for the coding agent to become ready
+ * (i.e. the user to finish any sign-in, trust, or onboarding step) before we
+ * give up and surface the failure. The normal end of a hold is the session
+ * going ready (prompt sent) or exiting — this is only a leak-guard for setup
+ * the user walks away from.
+ */
 
 const HELD_PROMPT_TIMEOUT_MS = 10 * 60_000;
 
@@ -835,15 +836,23 @@ export const App = (): JSX.Element => {
           e.preventDefault();
           return;
         }
-        // A LAYER ON TOP KEEPS THE SHORTCUT — the rule the Escape handler above
-        // already follows, and this handler did not. Unguarded, ⌘K stacked the
+        // A LAYER ON TOP SWALLOWS THE SHORTCUT. Unguarded, ⌘K stacked the
         // palette over an open dialog and native Tab then walked out of the
         // palette into the dialog behind it. A surface cannot contain focus for
         // a surface it does not own, so the fix is here rather than in either.
         // Found by the dialog-shell work (#800), which stopped at this file
         // rather than reaching into it. See the selector for what it excludes
         // and why it is not that branch's list.
-        if (document.querySelector(PALETTE_BLOCKING_LAYER_SELECTOR)) return;
+        //
+        // PREVENTED, THEN DROPPED — never returned unhandled. This handler owns
+        // ⌘P as well as ⌘K, and ⌘P is the browser's PRINT shortcut: returning
+        // early without preventing it opened a native print preview over the
+        // dialog, which is worse than the stacking it was added to stop. The
+        // shortcut does nothing here, exactly as it did nothing before.
+        if (document.querySelector(PALETTE_BLOCKING_LAYER_SELECTOR)) {
+          e.preventDefault();
+          return;
+        }
         e.preventDefault();
         setPaletteOpen(true);
         return;

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -1718,6 +1718,10 @@ export const App = (): JSX.Element => {
     label: string,
   ): void => {
     studioRestoreGenerationRef.current += 1;
+    // Selecting a project is a different question from creating in one, and
+    // the create scope outranks the map — so it has to be dropped here or
+    // selecting would land back on the screen you just left.
+    setComposingProject(null);
     const studioProjectId = workspaceScopes.find(
       (scope) => scope.workspaceKey === workspaceKey,
     )?.projectId;
@@ -2051,6 +2055,12 @@ export const App = (): JSX.Element => {
         projectId: project.projectId,
       };
       setStudioSelection(selection);
+      // BOTH ENTRANCES LAND ON THE NEW AGENT SCREEN, scoped to this project.
+      // A folder you just picked and a project you already have differ only in
+      // how the project was resolved, and by here they have both resolved to
+      // one, so from this line the two flows are the same flow. The map
+      // selection above rides along so the rail reads right underneath it.
+      setComposingProject({ projectId: project.projectId, label: name });
       setSelectedProject(null);
       setFocusedAgentPath(scope.cwd);
       setComposing(false);
@@ -2495,6 +2505,7 @@ export const App = (): JSX.Element => {
   const reviewPastSession = (summary: SessionSummary): void => {
     studioRestoreGenerationRef.current += 1;
     setStudioSelection(null);
+    setComposingProject(null);
     setComposing(false);
     setReviewSummary(summary);
     setTemplatesOpen(false);
@@ -2590,6 +2601,7 @@ export const App = (): JSX.Element => {
     preferredStudioBinding?: { projectId: string; agentId: string },
   ): void => {
     studioRestoreGenerationRef.current += 1;
+    setComposingProject(null);
     setComposing(false);
     setReviewSummary(null);
     setTemplatesOpen(false);
@@ -2926,6 +2938,10 @@ export const App = (): JSX.Element => {
             selectedWorkspaceKey={selectedProject?.workspaceKey ?? null}
             onSelectWorkspace={handleSelectWorkspace}
             onSelectAgentMap={(projectId, root, label) => {
+              // The map row opens the MAP, never the create screen — the two
+              // are different questions about the same project and the create
+              // scope has to be dropped or it would win over the map.
+              setComposingProject(null);
               const scope = workspaceScopes.find(
                 (candidate) => candidate.projectId === projectId,
               );
@@ -2949,6 +2965,7 @@ export const App = (): JSX.Element => {
             onSelectOverview={() => {
               studioRestoreGenerationRef.current += 1;
               setStudioSelection(null);
+              setComposingProject(null);
               setSelectedProject(null);
               setOverviewOpen(true);
               setComposing(false);
@@ -3357,7 +3374,14 @@ export const App = (): JSX.Element => {
                     </button>
                   }
                 />
-              ) : planningWorkspace ? (
+              ) : /* THE CREATE SCREEN COMES FIRST when it is scoped to this
+                     project. Both are "about" the same project and both are
+                     driven by `planningWorkspace`, so without this the map's
+                     chat pane wins the chain and the create entrance renders
+                     nothing — the state was right and the JSX never reached it.
+                     `showComposer` already encodes the precedence; this is the
+                     same rule, said where the branch is taken. */
+              planningWorkspace && !showComposer ? (
                 agentMapEntry.state.planner.status === "error" ? (
                   <EmptyState
                     className="terminal-empty"
@@ -3505,6 +3529,7 @@ export const App = (): JSX.Element => {
                   onBrowseTemplates={() => {
                     studioRestoreGenerationRef.current += 1;
                     setStudioSelection(null);
+                    setComposingProject(null);
                     setSelectedProject(null);
                     setTemplatesOpen(true);
                   }}

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -56,10 +56,14 @@ import type {
   WorkflowInfo,
   WorkflowInputContractResponse,
 } from "@shared/types";
-import type { WorkspaceKey } from "@shared/system-graph";
+import type {
+  WorkspaceKey,
+  WorkspaceScopeSummary,
+} from "@shared/system-graph";
 import type {
   PlannerSessionRequest,
   StudioProjectId,
+  StudioProjectSummary,
   StudioWorkspaceSelection,
 } from "@shared/agent-map";
 
@@ -215,16 +219,31 @@ const knownRootsOf = (
  * the user walks away from.
  */
 /**
- * What counts as a separate overlay LAYER, for hotkeys that must not fire over
- * one. See the ⌘K guard for why `.modal-backdrop` leads and why this is, for
- * now, a second copy of the dialog shell's `DIALOG_LAYER_SELECTOR`.
+ * A layer the COMMAND PALETTE must not open on top of.
+ *
+ * `.modal-backdrop` leads because it is the one thing every overlay in this app
+ * actually has, and because `CommandPalette` itself carries no `role` — a
+ * role-only selector (the shape the Escape handler below uses) cannot see it,
+ * so a guard written that way looks correct and detects nothing.
+ *
+ * THE OVERVIEW IS CARVED OUT, and it is not an oversight: the palette is
+ * deliberately reachable by shortcut while the Overview is up, and navigating
+ * from it dismisses the Overview rather than stacking behind it. That is a
+ * written contract with a spec behind it — `welcome.spec.ts`'s "the palette's
+ * Browse templates, opened over the Overview, leaves it (never stacks)". The
+ * Overview wears both `role="dialog"` and `aria-modal="true"`, so excluding it
+ * has to be done on each clause rather than by dropping a class from the list.
+ *
+ * DELIBERATELY NOT the dialog shell's `DIALOG_LAYER_SELECTOR` (#800). That one
+ * answers "which layer owns Tab", where the Overview IS a layer and belongs in
+ * the list. This one answers "may ⌘K open here", where it does not. Same shape,
+ * different question; collapsing them would break the contract above.
  */
-const DIALOG_LAYER_SELECTOR = [
+const PALETTE_BLOCKING_LAYER_SELECTOR = [
   ".modal-backdrop",
-  ".overview-modal",
-  '[role="dialog"]',
-  '[role="alertdialog"]',
-  '[aria-modal="true"]',
+  '[role="dialog"]:not(.overview-modal)',
+  '[role="alertdialog"]:not(.overview-modal)',
+  '[aria-modal="true"]:not(.overview-modal)',
 ].join(",");
 
 const HELD_PROMPT_TIMEOUT_MS = 10 * 60_000;
@@ -821,18 +840,10 @@ export const App = (): JSX.Element => {
         // palette over an open dialog and native Tab then walked out of the
         // palette into the dialog behind it. A surface cannot contain focus for
         // a surface it does not own, so the fix is here rather than in either.
-        //
-        // `.modal-backdrop` LEADS, and that is the whole reason this is not the
-        // selector 20 lines above: `CommandPalette` carries no `role` at all, so
-        // a role-only selector cannot see it, and a guard copied from there
-        // would look correct and detect nothing. The roles follow for surfaces
-        // that build their own scrim (`OverviewModal`, `HelpOverlay`).
-        //
         // Found by the dialog-shell work (#800), which stopped at this file
-        // rather than reaching into it; `DIALOG_LAYER_SELECTOR` here is a
-        // deliberate second copy of that branch's, and whichever lands second
-        // should delete one and import the other.
-        if (document.querySelector(DIALOG_LAYER_SELECTOR)) return;
+        // rather than reaching into it. See the selector for what it excludes
+        // and why it is not that branch's list.
+        if (document.querySelector(PALETTE_BLOCKING_LAYER_SELECTOR)) return;
         e.preventDefault();
         setPaletteOpen(true);
         return;
@@ -1874,6 +1885,44 @@ export const App = (): JSX.Element => {
    * on disk and rescans before any session starts. Still the harness creating
    * the agent; still no sentence sent to a model.
    */
+  /**
+   * OPEN A FOLDER AS A PROJECT AND SAY WHAT IT RESOLVED TO — once.
+   *
+   * Two handlers need exactly this prefix and had a line-for-line copy of it
+   * each: the rail's "add a project" route (which then restores whatever
+   * workspace that project remembers) and the create verb (which then goes to
+   * the map, because you are making something). They differ only in what they
+   * do with the answer, so the answer is computed here and the difference stays
+   * in the callers. Two copies of a four-call sequence over the settings API is
+   * how they come to disagree, and on the web folder fallback it was worse than
+   * drift: the verb ran the whole sequence twice per click, two
+   * `rememberProjectDir` writes and two registry sweeps of the same root.
+   *
+   * `openProject` resolves an agent's OWN folder to the folder that holds it,
+   * so `root` is what came back, never what was asked for.
+   */
+  const openProjectAndResolve = async (
+    requestedRoot: string,
+  ): Promise<
+    { root: string; workflows: WorkflowInfo[] } & (
+      | { scope: WorkspaceScopeSummary; project: StudioProjectSummary }
+      | { scope: null; project: null }
+    )
+  > => {
+    const root = await harness.openProject(requestedRoot);
+    const refreshed = await harness.api.getState();
+    const workflows = refreshed.workflows;
+    const scope = refreshed.workspaceScopes?.find((candidate) =>
+      samePath(candidate.cwd, root),
+    );
+    const project = refreshed.studioProjects?.find(
+      (candidate) => candidate.projectId === scope?.projectId,
+    );
+    return scope?.projectId && project
+      ? { root, workflows, scope, project }
+      : { root, workflows, scope: null, project: null };
+  };
+
   const handleNewAgentIn = async (
     root: string,
     label?: string,
@@ -1887,14 +1936,9 @@ export const App = (): JSX.Element => {
       // synchronous and could not fail, so an unhandled rejection here would be
       // a new failure mode whose only symptom is the most prominent control in
       // the product doing nothing at all.
-      openedRoot = await harness.openProject(root);
-      const refreshed = await harness.api.getState();
-      const scope = refreshed.workspaceScopes?.find((candidate) =>
-        samePath(candidate.cwd, openedRoot),
-      );
-      const project = refreshed.studioProjects?.find(
-        (candidate) => candidate.projectId === scope?.projectId,
-      );
+      const opened = await openProjectAndResolve(root);
+      openedRoot = opened.root;
+      const { scope, project } = opened;
       const name = label ?? basenameOf(openedRoot);
       if (!scope || !project) {
         handleCreateAgentInProject(openedRoot, name);
@@ -2835,20 +2879,18 @@ export const App = (): JSX.Element => {
               await harness.removeProject(root);
             }}
             onOpenProject={async (requestedRoot) => {
-              const openedRoot = await harness.openProject(requestedRoot);
               let restoringProject: {
                 projectId: StudioProjectId;
                 cwd: string;
               } | null = null;
               try {
-                const refreshed = await harness.api.getState();
-                const scope = refreshed.workspaceScopes?.find((candidate) =>
-                  samePath(candidate.cwd, openedRoot),
-                );
-                const project = refreshed.studioProjects?.find(
-                  (candidate) => candidate.projectId === scope?.projectId,
-                );
-                if (!scope?.projectId || !project) return;
+                // The same four calls the create verb makes, made once — see
+                // `openProjectAndResolve`. What differs is only what happens
+                // next: this route restores whatever workspace the project
+                // REMEMBERS, the verb goes to the map because it is creating.
+                const { scope, project, workflows } =
+                  await openProjectAndResolve(requestedRoot);
+                if (!scope || !project) return;
                 restoringProject = {
                   projectId: project.projectId,
                   cwd: scope.cwd,
@@ -2861,7 +2903,7 @@ export const App = (): JSX.Element => {
                 if (generation !== studioRestoreGenerationRef.current) return;
                 const restoredSelection = current.selection;
                 if (restoredSelection.kind === "agent") {
-                  const workflow = refreshed.workflows.find((candidate) =>
+                  const workflow = workflows.find((candidate) =>
                     candidate.studioBindings?.some(
                       (binding) =>
                         binding.projectId === restoredSelection.projectId &&

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -2360,11 +2360,71 @@ export const App = (): JSX.Element => {
     );
   };
 
+  /**
+   * SUBMITTING THE NEW AGENT SCREEN, in a project, through the real path.
+   *
+   * This is the swap the whole PR exists for. The other branch below still
+   * invents a folder and injects `composerScaffoldPrompt` — English typed at the
+   * coding agent, hoping it calls the scaffold tool — because with no project
+   * there is nothing to dispatch to. With one, there is: the map planner, which
+   * is the same conversation this screen opens, held by something that can
+   * actually build.
+   *
+   * `resume-or-create` rather than `fresh`, matching the map row, because a
+   * project may already have a planning conversation in progress and dropping
+   * the user into an empty planner would strand it.
+   *
+   * The idea itself rides in as the first message. Not as a prompt asking for a
+   * tool call — as the answer to the question the planner's opening turn asks.
+   */
+  const handleComposerSubmitInProject = async (
+    project: { projectId: StudioProjectId; label: string },
+    idea: string,
+    agentHarness: HarnessKind,
+  ): Promise<void> => {
+    setRightCollapsed(true);
+    // TWO CALLS, ONE SESSION, and that is what the mode is for. This dispatch
+    // is the deterministic one — it has the session id the first message needs
+    // — and `useAgentMapEntry`'s own effect fires a second time once
+    // `studioSelection` becomes this project's map. `resume-or-create` makes
+    // the second one resume rather than open a rival planner: measured against
+    // the mock rail, two open calls and one created session.
+    const opened = await harness.openPlannerSession(project.projectId, {
+      mode: "resume-or-create",
+      harness: agentHarness,
+      theme: getTheme(),
+    });
+    harness.setActiveSessionId(opened.session.id);
+    // The screen has done its job; the planner owns the conversation now.
+    setComposingProject(null);
+    setStudioSelection({ kind: "agent-map", projectId: project.projectId });
+    const text = idea.trim();
+    if (!text) return;
+    try {
+      await harness.api.sendPlannerMessage(
+        project.projectId,
+        opened.session.id,
+        { text },
+      );
+    } catch {
+      // The planner is open and the user can retype. Reporting a failed first
+      // message as a failed CREATE would be the same lie the injected prompt
+      // told, in the other direction.
+      harness.showToast(
+        "Couldn't send that to the planner — it's open, try sending again.",
+      );
+    }
+  };
+
   const handleComposerSubmitIdea = async (
     idea: string,
     agentHarness: HarnessKind,
     attachments: readonly NewSessionAttachment[],
   ): Promise<void> => {
+    if (composingProject) {
+      await handleComposerSubmitInProject(composingProject, idea, agentHarness);
+      return;
+    }
     const cwd = uniqueProjectDir(
       idea.trim() ? slugifyIdea(idea) : FALLBACK_PROJECT_NAME,
     );

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -214,6 +214,19 @@ const knownRootsOf = (
  * going ready (prompt sent) or exiting — this is only a leak-guard for setup
  * the user walks away from.
  */
+/**
+ * What counts as a separate overlay LAYER, for hotkeys that must not fire over
+ * one. See the ⌘K guard for why `.modal-backdrop` leads and why this is, for
+ * now, a second copy of the dialog shell's `DIALOG_LAYER_SELECTOR`.
+ */
+const DIALOG_LAYER_SELECTOR = [
+  ".modal-backdrop",
+  ".overview-modal",
+  '[role="dialog"]',
+  '[role="alertdialog"]',
+  '[aria-modal="true"]',
+].join(",");
+
 const HELD_PROMPT_TIMEOUT_MS = 10 * 60_000;
 
 /**
@@ -797,6 +810,29 @@ export const App = (): JSX.Element => {
         return;
       }
       if ((e.metaKey || e.ctrlKey) && (key === "k" || key === "p")) {
+        // ALREADY OPEN IS NOT A REASON TO OPEN IT AGAIN, and the palette is
+        // itself a modal layer, so this is answered before the guard below.
+        if (paletteOpen) {
+          e.preventDefault();
+          return;
+        }
+        // A LAYER ON TOP KEEPS THE SHORTCUT — the rule the Escape handler above
+        // already follows, and this handler did not. Unguarded, ⌘K stacked the
+        // palette over an open dialog and native Tab then walked out of the
+        // palette into the dialog behind it. A surface cannot contain focus for
+        // a surface it does not own, so the fix is here rather than in either.
+        //
+        // `.modal-backdrop` LEADS, and that is the whole reason this is not the
+        // selector 20 lines above: `CommandPalette` carries no `role` at all, so
+        // a role-only selector cannot see it, and a guard copied from there
+        // would look correct and detect nothing. The roles follow for surfaces
+        // that build their own scrim (`OverviewModal`, `HelpOverlay`).
+        //
+        // Found by the dialog-shell work (#800), which stopped at this file
+        // rather than reaching into it; `DIALOG_LAYER_SELECTOR` here is a
+        // deliberate second copy of that branch's, and whichever lands second
+        // should delete one and import the other.
+        if (document.querySelector(DIALOG_LAYER_SELECTOR)) return;
         e.preventDefault();
         setPaletteOpen(true);
         return;
@@ -1842,40 +1878,59 @@ export const App = (): JSX.Element => {
     root: string,
     label?: string,
   ): Promise<void> => {
-    const openedRoot = await harness.openProject(root);
-    const refreshed = await harness.api.getState();
-    const scope = refreshed.workspaceScopes?.find((candidate) =>
-      samePath(candidate.cwd, openedRoot),
-    );
-    const project = refreshed.studioProjects?.find(
-      (candidate) => candidate.projectId === scope?.projectId,
-    );
-    const name = label ?? basenameOf(openedRoot);
-    if (!scope || !project) {
-      handleCreateAgentInProject(openedRoot, name);
-      return;
+    let openedRoot = root;
+    try {
+      // NOTHING HERE IS ALLOWED TO FAIL SILENTLY. Both call sites are
+      // `void onNewAgentIn(...)` from a control that has already closed its
+      // popover, and `openProject` writes settings over the API while
+      // `getState` re-reads it — either can reject. The verb this replaced was
+      // synchronous and could not fail, so an unhandled rejection here would be
+      // a new failure mode whose only symptom is the most prominent control in
+      // the product doing nothing at all.
+      openedRoot = await harness.openProject(root);
+      const refreshed = await harness.api.getState();
+      const scope = refreshed.workspaceScopes?.find((candidate) =>
+        samePath(candidate.cwd, openedRoot),
+      );
+      const project = refreshed.studioProjects?.find(
+        (candidate) => candidate.projectId === scope?.projectId,
+      );
+      const name = label ?? basenameOf(openedRoot);
+      if (!scope || !project) {
+        handleCreateAgentInProject(openedRoot, name);
+        return;
+      }
+      studioRestoreGenerationRef.current += 1;
+      restoredStudioProjectsRef.current.add(project.projectId);
+      const selection: StudioWorkspaceSelection = {
+        kind: "agent-map",
+        projectId: project.projectId,
+      };
+      setStudioSelection(selection);
+      setSelectedProject(null);
+      setFocusedAgentPath(scope.cwd);
+      setComposing(false);
+      setReviewSummary(null);
+      setTemplatesOpen(false);
+      setOverviewOpen(false);
+      closeMobileDrawer();
+      if (isMobile) setRightCollapsed(true);
+      await harness.api
+        .putStudioCurrentWorkspace(project.projectId, selection)
+        .catch(() => {
+          // The map is already selected. Remembering it is best effort and must
+          // not turn a completed navigation into a failure.
+        });
+    } catch (error) {
+      // The folder may already be open even though resolving it failed, so the
+      // message names what could not be done rather than claiming nothing
+      // happened.
+      harness.showToast(
+        error instanceof Error && error.message
+          ? `Couldn't open ${basenameOf(openedRoot)} to create an agent in. ${error.message}`
+          : `Couldn't open ${basenameOf(openedRoot)} to create an agent in.`,
+      );
     }
-    studioRestoreGenerationRef.current += 1;
-    restoredStudioProjectsRef.current.add(project.projectId);
-    const selection: StudioWorkspaceSelection = {
-      kind: "agent-map",
-      projectId: project.projectId,
-    };
-    setStudioSelection(selection);
-    setSelectedProject(null);
-    setFocusedAgentPath(scope.cwd);
-    setComposing(false);
-    setReviewSummary(null);
-    setTemplatesOpen(false);
-    setOverviewOpen(false);
-    closeMobileDrawer();
-    if (isMobile) setRightCollapsed(true);
-    await harness.api
-      .putStudioCurrentWorkspace(project.projectId, selection)
-      .catch(() => {
-        // The map is already selected. Remembering it is best effort and must
-        // not turn a completed navigation into a failure.
-      });
   };
 
   const createAgentInProject = async (input: {

--- a/packages/harness/web/src/components/NewSessionComposer.tsx
+++ b/packages/harness/web/src/components/NewSessionComposer.tsx
@@ -7,6 +7,8 @@ import {
   type TemplateListResponse,
 } from "@shared/types";
 
+import type { StudioProjectId } from "@shared/agent-map";
+
 import type { FsListResponse } from "../lib/api";
 import {
   FALLBACK_HARNESSES,
@@ -30,12 +32,31 @@ import { Icon } from "./Icon";
 import { trackingAttrs } from "../lib/analytics/tracking-attrs";
 
 /**
- * The composer-first "new session" home. It stands in the centre pane whenever
- * there is no active session (first run, after closing sessions) and when the
- * user asks to start a new one — no terminal, no canvas yet. Describing an
- * outcome and sending starts a session and hands the agent that outcome (the
- * same create+inject path the "start from an idea" door uses); the screen then
- * gives way to the terminal. Templates are the other on-ramp.
+ * THE NEW AGENT SCREEN. One screen, two entrances.
+ *
+ * "What should your agent do?", the chips, the outcome box and the template
+ * cards are where creating an agent leads — from a folder you just picked, or
+ * from a project you already have. It also still stands in the centre pane when
+ * there is no active session at all, which is the same screen arrived at from a
+ * third direction rather than a different one.
+ *
+ * IT USED TO BE HALF OF A SPLIT, and closing that split is why it now takes a
+ * project. There were two implementations of one idea: this screen, with the
+ * good surface and the wrong plumbing — it invented a folder from a slug of what
+ * you typed and then asked the coding agent, in English, to please scaffold
+ * something in it — and the Agent Map planner, with the right plumbing and no
+ * landing screen at all. Both ask the same question; `plannerGreetingPrompt`
+ * instructs the planner's opening turn to "ask exactly one open-ended question
+ * about what kind of agent architecture the user wants to build", which is this
+ * screen's heading in other words.
+ *
+ * So the surface stayed and the plumbing was replaced: `project` scopes it, and
+ * submitting dispatches the planner for that project instead of typing English
+ * at a terminal.
+ *
+ * `project === null` is the no-project home — a first run, or every session
+ * closed — where there is nothing to scope to yet and the folder is still the
+ * first thing the flow has to establish.
  */
 
 /** Quick-start prompts. Net-new — the catalog has no "starter idea" list — so a
@@ -79,8 +100,18 @@ function chipSlug(label: string): string {
 }
 
 interface NewSessionComposerProps {
+  /**
+   * The project this screen is creating IN, or null for the no-project home.
+   *
+   * Present, the screen says which project it is about and submitting dispatches
+   * that project's planner. Absent, it is the home screen and submitting has to
+   * establish a folder first. The two entrances differ only in whether this is
+   * set — the screen itself is one screen.
+   */
+  project: { projectId: StudioProjectId; label: string } | null;
   /** Genuine first run (AppState.firstRun): changes the greeting and shows the
-   *  one-time telemetry opt-in + docs footer. */
+   *  one-time telemetry opt-in + docs footer. Never true when `project` is set:
+   *  a project you already have is not a first run. */
   firstRun: boolean;
   /** Start a session and hand the agent this outcome (empty → default starter).
    *  App derives the folder and runs the scaffold+inject path. */
@@ -114,6 +145,7 @@ interface NewSessionComposerProps {
 }
 
 export function NewSessionComposer({
+  project,
   firstRun,
   onSubmitIdea,
   onAttachmentError,
@@ -311,7 +343,15 @@ export function NewSessionComposer({
       <div className="composer-hero">
         <p className="composer-greeting" data-testid="composer-greeting">
           {timeGreeting(new Date())}{" "}
-          {firstRun ? "Let's build your first agent." : "Let's build a new agent."}
+          {/* NAME THE PROJECT when there is one. The screen is reached from two
+              entrances and only one of them stated where the agent will live;
+              arriving from the other with no mention of it is how you end up
+              building in a folder you did not mean. */}
+          {project
+            ? `Let's build a new agent in ${project.label}.`
+            : firstRun
+              ? "Let's build your first agent."
+              : "Let's build a new agent."}
         </p>
         <h1 className="composer-heading">What should your agent do?</h1>
 

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -36,6 +36,7 @@ import { PlanCard } from "./PlanCard";
 import { UpdateCard } from "./UpdateCard";
 import { SettingsPopover } from "./SettingsPopover";
 import { describeUpdateOutcome, getDesktopBridge } from "../lib/desktop";
+import { chooseProjectFolder } from "../lib/folder-step";
 import {
   ProjectRow,
   ProjectTreeRows,
@@ -147,8 +148,19 @@ interface WorkflowsRailProps {
    *  agent, or other destination leaves it. */
   overviewSelected: boolean;
   onSelectOverview: () => void;
-  /** The "Create new" CTA opens the composer-first "new session" home. */
-  onNewSession: () => void;
+  /**
+   * THE ONE CREATE VERB'S SECOND STEP: make an agent in a project the user has
+   * already named.
+   *
+   * `root` is a folder that is not necessarily a project yet — the folder step
+   * runs first and hands whatever it collected straight here, so App owns the
+   * "open it as a project, then create in it" order rather than the rail
+   * knowing it. This replaced `onNewSession`, which opened the composer and
+   * ended in an English sentence injected into a terminal (`App.tsx`'s
+   * `sendScaffoldPrompt`) — the mechanism SAP-2981 removed everywhere except
+   * the most prominent control in the product.
+   */
+  onNewAgentIn: (root: string, label?: string) => Promise<void> | void;
   /** Opens the past-session review pane for a history entry. */
   onReviewSummary: (summary: SessionSummary) => void;
   history: SessionSummary[];
@@ -476,7 +488,7 @@ export function WorkflowsRail({
   onSelectSession,
   overviewSelected,
   onSelectOverview,
-  onNewSession,
+  onNewAgentIn,
   onReviewSummary,
   history,
   historyLoading,
@@ -535,19 +547,58 @@ export function WorkflowsRail({
       );
     });
   }, []);
-  // "Add existing agents" opens the detection-driven StartDialog (register a
-  // folder that already holds an agent project). "Create new" goes to the
-  // composer home instead. connectTriggerRef anchors Escape focus return.
-  // ONE dialog, TWO questions. "Add a project" (the header `+`) and "find
-  // agents under here" (the nav row) both start from the same folder picker —
-  // that part is one question — but they differ in what they DO with the
-  // answer, so each gets its own control and its own primary action. Round 1
-  // pointed both at the detection flow, which made "add a project" mean "add a
-  // project that already contains an agent".
+  /**
+   * THE CREATE VERB'S FIRST STEP, and the folder dialog it may or may not need.
+   *
+   * `newAgentOpen` is the "where does it live" step: the projects you already
+   * have, plus one way out to a folder you do not. It is a popover rather than
+   * a dialog on purpose — it is a choice among places the rail is already
+   * showing, and the modal family is owned elsewhere.
+   *
+   * `startMode` is the folder dialog, and it is now the WEB fallback for that
+   * step plus the ⋮ menu's "Add existing agents". `startIntent` says what the
+   * answer is for, because the same dialog serves two questions and only one of
+   * them continues into creation. Pointing both at one intent is round 1's bug
+   * in mirror image: it made "add a project" mean "add a project that already
+   * contains an agent".
+   */
+  const [newAgentOpen, setNewAgentOpen] = useState(false);
   const [startMode, setStartMode] = useState<StartMode | null>(null);
+  const [startIntent, setStartIntent] = useState<"create" | "register">(
+    "register",
+  );
   const startOpen = startMode !== null;
-  const connectTriggerRef = useRef<HTMLButtonElement>(null);
   const addProjectTriggerRef = useRef<HTMLButtonElement>(null);
+
+  /**
+   * NATIVE ON DESKTOP, TYPED PATH ON THE WEB — gated HERE, at the entry point.
+   *
+   * The split already existed one level too deep, inside `FolderField`, where
+   * the bridge only decided whether to render a `<datalist>`. That is the wrong
+   * question: with a real OS folder browser available, a modal wrapping a text
+   * input is not a smaller version of it, it is a different and worse control.
+   * So the bridge decides whether the DIALOG opens at all. When it is there the
+   * user gets Finder/Explorer; when it is not (the `npx` browser host) the
+   * dialog is the fallback, unchanged.
+   *
+   * Feature-detected, never assumed: an older desktop build without
+   * `chooseDirectory` reads as a browser and gets the fallback, which is always
+   * safe. See `lib/desktop.ts`.
+   */
+  const chooseDirectory = getDesktopBridge()?.chooseDirectory ?? null;
+
+  const pickFolderForNewAgent = (): void => {
+    setNewAgentOpen(false);
+    void chooseProjectFolder({
+      chooseDirectory,
+      startingAt: projectRoot ?? launchDir,
+      openDialog: () => {
+        setStartIntent("create");
+        setStartMode("open");
+      },
+      onPicked: (root) => void onNewAgentIn(root),
+    });
+  };
   // The ⋮ menu opens BESIDE the rail (not over it), so it clears the whole
   // rail's right edge rather than just the header glyph's.
   const railRef = useRef<HTMLElement>(null);
@@ -856,41 +907,21 @@ export function WorkflowsRail({
         onGoForward={onGoForward}
       />
 
-      {/* The rail's top stack of labelled destinations. "Create new" leads as
-          the primary affirmative action (a solid ink button — the app's primary
-          CTA, like Deploy); Search opens the command palette (carrying the
-          unboxed ⌘K / Ctrl+K shortcut) and Templates opens the catalog. Search
-          and Templates read as rows, not a boxed field or a bare magnifier — a
-          destination is not chrome. */}
-      <nav className="rail-nav" aria-label="Primary">
-        {/* The primary creative action, promoted out of the header + ABOVE
-            Search: the fastest path to a new agent. It opens the composer-first
-            "new session" home. A standing ink-button CTA; when the rail has
-            nothing yet it gains a soft brand halo so an empty workspace has an
-            obvious next step. */}
-        <button
-          type="button"
-          className={"rail-nav-cta" + (isEmpty ? " is-empty" : "")}
-          data-testid="rail-create-new"
-          aria-label="Create a new agent"
-          data-tooltip="Describe an agent and this scaffolds it"
-          onClick={() => {
-            setHistoryOpen(false);
-            onNewSession();
-          }}
-        >
-          <Icon name="Plus" size={14} />
-          {/* "Create new AGENT", not "Create new" and not "Create new project".
-              Bare "Create new" never said what it made. "Project" would be
-              false: this opens the composer, which scaffolds an AGENT — and
-              adding a project is already the header's folder-plus, so calling
-              this one "project" would give two controls the same name for
-              different jobs. The related complaint, that it drops the agent
-              somewhere arbitrary, is not a naming problem: the fix is a create
-              affordance on each project row, which this does not replace. */}
-          <span>Create new agent</span>
-        </button>
+      {/* THE NAV IS DESTINATIONS ONLY. Search opens the command palette
+          (carrying the unboxed ⌘K / Ctrl+K shortcut) and Templates opens the
+          catalog; they read as rows, not a boxed field or a bare magnifier,
+          because a destination is not chrome.
 
+          A VERB USED TO LIVE HERE and does not any more. "Create new agent" sat
+          as the first row of this list, "Add existing agents" as the last, and
+          the Projects header carried a third folder-plus — three controls doing
+          folder-or-create work, two of them inside a list of places. IA-REVIEW
+          names the rule: "One create verb, `New agent`, as the rail header's
+          `+`. Not a row among places: a verb in a list of destinations is the
+          F-18 confusion." The verb moved to the header below. Registering a
+          folder that already holds agents is a different job and it moved into
+          the rail's own ⋮ menu, so it is reachable without competing. */}
+      <nav className="rail-nav" aria-label="Primary">
         <button
           type="button"
           className="rail-nav-row"
@@ -914,29 +945,12 @@ export function WorkflowsRail({
           <span>Templates</span>
         </button>
 
-        {/* Add EXISTING agents — a folder that already holds an agent project.
-            Creating a new one is "Create new" (the composer). */}
-        <button
-          type="button"
-          ref={connectTriggerRef}
-          className="rail-nav-row"
-          data-testid="add-existing-agents"
-          aria-haspopup="dialog"
-          aria-expanded={startOpen}
-          onClick={() => {
-            setHistoryOpen(false);
-            setStartMode("detect");
-          }}
-        >
-          <Icon name="FolderPlus" size={14} />
-          <span>Add existing agents</span>
-        </button>
       </nav>
 
       {/* A TITLE, not a control. Folding this header hid the only thing the
           rail is for and left a header sitting on nothing — so it has no
           disclosure of its own. Its two buttons ask two different questions:
-          `+` adds a project, the ellipsis opens the rail's settings. */}
+          `+` is THE create verb, the ellipsis opens the rail's settings. */}
       <div className="rail-header">
         {/* ALWAYS "Projects". This used to swap to "Groups" on the group axis,
             on the reasoning that a header should name what the list is filed
@@ -948,26 +962,41 @@ export function WorkflowsRail({
             of the Group-by control that set it. */}
         <span className="rail-header-label">Projects</span>
         <div className="rail-header-actions">
-          {/* ADD sits to the LEFT OF THE ELLIPSIS, both in the trailing group.
-              The label owns the leading edge: putting a control there made the
-              header read as one more nav button in the stack above it — same
-              icon slot, same indent — rather than as the title of the tree
-              below. FOLDER-with-plus, because what it adds is a folder. One `+`
-              per question: this one opens a project; starting another session
-              is the tab strip's trailing `+`, and project rows carry none. */}
+          {/* THE ONE CREATE VERB. It sits to the LEFT OF THE ELLIPSIS, both in
+              the trailing group: the label owns the leading edge, and a control
+              there made the header read as one more nav button in the stack
+              above it rather than as the title of the tree below.
+
+              A PLUS, not a folder-plus. It used to be "Add a project" and what
+              it added was a folder, so the glyph was right for the job it had.
+              The job changed: this opens the create flow, whose FIRST step is
+              where the agent lives (a project you already have, or a folder you
+              pick). A folder is now something that flow collects, not the thing
+              the control makes.
+
+              One `+` per question still holds — this one makes an agent;
+              starting another session is the tab strip's trailing `+`; project
+              rows carry none, because a project's Agent Map owns creation
+              inside it. */}
           <button
             type="button"
-            className="theme-toggle rail-header-btn"
+            className={
+              "theme-toggle rail-header-btn" + (isEmpty ? " is-empty" : "")
+            }
             ref={addProjectTriggerRef}
-            data-testid="rail-add-project"
-            aria-label="Add a project"
-            data-tooltip="Add a project"
+            data-testid="rail-create-new"
+            aria-label="New agent"
+            aria-haspopup="menu"
+            aria-expanded={newAgentOpen}
+            data-tooltip={
+              isEmpty ? "New agent — start here" : "New agent"
+            }
             onClick={() => {
               setHistoryOpen(false);
-              setStartMode("open");
+              setNewAgentOpen((prev) => !prev);
             }}
           >
-            <Icon name="FolderPlus" size={14} />
+            <Icon name="Plus" size={14} />
           </button>
           {/* AN ELLIPSIS, deliberately reversing the design doc's "sliders, not
               an ellipsis". That rule's reasoning was "an ellipsis has no
@@ -991,6 +1020,74 @@ export function WorkflowsRail({
           </button>
         </div>
       </div>
+
+      {/* WHERE DOES IT LIVE — the create verb's first step.
+          Every agent lives somewhere, and the old top control did not ask: it
+          opened a composer that invented a folder from a slug of whatever you
+          typed. So the first thing this asks is the one thing creation cannot
+          proceed without, and it answers it with the places the rail is already
+          showing rather than a blank field.
+          A popover, not a modal: this is a choice among destinations, and it
+          reuses the ⋮ menu's card so the create flow adds no new dialog. */}
+      <AnchoredPopover
+        open={newAgentOpen}
+        anchorRef={addProjectTriggerRef}
+        onDismiss={() => setNewAgentOpen(false)}
+        placement="right-start"
+        besideRef={railRef}
+        className="menu-flyer"
+        testid="new-agent-menu"
+      >
+        <div className="connect-card project-row-menu">
+          <div className="connect-card-header">
+            <span>New agent in</span>
+          </div>
+          <div className="connect-card-body" role="menu">
+            {projects.map((project) => (
+              <button
+                key={project.root}
+                type="button"
+                role="menuitem"
+                className="session-dropdown-item"
+                data-testid={`new-agent-in-${project.label}`}
+                title={project.root}
+                onClick={() => {
+                  setNewAgentOpen(false);
+                  void onNewAgentIn(project.root, project.label);
+                }}
+              >
+                <span className="session-item-icon">
+                  <Icon name="Folder" size={13} />
+                </span>
+                <span className="session-item-copy">
+                  <span className="session-item-title">{project.label}</span>
+                </span>
+              </button>
+            ))}
+            {/* THE WAY OUT, and on desktop it is the OS folder browser rather
+                than a dialog of ours — see `pickFolderForNewAgent`. */}
+            <button
+              type="button"
+              role="menuitem"
+              className="session-dropdown-item"
+              data-testid="new-agent-choose-folder"
+              onClick={pickFolderForNewAgent}
+            >
+              <span className="session-item-icon">
+                <Icon name="FolderPlus" size={13} />
+              </span>
+              <span className="session-item-copy">
+                <span className="session-item-title">
+                  {projects.length > 0
+                    ? "Another folder…"
+                    : "Choose a folder…"}
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </AnchoredPopover>
+
       <div className="rail-tree">
         {/* The ⋮ overflow menu. The popover is the TRACK, not the card: it
             opens BESIDE the rail (never over the tree it configures), and its
@@ -1021,6 +1118,33 @@ export function WorkflowsRail({
                 </button>
               </div>
               <div className="connect-card-body" role="menu">
+                {/* ADD EXISTING AGENTS, from here rather than from a nav row.
+                    Pointing a folder at Studio so it registers what is already
+                    in it is a real job and it stays one click deep — but it is
+                    not creating anything, and standing it beside the create
+                    verb as a peer is what made three controls read as three
+                    ways to make an agent. This menu is where the rail's own
+                    housekeeping already lives. */}
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="session-dropdown-item"
+                  data-testid="add-existing-agents"
+                  onClick={() => {
+                    closeHistory();
+                    setStartIntent("register");
+                    setStartMode("detect");
+                  }}
+                >
+                  <span className="session-item-icon">
+                    <Icon name="FolderPlus" size={13} />
+                  </span>
+                  <span className="session-item-copy">
+                    <span className="session-item-title">
+                      Add existing agents
+                    </span>
+                  </span>
+                </button>
                 {/* Hovering the fixed choices closes the Past-sessions flyout,
                     so moving off that row collapses its sub-card — the
                     hover-open's natural inverse. (A plain wrapper would flatten
@@ -1701,9 +1825,12 @@ export function WorkflowsRail({
         />
       </div>
 
-      {/* Add EXISTING agents: one detection-driven dialog that registers a
-          folder holding an agent project (or a folder of them). Creating a NEW
-          agent is "Create new" → the composer home (onNewSession). */}
+      {/* THE FOLDER DIALOG, on the web host only for `create`.
+          `startIntent` is why it opened, and it decides whether opening the
+          folder is the END of the flow (⋮ "Add existing agents": register what
+          is in there) or its FIRST STEP (the create verb's folder fallback,
+          which continues into `onNewAgentIn`). The dialog itself is unchanged:
+          it collects a folder, and the caller says what the folder is for. */}
       {startMode && (
         <StartDialog
           mode={startMode}
@@ -1715,10 +1842,17 @@ export function WorkflowsRail({
           onConnect={onConnect}
           onOpenProject={async (root) => {
             await onOpenProject(root);
+            if (startIntent === "create") await onNewAgentIn(root);
           }}
           onScan={onScanWorkflows}
+          /* Escape returns focus to a control that is still MOUNTED. The
+             detect dialog is opened from an item inside the ⋮ menu, and that
+             menu closes with the click — a `triggerRef` pointing at the item
+             would restore focus to <body>, which is the same detached-node bug
+             `ProjectRowMenu` documents on its remove item. So the ⋮ itself is
+             the trigger for that route. */
           triggerRef={
-            startMode === "open" ? addProjectTriggerRef : connectTriggerRef
+            startMode === "open" ? addProjectTriggerRef : historyTriggerRef
           }
         />
       )}

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -1841,8 +1841,14 @@ export function WorkflowsRail({
           onClose={() => setStartMode(null)}
           onConnect={onConnect}
           onOpenProject={async (root) => {
-            await onOpenProject(root);
+            // ONE OPEN PER CLICK. `onNewAgentIn` opens the folder itself — it
+            // has to, since the create verb can be pointed at a folder that is
+            // not a project yet — so calling `onOpenProject` first as well ran
+            // two `rememberProjectDir` writes and two registry sweeps of the
+            // same root, and let the remembered workspace be restored and then
+            // immediately overwritten.
             if (startIntent === "create") await onNewAgentIn(root);
+            else await onOpenProject(root);
           }}
           onScan={onScanWorkflows}
           /* Escape returns focus to a control that is still MOUNTED. The

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -219,7 +219,8 @@ export function isDemoSeedEnabled(): boolean {
 }
 
 /**
- * Mock mode only: `?mockError=listDir` forces the named operations to
+ * Mock mode only: `?mockError=listDir` (or `settings`, `deploy`, …) forces the
+ * named operations to
  * reject, so Playwright can exercise the error states of surfaces that talk to
  * the filesystem API (directory picker, command-palette path mode) without a
  * real server. Comma-separated; unknown names ignored.
@@ -2334,6 +2335,27 @@ export class MockApi implements HarnessApi {
             "credential rejected",
           );
         }
+      }
+    }
+    // `?mockError=stateRefresh` — every getState AFTER the boot pair rejects.
+    // The boot itself has to succeed or there is no shell to press anything in,
+    // and StrictMode double-invokes it, hence the counter rather than a flag.
+    //
+    // This is the honest injection point for the create verb's failure path:
+    // `rememberProjectDir` already swallows a settings 500 of its own accord
+    // (`use-harness-state.ts:1503-1513`, "whatever the caller was really doing
+    // already succeeded"), so `openProject` does not reject. The refreshed read
+    // that follows it does, and that is the one the handler has to survive.
+    if (typeof window !== "undefined" && mockErrorTargets().has("stateRefresh")) {
+      const win = window as unknown as { __MOCK_STATE_CALL_COUNT__?: number };
+      const count = (win.__MOCK_STATE_CALL_COUNT__ ?? 0) + 1;
+      win.__MOCK_STATE_CALL_COUNT__ = count;
+      if (count > 2) {
+        throw new ApiError(
+          500,
+          "GET /api/state → 500 (mock)",
+          "Could not read the workspace",
+        );
       }
     }
     // mockConsentSource query param lets Playwright exercise all chip states:

--- a/packages/harness/web/src/lib/folder-step.test.ts
+++ b/packages/harness/web/src/lib/folder-step.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { chooseProjectFolder } from "./folder-step";
+
+/**
+ * The desktop branch cannot be reached by the e2e tier — there is no Electron
+ * here, and the Playwright suite is the browser host by definition, so it can
+ * only ever prove the fallback. These are the desktop half's only proof, which
+ * is why they assert the NEGATIVE too: that the dialog never opens when the
+ * bridge is there. A test that only checked `chooseDirectory` was called would
+ * still pass on a build that opened both.
+ */
+describe("the create verb's folder step", () => {
+  it("goes straight to the OS picker when the bridge is there", async () => {
+    const chooseDirectory = vi.fn().mockResolvedValue("/Users/demo/acme-app");
+    const openDialog = vi.fn();
+    const onPicked = vi.fn();
+
+    await chooseProjectFolder({
+      chooseDirectory,
+      startingAt: "/Users/demo",
+      openDialog,
+      onPicked,
+    });
+
+    expect(chooseDirectory).toHaveBeenCalledWith("/Users/demo");
+    expect(onPicked).toHaveBeenCalledWith("/Users/demo/acme-app");
+    // The whole point: our dialog is not also shown.
+    expect(openDialog).not.toHaveBeenCalled();
+  });
+
+  it("opens the folder dialog when there is no bridge", async () => {
+    const openDialog = vi.fn();
+    const onPicked = vi.fn();
+
+    await chooseProjectFolder({
+      chooseDirectory: null,
+      startingAt: "/Users/demo",
+      openDialog,
+      onPicked,
+    });
+
+    expect(openDialog).toHaveBeenCalledTimes(1);
+    expect(onPicked).not.toHaveBeenCalled();
+  });
+
+  it("treats a cancelled native pick as nothing happening", async () => {
+    const openDialog = vi.fn();
+    const onPicked = vi.fn();
+
+    await chooseProjectFolder({
+      chooseDirectory: vi.fn().mockResolvedValue(null),
+      openDialog,
+      onPicked,
+    });
+
+    expect(onPicked).not.toHaveBeenCalled();
+    // Dismissing a folder browser must not fall back into our dialog: the user
+    // said no to the question, not to the way it was asked.
+    expect(openDialog).not.toHaveBeenCalled();
+  });
+
+  it("swallows a failed native pick without falling back", async () => {
+    const openDialog = vi.fn();
+    const onPicked = vi.fn();
+
+    await expect(
+      chooseProjectFolder({
+        chooseDirectory: vi.fn().mockRejectedValue(new Error("no window")),
+        openDialog,
+        onPicked,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(onPicked).not.toHaveBeenCalled();
+    expect(openDialog).not.toHaveBeenCalled();
+  });
+
+  it("omits the starting folder rather than passing an empty one", async () => {
+    const chooseDirectory = vi.fn().mockResolvedValue(null);
+
+    await chooseProjectFolder({
+      chooseDirectory,
+      startingAt: null,
+      openDialog: vi.fn(),
+      onPicked: vi.fn(),
+    });
+
+    expect(chooseDirectory).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/packages/harness/web/src/lib/folder-step.ts
+++ b/packages/harness/web/src/lib/folder-step.ts
@@ -1,0 +1,59 @@
+/**
+ * THE CREATE VERB'S FOLDER STEP: native on desktop, a dialog on the web.
+ *
+ * The split already existed, one level too deep. `FolderField` asks
+ * `getDesktopBridge()?.chooseDirectory` and uses the answer to decide whether
+ * to render a `<datalist>` — so on desktop the app still opened a modal
+ * wrapping a text input, and offered the OS folder browser as a button inside
+ * it. That is backwards. With Finder or Explorer available, our dialog is not a
+ * smaller version of it; it is a different and worse control, and the typed
+ * path is what a browser host is left with when it has nothing better.
+ *
+ * So the bridge decides whether the DIALOG OPENS AT ALL, and that decision
+ * lives here rather than at each entry point, because there is more than one
+ * entry point and two copies of this branch would eventually disagree.
+ *
+ * A FUNCTION RATHER THAN A HOOK, and pure over its inputs, because the desktop
+ * half cannot be exercised in this repo: there is no Electron in the test
+ * environment, and the browser half is the only one an e2e run can reach. A
+ * branch that only one host can run needs a test that does not need that host.
+ * See `folder-step.test.ts`.
+ */
+
+export interface FolderStepHost {
+  /**
+   * The desktop bridge's directory picker, or null in a browser. Feature
+   * detected by the caller, never assumed — an older desktop build without it
+   * reads as a browser and takes the fallback, which is always safe.
+   */
+  chooseDirectory: ((startingAt?: string) => Promise<string | null>) | null;
+  /** Where the OS picker should open. Ignored by the fallback, which has its
+   *  own recents and its own starting folder. */
+  startingAt?: string | null;
+  /** The web fallback: show the folder dialog. */
+  openDialog: () => void;
+  /** A folder the user settled on. Not called when they cancel. */
+  onPicked: (root: string) => void;
+}
+
+/**
+ * Ask for a folder the best way this host can.
+ *
+ * Resolves once the question has been ASKED, not answered: the dialog path
+ * returns as soon as the dialog is open. Only the native path has an answer to
+ * wait for, and a cancelled or failed pick is a no-op rather than an error —
+ * dismissing a folder browser is not a failure, and there is nothing to report.
+ */
+export async function chooseProjectFolder(host: FolderStepHost): Promise<void> {
+  if (!host.chooseDirectory) {
+    host.openDialog();
+    return;
+  }
+  let picked: string | null = null;
+  try {
+    picked = await host.chooseDirectory(host.startingAt ?? undefined);
+  } catch {
+    return;
+  }
+  if (picked) host.onPicked(picked);
+}

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -933,70 +933,21 @@ input {
   font-weight: 550;
 }
 
-/* "Create new": the primary affirmative action, promoted out of the header and
-   ABOVE Search. It's the app's primary CTA — a solid ink button (the same
-   --btn/--btn-ink treatment as Deploy / .btn-primary) — so it stays visually
-   distinct from the ghost Search/Templates rows while keeping their inset and
-   --sp2 rhythm. */
-.rail-nav-cta {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--sp2);
-  align-self: stretch;
-  margin: 0 calc(var(--pane-pad-x) - var(--row-bleed)) var(--sp2);
-  min-height: var(--control-h);
-  padding: 0 var(--row-bleed);
-  border: 1px solid transparent;
-  border-radius: var(--radius-sm);
-  background: var(--btn);
-  box-shadow: var(--shadow-xs);
-  text-align: center;
-  font-size: var(--type-ui);
-  font-weight: 550;
-  color: var(--btn-ink);
-  cursor: pointer;
-  transition:
-    background-color var(--transition-fast),
-    box-shadow var(--transition-fast),
-    transform var(--transition-fast);
-}
-
-/* The plus is the create signal — the one reserved brand accent, riding the ink
-   button. Mixed toward the button's ink so the green stays legible whichever way
-   the ink button flips with the theme (dark-in-light, light-in-dark). */
-.rail-nav-cta svg {
-  color: color-mix(in srgb, var(--brand) 65%, var(--btn-ink));
-}
-
-.rail-nav-cta:hover {
-  transform: translateY(-1px);
-  box-shadow: var(--shadow-soft);
-}
-
-.rail-nav-cta:focus-visible {
-  outline: 2px solid var(--focus);
-  outline-offset: 2px;
-}
-
-.rail-nav-cta:active {
-  transform: translateY(0);
-}
-
-/* Empty rail: keep the ink button but ring it in a soft brand halo, so the one
-   action a first-run user needs is the loudest thing on an otherwise empty rail
-   — without spending the reserved green as a full fill. */
-.rail-nav-cta.is-empty {
+/* THE CREATE VERB'S EMPTY-RAIL EMPHASIS.
+   `.rail-nav-cta` lived here: a solid ink button, first row of the nav, reading
+   "Create new agent". The verb moved to the rail header's `+` (IA-REVIEW: "Not
+   a row among places"), so the button and its brand halo went with it. What
+   survives is the halo's job — on a rail with nothing in it, the one action a
+   first-run user needs has to be the loudest thing on screen — now carried by
+   the header glyph, which is small enough that a ring is the whole treatment. */
+.rail-header-btn.is-empty {
   box-shadow:
     0 0 0 4px color-mix(in srgb, var(--brand) 24%, transparent),
     var(--shadow-xs);
 }
 
-.rail-nav-cta.is-empty:hover {
-  transform: translateY(-1px);
-  box-shadow:
-    0 0 0 4px color-mix(in srgb, var(--brand) 34%, transparent),
-    var(--shadow-soft);
+.rail-header-btn.is-empty svg {
+  color: color-mix(in srgb, var(--brand) 70%, var(--text));
 }
 
 .rail-header {


### PR DESCRIPTION
> Stacked on #801 (SAP-3142) and based on its branch, so this diff is only PR 2's
> change. #801 is the data fix; it must be provable on its own. GitHub retargets
> this to `main` when #801 merges.
>
> **NO TEST JOB HAS EVER RUN AGAINST THIS PR.** `test.yml` and `harness.yml` both
> trigger on `pull_request: branches: [main]`, and this PR's base is #801's
> branch, so neither fires — nor do `playwright-mock`, `desktop-smoke` or
> `examples`. The only workflow that runs here is Claude Code Review, which has
> no branch filter. **Read its rounds as code review, not as evidence anything
> runs.** The suites below were run locally; CI coverage arrives when #801 merges
> and this retargets to `main`.

SAP-3143. `SAP-2981` is titled **"Canonical create-agent flow"**, so the prompt
injection this replaces is the mechanism that ticket exists to remove, not
merely something adjacent to it.

## Three controls, one job

| control | testid | what it did |
|---|---|---|
| black CTA, first row of the nav | `rail-create-new` | `onNewSession` → `setComposing(true)` |
| nav row under it | `add-existing-agents` | `setStartMode("detect")` |
| Projects header folder-plus | `rail-add-project` | `setStartMode("open")` |

`agent-studio-demo/docs/IA-REVIEW.md:522` states the rule they broke:

> One create verb, `New agent`, as the rail header's `+`. Not a row among
> places: a verb in a list of destinations is the F-18 confusion.

Two of the three were rows in a list of destinations. Neither of the create-ish
ones asked the one thing creation cannot proceed without — where the agent
lives. The CTA answered it by inventing a folder from a slug of whatever you
typed into the composer.

## What it is now

**One create verb, the Projects header's `+`, `aria-label="New agent"`.** Its
first step is a popover: the projects the rail already shows, plus one way out
to a folder it does not.

| before | the verb's first step | where it lands |
|---|---|---|
| ![before](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/803/pr2-before-rail.png) | ![step 1](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/803/pr2-step1-where.png) | ![step 2](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/803/pr2-step2-map.png) |

The whole flow, recorded against `~/sapiom/agents`:
**[pr2-create-flow.webm](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/803/pr2-create-flow.webm)**

The nav now holds destinations only (Search, Templates). "Add existing agents"
is a real job and stays one click deep — in the rail's own ⋮ settings menu,
where its housekeeping already lives — without standing beside the verb as a
peer: ![⋮](https://raw.githubusercontent.com/sapiom/sapiom-js/pr-media/media/803/pr2-add-existing.png)

## (a) The folder step opens the native picker on desktop

The bridge worked already (`FolderField.tsx:55` → `dialogs.ts:41-44` →
`desktop.mts:55`). The split was one level too deep: `FolderField` asked
`getDesktopBridge()?.chooseDirectory` and used the answer to decide whether to
render a `<datalist>`, so a desktop user still got a modal wrapping a text field
with Finder offered as a button inside it. With a real OS folder browser
available, our dialog is not a smaller version of it.

The bridge now decides whether **the dialog opens at all**, in
`web/src/lib/folder-step.ts` — one shared place, because there is more than one
entry point and two copies of this branch would eventually disagree.

**Which half is proved how, since only one can run here:**

- **Web** — proved end to end. The CLI harness in a browser IS the web host, so
  every `test:ui` run exercises it. `folder-field.spec.ts`'s "browser host (npx)"
  describe still asserts no Choose button and a working datalist.
- **Desktop** — proved by unit-testing the branch (`folder-step.test.ts`, 5
  cases). There is no Electron in this repo's test environment and the Playwright
  tier is the browser host by definition, so a branch only the other host can run
  needs a test that does not need that host. The specs assert the NEGATIVE too —
  that our dialog never opens when the bridge is there — because a test that only
  checked `chooseDirectory` was called would pass on a build that opened both.
  **Mutation-tested**: making it call `openDialog()` unconditionally fails 3 of
  5; dropping the `onPicked` call fails 1. It is not an assertion that survives
  its own mutation.
- `folder-field.spec.ts`'s "desktop host" describe now reaches `FolderField`
  through the ⋮'s detection dialog instead of the create verb, because the verb
  deliberately never opens a dialog on that host any more.

## (b) The create verb stops typing English at the agent

`App.tsx`'s `sendScaffoldPrompt` starts a session at an invented folder and
injects `composerScaffoldPrompt` — an English request that the coding agent
please call `sapiom_dev_agents_scaffold`. It is the mechanism SAP-2981 set out to
remove and it was wired to the most prominent control in the product. It failed
the way a prompt fails: a create that did not happen arrived as a confused model
rather than an error.

`aaf721bb` (#790) had already fixed this for the project-row doors, and the fix
is the same one — **when a project has a durable Studio project, its Agent Map
owns creation**. So `handleNewAgentIn` resolves the folder to a project and hands
over to that map, exactly as selecting the project does. The folder does not have
to be a project yet: `openProject` is what makes it one (and resolves an agent's
own folder to the folder that holds it), and after #801 the server issues a
durable Studio project for exactly that root.

A payload with no Studio project catalog is the one case the map cannot serve.
It falls through to `handleCreateAgentInProject` — the dialog whose endpoint
creates the agent on disk and rescans before any session starts. Still the
harness creating the agent; still no sentence sent to a model.

**Measured on a real server** (`~/sapiom/agents`, 76 projects), pressing the verb
and confirming the project:

```
after picking the project: { agentMapFrame: true, agentMapSelectPressed: 'true', composer: 0 }
pageerrors: [] (one 404 for a resource, see "did not work")
```

The map planner's session does print text into the terminal — that is the
planner's own `SessionStart` hook, the shipped map-planner contract, visible in
the screenshot above. It is not `composerScaffoldPrompt`, which this PR's control
no longer reaches.

## The gap, stated

**The composer's own start still injects.** The composer is no longer a create
door — nothing in the rail opens it — but it remains what the app shows when
there is no session, no agent and nothing selected, and from there
`handleComposerSubmitIdea` still calls `sendScaffoldPrompt`.

The real path genuinely cannot serve it, and the reason is structural: the Agent
Map needs a project that already exists, and the composer's folder is invented
FROM the idea, after it. That inversion is exactly what the new verb's
folder-first step fixes, which is why the verb has no such case.

I did not disable the composer's send. Doing so would leave a fresh install's
home screen with no action at all, and moving new users onto the create verb's
folder step is a design decision I was not asked to make. Flagging it here rather
than silently keeping it: **this is the last `composerScaffoldPrompt` caller, it
is reachable from the home screen, and it should be someone's next ticket.**

## Spec changes (18 files)

Mechanical, through two new helpers in `mock-navigation.ts`:

- `openAddExistingAgents` — the item moved into the ⋮ menu (10 call sites).
- `openFolderStep` — the header `+` opens the where-step, not a folder dialog
  (5 call sites).

Judgement calls, each with the reason written into the spec:

- **`new-session-composer.spec.ts` (16 tests)** opens the composer via
  `?mockState=fresh` — the empty-state home — instead of the deleted CTA. Every
  assertion is unchanged; the subject was always the composer's own behaviour.
  One test, "Back returns to the session the composer was opened over", asserted
  the inverse of what is now true and became "the home screen has nothing to go
  Back to".
- **`smoke.spec.ts`'s CTA test** now asserts the verb is NOT in the nav and that
  pressing it asks where first.
- **`project-axis.spec.ts`'s header chrome** — the `+` is still left of the ⋮ and
  the label still owns the leading edge; what changed is what the `+` means.
- **`dismiss.spec.ts`** — Escape now returns focus to the ⋮, because the item
  that opened the dialog unmounts with the menu. A `triggerRef` pointing at a
  detached node restores focus to `<body>`, which is the bug that spec exists to
  catch; the fix is in the rail, not the spec.
- **`create-agent.spec.ts`** and `folder-field.spec.ts`'s desktop describe route
  through the ⋮, because the create verb's folder step CONTINUES into creation
  once the folder is named and those tests need the folder registered and nothing
  else.

## Two fixes this exposed

- `handleComposerSubmitIdea` now sets `composing` itself. It used to be set by
  the control that opened the composer, and holding it true is what keeps the
  composer mounted across the provisional session a start creates and a failed
  upload closes. Without it the attachment queue a rollback is supposed to retain
  went with the unmount.
- The empty-rail brand halo moved from `.rail-nav-cta.is-empty` to
  `.rail-header-btn.is-empty`, so the one action a first-run user needs is still
  the loudest thing on an empty rail. The dead `.rail-nav-cta` block is deleted;
  nothing in the modal block of `styles.css` is touched.

## Round 1

Findings 1, 2, 3 and 5 are fixed. Finding 4 is answered below with a citation
rather than a change.

**1 — the payload had no test.** `web/e2e/create-verb.spec.ts` (5 tests) asserts
where each branch LANDS, not that a menu opened: the Agent Map for a project that
has one, the create dialog **naming that project** for a payload that does not,
and the web folder step continuing into the flow instead of stopping at
registering the folder. The name is the assertion, because the named failure is
falling through silently with the wrong folder's basename.

Mutation-verified: forcing `scope` to null fails the map and folder-step tests;
stubbing the ⌘K guard fails its test; deleting the toast fails the failure test.

**A trap worth recording, because it nearly made this coverage a lie.** Mutating
a source file and THEN starting a fresh Vite dev server serves a CACHED
transform — the mutation never reaches the bundle and every spec passes, which
reads exactly like "the assertion survived its own mutation". Four consecutive
runs told me the map test was worthless. The file has to change while the server
is already running so HMR invalidates it.

**2 — it swallowed every failure.** Both call sites are `void onNewAgentIn(...)`
from a control that has already closed its popover, so a rejection left the
verb doing nothing at all, with an unhandled rejection as the only trace. It
reports now. The injection point is the workspace RE-READ, not the settings
write: `rememberProjectDir` swallows its own 500 by design
(`use-harness-state.ts:1503-1513`), so `openProject` does not reject and a test
built there would have asserted nothing.

**3 — it opened the project twice on the web fallback.** `openProjectAndResolve`
is now the one prefix shared by the verb and the rail's add-a-project route; the
difference stays in the callers. Two settings writes and two registry sweeps per
click, gone.

**4 — the two branches: the premise is wrong on the happy path, and the diff
cannot show why.** Selecting a project's map STARTS the creation flow one render
later. `use-agent-map-entry.ts:400-423` is an effect keyed on `projectId`:

```ts
if (startedProjectRef.current === projectId) return;
startedProjectRef.current = projectId;
...
if (!selectedResponse) loadPlanner(projectId, "resume-or-create");
```

`projectId` is `plannerProjectId` (`App.tsx:311-312`), read straight off
`studioSelection.kind === "agent-map"` — the one thing the handler sets. So the
map-planner session is resumed or created, and that planner is the surface where
an agent gets designed and generated. The screenshot above is that: the planner's
own SessionStart text, "Start by describing the outcome you want."

The create-verb spec now pins this rather than leaving it to a screenshot — it
waits for `session:/Users/demo/acme-app` in `createOrder` and asserts no
`scaffold:` entry. My first version asserted `createOrder` was EMPTY and was
simply wrong: landing on the map legitimately creates a session.

What genuinely differs between the branches is the KIND of surface, and the
payload forces that: there is no map to open when the catalog is absent. It is
the same asymmetry #790 shipped for the project-row doors. Forcing
`openFreshPlanner` instead was considered and rejected twice over — it reads
`currentProjectRef.current`, assigned during render, so it cannot be called in
the same tick as `setStudioSelection`; and resuming is the right behaviour when
the project already has a planning conversation in progress.

**5 — the changeset** is release copy now: what changed for someone using
Studio, no ticket IDs, no internal mechanisms.

## Also folded in: ⌘K stacked the palette over an open dialog

Found by the dialog-shell work (#800), which correctly stopped at `App.tsx`
rather than reaching into it. The pane-collapse hotkey 14 lines above the ⌘K
handler already bails when a layer is open; ⌘K did not, so the palette opened on
top of a dialog and native Tab then walked out of the palette into the dialog
behind it.

`.modal-backdrop` leads the selector because **`CommandPalette` carries no
`role` at all** — a role-only selector, which is the shape of the sibling
hotkey's, cannot see it and a guard copied from there would look correct and
detect nothing.

**The Overview is carved out, and the first version of this guard broke it.**
The palette is deliberately reachable by shortcut while the Overview is up, and
navigating from it dismisses the Overview rather than stacking behind it —
`welcome.spec.ts`'s "the palette's Browse templates, opened over the Overview,
leaves it (never stacks)" is that contract, and it failed until the carve-out
went in. The Overview wears both `role="dialog"` and `aria-modal="true"`, so the
exclusion is per clause.

This is also why the constant is NOT #800's `DIALOG_LAYER_SELECTOR` and should
not be collapsed into it. That one answers "which layer owns Tab", where the
Overview IS a layer and belongs in the list. This one answers "may ⌘K open
here", where it does not. Same shape, different question.

Scope, per #800's round 2: making the palette CONTAIN focus is pre-existing and
not attempted here.

## Held: two specs from #802 that this PR's IA orphans

#802 (`keep new-agent prompts in builder sessions`) landed while this was open
and added two specs that open the composer with `rail-create-new` on a fixture
that HAS projects. On this branch that control is the create verb: it opens the
"where does it live" step, and creation goes to the project's Agent Map. The
composer survives only as the home screen, which is by definition the state with
no session, no agent and nothing selected — so it cannot appear in a fixture
whose whole premise is that a parent project already exists. **Measured: the
composer renders 0 times at both of their URLs.**

The behaviour is intact — #802's `App.tsx` changes merged cleanly and the
standalone-builder intent is still here. What went is the door. Both specs are
held with `test.fixme` and a comment naming the collision, and the question is
escalated: whether the composer keeps an entry point is a product decision on
top of two PRs that landed hours apart, not a test edit. Nothing was deleted and
no assertion was changed.

This is the same question as the gap below — the composer's own submit is the
last `sendScaffoldPrompt` caller.

## Tests

- `pnpm test:ui` — **502 passed, 0 failed.**
- `create-verb.spec.ts` — 5 new e2e tests, mutation-verified (above).
- `folder-step.test.ts` — 5 new unit tests, mutation-verified (above).
- `pnpm typecheck` clean. `pnpm lint` is `eslint src` and does not reach
  `web/src`, so it says nothing about this diff.
