### PR TITLE
feat(harness): launch an isolated ELK comparison profile (SAP-3266)

### DIFF
--- a/.changeset/studio-elk-comparison-launcher.md
+++ b/.changeset/studio-elk-comparison-launcher.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Support opening saved maps without a coding provider in session-free CLI launches, and selecting the map layout in the authorized browser URL. Add a repository launcher that imports or reopens an isolated real-project comparison profile.

--- a/.changeset/studio-elk-comparison-launcher.md
+++ b/.changeset/studio-elk-comparison-launcher.md
@@ -1,5 +1,5 @@
 ---
-"@sapiom/harness": patch
+"@sapiom/harness": minor
 ---
 
-Support opening saved maps without a coding provider in session-free CLI launches, and selecting the map layout in the authorized browser URL. Add a repository launcher that imports or reopens an isolated real-project comparison profile.
+Add the public `--map-layout classic|elk` CLI flag and allow `--no-session` launches to view saved maps without a coding provider. Add a repository launcher that imports or reopens an isolated real-project comparison profile.

--- a/docs/studio-elk-comparison.md
+++ b/docs/studio-elk-comparison.md
@@ -1,0 +1,58 @@
+# Compare Vertical layout with the desktop app
+
+Check out the coworker trial branch and install with Node >= 20 and pnpm >= 10
+(the repository pins pnpm 10.34.3):
+
+```bash
+pnpm install --frozen-lockfile
+pnpm studio:elk-preview \
+  --source-state-root "$HOME/.sapiom/harness" \
+  --state-root "$HOME/.sapiom/studio-elk-trial" \
+  --project project_REPLACE_WITH_ID \
+  --port 4101
+```
+
+Read project IDs from the desktop profile's `studio-projects.json`; repeat
+`--project <id>` for each project to compare. The destination must be a new or
+empty directory outside the source profile. Mapless projects with active
+initialization are excluded and reported. Leave the desktop app running on its own port.
+At least one imported project root must be accessible; reconnect a missing
+directory before launching. The state directory is never registered as a project.
+
+The command builds this branch's dependencies and Studio, then serves the built
+SPA from the real localhost server with `mapLayout=elk`. It prints the branch,
+commit, snapshot time, canonical profile paths, project IDs, and authorized
+browser URL. `--no-open` prints the URL without opening a browser. An occupied
+port fails with instructions to choose another; `--port 0` selects a free port.
+
+Reopen the same snapshot, preserving map edits and initialization attempts:
+
+```bash
+pnpm studio:elk-preview --state-root "$HOME/.sapiom/studio-elk-trial" --port 4101
+```
+
+A fresh snapshot requires a distinct new destination. Nonempty profiles with
+missing or damaged manifests are rejected. One trial process may use a comparison profile
+at a time; Ctrl+C closes it. An interrupted process can leave a claim file whose
+PID must be checked before removing that stale file.
+
+Saved maps and their full history are copied unchanged. Only projects with no
+authored map use the existing discovery-gated initializer, without opening a
+session or executing agent code. Install and authenticate Claude Code or Codex
+on the terminal PATH for that inference; desktop-managed binaries may not be
+on PATH. Doctor reports the available provider. With none available, saved maps
+remain viewable and mapless projects show `provider_unavailable`. After provider
+setup, restart the trial and explicitly Retry failed initialization. Credential
+failures use the same normal failure/retry flow. Native provider authentication
+remains shared; credentials are never copied and telemetry is disabled.
+
+Comparison state is isolated, but registered agent source directories are shared.
+Viewing and initialization leave them unchanged. For comparison feedback, record:
+
+- The printed commit and snapshot time; compare the same saved revision and
+  node/edge counts in desktop and localhost before making test-map edits.
+- Classic versus Vertical in localhost, including normal and expanded views,
+  selection, disconnected groups, and legibility with many agents.
+- Node/edge additions and removals in the trial's map state, restart persistence,
+  visible errors, layout duration, and interaction responsiveness. Agent source
+  edits, sessions, deployments, and runs are ordinary actions on shared projects.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "packages/*"
   ],
   "scripts": {
+    "studio:elk-preview": "node packages/harness/scripts/elk-preview.mjs",
     "build": "pnpm -r --filter='./packages/*' build",
     "clean": "pnpm -r --filter='./packages/*' clean",
     "test": "pnpm -r --filter='./packages/*' test",

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -86,62 +86,12 @@ Architecture: a single Node process (Express + ws + node-pty) serves the built
 SPA, a small REST API, terminal WebSocket streams, and the local telemetry
 ingest endpoint. The interface contract lives in `src/shared/types.ts`.
 
-### Compare Vertical layout with the desktop app
+### Map layout
 
-Check out the coworker trial branch and install with Node >= 20 and pnpm >= 10
-(the repository pins pnpm 10.34.3):
-
-```bash
-pnpm install --frozen-lockfile
-pnpm studio:elk-preview \
-  --source-state-root "$HOME/.sapiom/harness" \
-  --state-root "$HOME/.sapiom/studio-elk-trial" \
-  --project project_REPLACE_WITH_ID \
-  --port 4101
-```
-
-Read project IDs from the desktop profile's `studio-projects.json`; repeat
-`--project <id>` for each project to compare. The destination must be a new or
-empty directory outside the source profile. Projects currently initializing are
-excluded and reported. Leave the desktop app running on its own port.
-
-The command builds this branch's dependencies and Studio, then serves the built
-SPA from the real localhost server with `mapLayout=elk`. It prints the branch,
-commit, snapshot time, canonical profile paths, project IDs, and authorized
-browser URL. `--no-open` prints the URL without opening a browser. An occupied
-port fails with instructions to choose another; `--port 0` selects a free port.
-
-Reopen the same snapshot, preserving map edits and initialization attempts:
-
-```bash
-pnpm studio:elk-preview --state-root "$HOME/.sapiom/studio-elk-trial" --port 4101
-```
-
-A fresh snapshot requires a distinct new destination. Nonempty profiles with
-missing or damaged manifests are rejected. One trial process may use a comparison profile
-at a time; Ctrl+C closes it. An interrupted process can leave a claim file whose
-PID must be checked before removing that stale file.
-
-Saved maps and their full history are copied unchanged. Only projects with no
-authored map use the existing discovery-gated initializer, without opening a
-session or executing agent code. Install and authenticate Claude Code or Codex
-on the terminal PATH for that inference; desktop-managed binaries may not be
-on PATH. Doctor reports the available provider. With none available, saved maps
-remain viewable and mapless projects show `provider_unavailable`. After provider
-setup, restart the trial and explicitly Retry failed initialization. Credential
-failures use the same normal failure/retry flow. Native provider authentication
-remains shared; credentials are never copied and telemetry is disabled.
-
-Comparison state is isolated, but registered agent source directories are shared.
-Viewing and initialization leave them unchanged. For comparison feedback, record:
-
-- The printed commit and snapshot time; compare the same saved revision and
-  node/edge counts in desktop and localhost before making test-map edits.
-- Classic versus Vertical in localhost, including normal and expanded views,
-  selection, disconnected groups, and legibility with many agents.
-- Node/edge additions and removals in the trial's map state, restart persistence,
-  visible errors, layout duration, and interaction responsiveness. Agent source
-  edits, sessions, deployments, and runs are ordinary actions on shared projects.
+Use `--map-layout classic|elk` to select the initial layout in the browser URL;
+`elk` selects Vertical. Add `--no-session` to view saved maps without starting a
+coding session, even without a coding provider installed. For comparisons against
+the desktop app, see the [repository comparison guide](https://github.com/sapiom/sapiom-js/blob/main/docs/studio-elk-comparison.md).
 
 ### Project sessions and Agent Map bootstrap
 

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -86,6 +86,63 @@ Architecture: a single Node process (Express + ws + node-pty) serves the built
 SPA, a small REST API, terminal WebSocket streams, and the local telemetry
 ingest endpoint. The interface contract lives in `src/shared/types.ts`.
 
+### Compare Vertical layout with the desktop app
+
+Check out the coworker trial branch and install with Node >= 20 and pnpm >= 10
+(the repository pins pnpm 10.34.3):
+
+```bash
+pnpm install --frozen-lockfile
+pnpm studio:elk-preview \
+  --source-state-root "$HOME/.sapiom/harness" \
+  --state-root "$HOME/.sapiom/studio-elk-trial" \
+  --project project_REPLACE_WITH_ID \
+  --port 4101
+```
+
+Read project IDs from the desktop profile's `studio-projects.json`; repeat
+`--project <id>` for each project to compare. The destination must be a new or
+empty directory outside the source profile. Projects currently initializing are
+excluded and reported. Leave the desktop app running on its own port.
+
+The command builds this branch's dependencies and Studio, then serves the built
+SPA from the real localhost server with `mapLayout=elk`. It prints the branch,
+commit, snapshot time, canonical profile paths, project IDs, and authorized
+browser URL. `--no-open` prints the URL without opening a browser. An occupied
+port fails with instructions to choose another; `--port 0` selects a free port.
+
+Reopen the same snapshot, preserving map edits and initialization attempts:
+
+```bash
+pnpm studio:elk-preview --state-root "$HOME/.sapiom/studio-elk-trial" --port 4101
+```
+
+A fresh snapshot requires a distinct new destination. Nonempty profiles with
+missing or damaged manifests are rejected. One trial process may use a comparison profile
+at a time; Ctrl+C closes it. An interrupted process can leave a claim file whose
+PID must be checked before removing that stale file.
+
+Saved maps and their full history are copied unchanged. Only projects with no
+authored map use the existing discovery-gated initializer, without opening a
+session or executing agent code. Install and authenticate Claude Code or Codex
+on the terminal PATH for that inference; desktop-managed binaries may not be
+on PATH. Doctor reports the available provider. With none available, saved maps
+remain viewable and mapless projects show `provider_unavailable`. After provider
+setup, restart the trial and explicitly Retry failed initialization. Credential
+failures use the same normal failure/retry flow. Native provider authentication
+remains shared; credentials are never copied and telemetry is disabled.
+
+Comparison state is isolated, but registered agent source directories are shared.
+Viewing and initialization leave them unchanged. For comparison feedback, record:
+
+- The printed commit and snapshot time; compare the same saved revision and
+  node/edge counts in desktop and localhost before making test-map edits.
+- Classic versus Vertical in localhost, including normal and expanded views,
+  selection, disconnected groups, and legibility with many agents.
+- Node/edge additions and removals in the trial's map state, restart persistence,
+  visible errors, layout duration, and interaction responsiveness. Agent source
+  edits, sessions, deployments, and runs are ordinary actions on shared projects.
+
 ### Project sessions and Agent Map bootstrap
 
 Every session whose working directory resolves to a Studio project is an

--- a/packages/harness/scripts/elk-preview.mjs
+++ b/packages/harness/scripts/elk-preview.mjs
@@ -1,0 +1,64 @@
+import { spawn, execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+try {
+  if (process.argv.includes("--help")) {
+    console.log(
+      "pnpm studio:elk-preview --state-root <trial> [--source-state-root <desktop> --project <id> ...] [--port 4101] [--no-open]\nFirst import requires a source and projects. Reopen with the same trial directory; a new snapshot requires a new directory.",
+    );
+  } else {
+    const pnpm = process.env.npm_execpath;
+    if (
+      Number(process.versions.node.split(".")[0]) < 20 ||
+      !pnpm ||
+      Number(
+        execFileSync(process.execPath, [pnpm, "--version"], {
+          encoding: "utf8",
+        })
+          .trim()
+          .split(".")[0],
+      ) < 10
+    )
+      throw new Error(
+        "Run with Node >= 20 and pnpm >= 10 after pnpm install --frozen-lockfile.",
+      );
+    const cwd = fileURLToPath(new URL("../../..", import.meta.url));
+    const branch = execFileSync("git", ["branch", "--show-current"], {
+      cwd,
+      encoding: "utf8",
+    }).trim();
+    const commit = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd,
+      encoding: "utf8",
+    }).trim();
+    const dirty = execFileSync("git", ["status", "--porcelain"], {
+      cwd,
+      encoding: "utf8",
+    }).trim();
+    console.log(
+      `Building Agent Studio: ${branch || "detached"} @ ${commit}${dirty ? " (uncommitted changes)" : ""}`,
+    );
+    await new Promise((resolve, reject) => {
+      const child = spawn(
+        process.execPath,
+        [pnpm, "--filter", "@sapiom/harness...", "build"],
+        {
+          cwd,
+          stdio: "inherit",
+          env: { ...process.env, VITE_MOCK: "0" },
+        },
+      );
+      child.once("error", reject);
+      child.once("exit", (code, signal) =>
+        code === 0
+          ? resolve()
+          : reject(new Error(`Studio build failed (${signal ?? code}).`)),
+      );
+    });
+    const { launchComparison } = await import("../dist/cli/elk-preview.js");
+    await launchComparison(process.argv.slice(2));
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/packages/harness/scripts/elk-preview.mjs
+++ b/packages/harness/scripts/elk-preview.mjs
@@ -45,7 +45,7 @@ try {
         {
           cwd,
           stdio: "inherit",
-          env: { ...process.env, VITE_MOCK: "0" },
+          env: { ...process.env, VITE_MOCK: "" },
         },
       );
       child.once("error", reject);

--- a/packages/harness/src/cli/args.ts
+++ b/packages/harness/src/cli/args.ts
@@ -9,6 +9,7 @@
  */
 import * as path from "node:path";
 import { DEFAULT_PORT } from "../shared/types.js";
+import type { DoctorReport } from "./doctor.js";
 
 export interface CliOptions {
   dir: string;
@@ -23,6 +24,16 @@ export interface CliOptions {
    *  root stand in for a fresh install — the first-run flow becomes testable
    *  without moving, renaming, or losing the real one. */
   stateRoot?: string;
+  mapLayout?: "classic" | "elk";
+}
+
+/** Viewing a saved map needs Node, but does not need a coding-agent process. */
+export function canStartCli(report: DoctorReport, noSession: boolean): boolean {
+  return (
+    report.ok ||
+    (noSession &&
+      report.checks.some((check) => check.name === "node" && check.ok))
+  );
 }
 
 /** Translate the CLI flag into the server's explicit process-wide policy. */
@@ -42,6 +53,7 @@ export function parseArgs(argv: string[]): CliOptions {
   let noSession = false;
   let dev = false;
   let stateRoot: string | undefined;
+  let mapLayout: CliOptions["mapLayout"];
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -72,6 +84,13 @@ export function parseArgs(argv: string[]): CliOptions {
       case "--no-open":
         noOpen = true;
         break;
+      case "--map-layout": {
+        const value = argv[++i];
+        if (value !== "classic" && value !== "elk")
+          throw new Error("--map-layout requires classic or elk");
+        mapLayout = value;
+        break;
+      }
       case "--no-session":
         noSession = true;
         break;
@@ -99,5 +118,6 @@ export function parseArgs(argv: string[]): CliOptions {
     noSession,
     dev,
     ...(stateRoot ? { stateRoot } : {}),
+    ...(mapLayout ? { mapLayout } : {}),
   };
 }

--- a/packages/harness/src/cli/banner.ts
+++ b/packages/harness/src/cli/banner.ts
@@ -1,5 +1,17 @@
 import type { HarnessIdentity } from "./auth.js";
 import { AGENT_STUDIO_PRODUCT_NAME } from "../shared/branding.js";
+import type { CliOptions } from "./args.js";
+
+export function cliBrowserUrl(
+  port: number,
+  uiToken: string,
+  mapLayout?: CliOptions["mapLayout"],
+): string {
+  const url = new URL(`http://localhost:${port}/`);
+  url.searchParams.set("uiToken", uiToken);
+  if (mapLayout) url.searchParams.set("mapLayout", mapLayout);
+  return url.href;
+}
 
 export interface PrintBannerOptions {
   dir: string;
@@ -11,6 +23,7 @@ export interface PrintBannerOptions {
   > | null;
   telemetryOptIn: boolean;
   serverStarted: boolean;
+  mapLayout?: CliOptions["mapLayout"];
 }
 
 /** Print the real CLI host banner after the Studio server boot attempt. */
@@ -33,7 +46,7 @@ export function printBanner(opts: PrintBannerOptions): void {
   console.log(
     `  url         ${
       opts.serverStarted
-        ? `http://localhost:${opts.port}/?uiToken=${opts.uiToken}`
+        ? cliBrowserUrl(opts.port, opts.uiToken, opts.mapLayout)
         : "(server not started)"
     }`,
   );

--- a/packages/harness/src/cli/bin.ts
+++ b/packages/harness/src/cli/bin.ts
@@ -14,6 +14,8 @@
  * --no-open, --no-session, --dev, --state-root <dir>.
  */
 import * as crypto from "node:crypto";
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import open from "open";
 import {
   runDoctor,
@@ -23,30 +25,34 @@ import {
   CODEX_INSTALL_COMMAND,
 } from "./doctor.js";
 import { ensureAuthenticated } from "./auth.js";
-import { printBanner } from "./banner.js";
+import { cliBrowserUrl, printBanner } from "./banner.js";
 import { ensureConsent } from "./consent.js";
 import { loadSettings, recordRecentDir } from "./settings.js";
 import { getOrCreateMachineId } from "./machine-id.js";
 import { resolveStatePaths } from "../core/paths.js";
-import { parseArgs, resolveCliAuthMode } from "./args.js";
+import { canStartCli, parseArgs, resolveCliAuthMode } from "./args.js";
 import { startServer, type HarnessServer } from "../server/index.js";
 
-const main = async (): Promise<void> => {
-  const options = parseArgs(process.argv.slice(2));
+export const runCli = async (argv: string[]): Promise<void> => {
+  const options = parseArgs(argv);
 
   const doctorReport = await runDoctor();
   printDoctorReport(doctorReport);
-  if (!doctorReport.ok) {
+  if (!canStartCli(doctorReport, options.noSession)) {
     console.error(
       "\nAgent Studio (`sapiom-harness`) requires Node >= 20 and at least one coding agent on PATH:\n" +
         `  Claude Code:  ${CLAUDE_INSTALL_COMMAND}\n` +
         `  Codex:        ${CODEX_INSTALL_COMMAND}\n` +
         "Fix the checks above and try again.",
     );
-    process.exit(1);
+    throw new Error("Agent Studio prerequisites failed");
   }
   const defaultHarnessKind = pickDefaultHarness(doctorReport);
-  if (!doctorReport.availableHarnesses.includes("claude-code")) {
+  if (doctorReport.availableHarnesses.length === 0) {
+    console.log(
+      "\nOpening saved maps without a coding provider. Map initialization needs an authenticated Claude Code or Codex on PATH; restart after setup, then use Retry.",
+    );
+  } else if (!doctorReport.availableHarnesses.includes("claude-code")) {
     console.log(
       `\n⚠ Claude Code not found — install with: ${CLAUDE_INSTALL_COMMAND}\n` +
         "  Continuing with the Codex coding agent.",
@@ -126,10 +132,11 @@ const main = async (): Promise<void> => {
     identity,
     telemetryOptIn: consentResult.telemetryOptIn,
     serverStarted: server !== null,
+    ...(options.mapLayout ? { mapLayout: options.mapLayout } : {}),
   });
 
   if (server && !options.noOpen) {
-    await open(`http://localhost:${server.port}/?uiToken=${server.uiToken}`);
+    await open(cliBrowserUrl(server.port, server.uiToken, options.mapLayout));
   }
 
   if (server) {
@@ -154,7 +161,12 @@ const main = async (): Promise<void> => {
   }
 };
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+if (
+  process.argv[1] &&
+  realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  runCli(process.argv.slice(2)).catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/harness/src/cli/doctor.ts
+++ b/packages/harness/src/cli/doctor.ts
@@ -68,7 +68,8 @@ export const CODEX_INSTALL_COMMAND = "npm i -g @openai/codex";
 /**
  * Node is a hard requirement. Neither coding agent is individually required —
  * the harness runs with whichever of claude/codex is on PATH — but at least
- * one of them must be, or there's nothing to launch.
+ * one is required to launch a coding session. Session-free CLI viewing can
+ * proceed without a provider; initialization reports provider_unavailable.
  */
 export interface DoctorReport {
   checks: DoctorCheck[];
@@ -110,9 +111,8 @@ export async function runDoctor(): Promise<DoctorReport> {
 
 /** First available harness in preference order, for callers that need a
  *  single default (e.g. the auto-created boot session). Only falls back to
- *  "claude-code" when the report itself is empty — main() already refuses to
- *  proceed past a report with no available harnesses, so real callers never
- *  hit that fallback. */
+ *  "claude-code" when the report itself is empty. Session-free viewing can
+ *  reach that fallback, but availableHarnesses remains empty for initialization. */
 export function pickDefaultHarness(report: DoctorReport): HarnessKind {
   return report.availableHarnesses[0] ?? "claude-code";
 }

--- a/packages/harness/src/cli/elk-preview.test.ts
+++ b/packages/harness/src/cli/elk-preview.test.ts
@@ -1,0 +1,210 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+import { createServer } from "node:net";
+import { afterEach, expect, it, vi } from "vitest";
+import { StudioProjectCatalog } from "../core/studio-project-catalog.js";
+import {
+  launchComparison,
+  parseComparisonArgs,
+  prepareComparisonProfile,
+  requireAvailablePort,
+} from "./elk-preview.js";
+import { runCli } from "./bin.js";
+import { canStartCli, parseArgs } from "./args.js";
+import { cliBrowserUrl } from "./banner.js";
+
+vi.mock("./bin.js", () => ({ runCli: vi.fn() }));
+let root = "";
+afterEach(async () => {
+  vi.restoreAllMocks();
+  vi.mocked(runCli).mockReset();
+  if (root) await fs.rm(root, { recursive: true, force: true });
+});
+async function fixture() {
+  root = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "elk-launch-")),
+  );
+  const source = path.join(root, "desktop");
+  const destination = path.join(root, "trial");
+  const catalog = new StudioProjectCatalog(
+    path.join(source, "studio-projects.json"),
+  );
+  const project = (
+    await catalog.reconcile([
+      { workspaceKey: "existing", cwd: path.join(root, "agents") },
+    ])
+  ).projects[0]!;
+  const argv = [
+    "--source-state-root",
+    source,
+    "--state-root",
+    destination,
+    "--project",
+    project.projectId,
+    "--port",
+    "0",
+    "--no-open",
+  ];
+  return {
+    source,
+    destination,
+    project,
+    argv,
+    options: parseComparisonArgs(argv),
+  };
+}
+
+it("reopens without resetting destination edits or initialization attempts", async () => {
+  const f = await fixture();
+  const manifest = await prepareComparisonProfile(f.options);
+  const sentinel = path.join(
+    f.destination,
+    "agent-map",
+    "projects",
+    f.project.projectId,
+    "initialization.json",
+  );
+  await fs.mkdir(path.dirname(sentinel), { recursive: true });
+  await fs.writeFile(sentinel, "retained test state");
+  await fs.writeFile(
+    path.join(f.source, "studio-projects.json"),
+    "source changed after snapshot",
+  );
+  expect(
+    await prepareComparisonProfile(
+      parseComparisonArgs(["--state-root", f.destination]),
+    ),
+  ).toEqual(manifest);
+  expect(await fs.readFile(sentinel, "utf8")).toBe("retained test state");
+  expect(await prepareComparisonProfile(f.options)).toEqual(manifest);
+});
+
+it("rejects missing, corrupt, relocated, or mismatched manifests without importing again", async () => {
+  const f = await fixture();
+  await prepareComparisonProfile(f.options);
+  const file = path.join(f.destination, "comparison-profile.json");
+  const bytes = await fs.readFile(file);
+  await expect(
+    prepareComparisonProfile({
+      ...f.options,
+      projectIds: ["project_00000000-0000-4000-8000-000000000099"],
+    }),
+  ).rejects.toThrow("Projects differ");
+  await expect(
+    prepareComparisonProfile({ ...f.options, sourceStateRoot: root }),
+  ).rejects.toThrow("Source differs");
+  for (const content of [
+    "{",
+    JSON.stringify({
+      ...JSON.parse(bytes.toString()),
+      destinationStateRoot: f.source,
+    }),
+  ]) {
+    await fs.writeFile(file, content);
+    await expect(prepareComparisonProfile(f.options)).rejects.toThrow(
+      /manifest|comparison-profile/,
+    );
+    expect(await fs.readFile(file, "utf8")).toBe(content);
+  }
+  await fs.rm(file);
+  await expect(prepareComparisonProfile(f.options)).rejects.toThrow(
+    "Invalid comparison-profile",
+  );
+  await fs.rm(f.destination, { recursive: true });
+  await fs.mkdir(f.destination);
+  await expect(prepareComparisonProfile(f.options)).resolves.toMatchObject({
+    published: true,
+  });
+});
+
+it("rejects symlinked state before boot and does not claim an empty selection", async () => {
+  const f = await fixture();
+  await expect(
+    prepareComparisonProfile({
+      ...f.options,
+      projectIds: ["project_00000000-0000-4000-8000-000000000099"],
+    }),
+  ).rejects.toThrow("No projects imported");
+  await expect(fs.stat(f.destination)).rejects.toMatchObject({
+    code: "ENOENT",
+  });
+  await prepareComparisonProfile(f.options);
+  const file = path.join(f.destination, "comparison-profile.json");
+  await fs.rename(file, path.join(root, "manifest.json"));
+  await fs.symlink(path.join(root, "manifest.json"), file);
+  await expect(prepareComparisonProfile(f.options)).rejects.toThrow("symlink");
+});
+
+it("retains the normal CLI auth boundary and releases its profile claim when boot fails", async () => {
+  const f = await fixture();
+  vi.mocked(runCli).mockRejectedValue(new Error("boot failed"));
+  await expect(launchComparison(f.argv)).rejects.toThrow("boot failed");
+  expect(runCli).toHaveBeenCalledWith([
+    f.destination,
+    "--state-root",
+    f.destination,
+    "--port",
+    "0",
+    "--no-session",
+    "--no-telemetry",
+    "--map-layout",
+    "elk",
+    "--no-open",
+  ]);
+  await expect(
+    fs.stat(path.join(f.destination, "comparison-profile.lock")),
+  ).rejects.toMatchObject({ code: "ENOENT" });
+  await fs.writeFile(
+    path.join(f.destination, "comparison-profile.lock"),
+    String(process.pid),
+  );
+  await expect(launchComparison(f.argv)).rejects.toThrow("already claimed");
+  expect(runCli).toHaveBeenCalledOnce();
+});
+
+it("reports a port collision without closing the existing listener", async () => {
+  const listener = createServer();
+  await new Promise<void>((resolve) =>
+    listener.listen(0, "127.0.0.1", resolve),
+  );
+  try {
+    const address = listener.address() as { port: number };
+    await expect(requireAvailablePort(address.port)).rejects.toThrow(
+      "choose another --port",
+    );
+    expect(listener.listening).toBe(true);
+  } finally {
+    await new Promise<void>((resolve) => listener.close(() => resolve()));
+  }
+});
+
+it("validates launcher inputs and includes Vertical in the actual authorized URL", () => {
+  expect(() => parseComparisonArgs([])).toThrow("--state-root");
+  expect(() => parseComparisonArgs(["--state-root", "--project"])).toThrow(
+    "requires a value",
+  );
+  expect(() =>
+    parseComparisonArgs(["--state-root", "/tmp/trial", "--port", "65536"]),
+  ).toThrow("--port");
+  expect(() => parseArgs(["--map-layout", "invalid"])).toThrow(
+    "classic or elk",
+  );
+  const options = parseArgs(["--no-session", "--map-layout", "elk"]);
+  expect(cliBrowserUrl(4101, "boot token", options.mapLayout)).toBe(
+    "http://localhost:4101/?uiToken=boot+token&mapLayout=elk",
+  );
+  const report = {
+    ok: false,
+    checks: [{ name: "node", ok: true, detail: "supported" }],
+    availableHarnesses: [],
+  };
+  expect(canStartCli(report, options.noSession)).toBe(true);
+  expect(canStartCli(report, false)).toBe(false);
+  expect(
+    canStartCli(
+      { ...report, checks: [{ name: "node", ok: false, detail: "old" }] },
+      true,
+    ),
+  ).toBe(false);
+});

--- a/packages/harness/src/cli/elk-preview.test.ts
+++ b/packages/harness/src/cli/elk-preview.test.ts
@@ -58,6 +58,12 @@ async function fixture() {
 it("reopens without resetting destination edits or initialization attempts", async () => {
   const f = await fixture();
   const manifest = await prepareComparisonProfile(f.options);
+  const sharedAgentRoot = path.join(root, "agents");
+  await fs.mkdir(sharedAgentRoot);
+  await fs.symlink(
+    f.source,
+    path.join(sharedAgentRoot, "unrelated-source-link"),
+  );
   const sentinel = path.join(
     f.destination,
     "agent-map",
@@ -161,6 +167,24 @@ it("retains the normal CLI auth boundary and releases its profile claim when boo
   );
   await expect(launchComparison(f.argv)).rejects.toThrow("already claimed");
   expect(runCli).toHaveBeenCalledOnce();
+});
+
+it.each([
+  "events.ndjson",
+  "records/session/events.ndjson",
+  "generated/session/context.json",
+])("rejects writable metadata links before boot: %s", async (relative) => {
+  const f = await fixture();
+  await prepareComparisonProfile(f.options);
+  const sourceLog = path.join(f.source, "events.ndjson");
+  await fs.writeFile(sourceLog, "desktop event bytes\n");
+  const target = path.join(f.destination, relative);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.symlink(sourceLog, target);
+  vi.mocked(runCli).mockRejectedValue(new Error("server boot reached"));
+  await expect(launchComparison(f.argv)).rejects.toThrow("symlink");
+  expect(runCli).not.toHaveBeenCalled();
+  expect(await fs.readFile(sourceLog, "utf8")).toBe("desktop event bytes\n");
 });
 
 it("reports a port collision without closing the existing listener", async () => {

--- a/packages/harness/src/cli/elk-preview.test.ts
+++ b/packages/harness/src/cli/elk-preview.test.ts
@@ -13,6 +13,7 @@ import {
 import { runCli } from "./bin.js";
 import { canStartCli, parseArgs } from "./args.js";
 import { cliBrowserUrl } from "./banner.js";
+import { loadSettings, recordRecentDir } from "./settings.js";
 
 vi.mock("./bin.js", () => ({ runCli: vi.fn() }));
 let root = "";
@@ -21,7 +22,7 @@ afterEach(async () => {
   vi.mocked(runCli).mockReset();
   if (root) await fs.rm(root, { recursive: true, force: true });
 });
-async function fixture() {
+async function fixture(count = 1) {
   root = await fs.realpath(
     await fs.mkdtemp(path.join(os.tmpdir(), "elk-launch-")),
   );
@@ -30,18 +31,24 @@ async function fixture() {
   const catalog = new StudioProjectCatalog(
     path.join(source, "studio-projects.json"),
   );
-  const project = (
-    await catalog.reconcile([
-      { workspaceKey: "existing", cwd: path.join(root, "agents") },
-    ])
-  ).projects[0]!;
+  const roots = Array.from({ length: count }, (_, i) =>
+    path.join(root, `agents-${i}`),
+  );
+  for (const cwd of roots) await fs.mkdir(cwd);
+  const { projects } = await catalog.reconcile(
+    roots.map((cwd) => ({ workspaceKey: cwd, cwd })),
+  );
+  await fs.writeFile(
+    path.join(source, "settings.json"),
+    JSON.stringify({ recentDirs: roots }),
+  );
+  const project = projects[0]!;
   const argv = [
     "--source-state-root",
     source,
     "--state-root",
     destination,
-    "--project",
-    project.projectId,
+    ...projects.flatMap((entry) => ["--project", entry.projectId]),
     "--port",
     "0",
     "--no-open",
@@ -50,6 +57,7 @@ async function fixture() {
     source,
     destination,
     project,
+    roots,
     argv,
     options: parseComparisonArgs(argv),
   };
@@ -58,8 +66,7 @@ async function fixture() {
 it("reopens without resetting destination edits or initialization attempts", async () => {
   const f = await fixture();
   const manifest = await prepareComparisonProfile(f.options);
-  const sharedAgentRoot = path.join(root, "agents");
-  await fs.mkdir(sharedAgentRoot);
+  const sharedAgentRoot = f.roots[0]!;
   await fs.symlink(
     f.source,
     path.join(sharedAgentRoot, "unrelated-source-link"),
@@ -135,6 +142,13 @@ it("rejects symlinked state before boot and does not claim an empty selection", 
   await expect(fs.stat(f.destination)).rejects.toMatchObject({
     code: "ENOENT",
   });
+  await prepareComparisonProfile({
+    ...f.options,
+    projectIds: [
+      ...f.options.projectIds,
+      "project_00000000-0000-4000-8000-000000000099",
+    ],
+  });
   await prepareComparisonProfile(f.options);
   const file = path.join(f.destination, "comparison-profile.json");
   await fs.rename(file, path.join(root, "manifest.json"));
@@ -142,12 +156,21 @@ it("rejects symlinked state before boot and does not claim an empty selection", 
   await expect(prepareComparisonProfile(f.options)).rejects.toThrow("symlink");
 });
 
-it("retains the normal CLI auth boundary and releases its profile claim when boot fails", async () => {
-  const f = await fixture();
-  vi.mocked(runCli).mockRejectedValue(new Error("boot failed"));
+it("launches an imported root without evicting recent projects and releases its claim when boot fails", async () => {
+  const f = await fixture(8);
+  vi.mocked(runCli).mockImplementation(async (argv) => {
+    await recordRecentDir(
+      parseArgs(argv).dir,
+      path.join(f.destination, "settings.json"),
+    );
+    throw new Error("boot failed");
+  });
   await expect(launchComparison(f.argv)).rejects.toThrow("boot failed");
+  expect(
+    (await loadSettings(path.join(f.destination, "settings.json"))).recentDirs,
+  ).toEqual(f.roots);
   expect(runCli).toHaveBeenCalledWith([
-    f.destination,
+    f.roots[0],
     "--state-root",
     f.destination,
     "--port",
@@ -169,6 +192,16 @@ it("retains the normal CLI auth boundary and releases its profile claim when boo
   expect(runCli).toHaveBeenCalledOnce();
 });
 
+it("requires reconnecting an imported root instead of registering an unrelated directory", async () => {
+  const f = await fixture();
+  await prepareComparisonProfile(f.options);
+  await fs.rm(f.roots[0]!, { recursive: true });
+  await expect(launchComparison(f.argv)).rejects.toThrow(
+    "Reconnect an imported project directory",
+  );
+  expect(runCli).not.toHaveBeenCalled();
+});
+
 it.each([
   "events.ndjson",
   "records/session/events.ndjson",
@@ -182,7 +215,9 @@ it.each([
   await fs.mkdir(path.dirname(target), { recursive: true });
   await fs.symlink(sourceLog, target);
   vi.mocked(runCli).mockRejectedValue(new Error("server boot reached"));
-  await expect(launchComparison(f.argv)).rejects.toThrow("symlink");
+  await expect(launchComparison(f.argv)).rejects.toThrow(
+    `symlink: ${path.normalize(relative)}`,
+  );
   expect(runCli).not.toHaveBeenCalled();
   expect(await fs.readFile(sourceLog, "utf8")).toBe("desktop event bytes\n");
 });

--- a/packages/harness/src/cli/elk-preview.test.ts
+++ b/packages/harness/src/cli/elk-preview.test.ts
@@ -192,14 +192,19 @@ it("launches an imported root without evicting recent projects and releases its 
   expect(runCli).toHaveBeenCalledOnce();
 });
 
-it("requires reconnecting an imported root instead of registering an unrelated directory", async () => {
-  const f = await fixture();
-  await prepareComparisonProfile(f.options);
-  await fs.rm(f.roots[0]!, { recursive: true });
-  await expect(launchComparison(f.argv)).rejects.toThrow(
+it("requires a reconnect and recovers from stale missing-root status", async () => {
+  const { options, roots, argv, destination } = await fixture();
+  await prepareComparisonProfile(options);
+  await fs.rm(roots[0]!, { recursive: true });
+  await expect(launchComparison(argv)).rejects.toThrow(
     "Reconnect an imported project directory",
   );
   expect(runCli).not.toHaveBeenCalled();
+  await new StudioProjectCatalog(
+    path.join(destination, "studio-projects.json"),
+  ).reconcile([]);
+  await fs.mkdir(roots[0]!);
+  expect((await prepareComparisonProfile(options)).launchDir).toBe(roots[0]);
 });
 
 it.each([

--- a/packages/harness/src/cli/elk-preview.ts
+++ b/packages/harness/src/cli/elk-preview.ts
@@ -3,7 +3,7 @@ import { rmSync } from "node:fs";
 import * as path from "node:path";
 import { createServer } from "node:net";
 import { z } from "zod";
-import { expandHome } from "../core/paths.js";
+import { expandHome, resolveStatePaths } from "../core/paths.js";
 import { importStudioComparisonProfile } from "../core/studio-comparison-profile.js";
 import {
   isStudioProjectId,
@@ -116,22 +116,23 @@ export async function prepareComparisonProfile(
       "Comparison destination must be a directory, not a symlink.",
     );
   const canonical = await fs.realpath(destination);
-  // Harness stores may write while reading; reject links back into desktop state.
-  for (const name of [
-    "comparison-profile.json",
-    "studio-projects.json",
-    "settings.json",
-    "workflows.json",
-    "machine-id",
-    "agent-map",
+  // Cover writable runtime metadata, including local events with telemetry off.
+  // Do not walk the root or catalog's shared agent source directories.
+  for (const file of [
+    path.join(canonical, "comparison-profile.json"),
+    path.join(canonical, "comparison-profile.lock"),
+    ...Object.values(resolveStatePaths(canonical)).filter(
+      (file) => file !== canonical,
+    ),
   ]) {
-    const file = path.join(canonical, name);
     const entry = await fs.lstat(file).catch((error: NodeJS.ErrnoException) => {
       if (error.code === "ENOENT") return null;
       throw error;
     });
     if (entry?.isSymbolicLink())
-      throw new Error(`Comparison state contains a symlink: ${name}`);
+      throw new Error(
+        `Comparison state contains a symlink: ${path.relative(canonical, file)}`,
+      );
     if (entry?.isDirectory())
       for (const child of await fs.readdir(file, {
         recursive: true,

--- a/packages/harness/src/cli/elk-preview.ts
+++ b/packages/harness/src/cli/elk-preview.ts
@@ -1,0 +1,267 @@
+import * as fs from "node:fs/promises";
+import { rmSync } from "node:fs";
+import * as path from "node:path";
+import { createServer } from "node:net";
+import { z } from "zod";
+import { expandHome } from "../core/paths.js";
+import { importStudioComparisonProfile } from "../core/studio-comparison-profile.js";
+import {
+  isStudioProjectId,
+  parseStudioProjectCatalog,
+} from "../core/studio-project-catalog.js";
+import { isWithinDir, samePath } from "../shared/paths.js";
+import { runCli } from "./bin.js";
+
+export function parseComparisonArgs(argv: string[]) {
+  let sourceStateRoot: string | undefined;
+  let destinationStateRoot = "";
+  const projectIds: string[] = [];
+  let port = 4101;
+  let noOpen = false;
+  for (let index = 0; index < argv.length; index++) {
+    const flag = argv[index];
+    if (flag === "--no-open") {
+      noOpen = true;
+      continue;
+    }
+    if (
+      !["--source-state-root", "--state-root", "--project", "--port"].includes(
+        flag!,
+      )
+    )
+      throw new Error(`Unknown comparison argument: ${flag}`);
+    const value = argv[++index];
+    if (!value || value.startsWith("--"))
+      throw new Error(`${flag} requires a value`);
+    if (flag === "--source-state-root") sourceStateRoot = expandHome(value);
+    if (flag === "--state-root") destinationStateRoot = expandHome(value);
+    if (flag === "--project") {
+      if (!isStudioProjectId(value))
+        throw new Error(`Invalid project ID: ${value}`);
+      projectIds.push(value);
+    }
+    if (flag === "--port") {
+      port = Number(value);
+      if (!Number.isInteger(port) || port < 0 || port > 65535)
+        throw new Error("--port must be an integer from 0 to 65535");
+    }
+  }
+  if (!destinationStateRoot)
+    throw new Error(
+      "--state-root is required for an isolated comparison profile",
+    );
+  return {
+    sourceStateRoot,
+    destinationStateRoot,
+    projectIds: [...new Set(projectIds)],
+    port,
+    noOpen,
+  };
+}
+
+const manifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  published: z.literal(true),
+  createdAt: z.string().datetime(),
+  sourceStateRoot: z.string(),
+  destinationStateRoot: z.string(),
+  projects: z
+    .array(
+      z.object({
+        projectId: z.string().refine(isStudioProjectId),
+        displayName: z.string(),
+      }),
+    )
+    .nonempty(),
+  excluded: z.array(
+    z.object({
+      projectId: z.string().refine(isStudioProjectId),
+      reason: z.enum(["initialization_busy", "project_not_found"]),
+    }),
+  ),
+});
+
+/** Reopening must never silently reimport, even when state is missing or damaged. */
+export async function prepareComparisonProfile(
+  options: ReturnType<typeof parseComparisonArgs>,
+) {
+  const destination = options.destinationStateRoot;
+  const stat = await fs
+    .lstat(destination)
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return null;
+      throw error;
+    });
+  if (
+    stat === null ||
+    (stat.isDirectory() && (await fs.readdir(destination)).length === 0)
+  ) {
+    if (!options.sourceStateRoot || options.projectIds.length === 0)
+      throw new Error(
+        "First import requires --source-state-root and at least one --project. Reopen requires an existing comparison-profile.json.",
+      );
+    const manifest = await importStudioComparisonProfile({
+      ...options,
+      sourceStateRoot: options.sourceStateRoot,
+    });
+    for (const excluded of manifest.excluded)
+      console.log(`Excluded ${excluded.projectId}: ${excluded.reason}`);
+    if (!manifest.published)
+      throw new Error(
+        "No projects imported; comparison server was not started.",
+      );
+  }
+  if (!(await fs.lstat(destination)).isDirectory())
+    throw new Error(
+      "Comparison destination must be a directory, not a symlink.",
+    );
+  const canonical = await fs.realpath(destination);
+  // Harness stores may write while reading; reject links back into desktop state.
+  for (const name of [
+    "comparison-profile.json",
+    "studio-projects.json",
+    "settings.json",
+    "workflows.json",
+    "machine-id",
+    "agent-map",
+  ]) {
+    const file = path.join(canonical, name);
+    const entry = await fs.lstat(file).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return null;
+      throw error;
+    });
+    if (entry?.isSymbolicLink())
+      throw new Error(`Comparison state contains a symlink: ${name}`);
+    if (entry?.isDirectory())
+      for (const child of await fs.readdir(file, {
+        recursive: true,
+        withFileTypes: true,
+      }))
+        if (child.isSymbolicLink())
+          throw new Error(`Comparison state contains a symlink: ${child.name}`);
+  }
+  let manifest: z.infer<typeof manifestSchema>;
+  try {
+    manifest = manifestSchema.parse(
+      JSON.parse(
+        await fs.readFile(
+          path.join(canonical, "comparison-profile.json"),
+          "utf8",
+        ),
+      ),
+    );
+  } catch {
+    throw new Error(
+      "Invalid comparison-profile.json; use the original comparison directory or a distinct new destination for a fresh snapshot.",
+    );
+  }
+  if (
+    !path.isAbsolute(manifest.sourceStateRoot) ||
+    !samePath(manifest.destinationStateRoot, canonical) ||
+    isWithinDir(manifest.sourceStateRoot, canonical) ||
+    isWithinDir(canonical, manifest.sourceStateRoot)
+  )
+    throw new Error(
+      "Comparison manifest paths do not match an isolated destination.",
+    );
+  if (
+    options.sourceStateRoot &&
+    !samePath(
+      await fs.realpath(options.sourceStateRoot),
+      manifest.sourceStateRoot,
+    )
+  )
+    throw new Error(
+      "Source differs from the saved snapshot; use a new destination.",
+    );
+  const selected = [...manifest.projects, ...manifest.excluded]
+    .map((project) => project.projectId)
+    .sort();
+  if (
+    options.projectIds.length &&
+    JSON.stringify([...options.projectIds].sort()) !== JSON.stringify(selected)
+  )
+    throw new Error(
+      "Projects differ from the saved snapshot; use a new destination.",
+    );
+  const catalog = parseStudioProjectCatalog(
+    JSON.parse(
+      await fs.readFile(path.join(canonical, "studio-projects.json"), "utf8"),
+    ),
+  );
+  if (
+    manifest.projects.some(
+      (project) =>
+        !catalog.projects.some(
+          (entry) => entry.projectId === project.projectId,
+        ),
+    )
+  )
+    throw new Error(
+      "Comparison profile is missing an imported project registration.",
+    );
+  return manifest;
+}
+
+export async function requireAvailablePort(port: number): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const probe = createServer();
+    probe.once("error", () =>
+      reject(
+        new Error(
+          `Cannot bind localhost:${port}; choose another --port. No existing server was stopped.`,
+        ),
+      ),
+    );
+    probe.listen(port, "127.0.0.1", () =>
+      probe.close((error) => (error ? reject(error) : resolve())),
+    );
+  });
+}
+
+export async function launchComparison(argv: string[]): Promise<void> {
+  const options = parseComparisonArgs(argv);
+  await requireAvailablePort(options.port);
+  const manifest = await prepareComparisonProfile(options);
+  const lockPath = path.join(
+    manifest.destinationStateRoot,
+    "comparison-profile.lock",
+  );
+  const lock = await fs
+    .open(lockPath, "wx", 0o600)
+    .catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "EEXIST")
+        throw new Error(
+          `Comparison profile is already claimed (${lockPath}). Stop its trial process first; after an interrupted shutdown, remove the stale lock only after confirming that process has exited.`,
+        );
+      throw error;
+    });
+  const release = () => rmSync(lockPath, { force: true });
+  try {
+    await lock.writeFile(String(process.pid));
+    await lock.close();
+    process.once("exit", release);
+    console.log(
+      `Snapshot: ${manifest.createdAt}\nSource: ${manifest.sourceStateRoot}\nComparison: ${manifest.destinationStateRoot}`,
+    );
+    for (const project of manifest.projects)
+      console.log(`Project: ${project.projectId} (${project.displayName})`);
+    await runCli([
+      manifest.destinationStateRoot,
+      "--state-root",
+      manifest.destinationStateRoot,
+      "--port",
+      String(options.port),
+      "--no-session",
+      "--no-telemetry",
+      "--map-layout",
+      "elk",
+      ...(options.noOpen ? ["--no-open"] : []),
+    ]);
+  } catch (error) {
+    await lock.close().catch(() => {});
+    process.removeListener("exit", release);
+    release();
+    throw error;
+  }
+}

--- a/packages/harness/src/cli/elk-preview.ts
+++ b/packages/harness/src/cli/elk-preview.ts
@@ -211,7 +211,6 @@ export async function prepareComparisonProfile(
   const roots = catalog.projects
     .filter((project) => imported.includes(project.projectId))
     .flatMap((project) => project.rootBindings)
-    .filter((binding) => binding.status === "active")
     .map((binding) => binding.localRootRef);
   const settings = await loadSettings(path.join(canonical, "settings.json"));
   // Keep the imported recent-dir order: a new entry would evict the eighth root.
@@ -231,7 +230,7 @@ export async function prepareComparisonProfile(
       return { ...manifest, launchDir };
   }
   throw new Error(
-    "Reconnect an imported project directory before launching this comparison; none of its active roots is available.",
+    "Reconnect an imported project directory before launching this comparison; none of its registered roots is available.",
   );
 }
 

--- a/packages/harness/src/cli/elk-preview.ts
+++ b/packages/harness/src/cli/elk-preview.ts
@@ -11,6 +11,7 @@ import {
 } from "../core/studio-project-catalog.js";
 import { isWithinDir, samePath } from "../shared/paths.js";
 import { runCli } from "./bin.js";
+import { loadSettings } from "./settings.js";
 
 export function parseComparisonArgs(argv: string[]) {
   let sourceStateRoot: string | undefined;
@@ -112,9 +113,7 @@ export async function prepareComparisonProfile(
       );
   }
   if (!(await fs.lstat(destination)).isDirectory())
-    throw new Error(
-      "Comparison destination must be a directory, not a symlink.",
-    );
+    throw new Error("Comparison destination must be a directory.");
   const canonical = await fs.realpath(destination);
   // Cover writable runtime metadata, including local events with telemetry off.
   // Do not walk the root or catalog's shared agent source directories.
@@ -139,7 +138,9 @@ export async function prepareComparisonProfile(
         withFileTypes: true,
       }))
         if (child.isSymbolicLink())
-          throw new Error(`Comparison state contains a symlink: ${child.name}`);
+          throw new Error(
+            `Comparison state contains a symlink: ${path.relative(canonical, path.join(child.parentPath, child.name))}`,
+          );
   }
   let manifest: z.infer<typeof manifestSchema>;
   try {
@@ -175,15 +176,21 @@ export async function prepareComparisonProfile(
     throw new Error(
       "Source differs from the saved snapshot; use a new destination.",
     );
-  const selected = [...manifest.projects, ...manifest.excluded]
-    .map((project) => project.projectId)
-    .sort();
+  const imported = manifest.projects.map((project) => project.projectId);
+  const selected = [
+    ...imported,
+    ...manifest.excluded.map((entry) => entry.projectId),
+  ];
   if (
     options.projectIds.length &&
-    JSON.stringify([...options.projectIds].sort()) !== JSON.stringify(selected)
+    ![imported, selected].some(
+      (ids) =>
+        JSON.stringify([...options.projectIds].sort()) ===
+        JSON.stringify([...ids].sort()),
+    )
   )
     throw new Error(
-      "Projects differ from the saved snapshot; use a new destination.",
+      "Projects differ from the saved snapshot; omit --project to reopen it, or use a new destination.",
     );
   const catalog = parseStudioProjectCatalog(
     JSON.parse(
@@ -201,7 +208,31 @@ export async function prepareComparisonProfile(
     throw new Error(
       "Comparison profile is missing an imported project registration.",
     );
-  return manifest;
+  const roots = catalog.projects
+    .filter((project) => imported.includes(project.projectId))
+    .flatMap((project) => project.rootBindings)
+    .filter((binding) => binding.status === "active")
+    .map((binding) => binding.localRootRef);
+  const settings = await loadSettings(path.join(canonical, "settings.json"));
+  // Keep the imported recent-dir order: a new entry would evict the eighth root.
+  const candidates = [
+    ...settings.recentDirs.filter((dir) =>
+      roots.some((root) => samePath(root, dir)),
+    ),
+    ...roots,
+  ];
+  for (const launchDir of new Set(candidates)) {
+    const resolved = await fs.realpath(launchDir).catch(() => null);
+    if (
+      resolved &&
+      !isWithinDir(canonical, resolved) &&
+      (await fs.stat(resolved).catch(() => null))?.isDirectory()
+    )
+      return { ...manifest, launchDir };
+  }
+  throw new Error(
+    "Reconnect an imported project directory before launching this comparison; none of its active roots is available.",
+  );
 }
 
 export async function requireAvailablePort(port: number): Promise<void> {
@@ -248,7 +279,7 @@ export async function launchComparison(argv: string[]): Promise<void> {
     for (const project of manifest.projects)
       console.log(`Project: ${project.projectId} (${project.displayName})`);
     await runCli([
-      manifest.destinationStateRoot,
+      manifest.launchDir,
       "--state-root",
       manifest.destinationStateRoot,
       "--port",

--- a/packages/harness/src/server/agent-map-initialization.test.ts
+++ b/packages/harness/src/server/agent-map-initialization.test.ts
@@ -5,6 +5,9 @@ import { afterEach, expect, it, vi } from "vitest";
 import { StudioProjectCatalog } from "../core/studio-project-catalog.js";
 import { TaskManager } from "../core/task-manager.js";
 import { AgentMapWorkspaceStore } from "../core/agent-map-workspace-store.js";
+import { AgentMapProposalService } from "../core/agent-map-proposal-service.js";
+import { importStudioComparisonProfile } from "../core/studio-comparison-profile.js";
+import type { HarnessKind } from "../shared/types.js";
 import { startServer, type HarnessServer } from "./index.js";
 
 let root: string | undefined;
@@ -16,12 +19,31 @@ afterEach(async () => {
   if (root) await fs.rm(root, { recursive: true, force: true });
 });
 
-it("discovers restored projects outside the desktop launch directory and initializes once without navigation", async () => {
-  root = await fs.mkdtemp(path.join(os.tmpdir(), "startup-map-projects-"));
+async function snapshot(directory: string) {
+  const result: Record<string, string> = {};
+  for (const entry of await fs.readdir(directory, {
+    recursive: true,
+    withFileTypes: true,
+  })) {
+    if (entry.isFile()) {
+      const file = path.join(entry.parentPath, entry.name);
+      result[path.relative(directory, file)] = (
+        await fs.readFile(file)
+      ).toString("base64");
+    }
+  }
+  return result;
+}
+
+async function verifyInitialization(providerMissing: boolean) {
+  root = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "startup-map-projects-")),
+  );
   const stateRoot = path.join(root, "profile");
+  const sourceStateRoot = path.join(root, "desktop");
   const projectRoot = path.join(root, "existing-project");
   const agentRoot = path.join(projectRoot, "research");
-  await fs.mkdir(stateRoot);
+  await fs.mkdir(sourceStateRoot);
   await fs.mkdir(agentRoot, { recursive: true });
   await fs.writeFile(
     path.join(agentRoot, "sapiom.json"),
@@ -35,15 +57,76 @@ it("discovers restored projects outside the desktop launch directory and initial
     'throw new Error("Never execute discovery evidence"); export const agent = defineAgent({ name: "research", description: "Research topics" });';
   await fs.writeFile(path.join(agentRoot, "index.ts"), source);
   await fs.writeFile(
-    path.join(stateRoot, "settings.json"),
+    path.join(sourceStateRoot, "settings.json"),
     JSON.stringify({ recentDirs: [projectRoot] }),
   );
   const catalog = new StudioProjectCatalog(
-    path.join(stateRoot, "studio-projects.json"),
+    path.join(sourceStateRoot, "studio-projects.json"),
   );
-  const project = (
-    await catalog.reconcile([{ workspaceKey: "existing", cwd: projectRoot }])
-  ).projects[0]!;
+  const savedRoots = [path.join(root, "saved"), path.join(root, "historical")];
+  for (const cwd of savedRoots)
+    await fs.cp(agentRoot, path.join(cwd, "research"), { recursive: true });
+  const projects = (
+    await catalog.reconcile(
+      [projectRoot, ...savedRoots].map((cwd) => ({ workspaceKey: cwd, cwd })),
+    )
+  ).projects;
+  const project = projects.find(
+    (entry) => entry.displayName === "existing-project",
+  )!;
+  const sourceStore = new AgentMapWorkspaceStore(
+    path.join(sourceStateRoot, "agent-map"),
+  );
+  const proposals = new AgentMapProposalService(sourceStore);
+  for (const saved of projects.filter(
+    (entry) => entry.projectId !== project.projectId,
+  )) {
+    const actor = {
+      projectId: saved.projectId,
+      userId: "author",
+      sessionId: "source-session",
+    };
+    const first = await proposals.propose(actor, {
+      schemaVersion: 1,
+      proposalId: null,
+      expectedVersion: 0,
+      requestId: "author",
+      operations: [
+        {
+          kind: "add-node",
+          draftRef: "authored",
+          node: {
+            kind: "agent",
+            name: "Authored",
+            purpose: "Preserve this map",
+            ownerAgent: null,
+            contractRefs: [],
+          },
+        },
+      ],
+    });
+    if (saved.displayName === "historical")
+      await proposals.propose(actor, {
+        schemaVersion: 1,
+        proposalId: first.proposalId,
+        expectedVersion: 1,
+        requestId: "delete",
+        operations: [
+          {
+            kind: "remove-node",
+            nodeId: Object.values(first.allocatedNodeIds)[0]!,
+          },
+        ],
+      });
+  }
+  const before = await snapshot(sourceStateRoot);
+  const sourceFiles = await snapshot(projectRoot);
+  const manifest = await importStudioComparisonProfile({
+    sourceStateRoot,
+    destinationStateRoot: stateRoot,
+    projectIds: projects.map((entry) => entry.projectId),
+  });
+  expect(manifest.published).toBe(true);
   const infer = vi
     .spyOn(TaskManager.prototype, "runStructuredInference")
     .mockImplementation(async ({ prompt }) => {
@@ -63,20 +146,51 @@ it("discovers restored projects outside the desktop launch directory and initial
         relationships: [],
       };
     });
-  const boot = () =>
+  const boot = (availableHarnesses: HarnessKind[] = ["claude-code"]) =>
     startServer({
       port: 0,
       bootToken: "test-token",
       telemetryOptIn: false,
       adapters: {},
-      availableHarnesses: ["claude-code"],
+      availableHarnesses,
       stateRoot,
       launchDir: stateRoot,
       projectRoot: path.join(stateRoot, "projects"),
       autoCreateSession: false,
       loadSystemPrompt: async () => "",
     });
-  server = await boot();
+  const status = async () =>
+    (
+      await fetch(
+        `http://127.0.0.1:${server!.port}/api/projects/${project.projectId}/agent-map/initialization`,
+        { headers: { "X-Harness-Token": "test-token" } },
+      )
+    ).json();
+  server = await boot(providerMissing ? [] : ["claude-code"]);
+  if (providerMissing) {
+    await vi.waitFor(
+      async () =>
+        expect(await status()).toMatchObject({
+          status: "failed",
+          errorCode: "provider_unavailable",
+          retryable: true,
+        }),
+      { timeout: 10000 },
+    );
+    expect(infer).not.toHaveBeenCalled();
+    await server.close();
+    server = await boot();
+    expect(await status()).toMatchObject({
+      status: "failed",
+      retryable: true,
+    });
+    expect(infer).not.toHaveBeenCalled();
+    const retry = await fetch(
+      `http://127.0.0.1:${server.port}/api/projects/${project.projectId}/agent-map/initialization/retry`,
+      { method: "POST", headers: { "X-Harness-Token": "test-token" } },
+    );
+    expect(retry.status).toBe(202);
+  }
   const store = new AgentMapWorkspaceStore(path.join(stateRoot, "agent-map"));
   await vi.waitFor(
     async () => {
@@ -87,6 +201,21 @@ it("discovers restored projects outside the desktop launch directory and initial
   );
   expect(infer).toHaveBeenCalledOnce();
   expect(server.sessionManager.list()).toHaveLength(0);
+  for (const saved of manifest.projects.filter(
+    (entry) => entry.map?.authored,
+  )) {
+    const file = path.join(
+      "agent-map",
+      "projects",
+      saved.projectId,
+      "workspace.json",
+    );
+    expect(
+      (await fs.readFile(path.join(stateRoot, file))).toString("base64"),
+    ).toBe(before[file]);
+  }
+  expect(await snapshot(sourceStateRoot)).toEqual(before);
+  expect(await snapshot(projectRoot)).toEqual(sourceFiles);
   expect(await fs.readFile(path.join(agentRoot, "index.ts"), "utf8")).toBe(
     source,
   );
@@ -105,4 +234,10 @@ it("discovers restored projects outside the desktop launch directory and initial
   await server.close();
   server = undefined;
   expect(infer).toHaveBeenCalledOnce();
-}, 20000);
+}
+
+it.each([false, true])(
+  "preserves imported authored maps and initializes only mapless projects without sessions (provider missing: %s)",
+  verifyInitialization,
+  30000,
+);

--- a/packages/harness/src/server/agent-map-initialization.test.ts
+++ b/packages/harness/src/server/agent-map-initialization.test.ts
@@ -7,7 +7,13 @@ import { TaskManager } from "../core/task-manager.js";
 import { AgentMapWorkspaceStore } from "../core/agent-map-workspace-store.js";
 import { AgentMapProposalService } from "../core/agent-map-proposal-service.js";
 import { importStudioComparisonProfile } from "../core/studio-comparison-profile.js";
-import type { HarnessKind } from "../shared/types.js";
+import { SessionManager } from "../core/session-manager.js";
+import {
+  parseComparisonArgs,
+  prepareComparisonProfile,
+} from "../cli/elk-preview.js";
+import { recordRecentDir } from "../cli/settings.js";
+import type { AppState, HarnessKind } from "../shared/types.js";
 import { startServer, type HarnessServer } from "./index.js";
 
 let root: string | undefined;
@@ -127,6 +133,14 @@ async function verifyInitialization(providerMissing: boolean) {
     projectIds: projects.map((entry) => entry.projectId),
   });
   expect(manifest.published).toBe(true);
+  const comparison = await prepareComparisonProfile(
+    parseComparisonArgs(["--state-root", stateRoot]),
+  );
+  await recordRecentDir(
+    comparison.launchDir,
+    path.join(stateRoot, "settings.json"),
+  );
+  const createSession = vi.spyOn(SessionManager.prototype, "create");
   const infer = vi
     .spyOn(TaskManager.prototype, "runStructuredInference")
     .mockImplementation(async ({ prompt }) => {
@@ -154,8 +168,7 @@ async function verifyInitialization(providerMissing: boolean) {
       adapters: {},
       availableHarnesses,
       stateRoot,
-      launchDir: stateRoot,
-      projectRoot: path.join(stateRoot, "projects"),
+      launchDir: comparison.launchDir,
       autoCreateSession: false,
       loadSystemPrompt: async () => "",
     });
@@ -167,7 +180,34 @@ async function verifyInitialization(providerMissing: boolean) {
       )
     ).json();
   server = await boot(providerMissing ? [] : ["claude-code"]);
+  const state = (await (
+    await fetch(`http://127.0.0.1:${server.port}/api/state`, {
+      headers: { "X-Harness-Token": "test-token" },
+    })
+  ).json()) as AppState;
+  expect(state.studioProjects?.map((entry) => entry.projectId).sort()).toEqual(
+    projects.map((entry) => entry.projectId).sort(),
+  );
   if (providerMissing) {
+    const session = await fetch(
+      `http://127.0.0.1:${server.port}/api/sessions`,
+      {
+        method: "POST",
+        headers: {
+          "X-Harness-Token": "test-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          cwd: comparison.launchDir,
+          harness: "claude-code",
+        }),
+      },
+    );
+    expect(session.status).toBe(503);
+    expect(await session.json()).toMatchObject({
+      code: "provider_unavailable",
+      error: expect.stringContaining("Install and authenticate"),
+    });
     await vi.waitFor(
       async () =>
         expect(await status()).toMatchObject({
@@ -200,6 +240,7 @@ async function verifyInitialization(providerMissing: boolean) {
     { timeout: 10000 },
   );
   expect(infer).toHaveBeenCalledOnce();
+  expect(createSession).not.toHaveBeenCalled();
   expect(server.sessionManager.list()).toHaveLength(0);
   for (const saved of manifest.projects.filter(
     (entry) => entry.map?.authored,
@@ -234,6 +275,7 @@ async function verifyInitialization(providerMissing: boolean) {
   await server.close();
   server = undefined;
   expect(infer).toHaveBeenCalledOnce();
+  expect(createSession).not.toHaveBeenCalled();
 }
 
 it.each([false, true])(

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -481,6 +481,14 @@ export function createRestRouter(options: RestRouterOptions): Router {
       res.status(400).json({ error: parsed.error.message });
       return;
     }
+    if (options.availableHarnesses?.length === 0) {
+      res.status(503).json({
+        error:
+          "Install and authenticate Claude Code or Codex on PATH, then restart Agent Studio to create a session.",
+        code: "provider_unavailable",
+      });
+      return;
+    }
     // Collapse whatever separators the client sent (see cwd-normalize.ts) so a
     // mixed-separator path can never reach the pty spawn or sessions.json.
     const request = { ...parsed.data, cwd: normalizeCwd(parsed.data.cwd) };

--- a/scripts/agent-studio-terminology-allowlist.json
+++ b/scripts/agent-studio-terminology-allowlist.json
@@ -1,12 +1,5 @@
 [
   {
-    "id": "studio-comparison-launcher-registry-filename",
-    "path": "packages/harness/src/cli/elk-preview.ts",
-    "pattern": "^workflows\\.json$",
-    "occurrences": 1,
-    "reason": "Comparison reopening checks the existing on-disk agent registry filename."
-  },
-  {
     "id": "studio-comparison-registry-filename",
     "path": "packages/harness/src/core/studio-comparison-profile.ts",
     "pattern": "^workflows\\.json$",

--- a/scripts/agent-studio-terminology-allowlist.json
+++ b/scripts/agent-studio-terminology-allowlist.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "studio-comparison-launcher-registry-filename",
+    "path": "packages/harness/src/cli/elk-preview.ts",
+    "pattern": "^workflows\\.json$",
+    "occurrences": 1,
+    "reason": "Comparison reopening checks the existing on-disk agent registry filename."
+  },
+  {
     "id": "studio-comparison-registry-filename",
     "path": "packages/harness/src/core/studio-comparison-profile.ts",
     "pattern": "^workflows\\.json$",


### PR DESCRIPTION
## Primary change type

- [x] Feature

## Problem and motivation

Coworkers need to compare the same saved Agent Map in desktop Studio and a local branch, while allowing genuinely mapless projects to use the normal initializer in isolated trial state.

## Summary and scope

Add `pnpm studio:elk-preview` to import or reopen selected projects, build the branch, and launch its real harness server and built SPA on a separate port with Vertical selected. Preserve saved maps and attempt history on reopen. Source agent directories remain shared; comparison metadata is isolated. The launcher starts no session or agent execution and disables telemetry.

Validate profile identity, managed paths, prerequisites, and port availability. Saved maps remain viewable without a native provider; mapless projects retain the normal provider requirement and explicit retry behavior. Print checkout identity and the actual browser URL.

Stack 4/4, based on SAP-3265. **999 raw changed lines** (968 additions + 31 deletions), including tests, documentation, and Changeset. This is the single coworker trial branch; SAP-3267 production promotion is separate.

## Related work

[SAP-3266](https://linear.app/sapiom/issue/SAP-3266), part of [SAP-3262](https://linear.app/sapiom/issue/SAP-3262). Depends on the importer and packed renderer in the preceding PRs.

## Validation

Final trial commit: **`e51427b0`**. The documented command was exercised on macOS with authenticated native Claude Code and the actual built SPA/server, without a mock API or production proxy.

- Imported an existing desktop project: both Classic and Vertical rendered the same **34 nodes / 13 relationships**, with no browser errors. The saved map stayed byte-identical and acquired no initialization journal.
- Added a separate two-agent scratch project only in trial state. The normal native initializer completed once through Claude Code; its **3-node / 2-relationship** output rendered through ELK. Source contains a throw guard and was not executed.
- Restarted through the same documented command. The generated map digest and initialization attempt ID stayed identical; saved maps did not regenerate. Both maps rendered again without browser errors.
- Fresh launch exposed exactly one imported project; mixed launch/restart exposed exactly the intended two. **Zero sessions were created throughout the corrected journey.** Machine identity differed from desktop; checked desktop profile files, saved map bytes, source Git status, and source diff stayed unchanged. Only trial servers were stopped.
- Final full workspace `pnpm build`, `pnpm typecheck`, and `pnpm lint` passed. 121 focused launcher/REST/real-server tests passed after the root/provider fixes, followed by all 10 launcher tests after the reconnect fix.
- Full macOS `pnpm test`: **3,908/3,910 harness tests passed**. The unchanged watcher assertion reproduces on original main; the session-manager test hits its 5-second deadline in the full parallel suite and passes its isolated 183-test run. Separate performance (10), desktop (205), and CLI (73) checks passed. Earlier combined Linux validation covered 3,909 passing harness tests; later changes have focused regression coverage.
- Formatting, terminology checks, and `git diff --check` passed.

Review fixes launch from an accessible imported root, preserving eight imported recent roots and avoiding a spurious state-folder project/bootstrap session. Unavailable source roots produce an actionable reconnect error; restored directories work despite stale catalog status. Providerless session creation returns an actionable error before spawn; the repository-only runbook is separated from the npm README. The follow-up PR review approves all original findings as addressed.

### Tests and documentation

[Repository comparison guide](https://github.com/sapiom/sapiom-js/blob/yashnadge/sap-3266-agent-studio-launch-the-elk-comparison-against-real-local/docs/studio-elk-comparison.md) includes installation, import/reopen commands, shared-source behavior, provider requirements, and a coworker comparison checklist. The package README documents the public `--map-layout` flag. The real-server test extends the existing initialization lifecycle rather than introducing another inference path.

## Compatibility and release impact

Existing commands preserve their behavior. New `--map-layout` affects the browser URL; the comparison command uses existing no-session and no-telemetry paths. Changeset: harness minor release, naming `--map-layout` and providerless `--no-session` viewing.

## Security

- [x] No credentials or machine identity are copied; no private project data or unsanitized logs are included.
- [x] This PR does not publicly disclose a suspected vulnerability.

## AI assistance

- [x] Codex assisted implementation and review. Validation includes source review, targeted regressions, real-server tests, typechecks, and production builds.

## Checklist

- [x] Followed `CONTRIBUTING.md` and the approved scope.
- [x] One focused problem; relevant tests, documentation, and Changeset included.
- [x] Required checks were run; final integration results and full-suite caveats are stated above.
