### PR TITLE
fix(sandbox): declare repository for trusted publishing

### DIFF
--- a/.changeset/sandbox-publishing-repository.md
+++ b/.changeset/sandbox-publishing-repository.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/sandbox": patch
+---
+
+Declare the package's GitHub repository so npm trusted publishing can match the
+release workflow to the package.

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -2,6 +2,11 @@
   "name": "@sapiom/sandbox",
   "version": "0.8.4",
   "description": "Sandbox environment management for Sapiom SDK",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sapiom/sapiom-js.git",
+    "directory": "packages/sandbox"
+  },
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.ts",


### PR DESCRIPTION
## Primary change type

- [x] Bug fix

## Problem and motivation

The release workflow currently fails to publish `@sapiom/sandbox@0.8.4` with `ENEEDAUTH`. Unlike the other public packages, sandbox does not declare its repository. npm trusted publishing requires `repository.url` to match the GitHub repository.

## Summary and scope

Add the standard repository URL and package directory to the sandbox manifest. This corrects package metadata needed by the existing OIDC publishing workflow; the next Publish run must confirm whether the package's npm-side trusted publisher also needs attention.

## Related work

- [Failed Publish run](https://github.com/sapiom/sapiom-js/actions/runs/33998011283)
- [npm trusted publishing requirements](https://docs.npmjs.com/trusted-publishers/)

## Validation

```text
Parsed the package manifest and verified repository.url matches the root manifest — passed
git diff --check — passed
```

### Tests and documentation

No runtime code changes. A metadata assertion directly checks this change; CI provides the repository checks. Publishing still requires verification from GitHub Actions, where the OIDC identity is available.

## Compatibility and release impact

- Breaking or externally visible changes: none; package repository attribution is added.
- Changeset: sandbox patch entry included.

## Security

- [x] No secrets, credentials, private data, or unsanitized logs included.
- [x] No suspected vulnerability publicly disclosed.

## AI assistance

- [x] Codex inspected the failed release, added the metadata, and verified the manifest.

## Checklist

- [x] Read CONTRIBUTING.md; this is a focused direct bug-fix PR.
- [x] Validation and its limits documented.
- [x] Changeset included.
