### PR TITLE
fix(tools): bound execStream post-stream status poll by timeout

### DIFF
--- a/.changeset/tools-execstream-poll-deadline.md
+++ b/.changeset/tools-execstream-poll-deadline.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/tools": patch
+---
+
+Bound `Sandbox.execStream`'s post-stream status reconciliation by the exec timeout.
+
+When a log stream ends before its process reaches a terminal status, `execStream` re-polls process status to resolve the real exit code. That loop had no deadline, so a process that never reported a terminal status left the caller awaiting the output iterable forever. `exec` / `pollProcess` already stop at the 60s exec timeout and throw `Process <pid> timed out after 60000ms`; the reconciliation loop now does the same.

--- a/packages/tools/src/sandboxes/index.spec.ts
+++ b/packages/tools/src/sandboxes/index.spec.ts
@@ -107,6 +107,75 @@ describe("Sandbox.exec — terminal status handling", () => {
   });
 });
 
+describe("Sandbox.execStream — post-stream status reconciliation", () => {
+  /**
+   * Route that returns a real streaming Response for `/logs/stream` (so
+   * `res.body.getReader()` works) and FakeResponses for process create/status.
+   */
+  function streamSandbox(pollStatuses: Array<Record<string, unknown>>) {
+    let polls = 0;
+    return sandboxWith((url, init) => {
+      if ((init.method ?? "GET") === "POST" && url.endsWith("/process")) {
+        return ok({ pid: "p-stream", status: "running" });
+      }
+      if (/\/logs\/stream$/.test(url)) {
+        // Real Response so ReadableStream is available to execStream.
+        return new Response("stdout:hello\n") as unknown as FakeResponse;
+      }
+      const body = pollStatuses[Math.min(polls, pollStatuses.length - 1)]!;
+      polls += 1;
+      return ok({ pid: "p-stream", ...body });
+    });
+  }
+
+  it("reconciles an exit code reported after the log stream ends", async () => {
+    jest.useFakeTimers();
+    try {
+      const box = streamSandbox([
+        { status: "running" },
+        { status: "failed", exitCode: 3 },
+      ]);
+
+      const stream = await box.execStream("false");
+      const drained = (async () => {
+        const seen: Array<{ stream: string; data: string }> = [];
+        for await (const line of stream.output) seen.push(line);
+        return seen;
+      })();
+
+      await jest.advanceTimersByTimeAsync(1_000);
+
+      expect(await drained).toEqual([{ stream: "stdout", data: "hello" }]);
+      expect(stream.exitCode).toBe(3);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  // Regression: the reconciliation poll above ran with no deadline, so a
+  // process that never reports a terminal status hung the consumer forever
+  // instead of failing with the exec timeout every other poll path applies.
+  it("times out when the process never reaches a terminal status", async () => {
+    jest.useFakeTimers();
+    try {
+      const box = streamSandbox([{ status: "running" }]);
+
+      const stream = await box.execStream("sleep 999");
+      const drained = (async () => {
+        for await (const line of stream.output) void line;
+      })();
+      const rejection = expect(drained).rejects.toThrow(
+        "Process p-stream timed out after 60000ms",
+      );
+
+      await jest.advanceTimersByTimeAsync(60_000);
+      await rejection;
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
 describe("Sandbox.uploadFile — multipart lifecycle", () => {
   it("initiates, uploads each part, and completes", async () => {
     const calls: string[] = [];

--- a/packages/tools/src/sandboxes/index.ts
+++ b/packages/tools/src/sandboxes/index.ts
@@ -548,9 +548,19 @@ export class Sandbox {
         reader.releaseLock();
       }
 
+      // If the process hasn't finished yet (e.g. stream disconnected before
+      // the process finished), poll until it does — bounded by the same exec
+      // timeout pollProcess applies, so a process that never reports a
+      // terminal status fails loudly instead of polling forever.
+      const deadline = Date.now() + DEFAULT_EXEC_TIMEOUT;
       let status = await readStatus();
       while (!isProcessTerminal(status.status)) {
-        await new Promise((r) => setTimeout(r, 1000));
+        if (Date.now() >= deadline) {
+          throw new Error(
+            `Process ${proc.pid} timed out after ${DEFAULT_EXEC_TIMEOUT}ms`,
+          );
+        }
+        await new Promise((r) => setTimeout(r, DEFAULT_POLL_INTERVAL));
         status = await readStatus();
       }
       finalExitCode = terminalExitCode(status);


### PR DESCRIPTION
## Summary
- Bound `@sapiom/tools` `Sandbox.execStream` post-stream status reconciliation with `DEFAULT_EXEC_TIMEOUT`.
- Matches `pollProcess` / the `@sapiom/sandbox` fix so a non-terminal process fails loudly instead of hanging forever.
- Add regression tests for successful reconciliation and timeout.

## Testing
- `pnpm --filter @sapiom/tools exec jest src/sandboxes/index.spec.ts --no-coverage`

Fixes #859