### PR TITLE
docs(mcp): say an App Link is a redirector, not a reverse proxy [SAP-3217]

### DIFF
--- a/.changeset/app-link-redirector-not-proxy.md
+++ b/.changeset/app-link-redirector-not-proxy.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/mcp": patch
+---
+
+Say that an App Link is a redirector, not a reverse proxy. `sapiom_dev_app_publish`'s description and its publish summary now state that the link's root answers a 302 to whichever preview URL is currently serving the app, that sub-paths are not proxied, and that the app's own API therefore lives at the preview URL — which must be re-resolved per use rather than stored, because it changes when a wake recreates the sandbox and for an org-scoped app carries a short-lived token that expires. They also say who can take those routes: for an org-scoped app the redirect and `GET {link}/__status` both need a logged-in member's browser session rather than an API key, so its API is browser-only and a machine caller needs the app published `public` (whose link and `__status` need no session) or inbound traffic on `/hook/…`, which requires `webhooksEnabled`, off by default. The summary branches on visibility, so a public app is not warned about a gate it does not have.

--- a/packages/mcp/src/tools/app-publish.test.ts
+++ b/packages/mcp/src/tools/app-publish.test.ts
@@ -135,12 +135,17 @@ const jsonRes = (body: unknown, status = 200) => ({
 });
 
 /** The happy-path backend: upsert → bundle → publish. */
-function mockHappyBackend(): ReturnType<typeof vi.fn> {
+function mockHappyBackend(
+  overrides: Partial<typeof APP_LINK> = {},
+): ReturnType<typeof vi.fn> {
+  // `overrides` exists for `visibility`: the summary branches on it, and the default
+  // fixture is org-scoped, so the public branch is unreachable without this.
+  const link = { ...APP_LINK, ...overrides };
   const fetchMock = vi
     .fn()
-    .mockResolvedValueOnce(jsonRes(APP_LINK, 201))
+    .mockResolvedValueOnce(jsonRes(link, 201))
     .mockResolvedValueOnce(jsonRes(BUNDLE))
-    .mockResolvedValueOnce(jsonRes(APP_LINK));
+    .mockResolvedValueOnce(jsonRes(link));
   globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
   return fetchMock;
 }
@@ -210,6 +215,39 @@ describe("sapiom_dev_app_publish tool", () => {
     expect(description).toMatch(/same slug again replaces the app in place/i);
     expect(description).toMatch(/TEXT-ONLY/);
     expect(description).toMatch(/10 MiB/);
+  });
+
+  it("says the link is a redirector, not a reverse proxy (SAP-3217)", () => {
+    // Studio feedback 7a59535a: "DURABLE link" plus "safe to hand to a teammate" reads
+    // as a stable BASE url, so an agent points the app's own fetches at sub-paths of it.
+    // The host serves the root (a 302), `/__status`, and `/hook`/`/hook/*` — every other
+    // sub-path is its 404, never the app. Assert the claim, not one phrasing of it.
+    const { description } = setup();
+    expect(description).toMatch(/REDIRECTOR, not a reverse proxy/);
+    expect(description).toMatch(/sub-paths are NOT proxied/);
+    expect(description).toMatch(/__status/);
+    expect(description).toMatch(/\/hook\//);
+    // Plus the facts that keep the bare claim from misleading in a new way. Re-resolve
+    // rather than store: an org app's tokenized URL 401s inside a single wake, which
+    // "changes across wakes" does not predict. `/hook/` forwards only for a link with
+    // `webhooksEnabled`, off by default and not in this schema.
+    expect(description).toMatch(/re-resolve it per use/);
+    expect(description).toMatch(/short-lived token that expires/);
+    expect(description).toMatch(/webhooksEnabled.*off by default/s);
+    // And WHO can take the recovery routes, scoped correctly. The gate reads a browser
+    // cookie and no API key, so an org app's API is browser-only — but the backend
+    // authorizes a public + browser resolve with no token at all, so a public app's link
+    // and `__status` need no session, and stating the gate unconditionally would rule out
+    // the one route a cron job has. `currentPreviewUrl` is deliberately never offered as
+    // an address: it is null right after a publish, and reading it wakes nothing.
+    expect(description).toMatch(/browser session/);
+    expect(description).toMatch(/NOT an API/);
+    expect(description).toMatch(/browser-only/);
+    expect(description).toMatch(/for an org-scoped app that means/);
+    expect(description).toMatch(
+      /public app's link and `\/__status` need no session/,
+    );
+    expect(description).not.toMatch(/currentPreviewUrl/);
   });
 
   it("is not authenticated without a cached credential, and makes no call", async () => {
@@ -462,7 +500,49 @@ describe("sapiom_dev_app_publish tool", () => {
     });
     expect(payload.summary).toContain("https://apps.sapiom.ai/acme/dash");
     expect(payload.summary).toMatch(/durable/i);
+    // SAP-3217: the summary is what the agent hands the user AND what it reads back when
+    // it decides where to point the app's own fetches, so it carries the redirector fact.
+    expect(payload.summary).toMatch(/REDIRECTOR, not a reverse proxy/);
+    expect(payload.summary).toContain(
+      "https://apps.sapiom.ai/acme/dash/__status",
+    );
+    // This fixture is the default org-scoped app, so the summary takes the browser-only
+    // branch: both recovery routes need a member's session, and the machine routes are a
+    // public app or `/hook/` (which needs webhooksEnabled, off by default).
+    expect(payload.summary).toMatch(/re-resolve it per use/);
+    expect(payload.summary).toMatch(/short-lived token that expires/);
+    expect(payload.summary).toMatch(/browser-only/);
+    expect(payload.summary).toMatch(/NOT an API key/);
+    expect(payload.summary).toContain("https://apps.sapiom.ai/acme/dash/hook/");
+    expect(payload.summary).toMatch(
+      /requires webhooksEnabled on\s+the link, off by default/,
+    );
     expect(payload.summary.split("\n")).toHaveLength(1);
+  });
+
+  it("takes the public branch of the summary — no browser-only warning", async () => {
+    // `mockHappyBackend` returns `visibility: "organization"`, so every other summary
+    // assertion in this file exercises the org branch only. A public app must NOT be told
+    // its API is browser-only and that it needs "the app published as `public`" — advice
+    // it has already taken — so the branch needs its own case.
+    mockHappyBackend({ visibility: "public" });
+    const res = await setup().handler({
+      dir: project(),
+      slug: "dash",
+      name: "Dash",
+      visibility: "public",
+      confirmPublic: true,
+      dailySpendCapUsd: "5.00",
+    });
+
+    const { summary } = parse(res);
+    expect(summary).toMatch(/REDIRECTOR, not a reverse proxy/);
+    expect(summary).toMatch(/need no login/);
+    expect(summary).toMatch(/what wakes the app/);
+    expect(summary).not.toMatch(/browser-only/);
+    expect(summary).not.toMatch(/NOT an API key/);
+    expect(summary).not.toMatch(/webhooksEnabled/);
+    expect(summary.split("\n")).toHaveLength(1);
   });
 
   it("forwards the optional metadata a public app needs", async () => {

--- a/packages/mcp/src/tools/app-publish.ts
+++ b/packages/mcp/src/tools/app-publish.ts
@@ -11,6 +11,36 @@
  * is provisioned here: no gateway call, no sandbox, no Blaxel. The wake happens
  * later, on demand.
  *
+ * What the durable address IS, and it is easy to read the copy the other way
+ * (SAP-3217): a redirector, not a reverse proxy. The host answers the root with a
+ * 302 to whichever preview URL is serving the app, answers `/__status` with the wake
+ * state that the "Starting …" page polls, forwards `/hook`/`/hook/*` when the link
+ * has `webhooksEnabled`, and 404s everything else. So the app's own API is only
+ * reachable at the preview URL the redirect lands on.
+ *
+ * Which is why the copy does not stop at "not the durable URL". Three further facts
+ * each turn one wrong inference into another, so all three are stated:
+ *   - RE-RESOLVE, do not store: the URL changes when a wake recreates the sandbox,
+ *     and for an org-scoped app it carries a token that expires inside one wake — so
+ *     a stored URL 401s minutes later, which "changes across wakes" does not predict.
+ *   - The redirect and `/__status` both run the link's access check, which verifies a
+ *     browser cookie and nothing else. An org-scoped app's API is therefore
+ *     browser-only; an API-key caller lands on the login page.
+ *   - `webhooksEnabled` is off by default and is not in this tool's schema, so
+ *     promising `/hook/` unconditionally would send an agent to register a URL that
+ *     404s indistinguishably from a typo'd slug.
+ *
+ * Both the tool description and the success summary say all of it, because the
+ * summary is what an agent reads back before it wires up a client, and the summary
+ * branches on visibility so a public app is not warned about a gate it does not have.
+ *
+ * The offline primer (instructions.ts) deliberately does NOT carry this paragraph yet:
+ * it and the backend's `DEFAULT_MCP_INSTRUCTIONS` are currently drifted by two unrelated
+ * release pairs (SAP-3180's vault/launch/receipts landed here, the backend's trigger-kinds
+ * release landed there), so neither body is a superset and syncing either way would delete
+ * the other's content. The redirector paragraph goes into the primer with that
+ * reconciliation, not ahead of it.
+ *
  * Three calls against the App Links REST API, in order:
  *   POST /v1/app-links            (upsert on slug)
  *   PUT  /v1/app-links/{id}/bundle
@@ -116,6 +146,15 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
       '(only logged-in members of your organization can open it); visibility "public" needs ' +
       "confirmPublic: true and a dailySpendCapUsd because your org pays for every wake. Publishing the " +
       "same slug again replaces the app in place at the SAME URL — that is how you ship an update. " +
+      "The link is a wake-on-visit REDIRECTOR, not a reverse proxy: its root answers a 302 to whichever " +
+      "preview URL is currently serving the app and sub-paths are NOT proxied, so the app's own API lives " +
+      "at that preview URL, never under the link. Read it off the redirect (or from `url` in " +
+      "GET {link}/__status) and re-resolve it per use — it changes when a wake recreates the sandbox and, " +
+      "for an org-scoped app, carries a short-lived token that expires. Both routes run the link's OWN " +
+      "access check — for an org-scoped app that means a logged-in member's browser session, NOT an API " +
+      "key, so its API is browser-only. A public app's link and `/__status` need no session at all, so for " +
+      "machine callers publish the app as `public`, or receive traffic on `/hook/…`, which needs " +
+      "`webhooksEnabled` on the link (off by default, not settable here — REST only). " +
       `Bundles are TEXT-ONLY (UTF-8 files; no images, fonts, or archives) and capped at ${BUNDLE_CAP_MIB} MiB; ` +
       "node_modules, .git, dotfiles, symlinks and the project's own sapiom.json are never uploaded — " +
       "install dependencies at wake via `build`. Both limits are checked locally, so a bad bundle costs no upload. " +
@@ -306,7 +345,19 @@ function summarize(
   return (
     `Published "${link.name}" to ${link.url} (${audience}; ${files}). ` +
     `The link is durable — republish the "${link.slug}" slug to update it in place. ` +
-    "The first visit after a publish cold-starts the app."
+    "The first visit after a publish cold-starts the app. " +
+    "It is a REDIRECTOR, not a reverse proxy: the root 302s to the preview URL currently " +
+    "serving the app and sub-paths are not proxied, so the app's own API lives at that preview " +
+    `URL, not under this link — read it off the redirect (or from \`url\` in GET ${link.url}/__status) ` +
+    "and re-resolve it per use, because it changes when a wake recreates the sandbox and, for an " +
+    "org-scoped app, carries a short-lived token that expires. " +
+    (link.visibility === "public"
+      ? `This app is public, so ${link.url} and ${link.url}/__status need no login — that is the ` +
+        "route for a server-side caller too, and it is what wakes the app."
+      : "Both of those routes need a logged-in member's browser session, NOT an API key, so this " +
+        "org-scoped app's API is browser-only: a machine caller needs the app published as " +
+        `\`public\`, or inbound traffic on ${link.url}/hook/… — which requires webhooksEnabled on ` +
+        "the link, off by default and settable only over REST.")
   );
 }
 


### PR DESCRIPTION
## What

`sapiom_dev_app_publish`'s **description** and its **publish summary** now say the link is a wake-on-visit REDIRECTOR, not a reverse proxy: the root 302s to whichever preview URL is serving the app, sub-paths are not proxied, so the app's own API lives at that preview URL.

Three facts ship with it, because review showed the bare claim just relocates the confusion:

| Fact | Why it has to be there |
| --- | --- |
| Re-resolve per use, don't store | an org app's tokenized URL 401s *inside a single wake* once the token expires — "changes across wakes" does not predict that |
| Org-scoped app's API is **browser-only** | the redirect and `/__status` both run the link's own access check, which reads a browser session and no API key. But only for an org app — a public app's link and `/__status` need no session, so those are the machine route |
| `webhooksEnabled` is off by default | it is `false` on upsert, is not in this tool's schema, and the disabled path 404s indistinguishably from a typo'd slug |

`currentPreviewUrl` is deliberately never offered as an address: the backend's `publish()` leaves the binding stale at `wakeStatus = 'idle'`, so it is null in exactly the state this summary is read in, it can point at an expired sandbox, and reading it wakes nothing.

The summary branches on visibility, so a public app is not warned about a gate it does not have.

## Why

Studio feedback `7a59535a-97c8-4b30-bcff-dcf4004fbbdf`:

> It was not obvious that an App Link is a redirector rather than a reverse proxy. The root path answers a 302 to the current preview URL, and sub-paths are not proxied at all, so anything calling the app's API has to use the underlying address rather than the durable one.

The copy pushed the other way — "DURABLE Sapiom link", "safe to hand to a teammate" — which reads as a stable base URL for API calls too.

## The offline primer is deliberately NOT touched

An earlier revision of this PR synced `instructions.ts` to backend content release 2.11. That is now dropped, because the two bodies have drifted **in both directions** across two unrelated release pairs:

- **sapiom-js main** carries SAP-3180's vault / `agents.launch` / receipts-and-replay content (#815). Its backend half has not merged.
- **The backend constant** carries the trigger-kinds release. Its sapiom-js half has not merged.

Neither body is a superset, so copying either over the other deletes a shipped release's content. So the redirector paragraph goes into the backend's `DEFAULT_MCP_INSTRUCTIONS` (where the ticket asks for it) and into this tool's own copy, and it reaches the primer with that reconciliation rather than ahead of it. The reasoning is recorded in `tools/app-publish.ts`, in the backend migration, and behind a ⚠️ on `SAPIOM_JS_FALLBACK_DIGEST` so the next person does not "fix" it by copying one side over the other.

Worth noting the primer on main already says webhooks are "off by default" and that "no `sapiom_dev_*` tool sets it yet" — SAP-3180 reached the same conclusion independently.

## Verification

- `pnpm --filter @sapiom/mcp typecheck` — clean
- `pnpm --filter @sapiom/mcp test` — **149 passed** (15 files)
- `pnpm --filter @sapiom/mcp lint` — clean
- New spec cases assert the claims rather than phrasings, including the public-visibility summary branch the suite could not reach before (`mockHappyBackend` only ever returned an org-scoped link)

Changeset: `@sapiom/mcp` patch.

## Related

- sapiom/Sapiom#4926 — `sapiom_app_publish` description, publish result, and the primer paragraph as content release 2.11
- sapiom/docs-internal#153 — the "What the URL does" section on docs.sapiom.ai (**merged**)
- Linear: [SAP-3217](https://linear.app/sapiom/issue/SAP-3217)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PAEku9HKnZUHmdnsQ3v5D1