### PR TITLE
fix(auth): restart stale MCP sessions

### DIFF
--- a/.changeset/restart-stale-studio-sessions.md
+++ b/.changeset/restart-stale-studio-sessions.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": minor
+---
+
+Offer an explicit restart when a session was opened before the current Sapiom connection changed.

--- a/.changeset/restart-stale-studio-sessions.md
+++ b/.changeset/restart-stale-studio-sessions.md
@@ -2,4 +2,4 @@
 "@sapiom/harness": minor
 ---
 
-Offer an explicit restart when a session was opened before the current Sapiom connection changed.
+Offer an explicit MCP session restart API and UI action when the Sapiom connection changes, and export `McpSessionRestartUnavailableError` for programmatic handling.

--- a/packages/harness/src/core/errors.ts
+++ b/packages/harness/src/core/errors.ts
@@ -8,6 +8,7 @@
  *   SessionNotReadyError      → 409
  *   SessionAlreadyLiveError   → 409
  *   SessionNotResumeableError → 409
+ *   McpSessionRestartUnavailableError → 409
  *   AgentSessionIdentityReservedError → 409
  *   McpCredentialGenerationChangedError → 409
  *   AdapterNotFoundError      → 400
@@ -80,6 +81,15 @@ export class SessionNotResumeableError extends HarnessError {
 export class SessionAlreadyLiveError extends HarnessError {
   constructor(id: string) {
     super("SESSION_ALREADY_LIVE", `Session "${id}" already has a live pty`);
+  }
+}
+
+/** A live session is not eligible for the credential-scoped restart action. */
+export class McpSessionRestartUnavailableError extends HarnessError {
+  constructor(
+    reason = "This session is not waiting for a Sapiom connection restart",
+  ) {
+    super("MCP_SESSION_RESTART_UNAVAILABLE", reason);
   }
 }
 

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -12,7 +12,11 @@ import type {
   SpawnSpec,
 } from "../shared/types.js";
 import { CodexAdapter } from "./adapters/codex.js";
-import { ExternalHarnessError, SessionNotResumeableError } from "./errors.js";
+import {
+  ExternalHarnessError,
+  McpSessionRestartUnavailableError,
+  SessionNotResumeableError,
+} from "./errors.js";
 import {
   SessionInputGuardRejectedError,
   SessionBackgroundInputPreemptedError,
@@ -4389,6 +4393,109 @@ describe("SessionManager", () => {
     });
 
     expect(session.mcpAuthState).toBe("not-applicable");
+  });
+
+  it("restarts the exact stale runtime through the existing resume path", async () => {
+    let generation = 1;
+    const { manager, adapter, spawns } = makeManager({
+      currentCredentialGeneration: () => generation,
+      buildLaunchOpts: async () => ({
+        mcpCredentialLaunch: {
+          generation,
+          credentialBearing: true,
+        },
+      }),
+    });
+    const states: Array<HarnessSession["mcpAuthState"]> = [];
+    manager.onStatusChange((updated) => states.push(updated.mcpAuthState));
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
+    await manager.setAgentSessionId(session.id, "agent-session-1");
+    generation = 2;
+    manager.reconcileMcpCredentialGeneration(generation);
+
+    const restarting = manager.restartForMcpCredentials(session.id);
+    await vi.waitFor(() => expect(spawns[0]!.pty.kill).toHaveBeenCalledOnce());
+    expect(manager.get(session.id)?.mcpAuthState).toBe("restarting");
+    spawns[0]!.emitExit(0);
+
+    await expect(restarting).resolves.toMatchObject({
+      id: session.id,
+      status: "running",
+      mcpAuthState: "current",
+    });
+    expect(spawns).toHaveLength(2);
+    expect(adapter.resume).toHaveBeenCalledWith(
+      "agent-session-1",
+      expect.objectContaining({ harnessSessionId: session.id }),
+    );
+    expect(states).toContain("restarting");
+  });
+
+  it("keeps an unresumable stale runtime running and restores restart-required", async () => {
+    let generation = 1;
+    const { manager, spawns } = makeManager({
+      adapter: createFakeAdapter({ canResume: vi.fn(async () => false) }),
+      currentCredentialGeneration: () => generation,
+      buildLaunchOpts: async () => ({
+        mcpCredentialLaunch: { generation, credentialBearing: true },
+      }),
+    });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
+    await manager.setAgentSessionId(session.id, "missing-conversation");
+    generation = 2;
+    manager.reconcileMcpCredentialGeneration(generation);
+
+    await expect(
+      manager.restartForMcpCredentials(session.id),
+    ).rejects.toBeInstanceOf(SessionNotResumeableError);
+    expect(spawns[0]!.pty.kill).not.toHaveBeenCalled();
+    expect(manager.get(session.id)).toMatchObject({
+      status: "running",
+      mcpAuthState: "restart-required",
+    });
+  });
+
+  it("never kills a session whose runtime changed during restart preparation", async () => {
+    const resumable = deferred<boolean>();
+    let generation = 1;
+    const { manager, spawns } = makeManager({
+      adapter: createFakeAdapter({ canResume: vi.fn(() => resumable.promise) }),
+      currentCredentialGeneration: () => generation,
+      buildLaunchOpts: async () => ({
+        mcpCredentialLaunch: { generation, credentialBearing: true },
+      }),
+    });
+    const session = await manager.create({
+      cwd: "/tmp/proj",
+      harness: "claude-code",
+    });
+    await manager.setAgentSessionId(session.id, "agent-session-1");
+    generation = 2;
+    manager.reconcileMcpCredentialGeneration(generation);
+
+    const restarting = manager.restartForMcpCredentials(session.id);
+    await vi.waitFor(() =>
+      expect(manager.get(session.id)?.mcpAuthState).toBe("restarting"),
+    );
+    manager.reconcileMcpCredentialGeneration(3);
+    expect(manager.get(session.id)?.mcpAuthState).toBe("restarting");
+    await expect(
+      manager.restartForMcpCredentials(session.id),
+    ).rejects.toBeInstanceOf(McpSessionRestartUnavailableError);
+
+    spawns[0]!.emitExit(0);
+    resumable.resolve(true);
+    await expect(restarting).rejects.toBeInstanceOf(
+      McpSessionRestartUnavailableError,
+    );
+    expect(spawns[0]!.pty.kill).not.toHaveBeenCalled();
+    expect(spawns).toHaveLength(1);
   });
 
   it("rechecks the MCP credential after resume runtime bookkeeping and before PTY admission", async () => {

--- a/packages/harness/src/core/session-manager.test.ts
+++ b/packages/harness/src/core/session-manager.test.ts
@@ -4461,6 +4461,66 @@ describe("SessionManager", () => {
     });
   });
 
+  it("rejects current, unstamped, Codex, and already-stopping runtimes", async () => {
+    let generation = 1;
+    const claude = createFakeAdapter();
+    const { manager, spawns } = makeManager({
+      adapter: claude,
+      adapters: { "claude-code": claude, codex: createFakeAdapter() },
+      currentCredentialGeneration: () => generation,
+      buildLaunchOpts: async (_id, request) =>
+        request.cwd.endsWith("unstamped")
+          ? {}
+          : {
+              mcpCredentialLaunch: {
+                generation,
+                credentialBearing: true,
+              },
+            },
+    });
+    const current = await manager.create({
+      cwd: "/tmp/current",
+      harness: "claude-code",
+    });
+    await expect(
+      manager.restartForMcpCredentials(current.id),
+    ).rejects.toBeInstanceOf(McpSessionRestartUnavailableError);
+    expect(spawns[0]!.pty.kill).not.toHaveBeenCalled();
+
+    const unstamped = await manager.create({
+      cwd: "/tmp/unstamped",
+      harness: "claude-code",
+    });
+    unstamped.mcpAuthState = "restart-required";
+    await expect(
+      manager.restartForMcpCredentials(unstamped.id),
+    ).rejects.toBeInstanceOf(McpSessionRestartUnavailableError);
+    expect(spawns[1]!.pty.kill).not.toHaveBeenCalled();
+
+    const codex = await manager.create({
+      cwd: "/tmp/codex",
+      harness: "codex",
+    });
+    const stopping = await manager.create({
+      cwd: "/tmp/stopping",
+      harness: "claude-code",
+    });
+    generation = 2;
+    manager.reconcileMcpCredentialGeneration(generation);
+    await expect(
+      manager.restartForMcpCredentials(codex.id),
+    ).rejects.toBeInstanceOf(McpSessionRestartUnavailableError);
+    expect(spawns[2]!.pty.kill).not.toHaveBeenCalled();
+
+    const termination = manager.kill(stopping.id);
+    await expect(
+      manager.restartForMcpCredentials(stopping.id),
+    ).rejects.toBeInstanceOf(McpSessionRestartUnavailableError);
+    expect(spawns[3]!.pty.kill).toHaveBeenCalledOnce();
+    spawns[3]!.emitExit(0);
+    await termination;
+  });
+
   it("never kills a session whose runtime changed during restart preparation", async () => {
     const resumable = deferred<boolean>();
     let generation = 1;

--- a/packages/harness/src/core/session-manager.ts
+++ b/packages/harness/src/core/session-manager.ts
@@ -52,6 +52,7 @@ import {
   AdapterNotFoundError,
   AgentSessionIdentityReservedError,
   ExternalHarnessError,
+  McpSessionRestartUnavailableError,
   McpCredentialGenerationChangedError,
   SessionAlreadyLiveError,
   SessionNotReadyError,
@@ -70,6 +71,7 @@ export {
   AdapterNotFoundError,
   AgentSessionIdentityReservedError,
   ExternalHarnessError,
+  McpSessionRestartUnavailableError,
   McpCredentialGenerationChangedError,
   SessionAlreadyLiveError,
   SessionNotReadyError,
@@ -1226,6 +1228,10 @@ export class SessionManager {
     for (const [id, handle] of this.ptys) {
       const session = this.sessions.get(id);
       if (!session) continue;
+      // The restart action owns this exact runtime until it either restores
+      // restart-required or replaces it. A concurrent credential change is
+      // still enforced by resume's launch-generation fence.
+      if (session.mcpAuthState === "restarting") continue;
       const next = handle.mcpCredentialLaunch
         ? handle.mcpCredentialLaunch.generation === currentGeneration
           ? "current"
@@ -1234,6 +1240,90 @@ export class SessionManager {
       if (session.mcpAuthState === next) continue;
       session.mcpAuthState = next;
       this.emitStatus(session, handle.runtimeEpoch);
+    }
+  }
+
+  /** Replace one stale Claude runtime only when its conversation is resumable. */
+  async restartForMcpCredentials(id: string): Promise<HarnessSession> {
+    if (this.closing) throw new SessionManagerClosingError();
+    const session = this.sessions.get(id);
+    if (!session) throw new UnknownSessionError(id);
+    const handle = this.ptys.get(id);
+    if (
+      session.harness !== "claude-code" ||
+      session.mcpAuthState !== "restart-required" ||
+      !handle?.mcpCredentialLaunch ||
+      handle.killed
+    ) {
+      throw new McpSessionRestartUnavailableError();
+    }
+
+    const runtimeEpoch = handle.runtimeEpoch;
+    const restoreRestartRequired = (): void => {
+      if (this.ptys.get(id) !== handle || this.sessions.get(id) !== session)
+        return;
+      session.mcpAuthState = "restart-required";
+      this.emitStatus(session, runtimeEpoch);
+    };
+    session.mcpAuthState = "restarting";
+    this.emitStatus(session, runtimeEpoch);
+
+    if (!session.agentSessionId) {
+      restoreRestartRequired();
+      throw new SessionNotResumeableError(
+        id,
+        "Claude Code has not saved this conversation yet, so it cannot be restarted safely. Start a new session instead.",
+      );
+    }
+    let resumable: boolean;
+    try {
+      resumable = await this.getAdapter(session.harness).canResume(
+        session.agentSessionId,
+        session.cwd,
+      );
+    } catch (error) {
+      restoreRestartRequired();
+      throw error;
+    }
+    if (!resumable) {
+      restoreRestartRequired();
+      throw new SessionNotResumeableError(
+        id,
+        "Claude Code no longer has this conversation, so it cannot be restarted safely. Start a new session instead.",
+      );
+    }
+    if (this.ptys.get(id) !== handle || handle.killed) {
+      restoreRestartRequired();
+      throw new McpSessionRestartUnavailableError(
+        "The session changed while its restart was being prepared. Try again from its current state.",
+      );
+    }
+
+    let killed: boolean;
+    try {
+      killed = await this.killIfRuntime(id, runtimeEpoch);
+    } catch (error) {
+      restoreRestartRequired();
+      throw error;
+    }
+    if (!killed) {
+      throw new McpSessionRestartUnavailableError(
+        "The session changed before it could be restarted. Try again from its current state.",
+      );
+    }
+
+    // markExited() clears runtime-only MCP state. Keep the action observable
+    // while the ordinary resume path performs its own final checks and spawn.
+    session.mcpAuthState = "restarting";
+    this.emitStatus(session);
+    try {
+      return await this.resume(id);
+    } catch (error) {
+      if (!this.ptys.has(id) && session.mcpAuthState === "restarting") {
+        session.mcpAuthState = "not-applicable";
+        this.emitStatus(session);
+      }
+      throw error;
     }
   }
 

--- a/packages/harness/src/index.ts
+++ b/packages/harness/src/index.ts
@@ -229,6 +229,7 @@ export {
   SessionNotResumeableError,
   SessionAlreadyLiveError,
   McpCredentialGenerationChangedError,
+  McpSessionRestartUnavailableError,
   SubsessionBindingMismatchError,
   SubsessionFreshRestartForbiddenError,
   AdapterNotFoundError,

--- a/packages/harness/src/server/auth-mcp-wiring.test.ts
+++ b/packages/harness/src/server/auth-mcp-wiring.test.ts
@@ -294,6 +294,45 @@ describe("Agent Studio MCP authentication wiring", () => {
     );
   });
 
+  it("explicitly restarts a stale session with a rotated key", async () => {
+    authFixture.credential = credential("key-a");
+    await boot({
+      identity: {
+        userId: "test-tenant",
+        tenantId: "test-tenant",
+        organizationName: "Test Org",
+        apiKey: "key-a",
+        source: "cached",
+      },
+    });
+    const session = await server!.sessionManager.create({
+      cwd: projectRoot,
+      harness: "claude-code",
+    });
+    await server!.sessionManager.setAgentSessionId(
+      session.id,
+      "agent-session-1",
+    );
+
+    authFixture.credential = credential("key-b");
+    await writeFile(authFixture.credentialsPath, "external rotation signal");
+    await vi.waitFor(() =>
+      expect(server!.sessionManager.get(session.id)?.mcpAuthState).toBe(
+        "restart-required",
+      ),
+    );
+
+    const restart = await post(`/api/sessions/${session.id}/restart-mcp`);
+    const restartBody = (await restart.json()) as Record<string, unknown>;
+    expect(restart.status, JSON.stringify(restartBody)).toBe(200);
+    expect(server!.sessionManager.get(session.id)).toMatchObject({
+      status: "running",
+      mcpAuthState: "current",
+    });
+    expect(captures.at(-1)).toMatchObject({ kind: "resume" });
+    expect(injectedKey(captures.at(-1)!)).toBe("key-b");
+  });
+
   it("waits for a credential-bearing session to exit before disconnect succeeds", async () => {
     authFixture.credential = credential("key-a");
     await boot({

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -37,6 +37,7 @@ import {
   AdapterNotFoundError,
   ExternalHarnessError,
   McpCredentialGenerationChangedError,
+  McpSessionRestartUnavailableError,
   SessionAlreadyLiveError,
   SessionNotResumeableError,
   SpawnTargetError,
@@ -62,6 +63,7 @@ function fakeSessionManager(initial: HarnessSession[] = []) {
     ),
     create: vi.fn(),
     resume: vi.fn(),
+    restartForMcpCredentials: vi.fn(),
     kill: vi.fn(() => true),
     write: vi.fn(() => true),
     submitInput: vi.fn(async () => true),
@@ -1362,6 +1364,56 @@ describe("createRestRouter", () => {
         },
       );
       expect(res.status).toBe(400);
+    });
+  });
+
+  describe("POST /sessions/:id/restart-mcp", () => {
+    it("returns the replacement session from the credential-scoped restart", async () => {
+      const stale = exitedSession({
+        id: "stale-session",
+        status: "running",
+        mcpAuthState: "restart-required",
+      });
+      const sessionManager = fakeSessionManager([stale]);
+      (
+        sessionManager.restartForMcpCredentials as ReturnType<typeof vi.fn>
+      ).mockResolvedValue({ ...stale, mcpAuthState: "current" });
+      start({ sessionManager });
+
+      const res = await fetch(
+        `${baseUrl}/sessions/stale-session/restart-mcp`,
+        { method: "POST", headers: TOKEN_HEADER },
+      );
+
+      expect(res.status).toBe(200);
+      expect(await res.json()).toMatchObject({
+        id: "stale-session",
+        status: "running",
+        mcpAuthState: "current",
+      });
+      expect(
+        sessionManager.restartForMcpCredentials,
+      ).toHaveBeenCalledWith("stale-session");
+    });
+
+    it("maps an ineligible restart to a stable 409", async () => {
+      const sessionManager = fakeSessionManager();
+      (
+        sessionManager.restartForMcpCredentials as ReturnType<typeof vi.fn>
+      ).mockRejectedValue(new McpSessionRestartUnavailableError());
+      start({ sessionManager });
+
+      const res = await fetch(`${baseUrl}/sessions/current/restart-mcp`, {
+        method: "POST",
+        headers: TOKEN_HEADER,
+      });
+
+      expect(res.status).toBe(409);
+      expect(await res.json()).toEqual({
+        error:
+          "This session is not waiting for a Sapiom connection restart",
+        code: "MCP_SESSION_RESTART_UNAVAILABLE",
+      });
     });
   });
 

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -43,6 +43,7 @@ import {
   AgentSessionIdentityReservedError,
   ExternalHarnessError,
   McpCredentialGenerationChangedError,
+  McpSessionRestartUnavailableError,
   SessionAlreadyLiveError,
   SessionNotResumeableError,
   SpawnTargetError,
@@ -693,8 +694,8 @@ export function createRestRouter(options: RestRouterOptions): Router {
   });
 
   /**
-   * Maps a resume failure onto its status code. Shared by both routes that
-   * resume — `/sessions/:id/resume` and `/sessions/adopt` — so a
+   * Maps a resume/restart failure onto its status code. Shared by all routes
+   * that resume a conversation so a
    * transcript-only row that turns out not to be resumable answers with the
    * same 409 + `code` the UI already knows how to surface. Returns false when
    * the error isn't a resume-shaped one, so the caller falls through to
@@ -721,6 +722,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
       err instanceof ExternalHarnessError ||
       err instanceof AgentSessionIdentityReservedError ||
       err instanceof McpCredentialGenerationChangedError ||
+      err instanceof McpSessionRestartUnavailableError ||
       err instanceof ProjectSessionScopeUnavailableError ||
       err instanceof SessionAlreadyLiveError ||
       err instanceof SessionNotResumeableError
@@ -844,6 +846,15 @@ export function createRestRouter(options: RestRouterOptions): Router {
     try {
       const session = await sessionManager.resume(req.params.id);
       res.json(session);
+    } catch (err) {
+      if (sendResumeError(res, err)) return;
+      next(err);
+    }
+  });
+
+  router.post("/sessions/:id/restart-mcp", async (req, res, next) => {
+    try {
+      res.json(await sessionManager.restartForMcpCredentials(req.params.id));
     } catch (err) {
       if (sendResumeError(res, err)) return;
       next(err);

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -694,12 +694,9 @@ export function createRestRouter(options: RestRouterOptions): Router {
   });
 
   /**
-   * Maps a resume/restart failure onto its status code. Shared by all routes
-   * that resume a conversation so a
-   * transcript-only row that turns out not to be resumable answers with the
-   * same 409 + `code` the UI already knows how to surface. Returns false when
-   * the error isn't a resume-shaped one, so the caller falls through to
-   * `next(err)`.
+   * Map failures shared by direct resume, transcript adoption, and the scoped
+   * MCP restart. A conversation that cannot be resumed answers with the same
+   * 409 + `code` on every path. Unknown errors still fall through to next().
    */
   const sendResumeError = (res: express.Response, err: unknown): boolean => {
     if (err instanceof UnknownSessionError) {

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -152,7 +152,11 @@ export type HarnessKind = (typeof SPAWNABLE_HARNESS_KINDS)[number];
 export type SessionStatus = "starting" | "running" | "exited";
 
 /** Browser-safe projection of a live session's private MCP credential stamp. */
-export type McpAuthState = "current" | "restart-required" | "not-applicable";
+export type McpAuthState =
+  | "current"
+  | "restart-required"
+  | "restarting"
+  | "not-applicable";
 
 /** A harness session = one pty running one agent process in one directory. */
 export interface HarnessSession {
@@ -1090,6 +1094,7 @@ export interface SessionRecord {
 // POST   /api/sessions/adopt            AdoptSessionRequest → HarnessSession (register + resume a transcript-only row)
 // GET    /api/sessions/:id/record       → SessionRecord (reconstructed transcript)
 // POST   /api/sessions/:id/resume       → HarnessSession (new pty, --resume)
+// POST   /api/sessions/:id/restart-mcp  → HarnessSession (replace exact stale resumable runtime)
 // DELETE /api/sessions/:id              → { ok: true }   (kill pty)
 // POST   /api/sessions/:id/input        InjectInputRequest → InjectInputResponse
 // POST   /api/sessions/:id/attachments  AttachFileRequest → AttachFileResponse (materialize only)

--- a/packages/harness/web/e2e/session-tabs.spec.ts
+++ b/packages/harness/web/e2e/session-tabs.spec.ts
@@ -16,6 +16,7 @@ interface SessionTestState {
   lastBindWorkflow?: {
     req?: { sessionId?: string; workflowPath?: string | null };
   };
+  restartMcpSessionCalls?: string[];
   publish?: (message: unknown) => void;
 }
 
@@ -55,6 +56,48 @@ test("renders oldest-first accessible tabs with provider tooltips", async ({
     "aria-label",
     "New session on leasing",
   );
+});
+
+test("offers one explicit restart when the active session has stale MCP auth", async ({
+  page,
+}) => {
+  await page.evaluate(() => {
+    const publish = (
+      window as unknown as {
+        __HARNESS_TEST__?: SessionTestState;
+      }
+    ).__HARNESS_TEST__?.publish;
+    publish?.({
+      type: "session.status",
+      session: {
+        id: "sess-boot",
+        agentSessionId: "agent-session-1",
+        boundWorkflowPath: "/Users/demo/acme-app/leasing",
+        harness: "claude-code",
+        cwd: "/Users/demo/acme-app",
+        title: "acme-app",
+        status: "running",
+        mcpAuthState: "restart-required",
+        createdAt: new Date(Date.now() - 60_000).toISOString(),
+        lastActiveAt: new Date().toISOString(),
+        exitCode: null,
+        ready: true,
+      },
+    });
+  });
+
+  const notice = page.getByTestId("mcp-auth-restart-notice");
+  await expect(notice).toContainText("The Sapiom connection changed.");
+  const restart = page.getByTestId("mcp-auth-restart");
+  await expect(restart).toHaveText("Restart session");
+
+  await restart.click();
+  await expect(restart).toBeDisabled();
+  await expect(restart).toHaveText("Restarting…");
+  await expect
+    .poll(async () => (await testState(page)).restartMcpSessionCalls)
+    .toEqual(["sess-boot"]);
+  await expect(notice).toHaveCount(0);
 });
 
 test("starts a fresh Claude sibling in the same folder and binding", async ({

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -71,6 +71,7 @@ import {
   ConnectivityBanner,
   ConnectivityScreen,
 } from "./components/ConnectivityState";
+import { McpAuthRestartNotice } from "./components/McpAuthRestartNotice";
 import { DeadSessionPane, PastSessionPane } from "./components/DeadSessionPane";
 import { EmptyState } from "./components/EmptyState";
 import { Icon } from "./components/Icon";
@@ -3188,6 +3189,19 @@ export const App = (): JSX.Element => {
                 ) : null
               }
             />
+
+            {sessionBarSession &&
+              (sessionBarSession.mcpAuthState === "restart-required" ||
+                sessionBarSession.mcpAuthState === "restarting") && (
+                <McpAuthRestartNotice
+                  restarting={
+                    sessionBarSession.mcpAuthState === "restarting"
+                  }
+                  onRestart={async () => {
+                    await harness.restartMcpSession(sessionBarSession.id);
+                  }}
+                />
+              )}
 
             <div className="terminal-slot">
               {showReview && reviewSummary ? (

--- a/packages/harness/web/src/components/McpAuthRestartNotice.tsx
+++ b/packages/harness/web/src/components/McpAuthRestartNotice.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import type { JSX } from "react";
+
+import { Icon } from "./Icon";
+
+interface McpAuthRestartNoticeProps {
+  restarting: boolean;
+  onRestart: () => Promise<void>;
+}
+
+/** A scoped, non-blocking recovery action for one stale Claude runtime. */
+export function McpAuthRestartNotice({
+  restarting,
+  onRestart,
+}: McpAuthRestartNoticeProps): JSX.Element {
+  const [requested, setRequested] = useState(false);
+  const pending = restarting || requested;
+  const handleRestart = async (): Promise<void> => {
+    if (pending) return;
+    setRequested(true);
+    try {
+      await onRestart();
+    } catch {
+      // The shared harness state presents the server's reason as a toast.
+    } finally {
+      setRequested(false);
+    }
+  };
+
+  return (
+    <div
+      className="connectivity-banner mcp-auth-restart-notice"
+      role="status"
+      aria-live="polite"
+      data-testid="mcp-auth-restart-notice"
+    >
+      <span className="connectivity-banner-icon" aria-hidden="true">
+        <Icon name="TriangleAlert" size={14} />
+      </span>
+      <span className="connectivity-banner-text">
+        {pending
+          ? "Restarting this session with the current Sapiom connection…"
+          : "The Sapiom connection changed. Restart this session to use the current connection."}
+      </span>
+      <button
+        type="button"
+        className="btn-ghost"
+        data-testid="mcp-auth-restart"
+        disabled={pending}
+        aria-busy={pending}
+        onClick={() => void handleRestart()}
+      >
+        {pending ? "Restarting…" : "Restart session"}
+      </button>
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/McpAuthRestartNotice.tsx
+++ b/packages/harness/web/src/components/McpAuthRestartNotice.tsx
@@ -29,7 +29,7 @@ export function McpAuthRestartNotice({
 
   return (
     <div
-      className="connectivity-banner mcp-auth-restart-notice"
+      className="connectivity-banner"
       role="status"
       aria-live="polite"
       data-testid="mcp-auth-restart-notice"
@@ -40,7 +40,7 @@ export function McpAuthRestartNotice({
       <span className="connectivity-banner-text">
         {pending
           ? "Restarting this session with the current Sapiom connection…"
-          : "The Sapiom connection changed. Restart this session to use the current connection."}
+          : "The Sapiom connection changed. Restart to reconnect; in-progress work will stop."}
       </span>
       <button
         type="button"

--- a/packages/harness/web/src/lib/api.ts
+++ b/packages/harness/web/src/lib/api.ts
@@ -404,6 +404,8 @@ export interface HarnessApi {
    */
   sessionRecord(id: string): Promise<SessionRecord | null>;
   resumeSession(id: string): Promise<HarnessSession>;
+  /** Restart one live Claude session whose launch-time MCP auth is stale. */
+  restartMcpSession(id: string): Promise<HarnessSession>;
   /** Take a transcript-only history row (`resumeMode: "agent-resume"`, no
    *  `harnessSessionId`) into the registry and resume it — the honest
    *  alternative to silently opening a fresh session in its directory.
@@ -760,6 +762,13 @@ class RealApi implements HarnessApi {
   resumeSession(id: string): Promise<HarnessSession> {
     return this.request<HarnessSession>(
       `/api/sessions/${encodeURIComponent(id)}/resume`,
+      { method: "POST" },
+    );
+  }
+
+  restartMcpSession(id: string): Promise<HarnessSession> {
+    return this.request<HarnessSession>(
+      `/api/sessions/${encodeURIComponent(id)}/restart-mcp`,
       { method: "POST" },
     );
   }
@@ -3024,6 +3033,47 @@ export class MockApi implements HarnessApi {
       session.id === resumed.id ? resumed : session,
     );
     return resumed;
+  }
+
+  async restartMcpSession(id: string): Promise<HarnessSession> {
+    const existing = this.sessions.find((session) => session.id === id);
+    if (!existing) throw new Error(`mock: no session to restart for ${id}`);
+    if (typeof window !== "undefined") {
+      const win = window as unknown as {
+        __HARNESS_TEST__?: Record<string, unknown>;
+      };
+      const previous =
+        (win.__HARNESS_TEST__?.restartMcpSessionCalls as string[] | undefined) ??
+        [];
+      win.__HARNESS_TEST__ = {
+        ...(win.__HARNESS_TEST__ ?? {}),
+        restartMcpSessionCalls: [...previous, id],
+      };
+    }
+    const restarting: HarnessSession = {
+      ...existing,
+      mcpAuthState: "restarting",
+    };
+    this.sessions = this.sessions.map((session) =>
+      session.id === id ? restarting : session,
+    );
+    void import("./events").then(({ publishMockBusMessage }) => {
+      publishMockBusMessage({ type: "session.status", session: restarting });
+    });
+    await delay(300);
+    const restarted: HarnessSession = {
+      ...restarting,
+      status: "running",
+      mcpAuthState: "current",
+      lastActiveAt: new Date().toISOString(),
+    };
+    this.sessions = this.sessions.map((session) =>
+      session.id === id ? restarted : session,
+    );
+    void import("./events").then(({ publishMockBusMessage }) => {
+      publishMockBusMessage({ type: "session.status", session: restarted });
+    });
+    return restarted;
   }
 
   /** Mirrors the real route: registers the transcript-only row as a session

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -188,6 +188,8 @@ export interface HarnessStateHook {
    *  recorded for it). Stable identity — safe as an effect dependency. */
   sessionRecord: (id: string) => Promise<SessionRecord | null>;
   resumeSession: (harnessSessionId: string) => Promise<HarnessSession>;
+  /** Explicitly replace one live Claude runtime with stale MCP auth. */
+  restartMcpSession: (harnessSessionId: string) => Promise<HarnessSession>;
   /**
    * Portable continue: a fresh session in `cwd`, seeded with our own
    * reconstruction of the session `from` identifies (either id form). For a
@@ -1583,6 +1585,35 @@ export function useHarnessState(): HarnessStateHook {
     [selectSession],
   );
 
+  const restartMcpSession = useCallback(
+    async (harnessSessionId: string): Promise<HarnessSession> => {
+      try {
+        const session = await api.restartMcpSession(harnessSessionId);
+        setState((prev) =>
+          prev
+            ? {
+                ...prev,
+                sessions: prev.sessions.map((candidate) =>
+                  candidate.id === session.id ? session : candidate,
+                ),
+              }
+            : prev,
+        );
+        return session;
+      } catch (err) {
+        setToast(
+          createToastMessage(
+            err instanceof ApiError && err.reason
+              ? err.reason
+              : (err as Error).message,
+          ),
+        );
+        throw err;
+      }
+    },
+    [],
+  );
+
   /**
    * Portable continue. A conversation the agent no longer holds can't be
    * reattached by anyone, so this starts a fresh session and hands it our own
@@ -2368,6 +2399,7 @@ export function useHarnessState(): HarnessStateHook {
     getWorkflowInputContract,
     sessionRecord,
     resumeSession,
+    restartMcpSession,
     rehydrateSession,
     resumeFromHistory,
     closeSession,


### PR DESCRIPTION
## Summary

- offer an explicit restart when the active Claude session needs the current Sapiom connection
- validate the exact live runtime and conversation before restarting through the existing resume path
- explain that restart stops in-progress work and surface failures through the existing toast flow
- reuse the existing status strip and button styles without new CSS

Closes [SAP-3116](https://linear.app/sapiom/issue/SAP-3116). Stacked on #869 and final in the stack.

## Release note

- minor changeset for `@sapiom/harness`

## Testing

- focused SessionManager, REST, and auth/MCP suites: 313 tests passed
- full harness suite: 238 files / 3,900 tests passed
- harness performance suite: 3 files / 10 tests passed
- full MCP suite: 16 files / 173 tests passed
- targeted Chromium restart flow: 1 test passed
- `pnpm --filter @sapiom/harness build`
- `pnpm --filter @sapiom/harness typecheck`
- `pnpm --filter @sapiom/harness lint`
- targeted Prettier checks
- `git diff --check`

Closes: SAP-3116
