### PR TITLE
feat(agent): add timeoutStep for in-workflow pause timeouts

### DIFF
--- a/.changeset/pause-timeout-step.md
+++ b/.changeset/pause-timeout-step.md
@@ -1,0 +1,10 @@
+---
+"@sapiom/agent": minor
+"@sapiom/agent-runtime": minor
+---
+
+feat: add `timeoutStep` for in-workflow pause timeouts
+
+A pause can now declare a `timeoutStep`: `pauseUntilSignal({ signal, resumeStep, timeoutMs, timeoutStep })` (with a matching `pause: { …, timeoutStep }` on the step). When `timeoutMs` elapses with no signal, the engine resumes the run at `timeoutStep` with a branded `PauseTimeoutPayload` as its input (narrow with `isPauseTimeout`) instead of failing the run — making the "wait for an event, otherwise proceed/escalate after N" pattern expressible in-workflow.
+
+Fully backward compatible: a pause with `timeoutMs` but no `timeoutStep` still fails with `PauseTimeoutError`, and the runtime store method that performs the resume (`resumeAtTimeoutStep`) is an optional capability — hosts that don't implement it fall back to the fail path.

--- a/packages/agent-runtime/src/execution-state.ts
+++ b/packages/agent-runtime/src/execution-state.ts
@@ -48,6 +48,12 @@ export interface ExecutionState {
   readonly pausedSignalName: string | null;
   readonly pausedSignalCorrelationId: string | null;
   readonly pausedUntil: Date | null;
+  /**
+   * The step to resume at if `pausedUntil` elapses with no signal, carried from
+   * the pause directive's `timeoutStep`. Null when the pause declared none, in
+   * which case a timeout fails the execution with `PauseTimeoutError`.
+   */
+  readonly pausedTimeoutStep: string | null;
   /** Non-null exactly while a step body is dispatched and in flight. */
   readonly dispatchedStepRowId: string | null;
   readonly dispatchDeadlineAt: Date | null;

--- a/packages/agent-runtime/src/in-memory-store.ts
+++ b/packages/agent-runtime/src/in-memory-store.ts
@@ -40,6 +40,7 @@ interface MutableExecution {
   pausedSignalName: string | null;
   pausedSignalCorrelationId: string | null;
   pausedUntil: Date | null;
+  pausedTimeoutStep: string | null;
   dispatchedStepRowId: string | null;
   dispatchDeadlineAt: Date | null;
   output: unknown;
@@ -91,6 +92,7 @@ function toReadonly(e: MutableExecution): ExecutionState {
     pausedSignalName: e.pausedSignalName,
     pausedSignalCorrelationId: e.pausedSignalCorrelationId,
     pausedUntil: e.pausedUntil,
+    pausedTimeoutStep: e.pausedTimeoutStep,
     dispatchedStepRowId: e.dispatchedStepRowId,
     dispatchDeadlineAt: e.dispatchDeadlineAt,
     output: e.output,
@@ -156,6 +158,7 @@ export class InMemoryExecutionStore implements ExecutionStore {
       pausedSignalName: null,
       pausedSignalCorrelationId: null,
       pausedUntil: null,
+      pausedTimeoutStep: null,
       dispatchedStepRowId: null,
       dispatchDeadlineAt: null,
       output: undefined,
@@ -185,6 +188,7 @@ export class InMemoryExecutionStore implements ExecutionStore {
     e.pausedSignalName = null;
     e.pausedSignalCorrelationId = null;
     e.pausedUntil = null;
+    e.pausedTimeoutStep = null;
     e.dispatchedStepRowId = null;
     e.dispatchDeadlineAt = null;
     e.error = null;
@@ -363,12 +367,37 @@ export class InMemoryExecutionStore implements ExecutionStore {
     e.pausedSignalName = args.directive.signal.name;
     e.pausedSignalCorrelationId = args.directive.signal.correlationId ?? null;
     e.pausedUntil = args.directive.timeoutMs ? new Date(Date.now() + args.directive.timeoutMs) : null;
+    e.pausedTimeoutStep = args.directive.timeoutStep ?? null;
     e.sharedState = args.sharedState;
     e.dispatchedStepRowId = null;
     e.dispatchDeadlineAt = null;
     if (args.directive.resumeStep) {
       e.currentStep = args.directive.resumeStep;
     }
+    e.version += 1;
+    return true;
+  }
+
+  async resumeAtTimeoutStep(args: {
+    executionId: string;
+    expectedVersion: number;
+    timeoutStep: string;
+    timeoutStepInput: unknown;
+    sharedState: Record<string, unknown>;
+  }): Promise<boolean> {
+    const e = this.executions.get(args.executionId);
+    if (!e || e.version !== args.expectedVersion) return false;
+    e.status = EXECUTION_STATUS.RUNNING;
+    e.currentStep = args.timeoutStep;
+    e.currentStepInput = args.timeoutStepInput;
+    e.currentStepAttempt = 0;
+    e.sharedState = args.sharedState;
+    e.pausedSignalName = null;
+    e.pausedSignalCorrelationId = null;
+    e.pausedUntil = null;
+    e.pausedTimeoutStep = null;
+    e.dispatchedStepRowId = null;
+    e.dispatchDeadlineAt = null;
     e.version += 1;
     return true;
   }

--- a/packages/agent-runtime/src/runner-core.spec.ts
+++ b/packages/agent-runtime/src/runner-core.spec.ts
@@ -12,6 +12,7 @@ import {
   CtxSharedSizeLimitExceededError,
   CtxSharedSerializationError,
   DIRECTIVE_KIND,
+  isPauseTimeout,
   MAX_SHARED_SNAPSHOT_BYTES,
   StepInputValidationError,
 } from '@sapiom/agent';
@@ -613,6 +614,119 @@ describe('AgentRunnerCore', () => {
     it('resetForResume on a non-existent execution throws', async () => {
       const { core } = setupCore();
       await expect(core.resetForResume('does-not-exist')).rejects.toThrow('Execution not found');
+    });
+  });
+
+  // ── pause timeout: resume at timeoutStep vs. fail ──────────────────────────
+
+  describe('pause timeout', () => {
+    /** A pause manifest whose `wait` step optionally declares a `timeoutStep`. */
+    function timeoutManifest(withTimeoutStep: boolean): AgentManifest {
+      return makeManifest({
+        entry: 'wait',
+        steps: {
+          wait: {
+            timeoutMs: null,
+            inputSchema: null,
+            transitions: [
+              {
+                kind: 'pause',
+                signal: 'thing.done',
+                resumeStep: 'proceed',
+                ...(withTimeoutStep ? { timeoutStep: 'escalate' } : {}),
+              },
+            ],
+          },
+          proceed: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'terminate' }] },
+          escalate: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'terminate' }] },
+        } as unknown as AgentManifest['steps'],
+      });
+    }
+
+    /** Advance `wait` to a PAUSED state whose deadline has already elapsed. */
+    async function pauseThenElapse(
+      core: AgentRunnerCore,
+      store: InMemoryExecutionStore,
+      dispatcher: SyncInProcessDispatcher,
+      manifest: AgentManifest,
+      timeoutStep?: string,
+    ): Promise<string> {
+      dispatcher.setSyncBody('wait', async () => ({
+        output: {},
+        directive: {
+          kind: DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL,
+          signal: { name: 'thing.done', correlationId: 'c-1' },
+          resumeStep: 'proceed',
+          timeoutMs: 1,
+          ...(timeoutStep ? { timeoutStep } : {}),
+        },
+      }));
+      const executionId = await core.createExecution('test-workflow', 'wait', {}, { manifest });
+      await core.advance(executionId);
+      expect(store.getExecution(executionId)?.status).toBe(EXECUTION_STATUS.PAUSED);
+      // Let the 1ms deadline pass.
+      await new Promise((r) => setTimeout(r, 5));
+      return executionId;
+    }
+
+    it('resumes at timeoutStep with a branded timeout payload instead of failing', async () => {
+      const manifest = timeoutManifest(true);
+      const { store, dispatcher, core } = setupCore();
+      let received: unknown;
+      dispatcher.setSyncBody('escalate', async (input) => {
+        received = input;
+        return { output: { escalated: true }, directive: { kind: DIRECTIVE_KIND.TERMINATE } };
+      });
+
+      const executionId = await pauseThenElapse(core, store, dispatcher, manifest, 'escalate');
+      const result = await core.expirePausedExecution(executionId);
+
+      // Resumed (RUNNING), not failed.
+      expect(result?.kind).toBe(ADVANCE_RESULT_KIND.RUNNING);
+      const resumed = store.getExecution(executionId);
+      expect(resumed?.status).toBe(EXECUTION_STATUS.RUNNING);
+      expect(resumed?.currentStep).toBe('escalate');
+      expect(resumed?.pausedTimeoutStep).toBeNull();
+      // The timeoutStep gets a branded, distinguishable payload as its input.
+      expect(isPauseTimeout(resumed?.currentStepInput)).toBe(true);
+
+      // And it advances to completion, seeing the timeout payload.
+      await core.advance(executionId);
+      expect(store.getExecution(executionId)?.status).toBe(EXECUTION_STATUS.COMPLETED);
+      expect(isPauseTimeout(received)).toBe(true);
+      if (isPauseTimeout(received)) {
+        expect(received.signal).toBe('thing.done');
+      }
+    });
+
+    it('fails with PauseTimeoutError when no timeoutStep is declared', async () => {
+      const manifest = timeoutManifest(false);
+      const { store, dispatcher, core } = setupCore();
+      const executionId = await pauseThenElapse(core, store, dispatcher, manifest);
+
+      const result = await core.expirePausedExecution(executionId);
+      expect(result?.kind).toBe(ADVANCE_RESULT_KIND.FAILED);
+      if (result?.kind === ADVANCE_RESULT_KIND.FAILED) {
+        expect((result.error as Error).name).toBe('PauseTimeoutError');
+      }
+      expect(store.getExecution(executionId)?.status).toBe(EXECUTION_STATUS.FAILED);
+    });
+
+    it('falls back to failing when the store lacks the resume capability', async () => {
+      // A store without resumeAtTimeoutStep — an external store on an older
+      // minor version. A declared timeoutStep must still degrade to the fail path.
+      const store = new InMemoryExecutionStore();
+      (store as { resumeAtTimeoutStep?: unknown }).resumeAtTimeoutStep = undefined;
+      const dispatcher = new SyncInProcessDispatcher();
+      const core = new AgentRunnerCore({ store, dispatcher });
+      dispatcher.setCore(core);
+
+      const manifest = timeoutManifest(true);
+      const executionId = await pauseThenElapse(core, store, dispatcher, manifest, 'escalate');
+
+      const result = await core.expirePausedExecution(executionId);
+      expect(result?.kind).toBe(ADVANCE_RESULT_KIND.FAILED);
+      expect(store.getExecution(executionId)?.status).toBe(EXECUTION_STATUS.FAILED);
     });
   });
 

--- a/packages/agent-runtime/src/runner-core.ts
+++ b/packages/agent-runtime/src/runner-core.ts
@@ -18,7 +18,12 @@ import {
   isTerminate,
   parseNonRetryableStepErrorPayload,
 } from '@sapiom/agent';
-import type { NextStepDirective, AgentManifest, NonRetryableStepErrorPayload } from '@sapiom/agent';
+import type {
+  NextStepDirective,
+  AgentManifest,
+  NonRetryableStepErrorPayload,
+  PauseTimeoutPayload,
+} from '@sapiom/agent';
 
 import { ADVANCE_RESULT_KIND } from './advance-result.js';
 import type { AdvanceResult, CompleteDispatchOutcome, CreateExecutionOptions } from './advance-result.js';
@@ -407,14 +412,53 @@ export class AgentRunnerCore {
   }
 
   /**
-   * Finalize a paused execution whose `paused_until` elapsed with no signal.
-   * Called by the sweep processor; null on benign races.
+   * Handle a paused execution whose `paused_until` elapsed with no signal.
+   *
+   * Two outcomes, decided by whether the pause declared a `timeoutStep`:
+   *   - `timeoutStep` declared (and the store supports the resume capability):
+   *     resume the run there with a branded `PauseTimeoutPayload` as input, so
+   *     the workflow can branch on the timeout instead of dying. Returns a
+   *     RUNNING result for the caller to advance.
+   *   - Otherwise: finalize the execution as failed with `PauseTimeoutError`
+   *     (the original behavior).
+   *
+   * Called by the sweep processor; null on benign races (CAS lost to a signal
+   * that resumed the same execution first).
    */
   async expirePausedExecution(executionId: string): Promise<AdvanceResult | null> {
     const row = await this.deps.store.loadExecution(executionId);
     if (!row || row.status !== EXECUTION_STATUS.PAUSED || !row.pausedUntil || row.pausedUntil.getTime() > Date.now()) {
       return null;
     }
+
+    // In-workflow timeout path: resume at the declared timeoutStep (when the
+    // store implements the capability and the target step exists) rather than
+    // failing the run.
+    const timeoutStep = row.pausedTimeoutStep;
+    if (timeoutStep && this.deps.store.resumeAtTimeoutStep && row.manifest.steps[timeoutStep]) {
+      const payload: PauseTimeoutPayload = {
+        __sapiomPauseTimeout: true,
+        signal: row.pausedSignalName ?? '',
+        pausedUntilMs: row.pausedUntil.getTime(),
+      };
+      const won = await this.deps.store.resumeAtTimeoutStep({
+        executionId,
+        expectedVersion: row.version,
+        timeoutStep,
+        timeoutStepInput: payload,
+        sharedState: row.sharedState ?? {},
+      });
+      if (!won) {
+        this.recordCasLoss('pause_timeout_resume', executionId, row.version);
+        return null;
+      }
+      this.obs.count({
+        name: 'workflow.pause.timeout_resumed',
+        attributes: { 'workflow.name': row.name },
+      });
+      return { kind: ADVANCE_RESULT_KIND.RUNNING };
+    }
+
     const err = new PauseTimeoutError(row.pausedSignalName ?? '(unknown signal)', row.pausedUntil);
     const won = await this.deps.store.failExecution({
       executionId,

--- a/packages/agent-runtime/src/stores.ts
+++ b/packages/agent-runtime/src/stores.ts
@@ -100,6 +100,24 @@ export interface ExecutionStore {
     directive: PauseUntilSignalDirective;
     sharedState: Record<string, unknown>;
   }): Promise<boolean>;
+
+  /**
+   * Optional capability: resume a paused execution at its declared
+   * `timeoutStep` when the pause's `timeoutMs` elapsed with no signal, instead
+   * of failing it. Transitions paused→running, points `currentStep` at
+   * `timeoutStep` with `timeoutStepInput` (a branded `PauseTimeoutPayload`), and
+   * clears the pause markers — all under one CAS so it loses cleanly to a signal
+   * that arrives at the same instant. Hosts that don't implement it fall back to
+   * the `PauseTimeoutError` fail path, preserving prior behavior for external
+   * stores across a minor-version upgrade.
+   */
+  resumeAtTimeoutStep?(args: {
+    executionId: string;
+    expectedVersion: number;
+    timeoutStep: string;
+    timeoutStepInput: unknown;
+    sharedState: Record<string, unknown>;
+  }): Promise<boolean>;
   completeExecution(args: {
     executionId: string;
     expectedVersion: number;

--- a/packages/agent-runtime/src/validate-directive.spec.ts
+++ b/packages/agent-runtime/src/validate-directive.spec.ts
@@ -1,4 +1,12 @@
-import { DisallowedTransitionError, UnknownStepError, type AgentManifest, goto, retry, terminate } from '@sapiom/agent';
+import {
+  DisallowedTransitionError,
+  UnknownStepError,
+  type AgentManifest,
+  goto,
+  pauseUntilSignal,
+  retry,
+  terminate,
+} from '@sapiom/agent';
 
 import { decideRetry, validateDirective } from './validate-directive.js';
 
@@ -55,6 +63,36 @@ describe('validateDirective', () => {
       a: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'continue', target: 'a' }] },
     } as unknown as Steps);
     expect(validateDirective(m, 'a', retry())).toBeNull();
+  });
+
+  it('allows a pause whose timeoutStep matches the declared transition', () => {
+    const m = manifest({
+      a: {
+        timeoutMs: null,
+        inputSchema: null,
+        transitions: [{ kind: 'pause', signal: 's', resumeStep: 'b', timeoutStep: 'c' }],
+      },
+      b: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'terminate' }] },
+      c: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'terminate' }] },
+    } as unknown as Steps);
+    expect(
+      validateDirective(m, 'a', pauseUntilSignal({ signal: 's', resumeStep: 'b', timeoutStep: 'c' })),
+    ).toBeNull();
+  });
+
+  it('rejects a pause whose timeoutStep does not match the declared transition', () => {
+    const m = manifest({
+      a: {
+        timeoutMs: null,
+        inputSchema: null,
+        transitions: [{ kind: 'pause', signal: 's', resumeStep: 'b', timeoutStep: 'c' }],
+      },
+      b: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'terminate' }] },
+      c: { timeoutMs: null, inputSchema: null, transitions: [{ kind: 'terminate' }] },
+    } as unknown as Steps);
+    expect(
+      validateDirective(m, 'a', pauseUntilSignal({ signal: 's', resumeStep: 'b', timeoutStep: 'b' })),
+    ).toBeInstanceOf(DisallowedTransitionError);
   });
 
   it('legacy manifest (no transitions) falls back to continue-target existence', () => {

--- a/packages/agent-runtime/src/validate-directive.ts
+++ b/packages/agent-runtime/src/validate-directive.ts
@@ -58,10 +58,15 @@ export function validateDirective(
   if (isPause(directive)) {
     const signalName = directive.signal.name;
     const resume = directive.resumeStep;
+    const timeout = directive.timeoutStep;
     const declared = transitions.some(
-      (t) => t.kind === 'pause' && t.signal === signalName && (resume === undefined || t.resumeStep === resume),
+      (t) =>
+        t.kind === 'pause' &&
+        t.signal === signalName &&
+        (resume === undefined || t.resumeStep === resume) &&
+        (timeout === undefined || t.timeoutStep === timeout),
     );
-    return declared ? null : new DisallowedTransitionError(stepName, 'pause', resume);
+    return declared ? null : new DisallowedTransitionError(stepName, 'pause', resume ?? timeout);
   }
   return null;
 }

--- a/packages/agent/src/build-manifest.ts
+++ b/packages/agent/src/build-manifest.ts
@@ -82,6 +82,9 @@ function transitionsFor(step: StepDefinition): ManifestTransition[] {
       kind: "pause",
       signal: step.pause.signal,
       resumeStep: step.pause.resumeStep,
+      ...(step.pause.timeoutStep !== undefined
+        ? { timeoutStep: step.pause.timeoutStep }
+        : {}),
     });
   }
   if (step.terminal) transitions.push({ kind: "terminate" });
@@ -109,7 +112,8 @@ export interface GraphValidation {
  * Warnings (best-effort):
  *   - steps unreachable from entry;
  *   - steps that cannot reach any `terminate`/`fail` (possible unbounded loop
- *     or a missing terminal). A `pause` counts as a forward edge via resumeStep.
+ *     or a missing terminal). A `pause` counts as forward edges via its
+ *     resumeStep and (if declared) timeoutStep.
  */
 export function validateGraph(manifest: AgentManifest): GraphValidation {
   const errors: string[] = [];
@@ -150,7 +154,8 @@ export function assertValidGraph(manifest: AgentManifest): string[] {
 }
 
 /**
- * Build the forward adjacency map (continue targets + pause resumeStep). Pushes
+ * Build the forward adjacency map (continue targets + pause resumeStep +
+ * pause timeoutStep). Pushes
  * a continue-target-missing error per unknown target and a dead-end error for a
  * step that declares no transitions at all.
  */
@@ -175,6 +180,13 @@ function buildForwardEdges(
           errors.push(
             `step '${name}' has a pause resumeStep '${t.resumeStep}' that is not in the steps map`,
           );
+        if (t.timeoutStep !== undefined) {
+          if (names.has(t.timeoutStep)) targets.add(t.timeoutStep);
+          else
+            errors.push(
+              `step '${name}' has a pause timeoutStep '${t.timeoutStep}' that is not in the steps map`,
+            );
+        }
       }
     }
     if (step.transitions.length === 0) {

--- a/packages/agent/src/directives.ts
+++ b/packages/agent/src/directives.ts
@@ -73,9 +73,45 @@ export interface PauseUntilSignalDirective {
     readonly name: string;
     readonly correlationId?: string;
   };
+  /**
+   * Wall-clock deadline (ms) for the wait. When it elapses before the signal
+   * arrives, the engine either resumes at `timeoutStep` (if declared) or, with
+   * no `timeoutStep`, fails the execution with `PauseTimeoutError`.
+   */
   readonly timeoutMs?: number;
   /** Step to run when the signal arrives. Defaults to the paused step. */
   readonly resumeStep?: string;
+  /**
+   * Step to run when `timeoutMs` elapses with no signal, instead of failing the
+   * run. It receives a branded {@link PauseTimeoutPayload} as its input (narrow
+   * with {@link isPauseTimeout}), so the workflow can branch on the timeout —
+   * "wait for an event, otherwise proceed / escalate after N". Requires a
+   * matching `pause: { …, timeoutStep }` declaration on the step. When omitted,
+   * a `timeoutMs` timeout is a hard failure (`PauseTimeoutError`).
+   */
+  readonly timeoutStep?: string;
+}
+
+/**
+ * The input handed to a `timeoutStep` when a pause's `timeoutMs` elapses with no
+ * signal. Branded with `__sapiomPauseTimeout` so a resumed step can distinguish
+ * a timeout from a real signal payload; narrow with {@link isPauseTimeout}.
+ */
+export interface PauseTimeoutPayload {
+  readonly __sapiomPauseTimeout: true;
+  /** The signal name the pause was waiting on. */
+  readonly signal: string;
+  /** The elapsed deadline (epoch ms) — when the wait was scheduled to expire. */
+  readonly pausedUntilMs: number;
+}
+
+/** True if `input` is the branded timeout payload a `timeoutStep` receives. */
+export function isPauseTimeout(input: unknown): input is PauseTimeoutPayload {
+  return (
+    typeof input === 'object' &&
+    input !== null &&
+    (input as { __sapiomPauseTimeout?: unknown }).__sapiomPauseTimeout === true
+  );
 }
 
 /** Finalize the workflow as completed. `output` (already on the StepResult) is the workflow's final output. */
@@ -190,6 +226,8 @@ export interface Pause<Resume extends string> {
   readonly signal: { readonly name: string; readonly correlationId?: string };
   readonly resumeStep?: Resume;
   readonly timeoutMs?: number;
+  /** Step to run when `timeoutMs` elapses with no signal (see {@link PauseUntilSignalDirective.timeoutStep}). */
+  readonly timeoutStep?: string;
   /** Optional audit output recorded for the pausing step. */
   readonly output?: unknown;
 }
@@ -243,18 +281,19 @@ export function pauseUntilSignal<const Resume extends string>(args: {
   resumeStep?: Resume;
   correlationId?: string;
   timeoutMs?: number;
+  timeoutStep?: string;
   output?: unknown;
 }): Pause<Resume>;
 export function pauseUntilSignal<const Resume extends string>(
   handle: DispatchHandle | Promise<DispatchHandle>,
-  opts?: { resumeStep?: Resume; timeoutMs?: number; output?: unknown },
+  opts?: { resumeStep?: Resume; timeoutMs?: number; timeoutStep?: string; output?: unknown },
 ): Promise<Pause<Resume>>;
 export function pauseUntilSignal<const Resume extends string>(
   argOrHandle:
-    | { signal: string; resumeStep?: Resume; correlationId?: string; timeoutMs?: number; output?: unknown }
+    | { signal: string; resumeStep?: Resume; correlationId?: string; timeoutMs?: number; timeoutStep?: string; output?: unknown }
     | DispatchHandle
     | Promise<DispatchHandle>,
-  opts?: { resumeStep?: Resume; timeoutMs?: number; output?: unknown },
+  opts?: { resumeStep?: Resume; timeoutMs?: number; timeoutStep?: string; output?: unknown },
 ): Pause<Resume> | Promise<Pause<Resume>> {
   // The launch promise — await it, then build from the resolved handle.
   if (isThenable(argOrHandle)) {
@@ -270,6 +309,7 @@ export function pauseUntilSignal<const Resume extends string>(
     signal: { name: argOrHandle.signal, correlationId: argOrHandle.correlationId },
     resumeStep: argOrHandle.resumeStep,
     timeoutMs: argOrHandle.timeoutMs,
+    timeoutStep: argOrHandle.timeoutStep,
     output: argOrHandle.output,
   };
 }
@@ -280,13 +320,14 @@ function isThenable(x: unknown): x is Promise<DispatchHandle> {
 
 function pauseFromHandle<Resume extends string>(
   handle: DispatchHandle,
-  opts: { resumeStep?: Resume; timeoutMs?: number; output?: unknown } | undefined,
+  opts: { resumeStep?: Resume; timeoutMs?: number; timeoutStep?: string; output?: unknown } | undefined,
 ): Pause<Resume> {
   return {
     kind: DIRECTIVE_KIND.PAUSE_UNTIL_SIGNAL,
     signal: { name: handle.dispatch.resultSignal, correlationId: handle.dispatch.correlationId },
     resumeStep: opts?.resumeStep,
     timeoutMs: opts?.timeoutMs,
+    timeoutStep: opts?.timeoutStep,
     output: opts?.output,
   };
 }

--- a/packages/agent/src/graph.spec.ts
+++ b/packages/agent/src/graph.spec.ts
@@ -144,6 +144,76 @@ describe('validateGraph', () => {
     expect(warnings).toEqual([]);
   });
 
+  it('treats a pause timeoutStep as a forward edge (no unreachable warning)', () => {
+    const def = defineAgent({
+      name: 'wait-or-escalate',
+      entry: 'await',
+      steps: {
+        await: defineStep({
+          name: 'await',
+          next: ['proceed'],
+          pause: { signal: 'thing.done', resumeStep: 'proceed', timeoutStep: 'escalate' },
+          async run() {
+            return pauseUntilSignal({
+              signal: 'thing.done',
+              resumeStep: 'proceed',
+              timeoutMs: 5000,
+              timeoutStep: 'escalate',
+            });
+          },
+        }),
+        proceed: defineStep({
+          name: 'proceed',
+          next: [],
+          terminal: true,
+          async run() {
+            return terminate(null);
+          },
+        }),
+        escalate: defineStep({
+          name: 'escalate',
+          next: [],
+          terminal: true,
+          async run() {
+            return terminate(null);
+          },
+        }),
+      },
+    });
+    const manifest = manifestOf(def);
+    // The pause transition carries the timeoutStep…
+    const awaitStep = manifest.steps.await;
+    expect(awaitStep.transitions).toContainEqual({
+      kind: 'pause',
+      signal: 'thing.done',
+      resumeStep: 'proceed',
+      timeoutStep: 'escalate',
+    });
+    // …and `escalate` is reachable through it (no unreachable warning).
+    const { errors, warnings } = validateGraph(manifest);
+    expect(errors).toEqual([]);
+    expect(warnings.some((w) => w.includes("'escalate'"))).toBe(false);
+  });
+
+  it('errors on a pause timeoutStep that does not exist', () => {
+    const manifest = {
+      protocol: 1 as const,
+      name: 'bad-timeout',
+      entry: 'a',
+      sdkVersion: '0.1.0',
+      artifact: ARTIFACT,
+      steps: {
+        a: {
+          timeoutMs: null,
+          inputSchema: null,
+          transitions: [{ kind: 'pause' as const, signal: 's', resumeStep: 'a', timeoutStep: 'ghost' }],
+        },
+      },
+    };
+    const { errors } = validateGraph(manifest);
+    expect(errors.some((e) => e.includes('timeoutStep') && e.includes("'ghost'"))).toBe(true);
+  });
+
   it('assertValidGraph throws on errors and returns warnings otherwise', () => {
     const bad = {
       protocol: 1 as const,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -11,13 +11,14 @@
  */
 
 // Directives — the load-bearing protocol contract
-export { DIRECTIVE_KIND, isContinue, isRetry, isPause, isTerminate, isFail } from './directives.js';
+export { DIRECTIVE_KIND, isContinue, isRetry, isPause, isTerminate, isFail, isPauseTimeout } from './directives.js';
 export type {
   DirectiveKind,
   NextStepDirective,
   ContinueDirective,
   RetryDirective,
   PauseUntilSignalDirective,
+  PauseTimeoutPayload,
   TerminateDirective,
   FailDirective,
 } from './directives.js';

--- a/packages/agent/src/manifest.spec.ts
+++ b/packages/agent/src/manifest.spec.ts
@@ -143,6 +143,49 @@ describe("agentManifestSchema", () => {
     expect(() => agentManifestSchema.parse(bad)).toThrow();
   });
 
+  it("round-trips a pause transition's optional timeoutStep", () => {
+    const manifest = {
+      protocol: 1,
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
+      steps: {
+        a: {
+          timeoutMs: null,
+          inputSchema: null,
+          transitions: [{ kind: "pause", signal: "s", resumeStep: "a", timeoutStep: "b" }],
+        },
+        b: { timeoutMs: null, inputSchema: null, transitions: [{ kind: "terminate" }] },
+      },
+    };
+    const parsed = agentManifestSchema.parse(manifest);
+    expect(parsed.steps.a.transitions[0]).toEqual({
+      kind: "pause",
+      signal: "s",
+      resumeStep: "a",
+      timeoutStep: "b",
+    });
+  });
+
+  it("accepts a pause transition without timeoutStep (back-compat)", () => {
+    const manifest = {
+      protocol: 1,
+      name: "wf",
+      entry: "a",
+      sdkVersion: "0.1.0",
+      artifact: { sha256: "x", entryFile: "f.mjs" },
+      steps: {
+        a: {
+          timeoutMs: null,
+          inputSchema: null,
+          transitions: [{ kind: "pause", signal: "s", resumeStep: "a" }],
+        },
+      },
+    };
+    expect(() => agentManifestSchema.parse(manifest)).not.toThrow();
+  });
+
   it("accepts null timeoutMs (engine default)", () => {
     const good = {
       protocol: 1,

--- a/packages/agent/src/manifest.ts
+++ b/packages/agent/src/manifest.ts
@@ -19,7 +19,14 @@ export type ManifestTransition =
   | { readonly kind: 'continue'; readonly target: string }
   | { readonly kind: 'terminate' }
   | { readonly kind: 'fail' }
-  | { readonly kind: 'pause'; readonly signal: string; readonly resumeStep: string };
+  | {
+      readonly kind: 'pause';
+      readonly signal: string;
+      readonly resumeStep: string;
+      /** Step routed to if the pause's `timeoutMs` elapses with no signal; a
+       *  forward edge. Optional for back-compat with manifests built before it. */
+      readonly timeoutStep?: string;
+    };
 
 /**
  * Per-step metadata emitted by the build phase and consumed by the engine.
@@ -87,7 +94,12 @@ const manifestTransitionSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('continue'), target: z.string().min(1) }),
   z.object({ kind: z.literal('terminate') }),
   z.object({ kind: z.literal('fail') }),
-  z.object({ kind: z.literal('pause'), signal: z.string().min(1), resumeStep: z.string().min(1) }),
+  z.object({
+    kind: z.literal('pause'),
+    signal: z.string().min(1),
+    resumeStep: z.string().min(1),
+    timeoutStep: z.string().min(1).optional(),
+  }),
 ]);
 
 const workflowStepManifestSchema = z.object({

--- a/packages/agent/src/sdk.spec.ts
+++ b/packages/agent/src/sdk.spec.ts
@@ -27,6 +27,7 @@ import {
   isContinue,
   isFail,
   isPause,
+  isPauseTimeout,
   isRetry,
   isTerminate,
   isAgentDefinition,
@@ -446,6 +447,20 @@ describe('directive guards', () => {
       expect(d.signal.correlationId).toBe('run-1');
       expect(d.resumeStep).toBe('finalize');
     }
+  });
+
+  it('isPauseTimeout narrows only the branded timeout payload', () => {
+    const timeoutPayload = { __sapiomPauseTimeout: true as const, signal: 'thing.done', pausedUntilMs: 123 };
+    expect(isPauseTimeout(timeoutPayload)).toBe(true);
+    if (isPauseTimeout(timeoutPayload)) {
+      expect(timeoutPayload.signal).toBe('thing.done');
+      expect(timeoutPayload.pausedUntilMs).toBe(123);
+    }
+    // A real signal payload (no brand) is not a timeout.
+    expect(isPauseTimeout({ signal: 'thing.done', result: 'ok' })).toBe(false);
+    expect(isPauseTimeout({ __sapiomPauseTimeout: false })).toBe(false);
+    expect(isPauseTimeout(null)).toBe(false);
+    expect(isPauseTimeout('timeout')).toBe(false);
   });
 });
 

--- a/packages/agent/src/step.ts
+++ b/packages/agent/src/step.ts
@@ -77,8 +77,12 @@ export interface StepDefinition<TShared extends Record<string, unknown> = Record
   readonly terminal: boolean;
   /** May `fail`. */
   readonly canFail: boolean;
-  /** Declared pause edge, if any. */
-  readonly pause?: { readonly signal: string; readonly resumeStep: string };
+  /**
+   * Declared pause edge, if any. `timeoutStep`, when present, is the step the
+   * engine routes to if the pause's `timeoutMs` elapses with no signal (instead
+   * of failing the run); it receives a branded `PauseTimeoutPayload`.
+   */
+  readonly pause?: { readonly signal: string; readonly resumeStep: string; readonly timeoutStep?: string };
   readonly inputSchema?: ZodType<unknown>;
   readonly timeoutMs?: number;
   /** Human-authored one-liner for the canvas step inspector (Option A —
@@ -110,7 +114,7 @@ export function defineStep<
   // Capture the whole pause object as a `const` type param (not a nested
   // property of a fixed-shape param) so its `resumeStep` literal is preserved —
   // a nested `resumeStep: PauseTo` widens to `string` and defeats enforcement.
-  const PauseDecl extends { signal: string; resumeStep: string } | undefined = undefined,
+  const PauseDecl extends { signal: string; resumeStep: string; timeoutStep?: string } | undefined = undefined,
 >(def: {
   name: string;
   next?: Next;

--- a/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
@@ -115,7 +115,7 @@ Export exactly one `defineAgent(...)` from `index.ts`.
 | `next`            | `readonly string[]`      | yes      | Step names this step may `goto`. Empty array if terminal                                                                                                                        |
 | `terminal`        | `boolean`                | no       | `true` if this step ends the agent's execution                                                                                                                                  |
 | `canFail`         | `boolean`                | no       | Must be `true` to return `fail()`                                                                                                                                               |
-| `pause`           | `{ signal, resumeStep }` | no       | Required when returning `pauseUntilSignal(...)`                                                                                                                                 |
+| `pause`           | `{ signal, resumeStep, timeoutStep? }` | no       | Required when returning `pauseUntilSignal(...)`. Optional `timeoutStep` routes a timed-out pause to a step instead of failing — see [Timing out a pause](#timing-out-a-pause)                                             |
 | `inputSchema`     | `ZodType`                | no       | Zod schema validating this step's input. On the **entry** step it is the agent's public API (see [The Entry Input Contract](#the-entry-input-contract--your-agents-public-api)) |
 | `timeoutMs`       | `number`                 | no       | Per-attempt step timeout; the engine separately caps attempts (three by default)                                                                                                |
 | `run(input, ctx)` | `async function`         | yes      | Returns a directive                                                                                                                                                             |
@@ -600,6 +600,56 @@ return pauseUntilSignal({
 Under `run_local`, a dispatch pause auto-resumes with the stub result; a manual gate
 auto-resumes with `{}`. There is no manual-signal payload override in the local runner, so
 type the resumed step's input with optional fields accordingly.
+
+### Timing out a pause
+
+Add `timeoutMs` to bound the wait. What happens when it elapses depends on whether you also
+declare a `timeoutStep`:
+
+- **`timeoutMs` alone → the run fails** with `PauseTimeoutError`. Use this only when a missed
+  deadline is genuinely terminal.
+- **`timeoutMs` + `timeoutStep` → the run resumes at `timeoutStep`** instead of failing, so the
+  workflow can branch on the timeout — the "wait for the event, otherwise proceed / escalate
+  after N" pattern (close bidding after 48h _or_ 3 bids; advance to the next vendor if no confirm
+  within 2h; escalate an unanswered request after 3 days).
+
+`timeoutStep` must be declared on the step's `pause: { …, timeoutStep }` (a graph edge, like
+`resumeStep`), and it is a **separate step with its own `inputSchema`**. It receives a branded
+`PauseTimeoutPayload` — narrow it with `isPauseTimeout` — distinct from the signal payload a
+normal resume delivers, so the two never have to share one schema.
+
+```typescript
+import { defineStep, goto, pauseUntilSignal, isPauseTimeout } from "@sapiom/agent";
+
+const wait = defineStep({
+  name: "wait",
+  next: [],
+  pause: { signal: "vendor.confirmed", resumeStep: "ship", timeoutStep: "next_vendor" },
+  async run(_input, ctx) {
+    return pauseUntilSignal({
+      signal: "vendor.confirmed",
+      resumeStep: "ship",
+      timeoutMs: 2 * 60 * 60 * 1000, // 2h
+      timeoutStep: "next_vendor",
+      correlationId: ctx.executionId,
+    });
+  },
+});
+
+const nextVendor = defineStep({
+  name: "next_vendor",
+  next: ["ship"],
+  async run(input) {
+    if (isPauseTimeout(input)) {
+      // no confirmation within 2h — fall through to the next vendor
+    }
+    return goto("ship");
+  },
+});
+```
+
+Note: `run_local` auto-resumes pauses, so a `timeoutStep` does not fire under the local runner —
+exercise the timeout branch with a direct unit test of the step body instead.
 
 ## Determinism
 


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

When a step returns `pauseUntilSignal({ signal, resumeStep, timeoutMs })` and the
timeout elapses before the signal arrives, the runtime raises `PauseTimeoutError`
and marks the execution **failed**. There is no way to handle the timeout inside
the workflow, so the common "wait for an external event, otherwise proceed after
N" pattern (close bidding after 48h *or* 3 bids; advance to vendor #2 if no
confirm within 2h; escalate after 3 days) cannot be expressed in-workflow — the
only workaround is to move the timer out to an external system that synthesizes
the signal, which defeats the point of durable in-workflow waits.

This addresses issue #156.

## Summary and scope

Adds an optional `timeoutStep` to the pause declaration. When a pause's
`timeoutMs` elapses with no signal, the engine resumes the run at `timeoutStep`
with a branded `PauseTimeoutPayload` (`{ __sapiomPauseTimeout: true, signal,
pausedUntilMs }`, narrow with the new `isPauseTimeout` guard) as its input,
instead of failing the run. `timeoutStep` is a separate step with its own input
schema, so the timeout payload never has to union with the signal payload.

`@sapiom/agent` (authoring + manifest):
- `pauseUntilSignal(...)`, the `Pause`/`PauseUntilSignalDirective` types, and the
  `defineStep` `pause` declaration all carry `timeoutStep`.
- New `PauseTimeoutPayload` type + `isPauseTimeout` guard, exported from the
  package root.
- The manifest `pause` transition (type + Zod schema) carries an optional
  `timeoutStep`; `buildManifest` emits it and `validateGraph` treats it as a
  forward edge (erroring on an unknown target, mirroring `resumeStep`).

`@sapiom/agent-runtime` (execution):
- `ExecutionState`/store carry `pausedTimeoutStep`; `pauseExecution` stamps it and
  the resume path clears it.
- `expirePausedExecution` branches: resume at `timeoutStep` (RUNNING) when
  declared and supported, otherwise fail with `PauseTimeoutError` as before.
- The resume is performed by a new **optional** store capability
  `resumeAtTimeoutStep` (CAS-guarded so it loses cleanly to a signal arriving at
  the same instant); hosts that don't implement it fall back to the fail path.
- `validateDirective` requires a directive's `timeoutStep` to match the declared
  pause transition.

Out of scope (intentionally): the server engine (`apps/workflows-engine`, a
separate repository) still needs a `paused_timeout_step` column migration, a
`resumeAtTimeoutStep` implementation on its SQL store, and its sweep processor
must re-advance the new RUNNING result — until that lands the feature is active
in the local runner only. Compile-time enforcement of `timeoutStep` at the
`run()` return type (an extra generic) was also deferred in favor of build-time
graph validation.

## Related work

Related issue or discussion: #156

## Validation

```text
pnpm --filter @sapiom/agent build          — ok
pnpm --filter @sapiom/agent test            — 180 passed, 10 suites
pnpm --filter @sapiom/agent typecheck       — ok (tsc --noEmit)
pnpm --filter @sapiom/agent lint            — ok (eslint, no findings)
pnpm --filter @sapiom/agent-runtime build   — ok
pnpm --filter @sapiom/agent-runtime test    — 51 passed, 4 suites
pnpm --filter @sapiom/agent-runtime typecheck — ok (tsc --noEmit)
pnpm --filter @sapiom/agent-runtime lint    — ok (eslint, no findings)
pnpm --filter @sapiom/agent-core typecheck  — ok (downstream consumer, unaffected)
pnpm terminology:check                      — passed (973 files)
pnpm provider-copy:check                    — passed (123 files)
```

### Tests and documentation

Tests added: `@sapiom/agent` — graph forward-edge + unknown-`timeoutStep` error,
manifest schema round-trip (with/without `timeoutStep`), and the `isPauseTimeout`
guard (+5). `@sapiom/agent-runtime` — resume-at-`timeoutStep` with branded payload
through to completion, the no-`timeoutStep` `PauseTimeoutError` regression guard,
the store-without-capability fail fallback, and two `validateDirective`
`timeoutStep` match/mismatch cases (+5). Documentation: a new "Timing out a pause"
section in the agent-authoring skill
(`plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md`) covering `timeoutStep`,
the branded `PauseTimeoutPayload` / `isPauseTimeout`, and the `timeoutMs`-alone
hard-failure caveat; plus JSDoc on `pauseUntilSignal`, the directive/step types, and
`expirePausedExecution`.

## Compatibility and release impact

- Breaking or externally visible changes: None. `timeoutStep` is optional
  everywhere; a pause with `timeoutMs` and no `timeoutStep` keeps failing with
  `PauseTimeoutError`. The manifest schema change is additive/optional, and
  `resumeAtTimeoutStep` is an optional store capability, so external stores keep
  working across the minor upgrade.
- Changeset: Added (`.changeset/pause-timeout-step.md`, minor for `@sapiom/agent`
  and `@sapiom/agent-runtime`).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Authored with Claude Code (Opus 4.8). It diagnosed issue #156 against the current
runtime, drafted the `timeoutStep` design, and implemented the changes and tests
across `@sapiom/agent` and `@sapiom/agent-runtime`. Verified by running the builds,
typecheck, lint, unit tests, and the terminology/provider-copy gates listed under
Validation, and by reviewing each diff for correctness and backward compatibility.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
