### PR TITLE
docs(mcp): re-sync offline primer to the served 2.12 body [SAP-3178]

### DIFF
--- a/.changeset/resync-offline-primer-2-12.md
+++ b/.changeset/resync-offline-primer-2-12.md
@@ -1,0 +1,9 @@
+---
+"@sapiom/mcp": patch
+---
+
+Re-sync the offline `AUTHORING_INSTRUCTIONS` fallback with the served 2.12 primer: the App Link
+management tools (`sapiom_dev_app_list` / `_settings` / `_delete`, `@sapiom/mcp` >= 0.15) are
+now taught inside the App Link webhook paragraph, whose "no `sapiom_dev_*` tool sets it yet"
+clause is retired, on top of the 2.11 additions (Vault semantics, `ctx.sapiom.agents.launch`,
+receipts and replay, App Link webhooks) that an offline session was not yet receiving.

--- a/packages/mcp/src/instructions.test.ts
+++ b/packages/mcp/src/instructions.test.ts
@@ -104,14 +104,13 @@ describe("server instructions", () => {
     expect(AUTHORING_INSTRUCTIONS).toContain("`@sapiom/mcp` >= 0.13");
   });
 
-  // SKIPPED, deliberately, for the same reason as the SAP-3180 block below: #816 moved this
-  // fallback to a body whose server-side release (sapiom/Sapiom#4886) has not merged. Sapiom
-  // `main` serves 2.10 (digest 47a4e3a3…). Un-skip when #4886 lands and this copy is re-synced.
-  it.skip("teaches App Link management from this server, version-gated (SAP-3178)", () => {
+  it("teaches App Link management from this server, version-gated (SAP-3178)", () => {
     // 2.8 taught publishing and nothing else about a link, so an offline session
     // could not learn that webhooks are off by default, how to turn them on, or
-    // that `/hook/*` is the receiver. The three management tools ship in 0.15;
-    // the gate is the same one `_publish` carries, for the same reason.
+    // that `/hook/*` is the receiver. The three management tools shipped in 0.15;
+    // the gate is the same one `_publish` carries, for the same reason. Served since
+    // the 2.12 release (sapiom/Sapiom#4886), which folded them into 2.11's webhook
+    // paragraph and retired its "no `sapiom_dev_*` tool sets it yet" clause.
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_app_list");
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_app_settings");
     expect(AUTHORING_INSTRUCTIONS).toContain("sapiom_dev_app_delete");
@@ -121,6 +120,9 @@ describe("server instructions", () => {
       "https://apps.sapiom.ai/{org}/{slug}/hook/<path>",
     );
     expect(AUTHORING_INSTRUCTIONS).toContain("settings need `org.write`");
+    expect(AUTHORING_INSTRUCTIONS).not.toContain(
+      "no `sapiom_dev_*` tool sets it yet",
+    );
   });
 
   it("names the entry step's inputSchema as the agent's public API (SAP-2227)", () => {
@@ -240,20 +242,21 @@ describe("server instructions", () => {
     // of PRs. Never re-point this digest on its own — that just re-blesses the
     // drift the guard exists to catch.
     //
-    // Current release: 2.10 (trigger kinds: `event` + `webhook`, webhook signing, `sapiom_dev_agents_schedule_secret`).
+    // Current release: 2.12 (App Link management tools folded into the webhook paragraph,
+    // SAP-3178) on top of 2.11 (Vault, `agents.launch`, receipts/replay, App Link webhooks,
+    // SAP-3180) and 2.10 (trigger kinds, SAP-3174). SAP-3179's alias wording is NOT in this
+    // body: its server-side release (sapiom/Sapiom#4884) is still open, so that block stays
+    // skipped until it lands and re-syncs this copy.
     const sha256 = createHash("sha256")
       .update(AUTHORING_INSTRUCTIONS, "utf8")
       .digest("hex");
     expect(sha256).toBe(
-      "47a4e3a355584f40345e4a6dc9d695663aa24fc613e93eaf4559465b02b8b457",
+      "ab310467f24b5b5fad94f030dfe9341544144a3c6842a25a1bfda13a5d008cba",
     );
   });
 
-  // SKIPPED, deliberately: #815 moved this fallback to a 2.9 body whose server-side release
-  // (sapiom/Sapiom#4885) has not merged — Sapiom `main` serves 2.10 (SAP-3174, digest
-  // 47a4e3a3…), which is what this copy tracks. Un-skip when #4885 lands (rebased onto 2.10 it
-  // becomes 2.11 and carries both sections) and this copy is re-synced to that body.
-  it.skip("teaches Vault semantics, agents.launch, receipts/replay, and App Link webhooks (SAP-3180)", () => {
+  it("teaches Vault semantics, agents.launch, receipts/replay, and App Link webhooks (SAP-3180)", () => {
+    // Served since 2.11 (sapiom/Sapiom#4885); this copy carries it from 2.12 on.
     // Each of these shipped without any served text teaching it, so an agent could only
     // guess at it. Byte-identical to the backend copy, so asserted here too.
     expect(AUTHORING_INSTRUCTIONS).toContain("ctx.sapiom.vault.get");

--- a/packages/mcp/src/instructions.ts
+++ b/packages/mcp/src/instructions.ts
@@ -74,6 +74,19 @@ and self-contained; republishing the same slug replaces the app in place at the 
 Org-scoped by default; \`public\` needs an explicit confirmation and a daily spend cap because
 your org pays for every wake. See https://docs.sapiom.ai/capabilities/app-links.
 
+An App Link can also receive webhooks. Webhooks are OFF by default on a link: turn on
+\`webhooksEnabled\` with \`sapiom_dev_app_settings\` and third parties POST to
+\`https://apps.sapiom.ai/{org}/{slug}/hook/<path>\`: the \`/hook\` prefix is stripped, the body is
+forwarded byte-exact so Slack/Stripe/GitHub signatures verify inside the app, and a request that
+arrives while the app sleeps is held up to 60 s (then 504 while the wake continues, so the
+sender's retry lands warm). Keep the receiver fast: dispatch real work with \`agents.launch\`
+(below) and return. \`_settings\` also sets visibility, dailySpendCapUsd and
+wakeRateLimitPerHour; \`sapiom_dev_app_list\` shows every link; \`sapiom_dev_app_delete\` removes
+one. All three need \`@sapiom/mcp\` >= 0.15 — on an older client use the dashboard App Links page
+or the REST routes: \`GET /v1/app-links\` to find the id, then \`PATCH\` / \`DELETE
+/v1/app-links/{id}\`. These settings need \`org.write\` — a credential without it gets the
+permission named in the tool's error; tell the user, do not retry.
+
 ## Triggers (run a deployed agent without a human)
 \`sapiom_dev_agents_schedule\` creates a trigger of one of four kinds on a deployed agent:
 \`schedule_cron\` (recurring), \`schedule_once\` (one future time), \`event\` (fires whenever this
@@ -108,6 +121,21 @@ https://docs.sapiom.ai/guides/triggers.
   don't memorize the catalog; use autocomplete/typecheck. Schedules (cron triggers) are
   a top-level \`@sapiom/tools\` import, not under \`ctx.sapiom\`.
 
+## Secrets, inbound events, receipts
+- **Secrets** set in the dashboard per deployed agent reach a step only as env vars
+  (\`process.env.SLACK_BOT_TOKEN\`); their Vault ref is derived server-side, so step code cannot
+  name it. \`ctx.sapiom.vault.get(ref, key)\` is for tenant secrets stored under your own ref
+  (e.g. \`vault.get("slack", "bot_token")\`) and returns \`null\` when absent — agent code cannot write
+  the Vault. Never route a Sapiom-managed resource's credentials (a repository, a sandbox, a
+  provisioned service) through Vault: use the handle the capability returned.
+- **Receipts and replay:** every inbound event or webhook leaves a receipt, matched or
+  unmatched, and a failed fire can be replayed by hand (never automatically). No tool yet —
+  use the REST surface: \`GET /v1/workflows/receipts?outcome=unmatched\`,
+  \`GET /v1/workflows/receipts/{id}\` (the chain it started),
+  \`POST /v1/workflows/receipts/{id}/replay\` (re-match an unmatched event against today's
+  triggers), \`POST /v1/workflows/fires/{id}/replay\` (re-drive a failed or stranded fire;
+  \`{"rerun":true}\` to repeat one that succeeded).
+
 ## Calling LLMs and running agent loops (from agent code)
 - **One LLM call → \`ctx.sapiom.llm.run\`** — summarize, extract, classify, one-shot generate.
   For a plain-text reply, read only \`type === 'text'\` content blocks (a \`thinking\` block
@@ -118,11 +146,13 @@ https://docs.sapiom.ai/guides/triggers.
   tool-calling task (minutes, not seconds). \`models.coding.run\` for sandboxed coding tasks.
   Never use this for a one-shot completion — it will loop and overthink.
 - **Dispatch a deployed agent by slug → \`ctx.sapiom.agents.run\`** — compose systems from
-  small deployed agents rather than one large monolith.
-- **You never pick a model.** Say how long you can wait (\`deadlineMinutes\` where supported)
-  — the platform picks the model. \`llm.run\`/\`models.run\` report the served class and lane
-  on the result (absent on older servers — treat missing as unknown); \`models.coding.run\`
-  reports both as \`null\` today.
+  small deployed agents rather than one large monolith. \`agents.run\` waits for the terminal
+  state; **\`ctx.sapiom.agents.launch\`** takes the same spec and returns a handle at once
+  (fire-and-forget). Use \`launch\` from anything that must return fast — a webhook receiver —
+  or with \`pauseUntilSignal(handle, …)\` for a long-running child.
+- **You never pick a model.** The platform picks it. \`llm.run\`/\`models.run\` report the
+  served class and lane on the result (absent on older servers — treat missing as unknown);
+  \`models.coding.run\` reports both as \`null\` today.
   **Omit \`model\` entirely (recommended)** — the platform routes it. Raw provider model ids
   are never honored.
 - **Debugging a run:** open the Run Inspector, or fetch a step's full input/output via


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [x] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

`@sapiom/mcp`'s offline `AUTHORING_INSTRUCTIONS` must be byte-identical to the primer the backend serves. `main` tracks the 2.10 body (after #817), while sapiom/Sapiom#4886 is the next content release: 2.12, which folds the App Link management tools (shipped in 0.15.0 by #816) into 2.11's webhook paragraph and carries SAP-3180's 2.11 additions. Without this, an offline session gets neither.

## Summary and scope

- `instructions.ts`: body copied verbatim from the 2.12 constant.
- `instructions.test.ts`: digest pin moved to `ab310467…`; the SAP-3178 and SAP-3180 blocks #817 parked are un-skipped (both are served text as of 2.11/2.12); the SAP-3178 block also asserts the retired "no `sapiom_dev_*` tool sets it yet" clause is gone. The SAP-3179 block stays skipped, with the reason updated: its server-side release (sapiom/Sapiom#4884) is still open, so that wording is not served.
- Patch changeset.

**Merge order:** after sapiom/Sapiom#4886, so the two digest pins agree at the moment both are on `main`.

## Related work

Related issue or discussion: https://linear.app/sapiom/issue/SAP-3178 — companion sapiom/Sapiom#4886 (2.12). Follows the #817 pattern for parked blocks.

## Validation

```text
npx vitest run src/instructions.test.ts (packages/mcp) — 10 passed, 1 skipped (SAP-3179, deliberate)
pnpm --filter @sapiom/mcp lint                      — clean
prettier --write on the three changed files         — clean
```

### Tests and documentation

Two previously skipped assertion blocks re-enabled; one new negative assertion. No code change.

## Compatibility and release impact

- Breaking or externally visible changes: None. Offline fallback text only.
- Changeset: Added (`@sapiom/mcp` patch).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Written with Claude Code in an AO-managed session; verified with the commands above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XN9b1ayG9LZRc31jQGZa7F
