### PR TITLE
fix(mcp): re-sync the offline primer fallback with content release 2.11 [SAP-3180]

### DIFF
--- a/.changeset/resync-primer-2-11.md
+++ b/.changeset/resync-primer-2-11.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/mcp": patch
+---
+
+Re-sync the offline `AUTHORING_INSTRUCTIONS` fallback with primer 2.11, which folds the 2.10
+trigger-kinds release (SAP-3174: `schedule_cron` / `schedule_once` / `event` / `webhook`, the
+webhook signing recipe, `sapiom_dev_agents_schedule_secret`) together with the SAP-3180
+teaching (Vault semantics, `agents.launch`, receipts/replay, App Link webhooks). The two landed
+in separate backend releases and the package had only the second; the digest pin moves with the
+body.

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -180,13 +180,13 @@ describe("server instructions", () => {
     // of PRs. Never re-point this digest on its own — that just re-blesses the
     // drift the guard exists to catch.
     //
-    // Current release: 2.9 (Vault semantics, `agents.launch`, receipts/replay, App Link
+    // Current release: 2.11 (2.10 trigger kinds + Vault semantics, `agents.launch`, receipts/replay, App Link
     // webhooks — SAP-3180).
     const sha256 = createHash("sha256")
       .update(AUTHORING_INSTRUCTIONS, "utf8")
       .digest("hex");
     expect(sha256).toBe(
-      "ffb497cade769284a3f068304e9368d4de41407d9305b33973d70bba2d0df258",
+      "46a48ad30cf15008d232ed496f055e3b39b160322adc7488ece6c4ea99ce2d89",
     );
   });
 

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -82,6 +82,24 @@ app, and a request that arrives while the app sleeps is held up to 60 s (then 50
 wake continues, so the sender's retry lands warm). Keep the receiver fast: dispatch real work
 with \`agents.launch\` (below) and return.
 
+## Triggers (run a deployed agent without a human)
+\`sapiom_dev_agents_schedule\` creates a trigger of one of four kinds on a deployed agent:
+\`schedule_cron\` (recurring), \`schedule_once\` (one future time), \`event\` (fires whenever this
+tenant emits its \`eventType\` through the tenant events API), and \`webhook\` (fires whenever an
+external system POSTs to a public hook URL minted for the trigger). "Run this agent when X POSTs
+to us" is a \`webhook\` trigger, not a hand-built HTTP server: the create result carries the hook
+URL, a shown-once secret, and the exact signing recipe — HMAC-SHA256 hex over
+\`timestamp.eventId.rawBody\` (epoch-ms timestamp, url-safe event id \`[A-Za-z0-9_-]{1,128}\`,
+±5 min skew), sent as \`X-Sapiom-Timestamp\` / \`X-Sapiom-Event-Id\` / \`X-Sapiom-Signature\`.
+Only a sender you control can sign that way; Slack, Meta, Stripe and GitHub sign with their own
+schemes and cannot produce our HMAC, so route those to an App Link \`/hook/*\` receiver
+(\`webhooksEnabled\`) that verifies their signature, or through a small translator that re-signs
+into a webhook trigger.
+\`_schedule_inspect\` / \`_schedule_cancel\` cover every kind; \`sapiom_dev_agents_schedule_secret\`
+rotates or revokes a webhook secret. The \`event\` and \`webhook\` kinds and the secret tool need
+\`@sapiom/mcp\` >= 0.15 — on an older client, use the REST trigger routes in the guide:
+https://docs.sapiom.ai/guides/triggers.
+
 ## Canonical rules (types are the source of truth — run \`npm run typecheck\`)
 - Import \`defineAgent\`, \`defineStep\`, and the directives
   (\`goto\` / \`terminate\` / \`fail\` / \`retry\` / \`pauseUntilSignal\`) from \`@sapiom/agent\`.


### PR DESCRIPTION
## Primary change type

- [x] Documentation

## Problem and motivation

Two backend authoring content releases were in flight at once. SAP-3174 landed as 2.10 (trigger kinds, webhook signing recipe) after #815 had synced this package's `AUTHORING_INSTRUCTIONS` to the SAP-3180 text, so the two repos now pin different bodies: the backend serves 2.10 without Vault/`agents.launch`/receipts/webhooks, and the fallback carries those without trigger kinds. The backend PR sapiom/Sapiom#4885 folds both into 2.11; this is its paired half.

## Summary and scope

- `AUTHORING_INSTRUCTIONS` copied verbatim from the backend 2.11 constant (generated by script and verified byte-identical), pin moved to `46a48ad3…`, release note in the test updated.
- Nothing else: the harness prompt fallback already matches the backend 1.1 constant (`d83fa57c…`) and the skill pointer landed in #815.

## Related work

Related issue or discussion: https://linear.app/sapiom/issue/SAP-3180 — backend half sapiom/Sapiom#4885 (must land together with this PR).

## Validation

```text
pnpm --filter @sapiom/mcp exec vitest run src/instructions.test.ts — 9 passed
pnpm --filter @sapiom/mcp typecheck                                — ok
pnpm --filter @sapiom/mcp lint                                     — ok
pnpm terminology:check                                             — passed
pnpm exec prettier --check <changed files>                         — clean
```

### Tests and documentation

Existing content assertions cover both the 2.10 and SAP-3180 facts; the digest pin moved.

## Compatibility and release impact

- Breaking or externally visible changes: None. Text-only fallback update.
- Changeset: Added (`@sapiom/mcp` patch).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code regenerated the fallback from the backend constant by script, verified byte-identity by evaluation, and ran the commands above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThB3ibgxg6QovWtRz3uqWB
