### PR TITLE
fix(agent): reject whitespace-only defineAgent names

### DIFF
--- a/.changeset/agent-define-whitespace-name.md
+++ b/.changeset/agent-define-whitespace-name.md
@@ -1,0 +1,7 @@
+---
+"@sapiom/agent": patch
+---
+
+Reject whitespace-only agent names in `defineAgent`.
+
+The authoring contract requires a non-empty name, but the check used truthiness (`if (!def.name)`), so `"   "` passed validation. Names are now rejected unless they contain non-whitespace characters after trim, matching how blank resource handles are treated in the same package.

--- a/packages/agent/src/agent.ts
+++ b/packages/agent/src/agent.ts
@@ -150,7 +150,7 @@ export function isLegacyOrchestrationDefinition(val: unknown): val is AgentDefin
 export function defineAgent<TInput = unknown, TShared extends Record<string, unknown> = Record<string, unknown>>(
   def: AgentDefinition<TInput, TShared>,
 ): AgentDefinition<TInput, TShared> {
-  if (!def.name) {
+  if (typeof def.name !== 'string' || def.name.trim() === '') {
     throw new Error('Agent definition must have a non-empty name');
   }
   if (!def.entry) {

--- a/packages/agent/src/sdk.spec.ts
+++ b/packages/agent/src/sdk.spec.ts
@@ -87,6 +87,16 @@ describe('defineAgent', () => {
     ).toThrow('Agent definition must have a non-empty name');
   });
 
+  it('throws when name is whitespace-only', () => {
+    expect(() =>
+      defineAgent({
+        name: '   ',
+        entry: 'start',
+        steps: { start: makeStep('start') },
+      }),
+    ).toThrow('Agent definition must have a non-empty name');
+  });
+
   it('throws when entry is empty string', () => {
     expect(() =>
       defineAgent({


### PR DESCRIPTION
## Summary
- Reject `defineAgent` names that are empty after trim (`\"   \"` no longer passes).
- Matches the documented non-empty name contract and how blank resource handles are treated.
- Add a regression test for whitespace-only names.

## Testing
- `pnpm --filter @sapiom/agent exec jest src/sdk.spec.ts --no-coverage -t \"name is\"`

Fixes #861