### PR TITLE
fix(harness): archive history before event retention

### DIFF
--- a/.changeset/archive-before-retention.md
+++ b/.changeset/archive-before-retention.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Archive historical conversations before event retention can remove their source events during startup.

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -2971,35 +2971,14 @@ export const startServer = async (
     };
   });
 
-  // Boot-time retention sweep: keeps events.ndjson within the 50 MB / 30-day
-  // caps even on long-lived installs. Runs through the store's exclusive queue
-  // so the sweep's read→filter→rename window never races a concurrent append.
-  // Fire-and-forget — a slow FS is no reason to delay server startup.
-  const runNdjsonSweep = (): void => {
-    void eventStore
-      .runExclusive(() => sweepNdjson(eventStorePath))
-      .catch((err: unknown) => {
-        console.error("[harness] events.ndjson retention sweep failed:", err);
-      });
-  };
-  runNdjsonSweep();
-  const ndjsonRetentionTimer = setInterval(
-    runNdjsonSweep,
-    NDJSON_RETENTION_SWEEP_MS,
-  );
-  ndjsonRetentionTimer.unref?.();
-
   // One boot-time pass that archives conversations the log still holds but the
   // archive doesn't, then sweeps the archive's own caps. This is what covers the
   // two cases archiving-at-exit can't: a harness that was force-killed (no exit
   // transition, no session.end), and every session that ended before this
   // existed — whose history would otherwise vanish at its 30-day mark.
   //
-  // It races the ndjson sweep queued above, and deliberately doesn't wait for
-  // it: reads run outside the store's exclusive queue by design (see store.ts),
-  // and either order is correct here — win the race and the record is archived
-  // from bytes retention was about to delete, lose it and the record is archived
-  // from what survived. Both beat not archiving it.
+  // Retention must wait for this pass: reads run outside the store's exclusive
+  // queue, so a sweep could otherwise delete old events before we archive them.
   //
   // Fire-and-forget: boot must not wait on it. The cost is one full index build
   // (~130 ms against a 50 MB log), which the first history open would have paid
@@ -3022,6 +3001,25 @@ export const startServer = async (
     .catch((err: unknown) => {
       console.error("[harness] session record backfill failed:", err);
     });
+
+  // Boot-time retention sweep: keeps events.ndjson within the 50 MB / 30-day
+  // caps even on long-lived installs. Runs through the store's exclusive queue
+  // so the sweep's read→filter→rename window never races a concurrent append.
+  // Wait for backfill before every sweep, including a timer tick during a slow
+  // boot pass. Server startup stays independent of both maintenance tasks.
+  const runNdjsonSweep = (): void => {
+    void recordBackfill
+      .then(() => eventStore.runExclusive(() => sweepNdjson(eventStorePath)))
+      .catch((err: unknown) => {
+        console.error("[harness] events.ndjson retention sweep failed:", err);
+      });
+  };
+  runNdjsonSweep();
+  const ndjsonRetentionTimer = setInterval(
+    runNdjsonSweep,
+    NDJSON_RETENTION_SWEEP_MS,
+  );
+  ndjsonRetentionTimer.unref?.();
 
   const harnessVersion = readVersion();
   const batcher = createHarnessEmitter({

--- a/packages/harness/src/server/record-archive-wiring.test.ts
+++ b/packages/harness/src/server/record-archive-wiring.test.ts
@@ -20,6 +20,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { startServer, type HarnessServer } from "./index.js";
+import * as recordArchive from "../core/record-archive.js";
+import * as retention from "../core/collector/store-retention.js";
 import type {
   AnalyticsEvent,
   HarnessAdapter,
@@ -79,6 +81,7 @@ describe("session record archive wiring", () => {
     await server?.close();
     await server?.sessionManager.flush();
     server = undefined;
+    vi.restoreAllMocks();
     await rm(dir, { recursive: true, force: true });
   });
 
@@ -232,11 +235,12 @@ describe("session record archive wiring", () => {
   it("archives conversations that ended before the archive existed", async () => {
     // An events file from an install that predates this feature: a complete
     // conversation, no archive, and no registry entry for it.
+    const expiredAt = Date.now() - retention.DEFAULT_MAX_AGE_MS - 60_000;
     const events: AnalyticsEvent[] = [
       {
         eventId: "evt-1",
         seq: 1,
-        ts: "2026-06-01T10:00:00.000Z",
+        ts: new Date(expiredAt).toISOString(),
         userId: null,
         tenantId: null,
         machineId: "machine-1",
@@ -249,7 +253,7 @@ describe("session record archive wiring", () => {
       {
         eventId: "evt-2",
         seq: 2,
-        ts: "2026-06-01T10:00:01.000Z",
+        ts: new Date(expiredAt + 1000).toISOString(),
         userId: null,
         tenantId: null,
         machineId: "machine-1",
@@ -262,14 +266,39 @@ describe("session record archive wiring", () => {
     ];
     await writeFile(eventStorePath, events.map((e) => `${JSON.stringify(e)}\n`).join(""), "utf8");
 
-    server = await boot();
+    // Hold the backfill to prove retention cannot delete its source events,
+    // even when startup finishes before the archive work does.
+    let releaseBackfill!: () => void;
+    const backfillGate = new Promise<void>((resolve) => { releaseBackfill = resolve; });
+    const backfill = recordArchive.backfillSessionRecords;
+    const backfillSpy = vi.spyOn(recordArchive, "backfillSessionRecords")
+      .mockImplementation(async (options) => {
+        await backfillGate;
+        return backfill(options);
+      });
+    const sweepSpy = vi.spyOn(retention, "sweepNdjson");
+    try {
+      server = await boot();
+      expect(backfillSpy).toHaveBeenCalledOnce();
+      expect(sweepSpy).not.toHaveBeenCalled();
+    } finally {
+      releaseBackfill();
+    }
 
     await vi.waitFor(
       async () => {
         const archived = await readArchived("sess-legacy");
         expect(archived?.turns[0].prompt).toBe("from before the archive existed");
+        expect(archived?.turns[0].assistantText).toBe("done");
       },
       { timeout: 10_000, interval: 100 },
     );
+    await vi.waitFor(async () => {
+      expect(await readFile(eventStorePath, "utf8")).not.toContain("sess-legacy");
+    });
+    const archived = await fetchRecord("agent-legacy");
+    expect(archived.status).toBe(200);
+    expect(archived.body?.turns[0].prompt).toBe("from before the archive existed");
+    expect(archived.body?.turns[0].assistantText).toBe("done");
   }, 20_000);
 });


### PR DESCRIPTION
## Problem and motivation

At startup, event retention could delete old conversations before archive backfill read them. This caused the archive test failure in #809 and could remove real session history.

## Summary and scope

Make retention wait for archive backfill. Startup still completes while maintenance runs. The regression holds backfill open, then verifies that the prompt and reply remain readable after retention removes their source events.

```mermaid
flowchart LR
    B[Before: backfill races retention] --> L[Old conversation can disappear]
    A[After: archive old conversations] --> S[Run retention]
```

| Changed area | Additions |
| --- | ---: |
| Startup ordering | 21 |
| Regression test | 32 |
| Changeset | 5 |
| **Total** | **58** |

## Related work

Prerequisite for #809. The race also exists on main; the harness-selection change did not introduce it.

## Validation

- 67 archive/retention tests passed. The controlled regression fails on unmodified main.
- Workspace build, typecheck, and lint passed.
- Full Harness: 3,902 passed, two failed. The Mac watcher failure reproduces on main; the session-manager timeout passes in isolation (183 tests). All 10 performance tests and other package suites passed.

<details>
<summary>Checklist and release details</summary>

## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

### Tests and documentation

Extended the existing archive wiring regression. README update: N/A; this restores archive behavior.

## Compatibility and release impact

- Legacy conversation events reach archive backfill before retention removes them. No migration required.
- Changeset: `@sapiom/harness` patch.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex investigated, implemented, and tested the change.

## Checklist

- [x] I read `CONTRIBUTING.md` and followed the contribution policy.
- [x] This pull request addresses one focused problem.
- [x] I added or updated tests.
- [x] I ran the required checks; the remaining failures are described above.
- [x] I updated documentation, or marked it N/A above.
- [x] I added a Changeset.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

</details>
