### PR TITLE
fix(core): omit undefined headers

### DIFF
--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -97,11 +97,7 @@ describe("Header Utilities", () => {
         "Content-Type": "text/plain",
       };
 
-      const result = setHeader(
-        headers,
-        "X-Sapiom-Transaction-Id",
-        "tx_123",
-      );
+      const result = setHeader(headers, "X-Sapiom-Transaction-Id", "tx_123");
 
       expect(result).toEqual({
         "Content-Type": "text/plain",

--- a/packages/core/src/utils/utils.test.ts
+++ b/packages/core/src/utils/utils.test.ts
@@ -90,6 +90,25 @@ describe("Header Utilities", () => {
       expect(result["X-Custom"]).toBe("final");
       expect(result["Other"]).toBe("keep");
     });
+
+    it("should omit unrelated headers with undefined values", () => {
+      const headers: Record<string, string | string[] | undefined> = {
+        Authorization: undefined,
+        "Content-Type": "text/plain",
+      };
+
+      const result = setHeader(
+        headers,
+        "X-Sapiom-Transaction-Id",
+        "tx_123",
+      );
+
+      expect(result).toEqual({
+        "Content-Type": "text/plain",
+        "X-Sapiom-Transaction-Id": "tx_123",
+      });
+      expect(result).not.toHaveProperty("Authorization");
+    });
   });
 
   describe("removeHeader", () => {
@@ -116,6 +135,18 @@ describe("Header Utilities", () => {
       expect(result["x-custom"]).toBeUndefined();
       expect(result["X-Custom"]).toBeUndefined();
       expect(result["Other-Header"]).toBe("keep");
+    });
+
+    it("should omit unrelated headers with undefined values", () => {
+      const headers: Record<string, string | string[] | undefined> = {
+        Authorization: undefined,
+        "Content-Type": "text/plain",
+      };
+
+      const result = removeHeader(headers, "Content-Type");
+
+      expect(result).toEqual({});
+      expect(result).not.toHaveProperty("Authorization");
     });
   });
 

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -57,8 +57,8 @@ export function setHeader(
 
   // Copy all headers except case variants of the one we're setting
   for (const [key, val] of Object.entries(headers)) {
-    if (key.toLowerCase() !== lowerHeaderName) {
-      newHeaders[key] = Array.isArray(val) ? val[0] || "" : val || "";
+    if (key.toLowerCase() !== lowerHeaderName && val !== undefined) {
+      newHeaders[key] = Array.isArray(val) ? val[0] || "" : val;
     }
   }
 
@@ -83,8 +83,8 @@ export function removeHeader(
   const newHeaders: Record<string, string> = {};
 
   for (const [key, val] of Object.entries(headers)) {
-    if (key.toLowerCase() !== lowerHeaderName) {
-      newHeaders[key] = Array.isArray(val) ? val[0] || "" : val || "";
+    if (key.toLowerCase() !== lowerHeaderName && val !== undefined) {
+      newHeaders[key] = Array.isArray(val) ? val[0] || "" : val;
     }
   }
 


### PR DESCRIPTION
## Summary
- skip undefined entries while copying headers in `setHeader` and `removeHeader`
- add regression coverage for both header helpers

## Tests
- `pnpm --filter @sapiom/core test --runInBand`
- `pnpm --filter @sapiom/core typecheck`
- `pnpm --filter @sapiom/core lint` (passes with 3 existing warnings)
- `pnpm exec prettier --check packages/core/src/utils/utils.ts packages/core/src/utils/utils.test.ts`

Fixes #625