### PR TITLE
fix(harness): read string definition IDs from markers

### DIFF
--- a/packages/harness/src/core/workflow-registry.test.ts
+++ b/packages/harness/src/core/workflow-registry.test.ts
@@ -252,7 +252,7 @@ describe("WorkflowRegistry", () => {
     const reloaded = (await new WorkflowRegistry(registryPath).list())[0]!;
 
     expect(scanned).toMatchObject({
-      definitionId: null,
+      definitionId: 99,
       definitionSlug: null,
       templateId: null,
       forkId: null,

--- a/packages/harness/src/core/workflow-registry.ts
+++ b/packages/harness/src/core/workflow-registry.ts
@@ -126,8 +126,16 @@ function safeOpaqueString(value: unknown): string | null {
 }
 
 function safeDefinitionId(value: unknown): number | null {
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
-    ? value
+  // agent-core persists definition IDs as JSON strings. Accept only their
+  // canonical positive-integer representation; other marker input stays null.
+  const parsed =
+    typeof value === "string" && /^[1-9]\d*$/.test(value)
+      ? Number(value)
+      : value;
+  return typeof parsed === "number" &&
+    Number.isSafeInteger(parsed) &&
+    parsed > 0
+    ? parsed
     : null;
 }
 


### PR DESCRIPTION
## Primary change type

- [x] Bug fix

## Problem and motivation

Harness rejected string definition IDs written to `sapiom.json` by agent-core. A linked production agent then appeared as undeployed locally, blocking production actions.

## Summary and scope

Normalize canonical positive integer strings such as `"268"` when loading marker metadata. Existing invalid values remain rejected.

## Related work

Related issue or discussion: N/A

## Validation

`pnpm --filter @sapiom/harness exec vitest run src/core/workflow-registry.test.ts -t 'normalizes untrusted marker fields identically'` — passed

`pnpm --filter @sapiom/harness typecheck` — passed

`pnpm -r --filter @sapiom/harness... build` — passed

### Tests and documentation

Updated the registry regression test. Documentation: N/A; internal compatibility fix.

## Compatibility and release impact

- Breaking or externally visible changes: None. Existing string markers now load correctly.
- Changeset: N/A; Harness behavior fix only.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability.

## AI assistance

- [x] I used AI assistance to prepare the patch and validation; reviewed the diff and test results.

## Checklist

- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests.
- [x] I ran relevant tests, typecheck, and build.
- [x] Documentation is N/A for this internal compatibility fix.
- [x] I can explain and maintain every submitted change.