### PR TITLE
fix(ci): count the third Agent Map Workflow icon in the terminology allowlist

### DIFF
--- a/scripts/agent-studio-terminology-allowlist.json
+++ b/scripts/agent-studio-terminology-allowlist.json
@@ -227,8 +227,8 @@
     "id": "agent-map-pane-icon-identifier",
     "path": "packages/harness/web/src/components/AgentMapPane.tsx",
     "pattern": "^Workflow$",
-    "occurrences": 2,
-    "reason": "The design-system Workflow icon identifier remains private in the neutral Agent Map loading and empty states."
+    "occurrences": 3,
+    "reason": "The design-system Workflow icon identifier remains private in the neutral Agent Map loading, generating, and empty states."
   },
   {
     "id": "agent-map-canvas-icon-identifier",


### PR DESCRIPTION
## Primary change type

- [x] Maintenance or refactor

## Problem and motivation

`pnpm terminology:check` (the `examples` job) is red on `main` since `4622f409`: `AgentMapPane.tsx` gained a third `icon="Workflow"` (the "Generating Agent Map…" state) while allowlist entry `agent-map-pane-icon-identifier` still expects two occurrences, so the gate reports a stale entry. Every open PR inherits the failure.

## Summary and scope

One-line allowlist change: occurrences 2 → 3, reason updated to name the third state. The identifier is the same private design-system icon token in all three places; no user-visible text changes. Nothing else touched.

## Related work

Related issue or discussion: N/A — direct CI fix for main at `8495be29`.

## Validation

```text
pnpm terminology:check       — Agent Studio terminology check passed (no stale allowlist entries)
pnpm terminology:check:test  — passed
```

### Tests and documentation

N/A — allowlist data only; the gate's own tests cover the entry shape.

## Compatibility and release impact

- Breaking or externally visible changes: None.
- Changeset: N/A — CI script data, not a published package.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code identified the stale entry while merging main into #815, made the one-line change, and ran both terminology commands above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThB3ibgxg6QovWtRz3uqWB
