### PR TITLE
fix(harness): resolve linked agents from the tenant-scoped definitions list [SAP-3214]

### DIFF
--- a/.changeset/studio-tenant-scoped-definition-list.md
+++ b/.changeset/studio-tenant-scoped-definition-list.md
@@ -1,0 +1,8 @@
+---
+"@sapiom/harness": minor
+---
+
+Resolve linked agents from one tenant-scoped definitions list per poll instead
+of a by-id lookup per agent: definitions the signed-in account cannot see are
+never requested and show as unavailable in Studio. `WorkflowInfo` gains an
+optional, serve-time `definitionAccess` field (never persisted).

--- a/packages/harness/src/core/canvas-render.test.ts
+++ b/packages/harness/src/core/canvas-render.test.ts
@@ -133,6 +133,23 @@ describe("renderCanvasForSession", () => {
     expect(await readRender(readyCwd, ORDER_TRIAGE)).toContain(">deployed<");
   });
 
+  it("labels a definition the signed-in account cannot see as unavailable, over any remembered build status", async () => {
+    const cwd = await tmpCwd();
+    await renderCanvasForSession({ cwd, boundWorkflowPath: ORDER_TRIAGE }, [
+      {
+        path: ORDER_TRIAGE,
+        name: "order-triage",
+        definitionId: 42,
+        activeBuildRunStatus: "ready",
+        definitionAccess: "unavailable",
+      },
+    ]);
+    const html = await readRender(cwd, ORDER_TRIAGE);
+    expect(html).toContain(">unavailable<");
+    expect(html).not.toContain(">deployed<");
+    expect(html).not.toContain(">linked<");
+  });
+
   it("serves the second render of an unchanged workflow from the extraction cache", async () => {
     const cwd = await tmpCwd();
     const workflows: RenderableWorkflow[] = [

--- a/packages/harness/src/core/canvas-render.ts
+++ b/packages/harness/src/core/canvas-render.ts
@@ -51,6 +51,9 @@ export interface RenderableWorkflow {
   name: string;
   definitionId: number | null;
   activeBuildRunStatus?: string | null;
+  /** "unavailable" = the signed-in account can't see the linked definition.
+   *  Absent = unknown. */
+  definitionAccess?: "visible" | "unavailable";
 }
 
 /**
@@ -138,6 +141,13 @@ export interface RenderCanvasOptions {
 }
 
 function badgesFor(workflow: RenderableWorkflow): string[] {
+  // First: a remembered build status is no evidence for an invisible definition.
+  if (
+    workflow.definitionId != null &&
+    workflow.definitionAccess === "unavailable"
+  ) {
+    return ["unavailable"];
+  }
   if (workflow.activeBuildRunStatus === "ready") return ["deployed"];
   if (
     ["pending", "queued", "building"].includes(

--- a/packages/harness/src/core/definition-slug-resolver.test.ts
+++ b/packages/harness/src/core/definition-slug-resolver.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { createDefinitionSlugResolver } from "./definition-slug-resolver.js";
+import {
+  createDefinitionSlugResolver,
+  type DefinitionSlugResolver,
+} from "./definition-slug-resolver.js";
 
 /** Builds a minimal fetch mock that returns a JSON body with a given status. */
 function makeFetch(status: number, body: unknown): typeof fetch {
@@ -268,7 +271,9 @@ describe("createDefinitionSlugResolver", () => {
     expect(String(errorSpy.mock.calls[0][0])).toContain("definitionId=777");
     expect(String(errorSpy.mock.calls[0][0])).toContain("metadata unavailable");
     expect(String(errorSpy.mock.calls[0][0])).toContain("HTTP 403");
-    expect(String(errorSpy.mock.calls[0][0])).toContain("account that owns this agent");
+    expect(String(errorSpy.mock.calls[0][0])).toContain(
+      "account that owns this agent",
+    );
     expect(JSON.stringify(errorSpy.mock.calls)).not.toMatch(
       /test-key|private upstream error/,
     );
@@ -299,7 +304,9 @@ const reply = (body: unknown, status = 200) =>
   ({ ok: status === 200, status, json: async () => body }) as Response;
 const delayedReply = () => {
   let release!: (value: Response) => void;
-  const response = new Promise<Response>((resolve) => { release = resolve; });
+  const response = new Promise<Response>((resolve) => {
+    release = resolve;
+  });
   return { response, release };
 };
 
@@ -317,10 +324,14 @@ describe("authenticated deployment evidence", () => {
     [503, {}],
     [404, {}],
     [404, { ...absent, message: "wrong definition" }],
-    [404, {
-      statusCode: 404, code: "not_found",
-      message: "Cannot GET /agents/v1/definitions/188",
-    }],
+    [
+      404,
+      {
+        statusCode: 404,
+        code: "not_found",
+        message: "Cannot GET /agents/v1/definitions/188",
+      },
+    ],
   ])(
     "retains confirmed evidence for unavailable %s %j",
     async (status, body) => {
@@ -345,7 +356,10 @@ describe("authenticated deployment evidence", () => {
   );
   it.each([
     [reply(ready), reply(absent, 404)],
-    [reply(ready), reply({ activeBuildRunId: null, activeBuildRunStatus: null })],
+    [
+      reply(ready),
+      reply({ activeBuildRunId: null, activeBuildRunStatus: null }),
+    ],
     [reply(ready), reply({ ...ready, activeBuildRunId: "new-build" })],
     [reply(absent, 404), reply(ready)],
   ])(
@@ -367,7 +381,8 @@ describe("authenticated deployment evidence", () => {
       await expect(pending).resolves.toEqual(latest);
       await expect(resolver.resolveMetadata("188")).resolves.toEqual({
         status: "unavailable",
-        lastConfirmedDeployed: latest.status === "available" &&
+        lastConfirmedDeployed:
+          latest.status === "available" &&
           latest.metadata.activeBuildRunStatus === "ready",
       });
       expect(fetchImpl).toHaveBeenCalledTimes(3);
@@ -434,5 +449,250 @@ describe("authenticated deployment evidence", () => {
     } finally {
       timeout.mockRestore();
     }
+
+    describe("createDefinitionSlugResolver.listVisible (SAP-3214)", () => {
+      let errorSpy: ReturnType<typeof vi.spyOn>;
+      beforeEach(() => {
+        errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      });
+      afterEach(() => {
+        errorSpy.mockRestore();
+      });
+
+      // Gateway list rows; ids arrive as strings, numbers are tolerated.
+      const ROWS = [
+        {
+          id: 4821,
+          slug: "order-triage",
+          name: "Order Triage",
+          description: null,
+          createdAt: "2026-09-01T00:00:00.000Z",
+          activeBuildRunId: "build-1",
+          activeBuildRunStatus: "ready",
+          isTemplate: false,
+        },
+        {
+          id: "77",
+          slug: "unbuilt",
+          name: "Unbuilt",
+          description: null,
+          createdAt: "2026-09-02T00:00:00.000Z",
+          activeBuildRunId: null,
+          activeBuildRunStatus: null,
+          isTemplate: false,
+        },
+      ];
+      const response = (body: unknown, status = 200) =>
+        ({ ok: status === 200, status, json: async () => body }) as Response;
+      const visibleOf = (
+        result: Awaited<ReturnType<DefinitionSlugResolver["listVisible"]>>,
+      ) => (result.status === "available" ? result.visible : null);
+
+      it("fetches the tenant-scoped list with the api key and keys rows by string id", async () => {
+        const fetchImpl = makeFetch(200, ROWS);
+        const resolver = createDefinitionSlugResolver({
+          apiKey: "sk-list",
+          baseUrl: "https://tools.sapiom.ai",
+          fetchImpl,
+        });
+
+        const visible = visibleOf(await resolver.listVisible());
+
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+        expect(fetchImpl).toHaveBeenCalledWith(
+          "https://tools.sapiom.ai/agents/v1/definitions",
+          expect.objectContaining({
+            headers: { "x-sapiom-api-key": "sk-list" },
+          }),
+        );
+        expect(visible).not.toBeNull();
+        expect([...visible!.keys()]).toEqual(["4821", "77"]);
+        expect(visible!.get("4821")).toEqual({
+          slug: "order-triage",
+          activeBuildRunId: "build-1",
+          activeBuildRunStatus: "ready",
+        });
+        expect(visible!.get("77")).toEqual({
+          slug: "unbuilt",
+          activeBuildRunId: null,
+          activeBuildRunStatus: null,
+        });
+      });
+
+      it("is unavailable without fetching or logging when signed out", async () => {
+        const fetchImpl = vi.fn();
+        const resolver = createDefinitionSlugResolver({
+          apiKey: null,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+        });
+
+        await expect(resolver.listVisible()).resolves.toEqual({
+          status: "unavailable",
+          lastConfirmedDeployed: new Map(),
+        });
+
+        expect(fetchImpl).not.toHaveBeenCalled();
+        expect(errorSpy).not.toHaveBeenCalled();
+      });
+
+      it("is unavailable on a non-2xx response and logs that failure once, not per poll", async () => {
+        const fetchImpl = makeFetch(500, { error: "boom" });
+        const resolver = createDefinitionSlugResolver({
+          apiKey: "sk",
+          fetchImpl,
+        });
+
+        for (let i = 0; i < 3; i += 1)
+          expect((await resolver.listVisible()).status).toBe("unavailable");
+
+        // Nothing is cached (a later poll may succeed), but the console line is.
+        expect(fetchImpl).toHaveBeenCalledTimes(3);
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        expect(String(errorSpy.mock.calls[0][0])).toContain("HTTP 500");
+      });
+
+      it("is unavailable when fetch throws (network error)", async () => {
+        const resolver = createDefinitionSlugResolver({
+          apiKey: "sk",
+          fetchImpl: makeThrowingFetch(new Error("ECONNREFUSED")),
+        });
+
+        expect((await resolver.listVisible()).status).toBe("unavailable");
+        expect(String(errorSpy.mock.calls[0][0])).toContain(
+          "network error or timeout",
+        );
+      });
+
+      it("is unavailable when the body is not an array", async () => {
+        const resolver = createDefinitionSlugResolver({
+          apiKey: "sk",
+          fetchImpl: makeFetch(200, { items: ROWS }),
+        });
+
+        expect((await resolver.listVisible()).status).toBe("unavailable");
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it("skips rows without a usable id instead of failing the whole list", async () => {
+        const resolver = createDefinitionSlugResolver({
+          apiKey: "sk",
+          fetchImpl: makeFetch(200, [null, { slug: "no-id" }, ROWS[0]]),
+        });
+
+        const visible = visibleOf(await resolver.listVisible());
+
+        expect([...visible!.keys()]).toEqual(["4821"]);
+      });
+
+      it("retains the last confirmed display bit through a list failure and forgets it on sign-out", async () => {
+        let key: string | null = "sk";
+        const fetchImpl = vi
+          .fn()
+          .mockResolvedValueOnce(response(ROWS))
+          .mockResolvedValue(response({ error: "boom" }, 503));
+        const resolver = createDefinitionSlugResolver({
+          apiKey: () => key,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+        });
+
+        expect((await resolver.listVisible()).status).toBe("available");
+        await expect(resolver.listVisible()).resolves.toEqual({
+          status: "unavailable",
+          lastConfirmedDeployed: new Map([
+            ["4821", true],
+            ["77", false],
+          ]),
+        });
+
+        key = null;
+        await expect(resolver.listVisible()).resolves.toEqual({
+          status: "unavailable",
+          lastConfirmedDeployed: new Map(),
+        });
+      });
+
+      it("shares one in-flight request between concurrent callers, then fetches again on the next pass", async () => {
+        let respond!: (value: Response) => void;
+        const fetchImpl = vi.fn().mockImplementation(
+          () =>
+            new Promise<Response>((resolve) => {
+              respond = resolve;
+            }),
+        );
+        const resolver = createDefinitionSlugResolver({
+          apiKey: "sk",
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+        });
+
+        // /api/state and /api/workflows polling together.
+        const first = resolver.listVisible();
+        const second = resolver.listVisible();
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+        respond(response(ROWS));
+        const [a, b] = await Promise.all([first, second]);
+        expect(a).toBe(b);
+        expect(visibleOf(a)?.size).toBe(2);
+
+        // Build status is mutable: nothing is kept once the request settles.
+        fetchImpl.mockResolvedValue(response([]));
+        expect(visibleOf(await resolver.listVisible())?.size).toBe(0);
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+      });
+
+      it("never shares an in-flight request across an account switch, and drops the stale one", async () => {
+        let currentKey: string | null = "sk-account-a";
+        const pending: Array<(value: Response) => void> = [];
+        const fetchImpl = vi.fn().mockImplementation(
+          () =>
+            new Promise<Response>((resolve) => {
+              pending.push(resolve);
+            }),
+        );
+        const resolver = createDefinitionSlugResolver({
+          apiKey: () => currentKey,
+          fetchImpl: fetchImpl as unknown as typeof fetch,
+        });
+
+        const before = resolver.listVisible();
+        currentKey = "sk-account-b";
+        const after = resolver.listVisible();
+
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+        expect(fetchImpl.mock.calls[0][1]).toEqual(
+          expect.objectContaining({
+            headers: { "x-sapiom-api-key": "sk-account-a" },
+          }),
+        );
+        expect(fetchImpl.mock.calls[1][1]).toEqual(
+          expect.objectContaining({
+            headers: { "x-sapiom-api-key": "sk-account-b" },
+          }),
+        );
+
+        pending[0]!(response(ROWS));
+        pending[1]!(response([]));
+        // Started under the old account: nothing from it may resolve.
+        await expect(before).resolves.toEqual({
+          status: "unavailable",
+          lastConfirmedDeployed: new Map(),
+        });
+        expect(visibleOf(await after)?.size).toBe(0);
+      });
+
+      it("seeds the stable slug cache so resolve() needs no per-id request afterwards", async () => {
+        const fetchImpl = makeFetch(200, ROWS);
+        const resolver = createDefinitionSlugResolver({
+          apiKey: "sk",
+          fetchImpl,
+        });
+
+        await resolver.listVisible();
+
+        await expect(resolver.resolve("4821")).resolves.toBe("order-triage");
+        await expect(resolver.resolve("77")).resolves.toBe("unbuilt");
+        expect(fetchImpl).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });

--- a/packages/harness/src/core/definition-slug-resolver.ts
+++ b/packages/harness/src/core/definition-slug-resolver.ts
@@ -1,13 +1,9 @@
 /**
- * Serve-time enrichment: resolves a deployed agent's `definitionSlug` from the
- * Sapiom Agents API by its `definitionId`. The registry only knows the id (from
- * `sapiom.json`'s `{ "definitionId": "188" }`) — the slug lives server-side,
- * keyed by id.
- *
- * Resolution is cached in-memory (id→slug is stable once deployed; a slug
- * never changes for a given id) so repeat calls across requests are free.
- * Null resolutions are NOT cached: a transient network failure should be
- * retryable without a server restart.
+ * Serve-time enrichment of linked agents (slug + build status) from the
+ * Agents API. `listVisible()`: one tenant-scoped list per pass; the engine
+ * 404s foreign ids, so callers intersect instead of asking per id.
+ * `resolveMetadata()`: per-id detail, for ids the list proved visible.
+ * Slugs are cached (stable); failed lookups retain only a display bit.
  *
  * Mirrors `@sapiom/tools`'s DEFAULT_BASE_URL for the base URL resolution.
  */
@@ -60,21 +56,36 @@ export type DefinitionMetadataResult =
   | { status: "available"; metadata: DefinitionMetadata }
   | { status: "not-found" }
   | { status: "unavailable"; lastConfirmedDeployed: boolean | null };
-type ConfirmedMetadata = Exclude<DefinitionMetadataResult, { status: "unavailable" }>;
+type ConfirmedMetadata = Exclude<
+  DefinitionMetadataResult,
+  { status: "unavailable" }
+>;
+
+/** One list pass: the account's visible definitions, or the retained display
+ *  bits when the list could not be read (signed out, outage, stale scope). */
+export type DefinitionListResult =
+  | { status: "available"; visible: ReadonlyMap<string, DefinitionMetadata> }
+  | {
+      status: "unavailable";
+      lastConfirmedDeployed: ReadonlyMap<string, boolean>;
+    };
 
 export interface DefinitionSlugResolver {
   resolve(definitionId: string): Promise<string | null>;
   /** Fetch mutable definition metadata. Unlike the stable slug lookup, build
-   *  state is deliberately not cached so a completed build becomes visible. */
+   *  state is deliberately not cached so a completed build becomes visible.
+   *  Ask only for ids {@link listVisible} proved visible: anything else 404s. */
   resolveMetadata(definitionId: string): Promise<DefinitionMetadataResult>;
+  /** One tenant-scoped list request. The engine returns the account's full
+   *  set, unpaginated: absence = not visible. Single-flight per api key; a
+   *  key change during the request yields "unavailable". */
+  listVisible(): Promise<DefinitionListResult>;
   invalidate(): void;
 }
 
 /**
- * Creates a resolver that fetches `GET /agents/v1/definitions/<id>` with the
- * caller's API key and returns the `slug` field from the response.
- *
- * Never throws. Failed metadata checks retain only a scoped display bit;
+ * Resolver over `GET /agents/v1/definitions` (list) and `/definitions/<id>`
+ * (detail). Never throws. Failed checks retain only a scoped display bit;
  * they never return cached runnable build fields.
  */
 export function createDefinitionSlugResolver(opts: {
@@ -87,12 +98,15 @@ export function createDefinitionSlugResolver(opts: {
   const { apiKey, baseUrl = resolveAgentsBaseUrl(), fetchImpl = fetch } = opts;
   const getApiKey = typeof apiKey === "function" ? apiKey : () => apiKey;
   const cache = new Map<string, string>();
-  const confirmed = new Map<string, {
-    request: number;
-    deployed: boolean | null;
-    pending: number;
-    result?: ConfirmedMetadata;
-  }>();
+  const confirmed = new Map<
+    string,
+    {
+      request: number;
+      deployed: boolean | null;
+      pending: number;
+      result?: ConfirmedMetadata;
+    }
+  >();
   const loggedFailures = new Set<string>();
   let key = getApiKey();
   let generation = 0;
@@ -107,6 +121,10 @@ export function createDefinitionSlugResolver(opts: {
   const syncKey = (): void => {
     if (key !== getApiKey()) invalidate();
   };
+  const isCurrent = (scope: number): boolean => {
+    syncKey();
+    return scope === generation;
+  };
   const warnOnce = (definitionId: string, reason: string): void => {
     // Throttle repeated polls without hiding a changed failure reason.
     const diagnostic = `${definitionId}:${reason}`;
@@ -115,6 +133,21 @@ export function createDefinitionSlugResolver(opts: {
     console.error(
       `[harness] definition metadata unavailable for definitionId=${definitionId}: ${reason}`,
     );
+  };
+  const warnListOnce = (reason: string): void => {
+    const diagnostic = `list:${reason}`;
+    if (loggedFailures.has(diagnostic)) return;
+    loggedFailures.add(diagnostic);
+    console.error(`[harness] definition list unavailable: ${reason}`);
+  };
+  const remember = (definitionId: string, deployed: boolean): void => {
+    const entry = confirmed.get(definitionId) ?? {
+      request: 0,
+      deployed: null,
+      pending: 0,
+    };
+    entry.deployed = deployed;
+    confirmed.set(definitionId, entry);
   };
 
   const resolveMetadata = async (
@@ -130,19 +163,19 @@ export function createDefinitionSlugResolver(opts: {
           ? (confirmed.get(definitionId)?.deployed ?? null)
           : null,
     });
-    const isCurrent = (): boolean => {
-      syncKey();
-      return scope === generation;
-    };
     if (!key) return unavailable();
-    const latest = confirmed.get(definitionId) ??
-      { request: 0, deployed: null, pending: 0 };
+    const latest = confirmed.get(definitionId) ?? {
+      request: 0,
+      deployed: null,
+      pending: 0,
+    };
     confirmed.set(definitionId, latest);
     latest.pending += 1;
     const confirm = (result: ConfirmedMetadata): DefinitionMetadataResult => {
       if (request < latest.request) return latest.result ?? unavailable();
       latest.request = request;
-      latest.deployed = result.status === "available" &&
+      latest.deployed =
+        result.status === "available" &&
         result.metadata.activeBuildRunStatus === "ready";
       latest.result = result;
       if (result.status === "not-found") cache.delete(definitionId);
@@ -159,9 +192,10 @@ export function createDefinitionSlugResolver(opts: {
       );
       failure = response.ok ? "invalid response" : `HTTP ${response.status}`;
       if (response.status === 401 || response.status === 403)
-        failure += "; check Studio is signed into the account that owns this agent";
+        failure +=
+          "; check Studio is signed into the account that owns this agent";
       const body: unknown = await response.json();
-      if (!isCurrent()) return unavailable();
+      if (!isCurrent(scope)) return unavailable();
       if (body === null || typeof body !== "object" || Array.isArray(body))
         throw new Error("Invalid metadata");
       const fields = body as Record<string, unknown>;
@@ -195,7 +229,7 @@ export function createDefinitionSlugResolver(opts: {
         metadata: { slug, activeBuildRunId, activeBuildRunStatus },
       });
     } catch {
-      if (isCurrent()) warnOnce(definitionId, failure);
+      if (isCurrent(scope)) warnOnce(definitionId, failure);
       return unavailable();
     } finally {
       // Share validated results only across overlapping successful reads. Every
@@ -204,8 +238,90 @@ export function createDefinitionSlugResolver(opts: {
     }
   };
 
+  const fetchList = async (
+    scope: number,
+    currentKey: string,
+  ): Promise<DefinitionListResult> => {
+    const listUnavailable = (): DefinitionListResult => {
+      const bits = new Map<string, boolean>();
+      if (scope === generation)
+        for (const [definitionId, entry] of confirmed)
+          if (entry.deployed !== null) bits.set(definitionId, entry.deployed);
+      return { status: "unavailable", lastConfirmedDeployed: bits };
+    };
+    let failure = "network error or timeout";
+    try {
+      const response = await fetchImpl(`${baseUrl}/agents/v1/definitions`, {
+        headers: { "x-sapiom-api-key": currentKey },
+        signal: AbortSignal.timeout(5_000),
+      });
+      failure = response.ok ? "invalid response" : `HTTP ${response.status}`;
+      if (response.status === 401 || response.status === 403)
+        failure +=
+          "; check Studio is signed into the account that owns these agents";
+      const body: unknown = await response.json();
+      if (!isCurrent(scope)) return listUnavailable();
+      if (!response.ok || !Array.isArray(body)) throw new Error("Invalid list");
+      const visible = new Map<string, DefinitionMetadata>();
+      for (const row of body) {
+        if (row === null || typeof row !== "object") continue;
+        const fields = row as Record<string, unknown>;
+        // bigint id serializes as a string; tolerate a number.
+        if (typeof fields.id !== "string" && typeof fields.id !== "number")
+          continue;
+        const definitionId = String(fields.id);
+        const metadata: DefinitionMetadata = {
+          slug: typeof fields.slug === "string" ? fields.slug : null,
+          activeBuildRunId:
+            typeof fields.activeBuildRunId === "string"
+              ? fields.activeBuildRunId
+              : null,
+          activeBuildRunStatus:
+            typeof fields.activeBuildRunStatus === "string"
+              ? fields.activeBuildRunStatus
+              : null,
+        };
+        visible.set(definitionId, metadata);
+        if (metadata.slug !== null) cache.set(definitionId, metadata.slug);
+        remember(definitionId, metadata.activeBuildRunStatus === "ready");
+      }
+      // A definition this account confirmed before and cannot see now is not
+      // deployed for it.
+      for (const [definitionId, entry] of confirmed)
+        if (!visible.has(definitionId)) {
+          entry.deployed = false;
+          cache.delete(definitionId);
+        }
+      return { status: "available", visible };
+    } catch {
+      if (isCurrent(scope)) warnListOnce(failure);
+      return listUnavailable();
+    }
+  };
+
+  // Single-flight per scope (the scope changes with the api key): concurrent
+  // polls share one request, a key change never does. Nothing kept once
+  // settled (build status is mutable).
+  let inflightList: {
+    scope: number;
+    promise: Promise<DefinitionListResult>;
+  } | null = null;
+  const listVisible = async (): Promise<DefinitionListResult> => {
+    syncKey();
+    const scope = generation;
+    if (!key)
+      return { status: "unavailable", lastConfirmedDeployed: new Map() };
+    if (inflightList?.scope === scope) return inflightList.promise;
+    const promise = fetchList(scope, key).finally(() => {
+      if (inflightList?.promise === promise) inflightList = null;
+    });
+    inflightList = { scope, promise };
+    return promise;
+  };
+
   return {
     resolveMetadata,
+    listVisible,
     invalidate,
     async resolve(definitionId: string): Promise<string | null> {
       syncKey();

--- a/packages/harness/src/server/canvas-build-status-wiring.test.ts
+++ b/packages/harness/src/server/canvas-build-status-wiring.test.ts
@@ -2,7 +2,10 @@
  * Wiring-level regression for the Canvas cloud-status badge. The SPA routes
  * already receive definition metadata through enrichWorkflows(); this proves
  * the real POST /api/canvas/:sessionId/render path receives the same mutable
- * active-build projection instead of the raw workflow registry snapshot.
+ * active-build projection instead of the raw workflow registry snapshot, and
+ * that the projection follows the tenant-scoped list (SAP-3214): one list
+ * request per pass, retained display bits through an outage, an absent id
+ * marked unavailable, nothing from a request started before sign-out.
  */
 import {
   createServer as createHttpServer,
@@ -48,46 +51,57 @@ function fakeClaudeAdapter(): HarnessAdapter {
   };
 }
 
+const readyRow = (id: string, slug: string) => ({
+  id,
+  slug,
+  activeBuildRunId: `build-ready-${id}`,
+  activeBuildRunStatus: "ready",
+});
+
 describe("Canvas build-status wiring", () => {
   let tempDir: string;
   let harness: HarnessServer | undefined;
   let definitionsApi: HttpServer | undefined;
   let previousAgentsUrl: string | undefined;
-  let definitionRequests: number;
-  let definitionStatus = 200;
-  let definitionBody: unknown;
-  let holdDefinition: ((url: string) => Promise<void>) | null = null;
-  let definitionApiKeys: Array<string | undefined>;
+  let listRequests: number;
+  let listStatus = 200;
+  let listRows: unknown;
+  let holdList: (() => Promise<void>) | null = null;
+  let listApiKeys: Array<string | undefined>;
+  let detailRequests: number;
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(
       path.join(os.tmpdir(), "harness-canvas-build-status-"),
     );
     previousAgentsUrl = process.env.SAPIOM_AGENTS_URL;
-    definitionRequests = 0;
-    definitionStatus = 200;
-    definitionBody = {
-      slug: "order-triage",
-      activeBuildRunId: "build-ready-1",
-      activeBuildRunStatus: "ready",
-    };
-    holdDefinition = null;
-    definitionApiKeys = [];
+    listRequests = 0;
+    listStatus = 200;
+    listRows = [
+      readyRow("4821", "order-triage"),
+      readyRow("4822", "other-agent"),
+    ];
+    holdList = null;
+    listApiKeys = [];
+    detailRequests = 0;
 
+    // Enrichment reads the tenant list; a ready row needs no detail request.
     definitionsApi = createHttpServer(async (req, res) => {
-      if (!/^\/agents\/v1\/definitions\/482[12]$/.test(req.url ?? "")) {
-        res.writeHead(404).end();
+      if (req.url === "/agents/v1/definitions") {
+        listRequests += 1;
+        listApiKeys.push(req.headers["x-sapiom-api-key"] as string | undefined);
+        const status = listStatus;
+        const body =
+          status === 200
+            ? listRows
+            : { message: "private upstream diagnostic" };
+        await holdList?.();
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(body));
         return;
       }
-      definitionRequests += 1;
-      definitionApiKeys.push(
-        req.headers["x-sapiom-api-key"] as string | undefined,
-      );
-      const status = definitionStatus;
-      const body = definitionBody;
-      await holdDefinition?.(req.url!);
-      res.writeHead(status, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(body));
+      if (req.url?.startsWith("/agents/v1/definitions/")) detailRequests += 1;
+      res.writeHead(404).end();
     });
     await new Promise<void>((resolve) => {
       definitionsApi!.listen(0, "127.0.0.1", resolve);
@@ -175,8 +189,9 @@ describe("Canvas build-status wiring", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toMatchObject({ ok: true, mode: "single" });
-    expect(definitionRequests).toBe(1);
-    expect(definitionApiKeys).toEqual(["sk-test"]);
+    expect(listRequests).toBe(1);
+    expect(listApiKeys).toEqual(["sk-test"]);
+    expect(detailRequests).toBe(0);
     await expect(
       fs.readFile(renderFileFor(sessionDir, ORDER_TRIAGE), "utf8"),
     ).resolves.toContain(">deployed<");
@@ -193,12 +208,14 @@ describe("Canvas build-status wiring", () => {
       return route === "state" ? body.workflows : body;
     };
     const readyRows = await rows("state");
-    expect(readyRows[0].deploymentLookup).toEqual({
-      lastConfirmedDeployed: true,
-      unavailable: false,
+    expect(readyRows[0]).toMatchObject({
+      definitionAccess: "visible",
+      deploymentLookup: { lastConfirmedDeployed: true, unavailable: false },
     });
-    definitionStatus = 503;
-    definitionBody = { message: "private upstream diagnostic" };
+
+    // The list is down: build fields cleared, the confirmed display bit kept,
+    // no per-id fallback, no upstream diagnostic leaked.
+    listStatus = 503;
     for (const route of ["state", "workflows"]) {
       const unavailable = await rows(route);
       expect(unavailable[0]).toMatchObject({
@@ -206,45 +223,49 @@ describe("Canvas build-status wiring", () => {
         activeBuildRunStatus: null,
         deploymentLookup: { lastConfirmedDeployed: true, unavailable: true },
       });
+      expect(unavailable[0].definitionAccess).toBeUndefined();
       expect(JSON.stringify(unavailable)).not.toContain(
         "private upstream diagnostic",
       );
     }
-    definitionStatus = 404;
-    definitionBody = {
-      statusCode: 404,
-      message: "Agent definition not found: 4821",
-    };
-    expect(
-      (await rows("workflows")).find((row) => row.definitionId === 4821)
-        ?.deploymentLookup,
-    ).toEqual({
-      lastConfirmedDeployed: false,
-      unavailable: false,
+    expect(detailRequests).toBe(0);
+
+    // 4821 left the account's list: not visible, never requested by id.
+    listStatus = 200;
+    listRows = [readyRow("4822", "other-agent")];
+    const partial = await rows("workflows");
+    expect(partial.find((row) => row.definitionId === 4821)).toMatchObject({
+      definitionAccess: "unavailable",
+      activeBuildRunStatus: null,
+      deploymentLookup: { lastConfirmedDeployed: false, unavailable: false },
     });
-    expect(
-      await fs.readFile(path.join(stateRoot, "workflows.json"), "utf8"),
-    ).not.toContain("deploymentLookup");
+    expect(partial.find((row) => row.definitionId === 4822)).toMatchObject({
+      definitionAccess: "visible",
+      activeBuildRunStatus: "ready",
+    });
+    expect(detailRequests).toBe(0);
+    const persisted = await fs.readFile(
+      path.join(stateRoot, "workflows.json"),
+      "utf8",
+    );
+    expect(persisted).not.toContain("deploymentLookup");
+    expect(persisted).not.toContain("definitionAccess");
 
     // A request started under the old identity must not return ready after logout.
-    definitionStatus = 200;
-    definitionBody = {
-      slug: "old-account-agent",
-      activeBuildRunId: "late-build",
-      activeBuildRunStatus: "ready",
-    };
+    listRows = [
+      { ...readyRow("4821", "old-account-agent") },
+      { ...readyRow("4822", "old-account-agent") },
+    ];
     let release!: () => void;
     let entered!: () => void;
     const started = new Promise<void>((resolve) => {
       entered = resolve;
     });
-    holdDefinition = (url) =>
-      url.endsWith("4821")
-        ? Promise.resolve()
-        : new Promise<void>((resolve) => {
-            release = resolve;
-            entered();
-          });
+    holdList = () =>
+      new Promise<void>((resolve) => {
+        release = resolve;
+        entered();
+      });
     const pending = rows("state");
     await started;
     expect((await request("auth/disconnect", "POST")).status).toBe(200);

--- a/packages/harness/src/server/definition-list-enrichment.test.ts
+++ b/packages/harness/src/server/definition-list-enrichment.test.ts
@@ -1,0 +1,349 @@
+/**
+ * Wiring regression for SAP-3214: one tenant-scoped list request per pass,
+ * never a by-id request for a definition the account can't see. Fake Agents
+ * API counting list and detail requests; `@sapiom/mcp/auth` mocked so the
+ * disconnect route never touches ~/.sapiom.
+ */
+import {
+  createServer as createHttpServer,
+  type Server as HttpServer,
+} from "node:http";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@sapiom/mcp/auth", () => ({
+  resolveEnvironment: vi.fn(async (environment?: string) => ({
+    name: environment === "dev" ? "staging" : "production",
+    appURL: "https://app.example.test",
+    apiURL: "https://api.example.test",
+    services: {},
+    credentials: null,
+  })),
+  readCredentials: vi.fn(async () => null),
+  readCredentialsOrThrow: vi.fn(async () => null),
+  performBrowserAuth: vi.fn(async () => {
+    throw new Error("browser auth is not part of this test");
+  }),
+  writeCredentials: vi.fn(async () => {}),
+  clearCredentials: vi.fn(async () => {}),
+}));
+
+import type {
+  HarnessAdapter,
+  LaunchOpts,
+  SpawnSpec,
+  WorkflowInfo,
+} from "../shared/types.js";
+import { startServer, type HarnessServer } from "./index.js";
+
+const BOOT_TOKEN = "test-token";
+const FIXTURES = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../core/__fixtures__",
+);
+const OWN_PROJECT = path.join(FIXTURES, "order-triage");
+const FOREIGN_PROJECT = path.join(FIXTURES, "hub");
+const OWN_ID = 4821;
+const FOREIGN_ID = 9999;
+
+function fakeClaudeAdapter(): HarnessAdapter {
+  const spec = (opts: LaunchOpts): SpawnSpec => ({
+    command: "bash",
+    args: [],
+    env: {},
+    cwd: opts.cwd,
+  });
+  return {
+    id: "claude-code",
+    eventSource: "hooks",
+    doctor: async () => [],
+    launch: spec,
+    resume: (_agentSessionId: string, opts: LaunchOpts): SpawnSpec =>
+      spec(opts),
+    listPastSessions: async () => [],
+    canResume: async () => true,
+  };
+}
+
+interface FakeAgentsApi {
+  listStatus: number;
+  listRows: unknown;
+  /** Detail bodies by definition id; an id without one answers 404. */
+  detailBodies: Record<string, unknown>;
+  listRequests: number;
+  listApiKeys: Array<string | undefined>;
+  detailRequests: Map<string, number>;
+  reset(): void;
+}
+
+describe("definition list enrichment wiring (SAP-3214)", () => {
+  let tempDir: string;
+  let harness: HarnessServer | undefined;
+  let agentsApi: HttpServer | undefined;
+  let previousAgentsUrl: string | undefined;
+  let api: FakeAgentsApi;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "harness-definition-list-enrichment-"),
+    );
+    previousAgentsUrl = process.env.SAPIOM_AGENTS_URL;
+    api = {
+      listStatus: 200,
+      listRows: [],
+      detailBodies: {},
+      listRequests: 0,
+      listApiKeys: [],
+      detailRequests: new Map(),
+      reset() {
+        this.listRequests = 0;
+        this.listApiKeys = [];
+        this.detailRequests = new Map();
+      },
+    };
+
+    agentsApi = createHttpServer((req, res) => {
+      if (req.url === "/agents/v1/definitions") {
+        api.listRequests += 1;
+        api.listApiKeys.push(
+          req.headers["x-sapiom-api-key"] as string | undefined,
+        );
+        res.writeHead(api.listStatus, { "Content-Type": "application/json" });
+        res.end(
+          api.listStatus === 200
+            ? JSON.stringify(api.listRows)
+            : JSON.stringify({ error: "list unavailable" }),
+        );
+        return;
+      }
+      const detail = /^\/agents\/v1\/definitions\/([^/?]+)$/.exec(
+        req.url ?? "",
+      );
+      if (detail) {
+        const id = decodeURIComponent(detail[1]!);
+        api.detailRequests.set(id, (api.detailRequests.get(id) ?? 0) + 1);
+        const body = api.detailBodies[id];
+        if (body === undefined) {
+          res.writeHead(404).end();
+          return;
+        }
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(body));
+        return;
+      }
+      res.writeHead(404).end();
+    });
+    await new Promise<void>((resolve) => {
+      agentsApi!.listen(0, "127.0.0.1", resolve);
+    });
+    const address = agentsApi.address();
+    const port = typeof address === "object" && address ? address.port : 0;
+    process.env.SAPIOM_AGENTS_URL = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    await harness?.sessionManager.flush();
+    await harness?.close();
+    harness = undefined;
+    if (agentsApi) {
+      await new Promise<void>((resolve) => agentsApi!.close(() => resolve()));
+      agentsApi = undefined;
+    }
+    if (previousAgentsUrl === undefined) delete process.env.SAPIOM_AGENTS_URL;
+    else process.env.SAPIOM_AGENTS_URL = previousAgentsUrl;
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  /** Two linked rows: one the account owns, one linked under another account. */
+  async function bootHarness(): Promise<HarnessServer> {
+    const stateRoot = path.join(tempDir, "state");
+    const launchDir = path.join(tempDir, "launch");
+    await fs.mkdir(stateRoot, { recursive: true });
+    await fs.mkdir(launchDir, { recursive: true });
+    await fs.writeFile(
+      path.join(stateRoot, "workflows.json"),
+      JSON.stringify([
+        {
+          name: "order-triage",
+          path: OWN_PROJECT,
+          definitionId: OWN_ID,
+          definitionSlug: null,
+          source: "connect",
+        },
+        {
+          name: "hub",
+          path: FOREIGN_PROJECT,
+          definitionId: FOREIGN_ID,
+          definitionSlug: null,
+          source: "connect",
+        },
+      ]),
+    );
+    harness = await startServer({
+      port: 0,
+      bootToken: BOOT_TOKEN,
+      telemetryOptIn: false,
+      identity: {
+        userId: "user-test",
+        tenantId: "tenant-test",
+        organizationName: "Test Org",
+        apiKey: "sk-test",
+        source: "cached",
+      },
+      adapters: { "claude-code": fakeClaudeAdapter() },
+      buildLaunchOpts: () => ({}),
+      stateRoot,
+      launchDir,
+      autoCreateSession: false,
+    });
+    return harness;
+  }
+
+  async function fetchWorkflows(
+    server: HarnessServer,
+    route: "/api/state" | "/api/workflows",
+  ): Promise<Record<number, WorkflowInfo>> {
+    const response = await fetch(`http://127.0.0.1:${server.port}${route}`, {
+      headers: { "X-Harness-Token": BOOT_TOKEN },
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as
+      | WorkflowInfo[]
+      | { workflows: WorkflowInfo[] };
+    const workflows = Array.isArray(body) ? body : body.workflows;
+    const byId: Record<number, WorkflowInfo> = {};
+    for (const workflow of workflows) {
+      if (workflow.definitionId != null) byId[workflow.definitionId] = workflow;
+    }
+    return byId;
+  }
+
+  const detailTotal = (): number =>
+    [...api.detailRequests.values()].reduce((sum, n) => sum + n, 0);
+
+  it("issues one list request per pass and never asks for an id the account cannot see", async () => {
+    api.listRows = [
+      {
+        id: String(OWN_ID),
+        slug: "order-triage",
+        activeBuildRunId: "build-1",
+        activeBuildRunStatus: "ready",
+      },
+    ];
+    const server = await bootHarness();
+
+    const rows = await fetchWorkflows(server, "/api/state");
+
+    expect(api.listRequests).toBe(1);
+    expect(api.listApiKeys).toEqual(["sk-test"]);
+    expect(detailTotal()).toBe(0);
+    expect(rows[OWN_ID]).toMatchObject({
+      definitionAccess: "visible",
+      definitionSlug: "order-triage",
+      activeBuildRunId: "build-1",
+      activeBuildRunStatus: "ready",
+      deploymentLookup: { lastConfirmedDeployed: true, unavailable: false },
+    });
+    expect(rows[FOREIGN_ID]).toMatchObject({
+      definitionAccess: "unavailable",
+      definitionSlug: null,
+      deploymentLookup: { lastConfirmedDeployed: false, unavailable: false },
+    });
+    expect(rows[FOREIGN_ID]!.activeBuildRunStatus ?? null).toBeNull();
+
+    // /api/workflows runs the same pass: one more list, still no detail.
+    const again = await fetchWorkflows(server, "/api/workflows");
+    expect(api.listRequests).toBe(2);
+    expect(detailTotal()).toBe(0);
+    expect(again[FOREIGN_ID]?.definitionAccess).toBe("unavailable");
+  });
+
+  it("leaves rows untouched, with no per-id fallback, when the list is unavailable", async () => {
+    api.listStatus = 500;
+    const server = await bootHarness();
+
+    const rows = await fetchWorkflows(server, "/api/state");
+
+    expect(api.listRequests).toBe(1);
+    expect(detailTotal()).toBe(0);
+    for (const id of [OWN_ID, FOREIGN_ID]) {
+      expect(rows[id]).toBeDefined();
+      expect(rows[id]!.definitionAccess).toBeUndefined();
+      expect(rows[id]!.definitionSlug).toBeNull();
+      // Nothing was ever confirmed for this account: no retained display bit.
+      expect(rows[id]!.deploymentLookup).toEqual({
+        lastConfirmedDeployed: null,
+        unavailable: true,
+      });
+    }
+  });
+
+  it("asks the detail only for a visible definition with no ready build yet, to surface its first deploy", async () => {
+    api.listRows = [
+      {
+        id: String(OWN_ID),
+        slug: "order-triage",
+        activeBuildRunId: null,
+        activeBuildRunStatus: null,
+      },
+    ];
+    api.detailBodies[String(OWN_ID)] = {
+      id: String(OWN_ID),
+      slug: "order-triage",
+      activeBuildRunId: "build-2",
+      activeBuildRunStatus: "building",
+    };
+    const server = await bootHarness();
+
+    const rows = await fetchWorkflows(server, "/api/state");
+
+    expect(api.listRequests).toBe(1);
+    expect(api.detailRequests.get(String(OWN_ID))).toBe(1);
+    expect(detailTotal()).toBe(1);
+    expect(rows[OWN_ID]).toMatchObject({
+      definitionAccess: "visible",
+      definitionSlug: "order-triage",
+      activeBuildRunId: "build-2",
+      activeBuildRunStatus: "building",
+      deploymentLookup: { lastConfirmedDeployed: false, unavailable: false },
+    });
+    expect(rows[FOREIGN_ID]?.definitionAccess).toBe("unavailable");
+  });
+
+  it("stops requesting anything once the account disconnects, with no restart", async () => {
+    api.listRows = [
+      {
+        id: String(OWN_ID),
+        slug: "order-triage",
+        activeBuildRunId: "build-1",
+        activeBuildRunStatus: "ready",
+      },
+    ];
+    const server = await bootHarness();
+    expect(
+      (await fetchWorkflows(server, "/api/state"))[OWN_ID]?.definitionAccess,
+    ).toBe("visible");
+    api.reset();
+
+    const disconnect = await fetch(
+      `http://127.0.0.1:${server.port}/api/auth/disconnect`,
+      { method: "POST", headers: { "X-Harness-Token": BOOT_TOKEN } },
+    );
+    expect(disconnect.status).toBe(200);
+
+    const rows = await fetchWorkflows(server, "/api/state");
+
+    expect(api.listRequests).toBe(0);
+    expect(detailTotal()).toBe(0);
+    for (const id of [OWN_ID, FOREIGN_ID]) {
+      expect(rows[id]!.definitionAccess).toBeUndefined();
+      expect(rows[id]!.deploymentLookup).toEqual({
+        lastConfirmedDeployed: null,
+        unavailable: true,
+      });
+    }
+  });
+});

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -759,11 +759,8 @@ export const startServer = async (
    *  place the create route may write (see `listProjectDirs` below). */
   const defaultProjectRoot = options.projectRoot ?? launchDir;
 
-  // Serve-time slug enrichment: resolves each workflow's definitionSlug from
-  // the Sapiom Agents API when it's absent (deployed sapiom.json files carry
-  // only { "definitionId": "188" }, not the slug). Constructed once per server
-  // boot; caches successful id→slug resolutions in-memory (ids are stable).
-  // Never throws — a failed resolution leaves definitionSlug as-is.
+  // Serve-time definition enrichment (slug + build status) for linked
+  // workflows. One resolver per boot; never throws.
   const slugResolver = createDefinitionSlugResolver({
     apiKey: () => apiKeyProvider.getKey(),
     baseUrl: resolveAgentsBaseUrl(),
@@ -781,40 +778,73 @@ export const startServer = async (
       unavailable: workflow.definitionId != null,
     },
   });
-  // Auth guards cover individual lookups AND the complete async projection.
-  // Neither raw build fields nor retained display bits are written to disk.
+  /** A definition the account's list does not contain: never requested,
+   *  confirmed not deployed for this account. */
+  const notVisible = (
+    workflow: RegistryWorkflowInfo,
+  ): RegistryWorkflowInfo => ({
+    ...clearDeployment(workflow),
+    definitionAccess: "unavailable",
+    deploymentLookup: { lastConfirmedDeployed: false, unavailable: false },
+  });
+  /** Fill slug + build status for linked workflows from ONE tenant-scoped
+   *  list per pass (SAP-3214). Ids absent from the list are never requested
+   *  (the engine 404s them permanently) and are marked `definitionAccess:
+   *  "unavailable"`. Detail lookup only for a visible definition with no
+   *  ready build: only the detail shows a first deploy's in-flight build (a
+   *  rebuild of a ready definition reports `ready` in both). Signed out or
+   *  list unavailable: build fields cleared, retained display bit kept, no
+   *  per-id fallback. Auth guards cover the list, each lookup AND the complete
+   *  async projection. Neither raw build fields nor retained display bits are
+   *  written to disk. */
   const enrichWorkflows = async (
     workflows: RegistryWorkflowInfo[],
   ): Promise<RegistryWorkflowInfo[]> => {
     const scope = deploymentGeneration;
-    const enriched = await Promise.all(
-      workflows.map(async (workflow) => {
-        const cleared = clearDeployment(workflow);
-        if (workflow.definitionId == null) return cleared;
-        const result = await slugResolver.resolveMetadata(
-          String(workflow.definitionId),
-        );
-        if (scope !== deploymentGeneration) return cleared;
-        if (result.status === "available")
-          return {
-            ...workflow,
-            definitionSlug: result.metadata.slug ?? workflow.definitionSlug,
-            activeBuildRunId: result.metadata.activeBuildRunId,
-            activeBuildRunStatus: result.metadata.activeBuildRunStatus,
-            deploymentLookup: {
-              lastConfirmedDeployed:
-                result.metadata.activeBuildRunStatus === "ready",
-              unavailable: false,
-            },
-          };
+    const cleared = (): RegistryWorkflowInfo[] =>
+      workflows.map(clearDeployment);
+    if (!workflows.some((workflow) => workflow.definitionId != null))
+      return cleared();
+    const list = await slugResolver.listVisible();
+    if (scope !== deploymentGeneration) return cleared();
+    if (list.status === "unavailable")
+      return workflows.map((workflow) => {
+        const row = clearDeployment(workflow);
+        if (workflow.definitionId == null) return row;
         return {
-          ...cleared,
+          ...row,
           deploymentLookup: {
             lastConfirmedDeployed:
-              result.status === "not-found"
-                ? false
-                : result.lastConfirmedDeployed,
-            unavailable: result.status === "unavailable",
+              list.lastConfirmedDeployed.get(String(workflow.definitionId)) ??
+              null,
+            unavailable: true,
+          },
+        };
+      });
+    const enriched = await Promise.all(
+      workflows.map(async (workflow) => {
+        if (workflow.definitionId == null) return clearDeployment(workflow);
+        const definitionId = String(workflow.definitionId);
+        const listed = list.visible.get(definitionId);
+        if (listed === undefined) return notVisible(workflow);
+        let metadata = listed;
+        if (listed.activeBuildRunStatus === null) {
+          const detail = await slugResolver.resolveMetadata(definitionId);
+          if (scope !== deploymentGeneration) return clearDeployment(workflow);
+          if (detail.status === "not-found") return notVisible(workflow);
+          // An unavailable detail changes nothing: the list already proved
+          // visibility and the absence of a ready build.
+          if (detail.status === "available") metadata = detail.metadata;
+        }
+        return {
+          ...workflow,
+          definitionAccess: "visible" as const,
+          definitionSlug: metadata.slug ?? workflow.definitionSlug,
+          activeBuildRunId: metadata.activeBuildRunId,
+          activeBuildRunStatus: metadata.activeBuildRunStatus,
+          deploymentLookup: {
+            lastConfirmedDeployed: metadata.activeBuildRunStatus === "ready",
+            unavailable: false,
           },
         };
       }),
@@ -2897,8 +2927,8 @@ export const startServer = async (
   /** Enrich only the bound workflow before a Canvas render. Canvas extraction
    *  needs the registry snapshot to resolve the binding, but its cloud badge
    *  needs the same mutable build projection exposed by /api/state. Limiting
-   *  the lookup to the bound workflow avoids one remote request per linked
-   *  agent on every source-triggered auto-render. */
+   *  the pass to the bound workflow avoids extra detail lookups on every
+   *  source-triggered auto-render. */
   const canvasWorkflowsForSession = async (
     session: Pick<HarnessSession, "boundWorkflowPath">,
   ): Promise<WorkflowInfo[]> => {

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -1704,6 +1704,12 @@ export interface WorkflowInfo {
     unavailable: boolean;
   };
   /**
+   * Visibility of the linked definition for the signed-in account, from the
+   * tenant-scoped list at serve time. "unavailable" = another account or
+   * deleted. Absent = unknown. Never persisted to workflows.json.
+   */
+  definitionAccess?: "visible" | "unavailable";
+  /**
    * Provenance from sapiom.json: the gallery template this project was cloned
    * from. Distinct from `source` below, which records how the REGISTRY learned
    * of the path. Optional for compatibility with older harness servers; null

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -177,7 +177,10 @@ import {
 } from "./lib/use-harness-state";
 import { useAgentMapEntry } from "./lib/use-agent-map-entry";
 import {
+  deploymentStateLabel,
+  deploymentStateTitle,
   isWorkflowRunnable,
+  prodRunBlockedToast,
   workflowDeploymentState,
 } from "./lib/workflow-deployment";
 import { SecretsPanel } from "./components/SecretsPanel";
@@ -2694,15 +2697,7 @@ export const App = (): JSX.Element => {
             const deploymentState = workflow
               ? workflowDeploymentState(workflow, lastErr)
               : "draft";
-            harness.showToast(
-              deploymentState === "failed"
-                ? "Last deploy failed — retry Deploy."
-                : deploymentState === "building"
-                  ? "The cloud build is still in progress."
-                  : deploymentState === "linked"
-                    ? "No ready deployment yet — deploy it first."
-                    : "This agent isn't deployed yet — deploy it first.",
-            );
+            harness.showToast(prodRunBlockedToast(deploymentState));
           }
         } else if (direct === "run-local") {
           if (!workflow) {
@@ -3455,7 +3450,23 @@ export const App = (): JSX.Element => {
                     so the link/build state lives here in the tab bar. */}
                 {shownTab === "canvas" &&
                   !atMapAltitude &&
-                  rightPaneWorkflow?.definitionId != null && (
+                  rightPaneWorkflow?.definitionId != null &&
+                  rightPaneDeploymentState === "unavailable" && (
+                    /* Not a link: this account can't open that dashboard page. */
+                    <span
+                      className="status-tag right-pane-deployed"
+                      data-testid="agent-unavailable-tag"
+                      data-deployment-state="unavailable"
+                      data-tooltip={deploymentStateTitle("unavailable")}
+                    >
+                      <Icon name="CloudOff" size={12} />
+                      {deploymentStateLabel("unavailable")}
+                    </span>
+                  )}
+                {shownTab === "canvas" &&
+                  !atMapAltitude &&
+                  rightPaneWorkflow?.definitionId != null &&
+                  rightPaneDeploymentState !== "unavailable" && (
                     <a
                       className="status-tag status-tag-action workflow-deployed-tag right-pane-deployed"
                       data-testid="workflow-dashboard-link"
@@ -3469,13 +3480,9 @@ export const App = (): JSX.Element => {
                       data-tooltip="Open this agent in the Sapiom dashboard"
                     >
                       <Icon name="Cloud" size={12} />
-                      {rightPaneDeploymentState === "ready"
-                        ? "deployed"
-                        : rightPaneDeploymentState === "building"
-                          ? "building"
-                          : rightPaneDeploymentState === "failed"
-                            ? "deploy failed"
-                            : "linked"}
+                      {deploymentStateLabel(
+                        rightPaneDeploymentState ?? "linked",
+                      )}
                     </a>
                   )}
                 {/* Full view belongs to the graph surface currently shown:

--- a/packages/harness/web/src/components/CanvasPane.tsx
+++ b/packages/harness/web/src/components/CanvasPane.tsx
@@ -20,7 +20,11 @@ import { Icon } from "./Icon";
 import { WorkflowActionsHeader } from "./WorkflowActionsHeader";
 import { RunWorkspace } from "./RunWorkspace";
 import { SnippetPanel } from "./SnippetPanel";
-import { isWorkflowRunnable, workflowDeploymentState } from "../lib/workflow-deployment";
+import {
+  isWorkflowRunnable,
+  snippetsPendingSentence,
+  workflowDeploymentState,
+} from "../lib/workflow-deployment";
 import { track as trackProduct } from "../lib/analytics/events";
 import { trackingAttrs } from "../lib/analytics/tracking-attrs";
 
@@ -1020,13 +1024,9 @@ export function CanvasPane({
   const snippetsPendingReason =
     snippetSubject == null || snippetsRunnable
       ? null
-      : ((state) =>
-          state === "building"
-            ? `${snippetSubject.name} is linked and building. The snippets appear once the cloud build is ready.`
-            : state === "failed"
-              ? `The last deploy of ${snippetSubject.name} did not produce a ready build. Fix it and deploy again.`
-              : `${snippetSubject.name} is linked to Sapiom, but Studio cannot confirm a ready cloud build. Deploy it before integrating.`)(
+      : snippetsPendingSentence(
           workflowDeploymentState(snippetSubject, null),
+          snippetSubject.name,
         );
   // Keyed by path rather than a boolean, so the disclosure does not stay open
   // over the NEXT agent you select — that agent has different snippets, and a

--- a/packages/harness/web/src/lib/direct-action-gating.test.ts
+++ b/packages/harness/web/src/lib/direct-action-gating.test.ts
@@ -15,6 +15,7 @@ import type { MacroDef, WorkflowInfo } from "@shared/types";
 import { macroDisabledReason } from "./macro-gating";
 import {
   isWorkflowRunnable,
+  prodRunBlockedToast,
   prodRunDisabledReason,
   workflowDeploymentState,
 } from "./workflow-deployment";
@@ -211,13 +212,7 @@ describe("Fix 1 — blocked direct actions produce a specific toast reason", () 
       const state = workflow
         ? workflowDeploymentState(workflow, lastDeployError)
         : "draft";
-      return state === "failed"
-        ? "Last deploy failed — retry Deploy."
-        : state === "building"
-          ? "The cloud build is still in progress."
-          : state === "linked"
-            ? "No ready deployment yet — deploy it first."
-            : "This agent isn't deployed yet — deploy it first.";
+      return prodRunBlockedToast(state);
     }
     if (kind === "run-local") {
       return workflow ? null : "Select an agent first.";
@@ -270,6 +265,18 @@ describe("Fix 1 — blocked direct actions produce a specific toast reason", () 
     const wf = makeWorkflow({ definitionId: 42 });
     expect(directActionToastReason("prod-run", wf, null)).toBe(
       "No ready deployment yet — deploy it first.",
+    );
+  });
+
+  it("prod-run on a definition this account cannot see toasts 'not available', even with a remembered ready build", () => {
+    const wf = makeWorkflow({
+      definitionId: 42,
+      activeBuildRunId: "build-1",
+      activeBuildRunStatus: "ready",
+      definitionAccess: "unavailable",
+    });
+    expect(directActionToastReason("prod-run", wf, null)).toBe(
+      "This agent isn't available on the signed-in account.",
     );
   });
 

--- a/packages/harness/web/src/lib/workflow-deployment.test.ts
+++ b/packages/harness/web/src/lib/workflow-deployment.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import type { WorkflowInfo } from "@shared/types";
 
 import {
+  deploymentStateLabel,
+  deploymentStateTitle,
   isWorkflowRunnable,
+  prodRunBlockedToast,
+  snippetsPendingSentence,
   prodRunDisabledReason,
   workflowDeploymentState,
   workflowDeploymentIndicator,
@@ -53,6 +57,44 @@ describe("workflowDeploymentState", () => {
     },
   );
 
+  it("reports a definition the signed-in account cannot see as unavailable, not linked", () => {
+    const hidden = workflow({
+      definitionId: 42,
+      definitionAccess: "unavailable",
+    });
+    expect(workflowDeploymentState(hidden)).toBe("unavailable");
+    expect(isWorkflowRunnable(hidden)).toBe(false);
+    expect(prodRunDisabledReason(hidden)).toBe(
+      "Agent not available on this account",
+    );
+  });
+
+  it("lets unavailable outrank a build status the registry remembered for that definition", () => {
+    const stale = workflow({
+      definitionId: 42,
+      activeBuildRunId: "build-1",
+      activeBuildRunStatus: "ready",
+      definitionAccess: "unavailable",
+    });
+    expect(workflowDeploymentState(stale, "old error")).toBe("unavailable");
+    expect(isWorkflowRunnable(stale)).toBe(false);
+  });
+
+  it("keeps a visible definition on the build-status path", () => {
+    const visible = workflow({
+      definitionId: 42,
+      activeBuildRunStatus: "ready",
+      definitionAccess: "visible",
+    });
+    expect(workflowDeploymentState(visible)).toBe("ready");
+    expect(isWorkflowRunnable(visible)).toBe(true);
+    expect(
+      workflowDeploymentState(
+        workflow({ definitionId: 42, definitionAccess: "visible" }),
+      ),
+    ).toBe("linked");
+  });
+
   it("uses a local terminal error when cloud status is unavailable", () => {
     const linked = workflow({ definitionId: 42 });
     expect(workflowDeploymentState(linked, "build failed")).toBe("failed");
@@ -67,6 +109,42 @@ describe("workflowDeploymentState", () => {
     expect(workflowDeploymentState(ready, "old error")).toBe("ready");
     expect(isWorkflowRunnable(ready)).toBe(true);
     expect(prodRunDisabledReason(ready, "old error")).toBeNull();
+  });
+});
+
+describe("deploymentStateTitle", () => {
+  it("gives every state its own tooltip and names the account for unavailable", () => {
+    const states = [
+      "draft",
+      "linked",
+      "unavailable",
+      "building",
+      "ready",
+      "failed",
+    ] as const;
+    const titles = states.map((state) => deploymentStateTitle(state));
+    expect(new Set(titles).size).toBe(states.length);
+    expect(deploymentStateTitle("unavailable")).toContain("this account");
+  });
+});
+
+describe("deployment-state copy helpers", () => {
+  it("give unavailable its own account-scoped copy on every surface", () => {
+    expect(deploymentStateLabel("unavailable")).toBe("unavailable");
+    expect(prodRunBlockedToast("unavailable")).toBe(
+      "This agent isn't available on the signed-in account.",
+    );
+    expect(snippetsPendingSentence("unavailable", "billing")).toContain(
+      "this account can't see",
+    );
+  });
+
+  it("treat ready as deployed with nothing pending", () => {
+    expect(deploymentStateLabel("ready")).toBe("deployed");
+    expect(snippetsPendingSentence("ready", "billing")).toBeNull();
+    expect(prodRunBlockedToast("linked")).toBe(
+      "No ready deployment yet — deploy it first.",
+    );
   });
 });
 
@@ -96,7 +174,9 @@ it("retains display evidence through list failures but forgets it on auth change
     indicator: "deployed",
     unavailable: true,
   });
-  expect(workflowDeploymentTitle(retained)).toBe(workflowDeploymentTitle(ready));
+  expect(workflowDeploymentTitle(retained)).toBe(
+    workflowDeploymentTitle(ready),
+  );
   expect(retained.activeBuildRunId).toBeNull();
   expect(isWorkflowRunnable(retained)).toBe(false);
   expect(prodRunDisabledReason(retained)).not.toBeNull();

--- a/packages/harness/web/src/lib/workflow-deployment.ts
+++ b/packages/harness/web/src/lib/workflow-deployment.ts
@@ -12,18 +12,30 @@ export interface DeployableWorkflow {
   definitionId: number | null;
   activeBuildRunStatus?: string | null;
   deploymentLookup?: WorkflowInfo["deploymentLookup"];
+  /** Visibility per the server's tenant-scoped list. Absent = unknown, which
+   *  keeps every other state as before. */
+  definitionAccess?: "visible" | "unavailable";
 }
 
-/** The five states Studio can prove from local linkage plus cloud build data. */
+/** The six states Studio can prove from local linkage plus cloud build data. */
 export type WorkflowDeploymentState =
   | "draft"
   | "linked"
+  | "unavailable"
   | "building"
   | "ready"
   | "failed";
 
 const BUILDING_STATUSES = new Set(["pending", "queued", "building"]);
 const FAILED_STATUSES = new Set(["failed", "cancelled", "superseded", "stale"]);
+
+/** Linked to a definition this account can't see. Checked before any build
+ *  status: the registry may still hold a stale one. */
+function isUnavailable(workflow: DeployableWorkflow): boolean {
+  return (
+    workflow.definitionId != null && workflow.definitionAccess === "unavailable"
+  );
+}
 
 /**
  * Derive the user-facing cloud state without treating `definitionId` as proof
@@ -34,6 +46,7 @@ export function workflowDeploymentState(
   workflow: DeployableWorkflow,
   lastDeployError: string | null = null,
 ): WorkflowDeploymentState {
+  if (isUnavailable(workflow)) return "unavailable";
   if (workflow.activeBuildRunStatus === "ready") return "ready";
   if (
     workflow.activeBuildRunStatus != null &&
@@ -51,11 +64,88 @@ export function workflowDeploymentState(
   return workflow.definitionId == null ? "draft" : "linked";
 }
 
-/** Only the backend's ready build projection proves a production run can start. */
+/** Only a ready build on a definition this account can see is runnable. */
 export function isWorkflowRunnable(
   workflow: DeployableWorkflow | null,
 ): boolean {
-  return workflow?.activeBuildRunStatus === "ready";
+  return (
+    workflow != null &&
+    !isUnavailable(workflow) &&
+    workflow.activeBuildRunStatus === "ready"
+  );
+}
+
+/** Tooltip of the cloud glyph every agent row carries (rail, unrooted list). */
+export function deploymentStateTitle(state: WorkflowDeploymentState): string {
+  switch (state) {
+    case "ready":
+      return "Deployed to Sapiom with a ready build.";
+    case "building":
+      return "Cloud build in progress.";
+    case "failed":
+      return "Cloud build failed.";
+    case "unavailable":
+      return "Linked to an agent this account can't see: another account, or deleted.";
+    case "linked":
+      return "Linked to Sapiom; no ready build confirmed.";
+    case "draft":
+      return "Draft. Not deployed to Sapiom yet.";
+  }
+}
+
+/** Short label of the right-pane cloud pill. */
+export function deploymentStateLabel(state: WorkflowDeploymentState): string {
+  switch (state) {
+    case "ready":
+      return "deployed";
+    case "building":
+      return "building";
+    case "failed":
+      return "deploy failed";
+    case "unavailable":
+      return "unavailable";
+    case "linked":
+    case "draft":
+      return "linked";
+  }
+}
+
+/** Toast shown when a production run is refused. */
+export function prodRunBlockedToast(state: WorkflowDeploymentState): string {
+  switch (state) {
+    case "failed":
+      return "Last deploy failed — retry Deploy.";
+    case "building":
+      return "The cloud build is still in progress.";
+    case "unavailable":
+      return "This agent isn't available on the signed-in account.";
+    case "linked":
+      return "No ready deployment yet — deploy it first.";
+    case "draft":
+    case "ready":
+      // `ready` is runnable and never reaches the toast; kept for exhaustiveness.
+      return "This agent isn't deployed yet — deploy it first.";
+  }
+}
+
+/** Why the integration snippets are not available yet; null once they are. */
+export function snippetsPendingSentence(
+  state: WorkflowDeploymentState,
+  agentName: string,
+): string | null {
+  switch (state) {
+    case "ready":
+      return null;
+    case "building":
+      return `${agentName} is linked and building. The snippets appear once the cloud build is ready.`;
+    case "failed":
+      return `The last deploy of ${agentName} did not produce a ready build. Fix it and deploy again.`;
+    case "unavailable":
+      return `${agentName} is linked to an agent this account can't see. Sign in to the account that owns it.`;
+    case "linked":
+    case "draft":
+      return `${agentName} is linked to Sapiom, but Studio cannot confirm a ready cloud build. Deploy it before integrating.`;
+  }
 }
 
 /** Exact action-bar reason when Prod Run is blocked, or null when runnable. */
@@ -70,6 +160,8 @@ export function prodRunDisabledReason(
       return "Build in progress";
     case "failed":
       return "Last deploy failed — retry Deploy";
+    case "unavailable":
+      return "Agent not available on this account";
     case "linked":
       return "No ready deployment yet";
     case "draft":
@@ -84,6 +176,9 @@ export function workflowDeploymentIndicator(workflow: DeployableWorkflow): {
   indicator: "draft" | "deployed" | null;
   unavailable: boolean;
 } {
+  // Confirmed not visible to this account: a plain draft glyph, no outage flag.
+  if (isUnavailable(workflow))
+    return { indicator: "draft", unavailable: false };
   const lookup = workflow.deploymentLookup;
   const deployed = lookup
     ? lookup.lastConfirmedDeployed
@@ -99,23 +194,13 @@ export function workflowDeploymentIndicator(workflow: DeployableWorkflow): {
 }
 
 export function workflowDeploymentTitle(workflow: DeployableWorkflow): string {
+  if (isUnavailable(workflow)) return deploymentStateTitle("unavailable");
   const display = workflowDeploymentIndicator(workflow);
   if (display.indicator === null) return DEPLOYMENT_UNAVAILABLE;
   let state = workflowDeploymentState(workflow);
   if (display.unavailable)
     state = display.indicator === "deployed" ? "ready" : "draft";
-  switch (state) {
-    case "ready":
-      return "Deployed to Sapiom with a ready build.";
-    case "building":
-      return "Cloud build in progress.";
-    case "failed":
-      return "Cloud build failed.";
-    case "linked":
-      return "Linked to Sapiom; no ready build confirmed.";
-    case "draft":
-      return "Draft. Not deployed to Sapiom yet.";
-  }
+  return deploymentStateTitle(state);
 }
 
 export function unavailableWorkflowDeployment(


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Studio asked the Agents API for every linked definition by id (`GET /agents/v1/definitions/<id>`) on every `/api/state` and `/api/workflows` poll, with no idea whether the signed-in account could see it. The engine answers 404 for any id outside the caller's tenant, and a 404 is a permanent answer for that account, but null resolutions are deliberately never cached (so transient network failures stay retryable). So every project linked to an agent of another account, or to a deleted agent, 404'd on every poll, forever: about 978 x 404 in 20 minutes from one machine, which paged the on-call (SAP-3213). The UI gave no signal either: the row silently fell back to the project name.

## Summary and scope

`packages/harness` only. No gateway or engine change.

- `src/core/definition-slug-resolver.ts`: new `listVisible()` fetches the tenant-scoped `GET /agents/v1/definitions` once per enrichment pass. Single-flight keyed by the api-key value, so concurrent polls share one request and an account switch is a miss with no cache to invalidate. Rows seed the existing slug cache. Returns null when signed out or when the list is unavailable, with one log line per failure reason.
- `src/server/index.ts` (`enrichWorkflows`): intersects the markers' ids with the list. An absent id is never requested and its row is marked `definitionAccess: "unavailable"`. A visible id takes slug and build status from the list row; only a visible definition with no ready build yet gets a by-id detail lookup, because only the detail reports a first deploy's in-flight build (SAP-1574). Signed out or list unavailable: rows are returned unchanged, with no per-id fallback.
- `src/shared/types.ts`: `WorkflowInfo.definitionAccess?: "visible" | "unavailable"`, serve-time only, never persisted to `workflows.json`.
- Integrates with the display evidence from #876 (`deploymentLookup`): a ready list row sets the retained bit, an absent row confirms "not deployed for this account", a failed list keeps the last confirmed bit and clears the build fields, and a sign-out during the request yields nothing (`invalidate()` and the generation guards are kept).
- UI: new `unavailable` deployment state (rail glyph tooltip, right-pane cloud pill rendered as a plain tag rather than a dashboard link, Canvas badge, prod-run toast, snippets copy, Run gating with the reason "Agent not available on this account"). It is evaluated before any build status because the registry can persist a stale `activeBuildRunStatus` for a definition this account cannot see. The cloud-glyph tooltip is shared through `deploymentStateTitle()` by the rail rows and the unrooted agent rows.

Out of scope: recording the owning `tenantId` on the `sapiom.json` marker (the only way to tell "another account" from "deleted"), and a TTL on the list (single-flight only for now).

## Related work

Related issue or discussion: [SAP-3214](https://linear.app/sapiom/issue/SAP-3214), follow-up to SAP-3213 (monitoring side).

## Validation

```text
pnpm --filter @sapiom/harness typecheck: passed (server and web)
pnpm --filter @sapiom/harness lint: passed
pnpm --filter @sapiom/harness build: passed
pnpm --filter @sapiom/harness exec vitest run src/core/definition-slug-resolver.test.ts src/core/canvas-render.test.ts src/server/canvas-build-status-wiring.test.ts src/server/definition-list-enrichment.test.ts web/src/lib/workflow-deployment.test.ts web/src/lib/direct-action-gating.test.ts: 108/108 passed (includes the #876 evidence suites)
pnpm --filter @sapiom/harness exec vitest run: 35 failed / 3961 passed; the same 35 fail on origin/main 421439be (timing tests: watchers, registry, codex-rollout-broker, agent-map wiring), none unique to this branch
pnpm --filter @sapiom/harness test:ui workflow-deployment.spec.ts unrooted-agents.spec.ts agent-map-deployment.spec.ts direct-action-feedback.spec.ts: 31/31 passed
pnpm terminology:check: passed
pnpm provider-copy:check: passed
```

### Tests and documentation

- New `src/server/definition-list-enrichment.test.ts`: boots the real server against a fake Agents API that counts list and detail requests separately. Asserts 1 list and 0 detail requests per pass on `/api/state` and `/api/workflows`, an `unavailable` row for the foreign id, no per-id fallback when the list answers 500, exactly one detail request for a visible row with a null build status, and 0 requests after `POST /api/auth/disconnect`.
- `src/core/definition-slug-resolver.test.ts`: 9 tests for `listVisible()` (URL and header, string ids, signed-out, non-2xx logged once, network error, non-array body, rows without id, single-flight sharing, no sharing across an api-key change, slug cache seeding).
- `src/server/canvas-build-status-wiring.test.ts` now serves the list and asserts 1 list and 0 detail requests, then replays the #876 cases against the list: outage keeps the retained bit, an id missing from the list becomes `unavailable`, nothing persists to `workflows.json`, and a sign-out mid-request clears every row. `canvas-render.test.ts`, `workflow-deployment.test.ts` and `direct-action-gating.test.ts` cover the `unavailable` state, including over a remembered ready status.
- `deploymentStateTitle()` has a unit test in `workflow-deployment.test.ts`.
- Documentation: N/A, no user-facing docs describe the enrichment; the changeset carries the release note.

## Compatibility and release impact

- Breaking or externally visible changes: None. `definitionAccess` is optional and absent on older servers, in which case every UI state behaves as before. The `resolve()` and `resolveMetadata()` contracts are unchanged.
- Changeset: Added `.changeset/studio-tenant-scoped-definition-list.md` (`@sapiom/harness` minor: `WorkflowInfo` is re-exported from the package root, so the optional `definitionAccess` field widens the published types).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Claude Code (Claude Fable 5.1) implemented the change and its tests from the plan recorded on SAP-3214 and ran the gates listed above. Verified by reading the full diff, by the request-count assertions in the new server test, and by comparing the full vitest run against origin/main to confirm the remaining failures are pre-existing.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
