### PR TITLE
fix(tools): reject whitespace-only search email inputs

### DIFF
--- a/.changeset/tools-search-whitespace-guards.md
+++ b/.changeset/tools-search-whitespace-guards.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/tools": patch
+---
+
+Reject whitespace-only inputs in search email client guards (`findEmail`, `verifyEmail`, `domainSearch`).
+
+These guards already blocked empty strings so invalid lookups failed before any network call. Truthiness checks still treated `"   "` as present, so whitespace-only domain/email/name values reached the capability endpoint. Presence now requires a non-empty trimmed string, matching speech and content-generation guards in the same package.

--- a/packages/tools/src/search/index.spec.ts
+++ b/packages/tools/src/search/index.spec.ts
@@ -692,6 +692,26 @@ describe("search.emailSearch.findEmail()", () => {
         expect(calls).toHaveLength(0);
       });
     }
+
+    it("throws SearchHttpError and does not fetch when fields are whitespace-only", async () => {
+      const { transport, calls } = makeTransport([() => jsonResponse({})]);
+
+      await expect(
+        findEmail(
+          { domain: "   ", fullName: "Ada Lovelace" },
+          transport,
+          BASE,
+        ),
+      ).rejects.toBeInstanceOf(SearchHttpError);
+      await expect(
+        findEmail(
+          { domain: "example.com", fullName: "   " },
+          transport,
+          BASE,
+        ),
+      ).rejects.toBeInstanceOf(SearchHttpError);
+      expect(calls).toHaveLength(0);
+    });
   });
 
   it("throws SearchHttpError (status + body) on a non-2xx", async () => {
@@ -803,6 +823,15 @@ describe("search.emailSearch.verifyEmail()", () => {
 
     await expect(
       verifyEmail({ email: "" as string }, transport, BASE),
+    ).rejects.toBeInstanceOf(SearchHttpError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws SearchHttpError before fetching when email is whitespace-only", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+
+    await expect(
+      verifyEmail({ email: "   " }, transport, BASE),
     ).rejects.toBeInstanceOf(SearchHttpError);
     expect(calls).toHaveLength(0);
   });
@@ -927,6 +956,15 @@ describe("search.emailSearch.domainSearch()", () => {
 
     await expect(
       domainSearch({ domain: "" } as { domain: string }, transport, BASE),
+    ).rejects.toBeInstanceOf(SearchHttpError);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws SearchHttpError before fetching when domain is whitespace-only", async () => {
+    const { transport, calls } = makeTransport([() => jsonResponse({})]);
+
+    await expect(
+      domainSearch({ domain: "   " }, transport, BASE),
     ).rejects.toBeInstanceOf(SearchHttpError);
     expect(calls).toHaveLength(0);
   });

--- a/packages/tools/src/search/index.ts
+++ b/packages/tools/src/search/index.ts
@@ -35,6 +35,12 @@ import { SearchHttpError } from "./errors.js";
 
 export { SearchHttpError };
 
+/** True when a string is present after trim — rejects null/undefined/""/"   ". */
+function hasText(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+
 /** Build the capability-specific error the routed call throws on a non-2xx. */
 const searchError = (message: string, status: number, body: unknown): Error =>
   new SearchHttpError(message, status, body);
@@ -377,10 +383,10 @@ export async function findEmail(
   // truthiness check rejects null/undefined/empty-string for JS callers. (The
   // router validates the same combination, but the client guard keeps the
   // no-network-on-invalid contract the SDK has always offered.)
-  const hasOrg = Boolean(input.domain) || Boolean(input.company);
+  const hasOrg = hasText(input.domain) || hasText(input.company);
   const hasPerson =
-    Boolean(input.fullName) ||
-    (Boolean(input.firstName) && Boolean(input.lastName));
+    hasText(input.fullName) ||
+    (hasText(input.firstName) && hasText(input.lastName));
   if (!hasOrg || !hasPerson) {
     throw new SearchHttpError(
       "findEmail requires (domain or company) and (fullName or firstName + lastName)",
@@ -474,7 +480,7 @@ export async function verifyEmail(
   transport: Transport = defaultTransport(),
   baseUrl: string = resolveCoreBaseUrl(),
 ): Promise<VerifyEmailResult> {
-  if (!input.email) {
+  if (!hasText(input.email)) {
     throw new SearchHttpError("verifyEmail requires an email", 400, undefined);
   }
   const raw = await capabilityCall<RawVerifyEmail>(
@@ -598,7 +604,7 @@ export async function domainSearch(
   transport: Transport = defaultTransport(),
   baseUrl: string = resolveCoreBaseUrl(),
 ): Promise<DomainSearchResult> {
-  if (!input.domain) {
+  if (!hasText(input.domain)) {
     throw new SearchHttpError("domainSearch requires a domain", 400, undefined);
   }
   // Forward only the provided fields. Array filters travel as arrays in the router


### PR DESCRIPTION
## Summary
- Treat search email inputs as present only after trim in `findEmail`, `verifyEmail`, and `domainSearch`.
- Whitespace-only values now throw `SearchHttpError` before any network call.
- Aligns with speech/content-generation client guards in the same package.

## Testing
- `pnpm --filter @sapiom/tools exec jest src/search/index.spec.ts --no-coverage -t whitespace`

Fixes #860