### PR TITLE
feat(harness): import isolated Studio comparison profiles [SAP-3263]

### DIFF
--- a/.changeset/studio-comparison-profile.md
+++ b/.changeset/studio-comparison-profile.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Add a validated comparison-profile importer that preserves selected Studio maps and agent identities without modifying the source profile.

--- a/.changeset/studio-comparison-profile.md
+++ b/.changeset/studio-comparison-profile.md
@@ -1,5 +1,5 @@
 ---
-"@sapiom/harness": patch
+"@sapiom/harness": minor
 ---
 
-Add a validated comparison-profile importer that preserves selected Studio maps and agent identities without modifying the source profile.
+Export importStudioComparisonProfile to copy selected Studio project identities, inventory, and complete map histories into an isolated comparison profile without modifying the source.

--- a/packages/harness/src/core/studio-comparison-profile.test.ts
+++ b/packages/harness/src/core/studio-comparison-profile.test.ts
@@ -22,16 +22,15 @@ vi.mock("node:fs/promises", async (original) => ({
 const temporary: string[] = [];
 afterEach(async () => {
   vi.restoreAllMocks();
-  await Promise.all(
-    temporary
-      .splice(0)
-      .map((root) => fs.rm(root, { recursive: true, force: true })),
-  );
+  for (const root of temporary.splice(0))
+    await fs.rm(root, { recursive: true, force: true });
 });
 const hash = (bytes: Buffer) =>
   `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
 const readJson = async (file: string) =>
   JSON.parse(await fs.readFile(file, "utf8"));
+const expectMissing = (file: string) =>
+  expect(fs.stat(file)).rejects.toMatchObject({ code: "ENOENT" });
 async function write(file: string, value: unknown) {
   await fs.mkdir(path.dirname(file), { recursive: true });
   await fs.writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
@@ -120,8 +119,8 @@ async function fixture() {
     "agent-map/project-bootstrap/job.json",
   ])
     await write(path.join(source, file), { excluded: true });
-  const mapFile = (id = ids[0]!) =>
-    path.join(source, "agent-map/projects", id, "workspace.json");
+  const mapFile = (id = ids[0]!, state = source) =>
+    path.join(state, "agent-map/projects", id, "workspace.json");
   const store = new AgentMapWorkspaceStore(path.join(source, "agent-map"));
   const service = new AgentMapProposalService(store);
   const actor = {
@@ -196,6 +195,7 @@ async function fixture() {
     mapFile,
     journal,
     run,
+    readTarget: (file: string) => readJson(path.join(destination, file)),
   };
 }
 
@@ -254,11 +254,7 @@ it("preserves complete map bytes, plans, briefs, identities and cross-root agent
       { projectId: f.ids[1], map: null },
     ],
   });
-  const targetMap = path.join(
-    f.destination,
-    path.relative(f.source, f.mapFile()),
-  );
-  const copied = await fs.readFile(targetMap);
+  const copied = await fs.readFile(f.mapFile(undefined, f.destination));
   expect(copied).toEqual(await fs.readFile(f.mapFile()));
   expect(result.projects[0]!.map!.byteDigest).toBe(hash(copied));
   const parsed = JSON.parse(copied.toString());
@@ -267,9 +263,7 @@ it("preserves complete map bytes, plans, briefs, identities and cross-root agent
   expect(parsed.buildPlanVersions).toHaveLength(1);
   expect(Object.keys(parsed.briefVersionsById)).not.toHaveLength(0);
   const catalog = await readJson(path.join(f.source, "studio-projects.json"));
-  expect(
-    await readJson(path.join(f.destination, "studio-projects.json")),
-  ).toEqual({
+  expect(await f.readTarget("studio-projects.json")).toEqual({
     schemaVersion: catalog.schemaVersion,
     projects: catalog.projects.filter((project: { projectId: string }) =>
       f.ids.slice(0, 2).includes(project.projectId),
@@ -277,7 +271,7 @@ it("preserves complete map bytes, plans, briefs, identities and cross-root agent
   });
   const prefsFile = "agent-map/studio-workspace-preferences.json";
   const sourcePrefs = await readJson(path.join(f.source, prefsFile));
-  expect(await readJson(path.join(f.destination, prefsFile))).toEqual({
+  expect(await f.readTarget(prefsFile)).toEqual({
     schemaVersion: 1,
     preferences: [],
     agentBindings: sourcePrefs.agentBindings.filter(
@@ -285,9 +279,7 @@ it("preserves complete map bytes, plans, briefs, identities and cross-root agent
         f.ids.slice(0, 2).includes(binding.projectId),
     ),
   });
-  const copiedInventory = await readJson(
-    path.join(f.destination, "workflows.json"),
-  );
+  const copiedInventory = await f.readTarget("workflows.json");
   expect(copiedInventory.map((row: { path: string }) => row.path)).toEqual([
     f.inventory[0]!.path,
     f.inventory[1]!.path,
@@ -296,12 +288,11 @@ it("preserves complete map bytes, plans, briefs, identities and cross-root agent
   expect(copiedInventory.some((row: object) => "activeBuildRunId" in row)).toBe(
     false,
   );
-  expect(
-    await readJson(path.join(f.destination, "settings.json")),
-  ).toMatchObject({ recentDirs: f.roots.slice(0, 2), telemetryOptIn: false });
-  expect(
-    await readJson(path.join(f.destination, "comparison-profile.json")),
-  ).toEqual(result);
+  expect(await f.readTarget("settings.json")).toMatchObject({
+    recentDirs: f.roots.slice(0, 2),
+    telemetryOptIn: false,
+  });
+  expect(await f.readTarget("comparison-profile.json")).toEqual(result);
   expect(
     Object.keys(await hashes(f.destination)).some((name) =>
       /initialization|bootstrap|\.lock|machine-id|sessions|pending-secrets|credentials/.test(
@@ -331,9 +322,7 @@ it("retains deliberately empty authored maps and un-authored empty containers di
     true,
     false,
   ]);
-  const copied = await new AgentMapWorkspaceStore(
-    path.join(f.destination, "agent-map"),
-  ).readAggregate(f.ids[0]!);
+  const copied = await readJson(f.mapFile(undefined, f.destination));
   expect(copied.mapVersions.at(-1)!.graph.nodes).toEqual([]);
   expect(copied.mapVersions).toHaveLength(3);
   expect(hasAuthoredAgentMap(copied)).toBe(true);
@@ -359,25 +348,26 @@ it.each(["queued", "running"])(
         { projectId: absent, reason: "project_not_found" },
       ],
     });
-    await expect(fs.stat(f.destination)).rejects.toMatchObject({
-      code: "ENOENT",
-    });
+    await expectMissing(f.destination);
     expect((await f.run()).projects.map(({ projectId }) => projectId)).toEqual([
       f.ids[0],
     ]);
-    await expect(
-      fs.stat(
-        path.join(
-          f.destination,
-          "agent-map/projects",
-          f.ids[1]!,
-          "workspace.json",
-        ),
-      ),
-    ).rejects.toMatchObject({ code: "ENOENT" });
+    await expectMissing(f.mapFile(f.ids[1], f.destination));
     expect(await hashes(f.source)).toEqual(before);
   },
 );
+
+it.each(["ESRCH", "EPERM"])("imports only dead owners: %s", async (code) => {
+  const f = await fixture();
+  await f.journal(f.ids[1]!, "running");
+  const before = await hashes(f.source);
+  const probe = vi.spyOn(process, "kill").mockImplementation(() => {
+    throw Object.assign(new Error(code), { code });
+  });
+  expect((await f.run([f.ids[1]!])).published).toBe(code === "ESRCH");
+  expect(probe).toHaveBeenCalledWith(process.pid, 0);
+  expect(await hashes(f.source)).toEqual(before);
+});
 
 it.each([
   "malformed",
@@ -435,9 +425,7 @@ it.each([
     });
     failure?.mockRestore();
     expect(await hashes(f.source)).toEqual(before);
-    await expect(fs.stat(f.destination)).rejects.toMatchObject({
-      code: "ENOENT",
-    });
+    await expectMissing(f.destination);
   },
 );
 
@@ -458,9 +446,7 @@ it("rejects a source mutation during staging and cleans the unpublished stage", 
       name.startsWith(".studio-comparison-"),
     ),
   ).toEqual([]);
-  await expect(fs.stat(f.destination)).rejects.toMatchObject({
-    code: "ENOENT",
-  });
+  await expectMissing(f.destination);
 });
 
 it("rejects a map removed between stat and read instead of importing it as mapless", async () => {
@@ -474,9 +460,7 @@ it("rejects a map removed between stat and read instead of importing it as maple
     return actualRead(...args);
   });
   await expect(f.run()).rejects.toMatchObject({ code: "source_changed" });
-  await expect(fs.stat(f.destination)).rejects.toMatchObject({
-    code: "ENOENT",
-  });
+  await expectMissing(f.destination);
 });
 
 it("rejects aliasing, overlapping, populated and symlinked destinations; accepts a fresh empty directory", async () => {
@@ -503,7 +487,7 @@ it("rejects aliasing, overlapping, populated and symlinked destinations; accepts
   await fs.rm(path.join(f.destination, "keep.json"));
   const rename = fs.rename;
   vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
-    await expect(fs.stat(to)).rejects.toMatchObject({ code: "ENOENT" });
+    await expectMissing(String(to));
     await rename(from, to);
   });
   expect((await f.run()).published).toBe(true);
@@ -519,10 +503,9 @@ it("cleans staging after a publish failure without leaving a partial destination
   );
   await expect(f.run()).rejects.toMatchObject({
     code: "destination_unavailable",
+    cause: { code: "ENOSPC" },
   });
-  await expect(fs.stat(f.destination)).rejects.toMatchObject({
-    code: "ENOENT",
-  });
+  await expectMissing(f.destination);
   expect(
     (await fs.readdir(f.root)).some((name) =>
       name.startsWith(".studio-comparison-"),

--- a/packages/harness/src/core/studio-comparison-profile.test.ts
+++ b/packages/harness/src/core/studio-comparison-profile.test.ts
@@ -1,0 +1,533 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import { afterEach, expect, it, vi } from "vitest";
+import { importStudioComparisonProfile } from "./studio-comparison-profile.js";
+import { StudioProjectCatalog } from "./studio-project-catalog.js";
+import { StudioWorkspacePreferenceStore } from "./studio-workspace-preferences.js";
+import { AgentMapWorkspaceStore } from "./agent-map-workspace-store.js";
+import { AgentMapProposalService } from "./agent-map-proposal-service.js";
+import { hasAuthoredAgentMap } from "./agent-map-initialization-record.js";
+import {
+  parseProjectPlanningAggregate,
+  createEmptyProjectPlanningAggregate,
+} from "./agent-map-aggregate-migration.js";
+import { emptyProjectBuildPlanContent } from "../shared/build-plan.js";
+import { BuildPlanStore } from "./build-plan-store.js";
+import { BuildPlanService } from "./build-plan-service.js";
+import { AgentBriefService } from "./agent-brief-service.js";
+
+vi.mock("node:fs/promises", async (original) => ({
+  ...(await original<typeof import("node:fs/promises")>()),
+}));
+
+const temporary: string[] = [];
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(
+    temporary
+      .splice(0)
+      .map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+const hash = (bytes: Buffer) =>
+  `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+const readJson = async (file: string) =>
+  JSON.parse(await fs.readFile(file, "utf8"));
+async function write(file: string, value: unknown) {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, `${JSON.stringify(value, null, 2)}\n`);
+}
+async function hashes(root: string): Promise<Record<string, string>> {
+  const result: Record<string, string> = {};
+  for (const entry of await fs.readdir(root, {
+    recursive: true,
+    withFileTypes: true,
+  })) {
+    const file = path.join(entry.parentPath, entry.name);
+    result[path.relative(root, file)] = entry.isFile()
+      ? hash(await fs.readFile(file))
+      : "directory";
+  }
+  return result;
+}
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "studio-comparison-"));
+  temporary.push(root);
+  const source = path.join(root, "desktop");
+  const destination = path.join(root, "trial");
+  const roots = ["mapped", "mapless", "unselected"].map((name) =>
+    path.join(root, name),
+  );
+  const inventory = [
+    ...roots.map((dir) => path.join(dir, "agent")),
+    path.join(root, "sibling-agent"),
+  ].map((agentPath, index) => ({
+    path: agentPath,
+    name: `Agent ${index}`,
+    definitionId: null,
+    definitionSlug: null,
+    source: "scan",
+  }));
+  for (const agent of inventory) {
+    await fs.mkdir(agent.path, { recursive: true });
+    await fs.writeFile(
+      path.join(agent.path, "index.ts"),
+      'throw new Error("Never execute source");',
+    );
+  }
+  const catalog = new StudioProjectCatalog(
+    path.join(source, "studio-projects.json"),
+  );
+  const projects = (
+    await catalog.reconcile(roots.map((cwd) => ({ cwd, workspaceKey: cwd })))
+  ).projects;
+  const ids = roots.map(
+    (dir) =>
+      projects.find(({ displayName }) => displayName === path.basename(dir))!
+        .projectId,
+  );
+  const preferences = new StudioWorkspacePreferenceStore(
+    path.join(source, "agent-map/studio-workspace-preferences.json"),
+  );
+  await preferences.registerCreatedAgent(
+    ids[0]!,
+    "source-creator",
+    inventory[3]!,
+  );
+  for (const [index, projectId] of ids.entries())
+    await preferences.current(
+      "source-user",
+      projectId,
+      [roots[index]!],
+      inventory,
+      true,
+    );
+  await write(
+    path.join(source, "workflows.json"),
+    inventory.map((row) => ({ ...row, activeBuildRunId: "excluded-run" })),
+  );
+  await write(path.join(source, "settings.json"), {
+    recentDirs: roots,
+    projectRoot: root,
+    telemetryOptIn: true,
+  });
+  for (const file of [
+    "machine-id",
+    "sessions.json",
+    "pending-secrets.json",
+    "credentials.json",
+    "agent-map/project-bootstrap/job.json",
+  ])
+    await write(path.join(source, file), { excluded: true });
+  const mapFile = (id = ids[0]!) =>
+    path.join(source, "agent-map/projects", id, "workspace.json");
+  const store = new AgentMapWorkspaceStore(path.join(source, "agent-map"));
+  const service = new AgentMapProposalService(store);
+  const actor = {
+    projectId: ids[0]!,
+    userId: "source-user",
+    sessionId: "source-session",
+  };
+  const first = await service.propose(actor, {
+    schemaVersion: 1,
+    proposalId: null,
+    expectedVersion: 0,
+    requestId: "first",
+    operations: [
+      {
+        kind: "add-node",
+        draftRef: "research",
+        node: {
+          kind: "agent",
+          name: "Research",
+          purpose: "Research",
+          ownerAgent: null,
+          contractRefs: [],
+        },
+      },
+    ],
+  });
+  const nodeId = Object.values(first.allocatedNodeIds)[0]!;
+  await service.propose(actor, {
+    schemaVersion: 1,
+    proposalId: first.proposalId,
+    expectedVersion: 1,
+    requestId: "second",
+    operations: [
+      {
+        kind: "update-node",
+        nodeId,
+        changes: { purpose: "Retain this history" },
+      },
+    ],
+  });
+  const journal = (id: string, status: string) =>
+    write(path.join(path.dirname(mapFile(id)), "initialization.json"), {
+      schemaVersion: 1,
+      projectId: id,
+      userId: "source-user",
+      attemptId: randomUUID(),
+      status,
+      ownerId: status === "running" ? randomUUID() : null,
+      ownerPid: status === "running" ? process.pid : null,
+      provider: "claude-code",
+      errorCode: status === "failed" ? "interrupted" : null,
+      updatedAt: new Date().toISOString(),
+    });
+  const run = (projectIds = ids.slice(0, 2), target = destination) =>
+    importStudioComparisonProfile({
+      sourceStateRoot: source,
+      destinationStateRoot: target,
+      projectIds,
+    });
+  return {
+    root,
+    source,
+    destination,
+    roots,
+    ids,
+    inventory,
+    store,
+    service,
+    actor,
+    first,
+    nodeId,
+    mapFile,
+    journal,
+    run,
+  };
+}
+
+it("preserves complete map bytes, plans, briefs, identities and cross-root agents while isolating bookkeeping", async () => {
+  const f = await fixture();
+  const aggregate = await f.store.readAggregate(f.ids[0]!);
+  const expectedMap = {
+    versionId: aggregate.current.map!.versionId,
+    contentDigest: aggregate.current.map!.contentDigest,
+  };
+  const plans = new BuildPlanStore(f.store);
+  const plan = await new BuildPlanService(plans).apply(f.actor, {
+    schemaVersion: 1,
+    requestId: "plan",
+    expectedMap,
+    expectedPlan: null,
+    operations: [
+      {
+        op: "replace-content",
+        content: {
+          ...emptyProjectBuildPlanContent(),
+          outcome: "Research",
+          assignments: [
+            {
+              id: { clientRef: "assignment" },
+              plannedAgentId: f.nodeId,
+              briefId: null,
+              mission: "Research",
+              scope: ["Research"],
+              nonGoals: [],
+              dependencies: [],
+            },
+          ],
+        },
+      },
+    ],
+  });
+  await new AgentBriefService(plans).refreshAfterPlanMutation(f.actor, {
+    expectedMap,
+    expectedPlan: {
+      planId: plan.plan.planId,
+      versionId: plan.plan.versionId,
+      semanticDigest: plan.plan.semanticDigest,
+    },
+  });
+  await f.journal(f.ids[0]!, "completed");
+  await f.journal(f.ids[1]!, "failed");
+  const before = await hashes(f.source);
+  const sourceCode = await hashes(f.inventory[3]!.path);
+  const result = await f.run();
+  expect(result).toMatchObject({
+    published: true,
+    excluded: [],
+    projects: [
+      { projectId: f.ids[0], map: { authored: true } },
+      { projectId: f.ids[1], map: null },
+    ],
+  });
+  const targetMap = path.join(
+    f.destination,
+    path.relative(f.source, f.mapFile()),
+  );
+  const copied = await fs.readFile(targetMap);
+  expect(copied).toEqual(await fs.readFile(f.mapFile()));
+  expect(result.projects[0]!.map!.byteDigest).toBe(hash(copied));
+  const parsed = parseProjectPlanningAggregate(
+    JSON.parse(copied.toString()),
+    f.ids[0]!,
+  );
+  expect(parsed.mapVersions).toHaveLength(2);
+  expect(parsed.mapOperationHistory).toHaveLength(2);
+  expect(parsed.buildPlanVersions).toHaveLength(1);
+  expect(Object.keys(parsed.briefVersionsById)).not.toHaveLength(0);
+  const catalog = await readJson(path.join(f.source, "studio-projects.json"));
+  expect(
+    await readJson(path.join(f.destination, "studio-projects.json")),
+  ).toEqual({
+    schemaVersion: catalog.schemaVersion,
+    projects: catalog.projects.filter((project: { projectId: string }) =>
+      f.ids.slice(0, 2).includes(project.projectId),
+    ),
+  });
+  const prefsFile = "agent-map/studio-workspace-preferences.json";
+  const sourcePrefs = await readJson(path.join(f.source, prefsFile));
+  expect(await readJson(path.join(f.destination, prefsFile))).toEqual({
+    schemaVersion: 1,
+    preferences: [],
+    agentBindings: sourcePrefs.agentBindings.filter(
+      (binding: { projectId: string }) =>
+        f.ids.slice(0, 2).includes(binding.projectId),
+    ),
+  });
+  const copiedInventory = await readJson(
+    path.join(f.destination, "workflows.json"),
+  );
+  expect(copiedInventory.map((row: { path: string }) => row.path)).toEqual([
+    f.inventory[0]!.path,
+    f.inventory[1]!.path,
+    f.inventory[3]!.path,
+  ]);
+  expect(copiedInventory.some((row: object) => "activeBuildRunId" in row)).toBe(
+    false,
+  );
+  expect(
+    await readJson(path.join(f.destination, "settings.json")),
+  ).toMatchObject({ recentDirs: f.roots.slice(0, 2), telemetryOptIn: false });
+  expect(
+    await readJson(path.join(f.destination, "comparison-profile.json")),
+  ).toEqual(result);
+  for (const forbidden of [
+    "machine-id",
+    "sessions.json",
+    "pending-secrets.json",
+    "credentials.json",
+  ])
+    expect(Object.keys(await hashes(f.destination))).not.toContain(forbidden);
+  expect(
+    Object.keys(await hashes(f.destination)).some((name) =>
+      /initialization|bootstrap|\.lock/.test(name),
+    ),
+  ).toBe(false);
+  expect(await hashes(f.source)).toEqual(before);
+  expect(await hashes(f.inventory[3]!.path)).toEqual(sourceCode);
+});
+
+it("retains deliberately empty authored maps and un-authored empty containers distinctly", async () => {
+  const f = await fixture();
+  await f.service.propose(f.actor, {
+    schemaVersion: 1,
+    proposalId: f.first.proposalId,
+    expectedVersion: 2,
+    requestId: "remove",
+    operations: [{ kind: "remove-node", nodeId: f.nodeId }],
+  });
+  await write(
+    f.mapFile(f.ids[1]),
+    createEmptyProjectPlanningAggregate(f.ids[1]!, new Date().toISOString()),
+  );
+  const result = await f.run();
+  expect(result.projects.map(({ map }) => map?.authored)).toEqual([
+    true,
+    false,
+  ]);
+  const copied = await new AgentMapWorkspaceStore(
+    path.join(f.destination, "agent-map"),
+  ).readAggregate(f.ids[0]!);
+  expect(copied.mapVersions.at(-1)!.graph.nodes).toEqual([]);
+  expect(copied.mapVersions).toHaveLength(3);
+  expect(hasAuthoredAgentMap(copied)).toBe(true);
+});
+
+it.each(["queued", "running"])(
+  "defers %s source initialization and returns exclusions without an empty trial",
+  async (status) => {
+    const f = await fixture();
+    await f.journal(f.ids[1]!, status);
+    const before = await hashes(f.source);
+    const absent = `project_${randomUUID()}`;
+    expect(await f.run([f.ids[1]!, absent])).toMatchObject({
+      published: false,
+      projects: [],
+      excluded: [
+        { projectId: f.ids[1], reason: "initialization_busy" },
+        { projectId: absent, reason: "project_not_found" },
+      ],
+    });
+    await expect(fs.stat(f.destination)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    expect((await f.run()).projects.map(({ projectId }) => projectId)).toEqual([
+      f.ids[0],
+    ]);
+    expect(await hashes(f.source)).toEqual(before);
+  },
+);
+
+it.each([
+  "malformed",
+  "digest",
+  "future",
+  "directory",
+  "symlink",
+  "unreadable",
+  "journal",
+])(
+  "rejects %s map state without publishing or writing source",
+  async (kind) => {
+    const f = await fixture();
+    const file =
+      kind === "journal"
+        ? path.join(path.dirname(f.mapFile()), "initialization.json")
+        : f.mapFile();
+    if (kind === "journal") await fs.writeFile(file, "null");
+    if (kind === "malformed") await fs.writeFile(f.mapFile(), "{");
+    if (kind === "digest") {
+      const value = await readJson(f.mapFile());
+      value.recordVersion++;
+      await write(f.mapFile(), value);
+    }
+    if (kind === "future")
+      await write(f.mapFile(), { storageSchemaVersion: 99 });
+    if (kind === "directory" || kind === "symlink") {
+      await fs.rm(f.mapFile());
+      if (kind === "directory") await fs.mkdir(f.mapFile());
+      else
+        await fs.symlink(path.join(f.source, "credentials.json"), f.mapFile());
+    }
+    const before = await hashes(f.source);
+    const actualRead = fs.readFile;
+    const failure =
+      kind === "unreadable"
+        ? vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+            if (String(args[0]) === f.mapFile())
+              throw Object.assign(new Error("permission denied"), {
+                code: "EACCES",
+              });
+            return actualRead(...args);
+          })
+        : null;
+    await expect(f.run()).rejects.toMatchObject({
+      file: path.relative(f.source, file).split(path.sep).join("/"),
+      code:
+        kind === "future"
+          ? "unsupported_schema"
+          : kind === "directory" || kind === "unreadable"
+            ? "source_unavailable"
+            : kind === "symlink"
+              ? "unsafe_source"
+              : "invalid_state",
+    });
+    failure?.mockRestore();
+    expect(await hashes(f.source)).toEqual(before);
+    await expect(fs.stat(f.destination)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  },
+);
+
+it("rejects a source mutation during staging and cleans the unpublished stage", async () => {
+  const f = await fixture();
+  const actualWrite = fs.writeFile;
+  let changed = false;
+  vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+    await actualWrite(...args);
+    if (!changed && String(args[0]).includes(".studio-comparison-")) {
+      changed = true;
+      await actualWrite(f.mapFile(), "{}");
+    }
+  });
+  await expect(f.run()).rejects.toMatchObject({ code: "source_changed" });
+  expect(
+    (await fs.readdir(f.root)).filter((name) =>
+      name.startsWith(".studio-comparison-"),
+    ),
+  ).toEqual([]);
+  await expect(fs.stat(f.destination)).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+});
+
+it("rejects a map removed between stat and read instead of importing it as mapless", async () => {
+  const f = await fixture();
+  const actualRead = fs.readFile;
+  vi.spyOn(fs, "readFile").mockImplementation(async (...args) => {
+    if (String(args[0]) === f.mapFile()) {
+      await fs.rm(f.mapFile());
+      throw Object.assign(new Error("removed during read"), { code: "ENOENT" });
+    }
+    return actualRead(...args);
+  });
+  await expect(f.run()).rejects.toMatchObject({ code: "source_changed" });
+  await expect(fs.stat(f.destination)).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+});
+
+it("rejects aliasing, overlapping, populated and symlinked destinations; accepts a fresh empty directory", async () => {
+  const f = await fixture();
+  const before = await hashes(f.source);
+  await fs.symlink(f.source, path.join(f.root, "alias"));
+  for (const target of [
+    f.source,
+    f.root,
+    path.join(f.source, "nested"),
+    path.join(f.root, "alias", "nested"),
+  ])
+    await expect(f.run(undefined, target)).rejects.toMatchObject({
+      code: "unsafe_destination",
+    });
+  await fs.mkdir(f.destination);
+  await write(path.join(f.destination, "keep.json"), { preserve: true });
+  await expect(f.run()).rejects.toMatchObject({
+    code: "destination_not_empty",
+  });
+  expect(await readJson(path.join(f.destination, "keep.json"))).toEqual({
+    preserve: true,
+  });
+  await fs.rm(path.join(f.destination, "keep.json"));
+  expect((await f.run()).published).toBe(true);
+  expect(await hashes(f.source)).toEqual(before);
+});
+
+it("cleans staging after a write failure without replacing an existing empty destination", async () => {
+  const f = await fixture();
+  await fs.mkdir(f.destination);
+  const before = await hashes(f.source);
+  vi.spyOn(fs, "rename").mockRejectedValue(
+    Object.assign(new Error("disk full"), { code: "ENOSPC" }),
+  );
+  await expect(f.run()).rejects.toMatchObject({
+    code: "destination_unavailable",
+  });
+  expect(await fs.readdir(f.destination)).toEqual([]);
+  expect(
+    (await fs.readdir(f.root)).some((name) =>
+      name.startsWith(".studio-comparison-"),
+    ),
+  ).toBe(false);
+  expect(await hashes(f.source)).toEqual(before);
+});
+
+it("canonicalizes a harmless symlink ancestor while rejecting a symlink destination", async () => {
+  const f = await fixture();
+  const parent = path.join(f.root, "elsewhere");
+  const alias = path.join(f.root, "alias");
+  await fs.mkdir(parent);
+  await fs.symlink(parent, alias);
+  await expect(f.run(undefined, alias)).rejects.toMatchObject({
+    code: "unsafe_destination",
+  });
+  const result = await f.run(undefined, path.join(alias, "new-trial"));
+  expect(result.destinationStateRoot).toBe(path.join(parent, "new-trial"));
+  expect(result.published).toBe(true);
+});

--- a/packages/harness/src/core/studio-comparison-profile.test.ts
+++ b/packages/harness/src/core/studio-comparison-profile.test.ts
@@ -53,7 +53,9 @@ async function hashes(root: string): Promise<Record<string, string>> {
   return result;
 }
 async function fixture() {
-  const root = await fs.mkdtemp(path.join(os.tmpdir(), "studio-comparison-"));
+  const root = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "studio-comparison-")),
+  );
   temporary.push(root);
   const source = path.join(root, "desktop");
   const destination = path.join(root, "trial");

--- a/packages/harness/src/core/studio-comparison-profile.test.ts
+++ b/packages/harness/src/core/studio-comparison-profile.test.ts
@@ -9,10 +9,7 @@ import { StudioWorkspacePreferenceStore } from "./studio-workspace-preferences.j
 import { AgentMapWorkspaceStore } from "./agent-map-workspace-store.js";
 import { AgentMapProposalService } from "./agent-map-proposal-service.js";
 import { hasAuthoredAgentMap } from "./agent-map-initialization-record.js";
-import {
-  parseProjectPlanningAggregate,
-  createEmptyProjectPlanningAggregate,
-} from "./agent-map-aggregate-migration.js";
+import { createEmptyProjectPlanningAggregate } from "./agent-map-aggregate-migration.js";
 import { emptyProjectBuildPlanContent } from "../shared/build-plan.js";
 import { BuildPlanStore } from "./build-plan-store.js";
 import { BuildPlanService } from "./build-plan-service.js";
@@ -264,10 +261,7 @@ it("preserves complete map bytes, plans, briefs, identities and cross-root agent
   const copied = await fs.readFile(targetMap);
   expect(copied).toEqual(await fs.readFile(f.mapFile()));
   expect(result.projects[0]!.map!.byteDigest).toBe(hash(copied));
-  const parsed = parseProjectPlanningAggregate(
-    JSON.parse(copied.toString()),
-    f.ids[0]!,
-  );
+  const parsed = JSON.parse(copied.toString());
   expect(parsed.mapVersions).toHaveLength(2);
   expect(parsed.mapOperationHistory).toHaveLength(2);
   expect(parsed.buildPlanVersions).toHaveLength(1);
@@ -308,16 +302,11 @@ it("preserves complete map bytes, plans, briefs, identities and cross-root agent
   expect(
     await readJson(path.join(f.destination, "comparison-profile.json")),
   ).toEqual(result);
-  for (const forbidden of [
-    "machine-id",
-    "sessions.json",
-    "pending-secrets.json",
-    "credentials.json",
-  ])
-    expect(Object.keys(await hashes(f.destination))).not.toContain(forbidden);
   expect(
     Object.keys(await hashes(f.destination)).some((name) =>
-      /initialization|bootstrap|\.lock/.test(name),
+      /initialization|bootstrap|\.lock|machine-id|sessions|pending-secrets|credentials/.test(
+        name,
+      ),
     ),
   ).toBe(false);
   expect(await hashes(f.source)).toEqual(before);
@@ -354,6 +343,11 @@ it.each(["queued", "running"])(
   "defers %s source initialization and returns exclusions without an empty trial",
   async (status) => {
     const f = await fixture();
+    await f.journal(f.ids[0]!, status);
+    await write(
+      f.mapFile(f.ids[1]),
+      createEmptyProjectPlanningAggregate(f.ids[1]!, new Date().toISOString()),
+    );
     await f.journal(f.ids[1]!, status);
     const before = await hashes(f.source);
     const absent = `project_${randomUUID()}`;
@@ -371,6 +365,16 @@ it.each(["queued", "running"])(
     expect((await f.run()).projects.map(({ projectId }) => projectId)).toEqual([
       f.ids[0],
     ]);
+    await expect(
+      fs.stat(
+        path.join(
+          f.destination,
+          "agent-map/projects",
+          f.ids[1]!,
+          "workspace.json",
+        ),
+      ),
+    ).rejects.toMatchObject({ code: "ENOENT" });
     expect(await hashes(f.source)).toEqual(before);
   },
 );
@@ -497,11 +501,16 @@ it("rejects aliasing, overlapping, populated and symlinked destinations; accepts
     preserve: true,
   });
   await fs.rm(path.join(f.destination, "keep.json"));
+  const rename = fs.rename;
+  vi.spyOn(fs, "rename").mockImplementation(async (from, to) => {
+    await expect(fs.stat(to)).rejects.toMatchObject({ code: "ENOENT" });
+    await rename(from, to);
+  });
   expect((await f.run()).published).toBe(true);
   expect(await hashes(f.source)).toEqual(before);
 });
 
-it("cleans staging after a write failure without replacing an existing empty destination", async () => {
+it("cleans staging after a publish failure without leaving a partial destination", async () => {
   const f = await fixture();
   await fs.mkdir(f.destination);
   const before = await hashes(f.source);
@@ -511,7 +520,9 @@ it("cleans staging after a write failure without replacing an existing empty des
   await expect(f.run()).rejects.toMatchObject({
     code: "destination_unavailable",
   });
-  expect(await fs.readdir(f.destination)).toEqual([]);
+  await expect(fs.stat(f.destination)).rejects.toMatchObject({
+    code: "ENOENT",
+  });
   expect(
     (await fs.readdir(f.root)).some((name) =>
       name.startsWith(".studio-comparison-"),

--- a/packages/harness/src/core/studio-comparison-profile.ts
+++ b/packages/harness/src/core/studio-comparison-profile.ts
@@ -1,0 +1,423 @@
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import type { AgentMapVersionRef } from "../shared/agent-map.js";
+import type { HarnessSettings } from "../shared/types.js";
+import { isWithinDir, samePath } from "../shared/paths.js";
+import { sanitizeRecentDirs } from "../cli/settings.js";
+import { expandHome } from "./paths.js";
+import { parseProjectPlanningAggregate } from "./agent-map-aggregate-migration.js";
+import {
+  hasAuthoredAgentMap,
+  initializationRecordSchema,
+} from "./agent-map-initialization-record.js";
+import {
+  isStudioProjectId,
+  parseStudioProjectCatalog,
+  type ProjectRootBinding,
+} from "./studio-project-catalog.js";
+import { parseStudioWorkspacePreferences } from "./studio-workspace-preferences.js";
+
+export interface StudioComparisonImportOptions {
+  sourceStateRoot: string;
+  destinationStateRoot: string;
+  projectIds: readonly string[];
+}
+
+export interface StudioComparisonManifest {
+  schemaVersion: 1;
+  sourceStateRoot: string;
+  destinationStateRoot: string;
+  createdAt: string;
+  published: boolean;
+  projects: Array<{
+    projectId: string;
+    displayName: string;
+    rootBindings: ProjectRootBinding[];
+    map: null | {
+      byteDigest: string;
+      aggregateDigest: string;
+      recordVersion: number;
+      currentMap: AgentMapVersionRef | null;
+      authored: boolean;
+    };
+  }>;
+  excluded: Array<{
+    projectId: string;
+    reason: "initialization_busy" | "project_not_found";
+  }>;
+}
+
+export class StudioComparisonImportError extends Error {
+  constructor(
+    readonly code:
+      | "invalid_selection"
+      | "invalid_state"
+      | "unsupported_schema"
+      | "source_unavailable"
+      | "source_changed"
+      | "unsafe_source"
+      | "unsafe_destination"
+      | "destination_not_empty"
+      | "destination_unavailable",
+    readonly file?: string,
+  ) {
+    super(`Studio comparison import: ${code}${file ? ` (${file})` : ""}`);
+    this.name = "StudioComparisonImportError";
+  }
+}
+
+const digest = (bytes: Buffer) =>
+  `sha256:${createHash("sha256").update(bytes).digest("hex")}`;
+const record = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+const missing = (error: unknown) =>
+  (error as NodeJS.ErrnoException).code === "ENOENT";
+const fail = (
+  code: StudioComparisonImportError["code"],
+  file?: string,
+): never => {
+  throw new StudioComparisonImportError(code, file);
+};
+
+function validate<T>(file: string, operation: () => T): T {
+  try {
+    return operation();
+  } catch (error) {
+    if (error instanceof StudioComparisonImportError) throw error;
+    return fail(
+      (error as { code?: string })?.code === "unsupported_schema"
+        ? "unsupported_schema"
+        : "invalid_state",
+      file,
+    );
+  }
+}
+
+// No source store APIs: even a map-store read can create locks or migrate data.
+class SourceSnapshot {
+  readonly files = new Map<string, Buffer | null>();
+  constructor(private readonly root: string) {}
+
+  private async readFile(file: string): Promise<Buffer | null> {
+    let present = false;
+    try {
+      let current = this.root;
+      const parts = file.split("/");
+      for (const [index, part] of parts.entries()) {
+        current = path.join(current, part);
+        const stat = await fs.lstat(current);
+        if (stat.isSymbolicLink()) return fail("unsafe_source", file);
+        if (index === parts.length - 1 ? !stat.isFile() : !stat.isDirectory())
+          return fail("source_unavailable", file);
+      }
+      present = true;
+      return await fs.readFile(current);
+    } catch (error) {
+      if (missing(error)) {
+        if (present) fail("source_changed", file);
+        return null;
+      }
+      if (error instanceof StudioComparisonImportError) throw error;
+      return fail("source_unavailable", file);
+    }
+  }
+
+  async read(file: string, required = false): Promise<Buffer | null> {
+    const bytes = await this.readFile(file);
+    if (required && bytes === null) return fail("source_unavailable", file);
+    this.files.set(file, bytes);
+    return bytes;
+  }
+
+  async json(file: string, fallback?: unknown): Promise<unknown> {
+    const bytes = await this.read(file, fallback === undefined);
+    return bytes === null
+      ? fallback
+      : validate(file, () => JSON.parse(bytes.toString("utf8")));
+  }
+
+  async verify(): Promise<void> {
+    for (const [file, before] of this.files) {
+      const after = await this.readFile(file);
+      if (
+        before === null
+          ? after !== null
+          : after === null || digest(before) !== digest(after)
+      )
+        fail("source_changed", file);
+    }
+  }
+}
+
+async function destinationPath(input: string, source: string): Promise<string> {
+  const destination = expandHome(input);
+  let ancestor = destination;
+  const suffix: string[] = [];
+  while (true) {
+    try {
+      const stat = await fs.lstat(ancestor);
+      if (
+        (ancestor === destination && stat.isSymbolicLink()) ||
+        !(await fs.stat(ancestor)).isDirectory()
+      )
+        fail("unsafe_destination");
+      break;
+    } catch (error) {
+      if (!missing(error)) throw error;
+      if (path.dirname(ancestor) === ancestor) fail("unsafe_destination");
+      suffix.unshift(path.basename(ancestor));
+      ancestor = path.dirname(ancestor);
+    }
+  }
+  const canonical = path.join(await fs.realpath(ancestor), ...suffix);
+  if (isWithinDir(source, canonical) || isWithinDir(canonical, source))
+    fail("unsafe_destination");
+  return canonical;
+}
+
+async function requireEmpty(destination: string): Promise<void> {
+  try {
+    const stat = await fs.lstat(destination);
+    if (stat.isSymbolicLink() || !stat.isDirectory())
+      fail("unsafe_destination");
+    if ((await fs.readdir(destination)).length) fail("destination_not_empty");
+  } catch (error) {
+    if (!missing(error)) throw error;
+  }
+}
+
+/** Copies selected metadata into a new profile; trial jobs and identity are created at boot. */
+async function importProfile(
+  options: StudioComparisonImportOptions,
+): Promise<StudioComparisonManifest> {
+  const selected = [...new Set(options.projectIds)];
+  if (!selected.length || selected.some((id) => !isStudioProjectId(id)))
+    fail("invalid_selection");
+  let source: string;
+  try {
+    source = await fs.realpath(expandHome(options.sourceStateRoot));
+  } catch {
+    return fail("source_unavailable");
+  }
+  const destination = await destinationPath(
+    options.destinationStateRoot,
+    source,
+  );
+  await requireEmpty(destination);
+  const snapshot = new SourceSnapshot(source);
+  const catalogFile = "studio-projects.json";
+  const rawCatalog = await snapshot.json(catalogFile);
+  const catalog = validate(catalogFile, () =>
+    parseStudioProjectCatalog(rawCatalog),
+  );
+  const preferencesFile = "agent-map/studio-workspace-preferences.json";
+  const rawPreferences = await snapshot.json(preferencesFile, {
+    schemaVersion: 1,
+    preferences: [],
+    agentBindings: [],
+  });
+  const preferences = validate(preferencesFile, () =>
+    parseStudioWorkspacePreferences(rawPreferences),
+  );
+  const workflows = await snapshot.json("workflows.json", []);
+  if (
+    !Array.isArray(workflows) ||
+    workflows.some(
+      (row) =>
+        !record(row) ||
+        typeof row.path !== "string" ||
+        !path.isAbsolute(row.path) ||
+        typeof row.name !== "string" ||
+        !row.name ||
+        (row.definitionId !== null && !Number.isSafeInteger(row.definitionId)),
+    )
+  )
+    fail("invalid_state", "workflows.json");
+  const settings = await snapshot.json("settings.json", { recentDirs: [] });
+  if (
+    !record(settings) ||
+    (settings.recentDirs !== undefined &&
+      (!Array.isArray(settings.recentDirs) ||
+        settings.recentDirs.some((dir) => typeof dir !== "string")))
+  )
+    fail("invalid_state", "settings.json");
+  const manifest: StudioComparisonManifest = {
+    schemaVersion: 1,
+    sourceStateRoot: source,
+    destinationStateRoot: destination,
+    createdAt: new Date().toISOString(),
+    published: false,
+    projects: [],
+    excluded: [],
+  };
+  const maps = new Map<string, Buffer>();
+  for (const projectId of selected) {
+    const project = catalog.projects.find(
+      (item) => item.projectId === projectId,
+    );
+    if (!project) {
+      manifest.excluded.push({ projectId, reason: "project_not_found" });
+      continue;
+    }
+    const directory = `agent-map/projects/${projectId}`;
+    const journalFile = `${directory}/initialization.json`;
+    const journalBytes = await snapshot.read(journalFile);
+    if (journalBytes !== null) {
+      const journal = validate(journalFile, () =>
+        initializationRecordSchema.parse(
+          JSON.parse(journalBytes.toString("utf8")),
+        ),
+      );
+      if (journal.projectId !== projectId) fail("invalid_state", journalFile);
+      if (journal.status === "running" || journal.status === "queued") {
+        manifest.excluded.push({ projectId, reason: "initialization_busy" });
+        continue;
+      }
+    }
+    const file = `${directory}/workspace.json`;
+    const bytes = await snapshot.read(file);
+    let map: StudioComparisonManifest["projects"][number]["map"] = null;
+    if (bytes !== null) {
+      const aggregate = validate(file, () =>
+        parseProjectPlanningAggregate(
+          JSON.parse(bytes.toString("utf8")),
+          projectId,
+        ),
+      );
+      maps.set(file, bytes);
+      map = {
+        byteDigest: digest(bytes),
+        aggregateDigest: aggregate.aggregateDigest,
+        recordVersion: aggregate.recordVersion,
+        currentMap: aggregate.current.map,
+        authored: hasAuthoredAgentMap(aggregate),
+      };
+    }
+    manifest.projects.push({
+      projectId,
+      displayName: project.displayName,
+      rootBindings: project.rootBindings,
+      map,
+    });
+  }
+  await snapshot.verify();
+  if (!manifest.projects.length) return manifest;
+  const imported = new Set(manifest.projects.map(({ projectId }) => projectId));
+  const roots = manifest.projects.flatMap(({ rootBindings }) =>
+    rootBindings
+      .filter(({ status }) => status === "active")
+      .map(({ localRootRef }) => localRootRef),
+  );
+  const bindings = preferences.agentBindings.filter(({ projectId }) =>
+    imported.has(projectId),
+  );
+  const inventory = (workflows as Array<Record<string, unknown>>)
+    .filter((row) => {
+      const agentPath = row.path as string;
+      const owner = preferences.agentBindings.find(
+        (binding) =>
+          binding.createdBySessionId && samePath(binding.path, agentPath),
+      );
+      return owner
+        ? imported.has(owner.projectId)
+        : bindings.some((binding) => samePath(binding.path, agentPath)) ||
+            roots.some((root) => isWithinDir(root, agentPath));
+    })
+    .map((row) =>
+      Object.fromEntries(
+        Object.entries(row).filter(([key]) =>
+          [
+            "name",
+            "path",
+            "definitionId",
+            "definitionSlug",
+            "templateId",
+            "forkId",
+            "starterId",
+            "source",
+            "sourceDefinitionName",
+            "markerPresent",
+          ].includes(key),
+        ),
+      ),
+    );
+  const discoverySettings: HarnessSettings = {
+    telemetryOptIn: false,
+    productAnalyticsOptIn: false,
+    rollingSummary: false,
+    recentDirs: await sanitizeRecentDirs([
+      ...((settings as { recentDirs?: string[] }).recentDirs ?? []).filter(
+        (dir) => roots.some((root) => samePath(root, dir)),
+      ),
+      ...roots,
+    ]),
+  };
+  const copiedCatalog = {
+    schemaVersion: catalog.schemaVersion,
+    projects: catalog.projects.filter(({ projectId }) =>
+      imported.has(projectId),
+    ),
+  };
+  const copiedPreferences = {
+    schemaVersion: preferences.schemaVersion,
+    preferences: [],
+    agentBindings: bindings,
+  };
+  validate(catalogFile, () => parseStudioProjectCatalog(copiedCatalog));
+  validate(preferencesFile, () =>
+    parseStudioWorkspacePreferences(copiedPreferences),
+  );
+  const parent = path.dirname(destination);
+  if (!samePath(await destinationPath(destination, source), destination))
+    fail("unsafe_destination");
+  await fs.mkdir(parent, { recursive: true });
+  if (!samePath(await destinationPath(destination, source), destination))
+    fail("unsafe_destination");
+  const stage = await fs.mkdtemp(path.join(parent, ".studio-comparison-"));
+  try {
+    const write = async (file: string, bytes: Buffer | string) => {
+      await fs.mkdir(path.dirname(path.join(stage, file)), {
+        recursive: true,
+        mode: 0o700,
+      });
+      await fs.writeFile(path.join(stage, file), bytes, {
+        mode: 0o600,
+        flag: "wx",
+      });
+    };
+    for (const [file, bytes] of maps) await write(file, bytes);
+    for (const [file, value] of [
+      [catalogFile, copiedCatalog],
+      [preferencesFile, copiedPreferences],
+      ["workflows.json", inventory],
+      ["settings.json", discoverySettings],
+    ] as const)
+      await write(file, `${JSON.stringify(value, null, 2)}\n`);
+    manifest.published = true;
+    await write(
+      "comparison-profile.json",
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    );
+    // A second verification brackets staging as well as the initial collection.
+    await snapshot.verify();
+    if (!samePath(await destinationPath(destination, source), destination))
+      fail("unsafe_destination");
+    await requireEmpty(destination);
+    await fs.rename(stage, destination);
+    return manifest;
+  } finally {
+    await fs.rm(stage, { recursive: true, force: true });
+  }
+}
+
+export async function importStudioComparisonProfile(
+  options: StudioComparisonImportOptions,
+): Promise<StudioComparisonManifest> {
+  try {
+    return await importProfile(options);
+  } catch (error) {
+    if (error instanceof StudioComparisonImportError) throw error;
+    return fail("destination_unavailable");
+  }
+}

--- a/packages/harness/src/core/studio-comparison-profile.ts
+++ b/packages/harness/src/core/studio-comparison-profile.ts
@@ -154,7 +154,7 @@ async function destinationPath(input: string, source: string): Promise<string> {
   const destination = expandHome(input);
   let ancestor = destination;
   const suffix: string[] = [];
-  while (true) {
+  for (;;) {
     try {
       const stat = await fs.lstat(ancestor);
       if (

--- a/packages/harness/src/core/studio-comparison-profile.ts
+++ b/packages/harness/src/core/studio-comparison-profile.ts
@@ -18,12 +18,14 @@ import {
 } from "./studio-project-catalog.js";
 import { parseStudioWorkspacePreferences } from "./studio-workspace-preferences.js";
 
+/** Source, isolated destination, and selected durable Studio project IDs. */
 export interface StudioComparisonImportOptions {
   sourceStateRoot: string;
   destinationStateRoot: string;
   projectIds: readonly string[];
 }
 
+/** Snapshot identities and map references, including publication and exclusions. */
 export interface StudioComparisonManifest {
   schemaVersion: 1;
   sourceStateRoot: string;
@@ -48,6 +50,7 @@ export interface StudioComparisonManifest {
   }>;
 }
 
+/** Bounded import failure with an optional file reference and underlying cause. */
 export class StudioComparisonImportError extends Error {
   constructor(
     readonly code:
@@ -430,6 +433,7 @@ async function importProfile(
  * all excluded returns published:false without publishing a destination.
  * Throws StudioComparisonImportError for unsafe, invalid, changing or unavailable state.
  * Trial journals and machine identity start independently at boot.
+ * A failed final publish may consume a pre-existing empty destination directory.
  */
 export async function importStudioComparisonProfile(
   options: StudioComparisonImportOptions,

--- a/packages/harness/src/core/studio-comparison-profile.ts
+++ b/packages/harness/src/core/studio-comparison-profile.ts
@@ -61,6 +61,7 @@ export class StudioComparisonImportError extends Error {
       | "destination_not_empty"
       | "destination_unavailable",
     readonly file?: string,
+    readonly cause?: unknown,
   ) {
     super(`Studio comparison import: ${code}${file ? ` (${file})` : ""}`);
     this.name = "StudioComparisonImportError";
@@ -76,8 +77,9 @@ const missing = (error: unknown) =>
 const fail = (
   code: StudioComparisonImportError["code"],
   file?: string,
+  cause?: unknown,
 ): never => {
-  throw new StudioComparisonImportError(code, file);
+  throw new StudioComparisonImportError(code, file, cause);
 };
 
 function validate<T>(file: string, operation: () => T): T {
@@ -187,7 +189,6 @@ async function requireEmpty(destination: string): Promise<void> {
   }
 }
 
-/** Copies selected metadata into a new profile; trial jobs and identity are created at boot. */
 async function importProfile(
   options: StudioComparisonImportOptions,
 ): Promise<StudioComparisonManifest> {
@@ -288,10 +289,16 @@ async function importProfile(
         ),
       );
       if (journal.projectId !== projectId) fail("invalid_state", journalFile);
-      if (
-        !map?.authored &&
-        (journal.status === "running" || journal.status === "queued")
-      ) {
+      let busy = journal.status === "queued";
+      if (journal.status === "running" && journal.ownerPid !== null) {
+        try {
+          process.kill(journal.ownerPid, 0);
+          busy = true;
+        } catch (error) {
+          busy = (error as NodeJS.ErrnoException).code !== "ESRCH";
+        }
+      }
+      if (!map?.authored && busy) {
         manifest.excluded.push({ projectId, reason: "initialization_busy" });
         continue;
       }
@@ -417,6 +424,13 @@ async function importProfile(
   }
 }
 
+/**
+ * Copy selected identities, inventory and full map histories into a new/empty profile.
+ * The source is read-only. Missing or busy unauthored projects are excluded;
+ * all excluded returns published:false without publishing a destination.
+ * Throws StudioComparisonImportError for unsafe, invalid, changing or unavailable state.
+ * Trial journals and machine identity start independently at boot.
+ */
 export async function importStudioComparisonProfile(
   options: StudioComparisonImportOptions,
 ): Promise<StudioComparisonManifest> {
@@ -424,6 +438,6 @@ export async function importStudioComparisonProfile(
     return await importProfile(options);
   } catch (error) {
     if (error instanceof StudioComparisonImportError) throw error;
-    return fail("destination_unavailable");
+    return fail("destination_unavailable", undefined, error);
   }
 }

--- a/packages/harness/src/core/studio-comparison-profile.ts
+++ b/packages/harness/src/core/studio-comparison-profile.ts
@@ -261,20 +261,6 @@ async function importProfile(
       continue;
     }
     const directory = `agent-map/projects/${projectId}`;
-    const journalFile = `${directory}/initialization.json`;
-    const journalBytes = await snapshot.read(journalFile);
-    if (journalBytes !== null) {
-      const journal = validate(journalFile, () =>
-        initializationRecordSchema.parse(
-          JSON.parse(journalBytes.toString("utf8")),
-        ),
-      );
-      if (journal.projectId !== projectId) fail("invalid_state", journalFile);
-      if (journal.status === "running" || journal.status === "queued") {
-        manifest.excluded.push({ projectId, reason: "initialization_busy" });
-        continue;
-      }
-    }
     const file = `${directory}/workspace.json`;
     const bytes = await snapshot.read(file);
     let map: StudioComparisonManifest["projects"][number]["map"] = null;
@@ -285,7 +271,6 @@ async function importProfile(
           projectId,
         ),
       );
-      maps.set(file, bytes);
       map = {
         byteDigest: digest(bytes),
         aggregateDigest: aggregate.aggregateDigest,
@@ -294,6 +279,24 @@ async function importProfile(
         authored: hasAuthoredAgentMap(aggregate),
       };
     }
+    const journalFile = `${directory}/initialization.json`;
+    const journalBytes = await snapshot.read(journalFile);
+    if (journalBytes !== null) {
+      const journal = validate(journalFile, () =>
+        initializationRecordSchema.parse(
+          JSON.parse(journalBytes.toString("utf8")),
+        ),
+      );
+      if (journal.projectId !== projectId) fail("invalid_state", journalFile);
+      if (
+        !map?.authored &&
+        (journal.status === "running" || journal.status === "queued")
+      ) {
+        manifest.excluded.push({ projectId, reason: "initialization_busy" });
+        continue;
+      }
+    }
+    if (bytes !== null) maps.set(file, bytes);
     manifest.projects.push({
       projectId,
       displayName: project.displayName,
@@ -404,6 +407,9 @@ async function importProfile(
     if (!samePath(await destinationPath(destination, source), destination))
       fail("unsafe_destination");
     await requireEmpty(destination);
+    await fs.rmdir(destination).catch((error) => {
+      if (!missing(error)) throw error;
+    });
     await fs.rename(stage, destination);
     return manifest;
   } finally {

--- a/packages/harness/src/core/studio-project-catalog.ts
+++ b/packages/harness/src/core/studio-project-catalog.ts
@@ -217,7 +217,7 @@ function parseProject(value: unknown): StudioProjectIdentity | null {
   };
 }
 
-function parseCatalog(value: unknown): PersistedStudioProjectCatalog & { migrated: boolean } {
+export function parseStudioProjectCatalog(value: unknown): PersistedStudioProjectCatalog & { migrated: boolean } {
   if (
     isRecord(value) &&
     Number.isSafeInteger(value.schemaVersion) &&
@@ -425,7 +425,7 @@ export class StudioProjectCatalog {
       } catch {
         throw new StudioProjectCatalogError("malformed_state");
       }
-      const parsed = parseCatalog(decoded);
+      const parsed = parseStudioProjectCatalog(decoded);
       this.projects = parsed.projects;
       this.migrationPending = parsed.migrated;
     })().finally(() => {

--- a/packages/harness/src/core/studio-workspace-preferences.ts
+++ b/packages/harness/src/core/studio-workspace-preferences.ts
@@ -87,7 +87,7 @@ function validSelection(
   );
 }
 
-function parseState(value: unknown): PersistedPreferences {
+export function parseStudioWorkspacePreferences(value: unknown): PersistedPreferences {
   if (!isRecord(value))
     throw new StudioWorkspacePreferenceStoreError("malformed_state");
   if (
@@ -161,7 +161,7 @@ export class StudioWorkspacePreferenceStore {
   private async load(): Promise<PersistedPreferences> {
     if (this.state) return this.state;
     try {
-      this.state = parseState(
+      this.state = parseStudioWorkspacePreferences(
         JSON.parse(await fs.readFile(this.filePath, "utf8")) as unknown,
       );
     } catch (error) {

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -4,6 +4,8 @@
  */
 
 export * from "./shared/types.js";
+export { importStudioComparisonProfile, StudioComparisonImportError } from "./core/studio-comparison-profile.js";
+export type { StudioComparisonImportOptions, StudioComparisonManifest } from "./core/studio-comparison-profile.js";
 export type {
   AgentMapInitializationError,
   AgentMapInitializationState,

--- a/scripts/agent-studio-terminology-allowlist.json
+++ b/scripts/agent-studio-terminology-allowlist.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "studio-comparison-registry-filename",
+    "path": "packages/harness/src/core/studio-comparison-profile.ts",
+    "pattern": "^workflows\\.json$",
+    "occurrences": 3,
+    "reason": "The importer preserves the existing on-disk agent registry filename."
+  },
+  {
     "id": "desktop-release-manual-trigger-key",
     "path": ".github/workflows/desktop-release.yml",
     "pattern": "(?:^|\\n)\\s*workflow_dispatch:\\s*(?:\\n|$)",


### PR DESCRIPTION
## Primary change type

- [x] Feature

## Problem and motivation

Comparing a new Studio map renderer against existing desktop projects requires a separate profile that preserves the same maps and agent identities. Copying runtime state would also copy initialization attempts and machine identity.

## Summary and scope

Add `importStudioComparisonProfile()` to copy selected project metadata, durable agent bindings, and complete canonical map bytes/history into a fresh profile. Validate the source without calling migrating stores, check it again before atomic publication, and record map digests in `comparison-profile.json`. Exclude busy initializers and reject invalid, changing, or unsafe snapshots. New profiles get their own identity and initialization bookkeeping at boot.

Stack 1/4, based on `main`. **998 raw changed lines** (994 additions + 4 deletions), including tests and Changeset. The launcher follows in SAP-3266.

## Related work

[SAP-3263](https://linear.app/sapiom/issue/SAP-3263), part of [SAP-3262](https://linear.app/sapiom/issue/SAP-3262).

## Validation

- All current-head GitHub checks passed: Node 20/22 tests, examples/terminology, desktop smoke, Playwright mock, and CodeQL.
- 18 importer tests passed after review fixes, alongside package build/typecheck/lint and terminology checks. Regression coverage includes stale dead-PID journals, authored-map precedence, and publishing to a pre-existing empty directory on Windows.
- Combined stack: full workspace build, typecheck, and lint passed; Linux harness validation covered 3,909 passing tests. macOS performance (10 tests), desktop (205), and CLI (73) passed.
- The full macOS test command still encounters an unchanged workspace-watcher assertion, reproduced on the original main baseline. A separate session-manager wall-clock timeout passed its isolated 183-test rerun.
- Actual desktop-profile import preserved the saved 34-node/13-edge map bytes and project identity, produced a distinct machine identity, and left the checked source metadata and Git state unchanged. Both real built UI engines rendered the copied map without browser errors.
- Formatting and `git diff --check` passed.

An independent review of the final importer fix delta found no introduced correctness issues. Review fixes include the minor Changeset, public API JSDoc, preserved error causes, read-only dead-owner recovery, and portable publication. The documented failure case may consume a pre-existing empty destination directory.

### Tests and documentation

Tests cover complete plans/briefs/map history, authored empty maps, cross-root agent identity, source immutability, busy initialization, malformed/changing state, symlink aliases, unsafe destinations, and atomic publication failures. Public API documentation is included; the coworker command and walkthrough follow in SAP-3266.

## Compatibility and release impact

- Additive API; existing Studio startup behavior is unchanged.
- Changeset: harness minor release.

## Security

- [x] No secrets, credentials, private project data, or unsanitized logs are included.
- [x] This PR does not publicly disclose a suspected vulnerability.

## AI assistance

- [x] AI assistance was used: Codex implemented and reviewed the change; validation includes source review, focused tests, builds, and broader workspace checks.

## Checklist

- [x] Followed `CONTRIBUTING.md` and the approved Linear scope.
- [x] One focused problem; no unrelated cleanup.
- [x] Relevant tests and documentation included.
- [x] Required checks were run; results and outstanding validation are reported above.
- [x] Changeset included.
- [x] Submitted behavior and AI-assisted changes have been reviewed and can be explained.
