### PR TITLE
fix(harness): count the Agent Map generating state in the terminology allowlist

### DIFF
--- a/scripts/agent-studio-terminology-allowlist.json
+++ b/scripts/agent-studio-terminology-allowlist.json
@@ -227,8 +227,8 @@
     "id": "agent-map-pane-icon-identifier",
     "path": "packages/harness/web/src/components/AgentMapPane.tsx",
     "pattern": "^Workflow$",
-    "occurrences": 2,
-    "reason": "The design-system Workflow icon identifier remains private in the neutral Agent Map loading and empty states."
+    "occurrences": 3,
+    "reason": "The design-system Workflow icon identifier remains private in the neutral Agent Map loading, generating and empty states."
   },
   {
     "id": "agent-map-canvas-icon-identifier",


### PR DESCRIPTION
`main` is red on `pnpm terminology:check` and has been since 8495be29 (the merge of #844). This is the one-line fix.

## What happened

#844 added a third neutral state to `AgentMapPane.tsx`, `agent-map-generating`, carrying the same private design-system `icon="Workflow"` identifier the loading and empty states already carry. The allowlist entry covering that file still declares `"occurrences": 2`. The guard fails an entry that matches more than it declares, which is the guard doing its job: an allowlist that silently absorbs new matches would stop being a record of what was reviewed.

```
Stale terminology allowlist entries found:
  agent-map-pane-icon-identifier [workflow] - packages/harness/web/src/components/AgentMapPane.tsx / ^Workflow$ (expected 2, matched 3)
```

## Why bumping the count is the right fix, not changing the code

All three matches are the `icon` prop, a private design-system identifier, on neutral states:

| Line | State | Visible title |
|---|---|---|
| 107 | `agent-map-loading` | "Loading Agent Map…" |
| 129 | `agent-map-generating` | "Generating Agent Map…" |
| 159 | `agent-map-empty` | "Nothing generated yet" |

No user-visible string says "workflow" in any of them, which is what the guard is actually protecting. The declared count is what is out of date, so it moves to three and the reason now names the generating state alongside the other two.

## Verification

`pnpm terminology:check` goes from the failure above to `Agent Studio terminology check passed (965 files, no stale allowlist entries)`.

## Why this is its own PR

It is nobody's feature, and it blocks every PR rebased past 8495be29, including #841. It should be able to merge on its own rather than ride in behind a feature review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019o9uM8fivJobCpT5zd4ChM
