### PR TITLE
fix(examples): add local mock server for the x402 demo examples

### DIFF
--- a/examples/.env.example
+++ b/examples/.env.example
@@ -8,4 +8,8 @@ ANTHROPIC_API_KEY=sk-ant-your-anthropic-key-here
 # OPENAI_API_KEY=sk-your-openai-key-here
 
 # Test Server URL (for axios/fetch/node-http examples)
-DUMMY_SERVER_URL=https://x402-demo.sapiom.ai
+# Defaults to the local mock server — run it with:
+#   cd examples/mock-server && npm install && npm start
+# The original hosted demo (https://x402-demo.sapiom.ai) may be unavailable;
+# see https://github.com/sapiom/sapiom-js/issues/88
+DUMMY_SERVER_URL=http://localhost:3101

--- a/examples/README.md
+++ b/examples/README.md
@@ -35,14 +35,25 @@ Edit `.env` and fill in your keys:
 SAPIOM_API_KEY=your-key-from-step-1
 SAPIOM_API_URL=https://api.sapiom.ai
 
-# For axios/fetch/node-http examples:
-DUMMY_SERVER_URL=https://x402-demo.sapiom.ai
+# For axios/fetch/node-http examples (defaults to the local mock server):
+DUMMY_SERVER_URL=http://localhost:3101
 
 # For langchain examples only:
 ANTHROPIC_API_KEY=sk-ant-your-key
 ```
 
-> **Note:** The `DUMMY_SERVER_URL` points to a public demo server that simulates paid API endpoints. The default URL in `.env.example` is ready to use.
+> **Note:** The `axios`/`fetch`/`node-http` examples send their HTTP requests to
+> `DUMMY_SERVER_URL`. The default is the bundled **local mock server** — start it
+> in a separate terminal before running those examples:
+>
+> ```bash
+> cd mock-server && npm install && npm start   # http://localhost:3101
+> ```
+>
+> The original hosted demo, `https://x402-demo.sapiom.ai`, may be unavailable
+> (see [issue #88](https://github.com/sapiom/sapiom-js/issues/88)); the local
+> mock server replaces it. See [`mock-server/README.md`](./mock-server/README.md)
+> for the endpoints and an optional real-x402 (`402`) mode.
 
 ### 3. Run an example
 
@@ -148,7 +159,13 @@ The Sapiom SDK handles all authorization and payment automatically - your code j
 - Make sure you copied `.env.example` to `.env` and filled in your API key
 
 **Connection refused / timeout**
-- Check that `DUMMY_SERVER_URL` is correct and the test server is running
+- Check that `DUMMY_SERVER_URL` is correct and the test server is running. With
+  the default (`http://localhost:3101`), start the bundled mock server first:
+  `cd mock-server && npm install && npm start`.
+
+**`403` from `https://x402-demo.sapiom.ai`**
+- The hosted demo may be unavailable ([issue #88](https://github.com/sapiom/sapiom-js/issues/88)).
+  Use the local mock server (the default `DUMMY_SERVER_URL`) instead.
 
 **AuthorizationDeniedError on first request**
 - Check your Rules in the dashboard - you may have a restrictive policy

--- a/examples/mock-server/README.md
+++ b/examples/mock-server/README.md
@@ -1,0 +1,48 @@
+# Mock x402 demo server
+
+A tiny local stand-in for the hosted demo at `https://x402-demo.sapiom.ai`, which
+has been returning `403` (see [issue #88](https://github.com/sapiom/sapiom-js/issues/88)).
+It serves the endpoints the `axios`, `fetch`, and `node-http` examples call, with
+realistic stub JSON, using only Node's built-in `http` module (no dependencies).
+
+## Run it
+
+```bash
+cd examples/mock-server
+npm install
+npm start          # listens on http://localhost:3101
+```
+
+Then, in another terminal, point an example at it (this is the default in
+`examples/.env.example`):
+
+```bash
+DUMMY_SERVER_URL=http://localhost:3101
+```
+
+## Endpoints
+
+| Endpoint | Auth | Payment | Description |
+| --- | --- | --- | --- |
+| `GET /api/public/time` | No | No | Current server time |
+| `GET /api/public/status` | No | No | Server health check |
+| `GET /api/crm/customers` | Yes | No | Customer list (`?limit`, `?segment`) |
+| `POST /api/sms` | No | $0.0075 | Send an SMS message |
+| `POST /api/campaigns/analytics` | Yes | $0.05 | Campaign analytics |
+
+The two `/api/public/*` endpoints need no Sapiom account at all. The CRM and paid
+endpoints are still gated by the Sapiom **authorization** layer in the SDK, which
+talks to `SAPIOM_API_URL` — that's separate from this server and unchanged by it.
+
+## x402 payment challenge mode
+
+By default the paid endpoints return `200` directly, so the examples "just work"
+offline. To exercise the real x402 flow, start the server with:
+
+```bash
+MOCK_X402=1 npm start
+```
+
+Paid endpoints then respond with an x402 `402` payment challenge (matching
+`X402ResponseV2`) until the SDK retries with a payment header. Completing that
+flow requires a funded Sapiom account.

--- a/examples/mock-server/index.ts
+++ b/examples/mock-server/index.ts
@@ -1,0 +1,181 @@
+/**
+ * Local mock server for the HTTP SDK examples (axios / fetch / node-http).
+ *
+ * Stands in for the hosted demo at https://x402-demo.sapiom.ai, which has been
+ * returning 403 (see https://github.com/sapiom/sapiom-js/issues/88). It serves
+ * the endpoints those examples call — the free `/api/public/*` and CRM routes,
+ * plus the paid `/api/sms` and `/api/campaigns/analytics` routes — with
+ * realistic stub JSON, using only Node's built-in `http` module (no deps).
+ *
+ * Run: `npm start` (listens on http://localhost:3101). Point the examples at it
+ * with `DUMMY_SERVER_URL=http://localhost:3101` (now the default in
+ * `.env.example`).
+ *
+ * By default the paid endpoints return `200` directly so the examples "just
+ * work" offline. Set `MOCK_X402=1` to have them instead emit a real x402 `402`
+ * payment challenge until the SDK retries with a payment header — the faithful
+ * flow, which completes only against a funded Sapiom account.
+ */
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+
+const PORT = Number(process.env.PORT) || 3101;
+const X402_ENABLED = process.env.MOCK_X402 === "1" || process.env.MOCK_X402 === "true";
+const STARTED_AT = Date.now();
+
+/** Customers returned by /api/crm/customers, filterable by segment. */
+const CUSTOMERS = [
+  { id: "cus_001", name: "Acme Corp", email: "ops@acme.example", phone: "+15550100101", segment: "enterprise", revenue: 1_250_000 },
+  { id: "cus_002", name: "Globex", email: "hello@globex.example", phone: "+15550100102", segment: "enterprise", revenue: 980_000 },
+  { id: "cus_003", name: "Initech", email: "team@initech.example", phone: "+15550100103", segment: "enterprise", revenue: 640_000 },
+  { id: "cus_004", name: "Umbrella LLC", email: "contact@umbrella.example", phone: "+15550100104", segment: "midmarket", revenue: 210_000 },
+  { id: "cus_005", name: "Hooli", email: "info@hooli.example", phone: "+15550100105", segment: "smb", revenue: 48_000 },
+];
+
+/** Per-endpoint price, mirrored from the README endpoint table (USD). */
+const PRICES: Record<string, number> = {
+  "/api/sms": 0.0075,
+  "/api/campaigns/analytics": 0.05,
+};
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body, null, 2);
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(payload);
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  if (chunks.length === 0) return {};
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+/** True if the request already carries a payment header (x402 V2 or V1). */
+function hasPaymentHeader(req: IncomingMessage): boolean {
+  return Boolean(req.headers["payment-signature"] || req.headers["x-payment"]);
+}
+
+/**
+ * An x402 V2 payment-required response body, matching X402ResponseV2 from
+ * `@sapiom/core`. `amount` is in USDC atomic units (6 decimals) — illustrative.
+ */
+function x402Challenge(path: string, resourceUrl: string): unknown {
+  const usd = PRICES[path] ?? 0;
+  const atomic = Math.round(usd * 1_000_000).toString();
+  return {
+    x402Version: 2,
+    error: "payment required",
+    resource: {
+      url: resourceUrl,
+      description: `Mock paid endpoint ${path}`,
+      mimeType: "application/json",
+    },
+    accepts: [
+      {
+        scheme: "exact",
+        network: "sapiom:main",
+        amount: atomic,
+        payTo: "0x0000000000000000000000000000000000000000",
+        maxTimeoutSeconds: 60,
+        asset: "USDC",
+        extra: {},
+      },
+    ],
+  };
+}
+
+/** Paid endpoints: gate on a payment header only when MOCK_X402 is enabled. */
+function paymentGate(req: IncomingMessage, res: ServerResponse, path: string): boolean {
+  if (!X402_ENABLED || hasPaymentHeader(req)) return true;
+  sendJson(res, 402, x402Challenge(path, `http://localhost:${PORT}${path}`));
+  return false;
+}
+
+const server = createServer((req, res) => {
+  void handle(req, res).catch((err) => {
+    sendJson(res, 500, { error: "internal", detail: String(err) });
+  });
+});
+
+async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const method = req.method ?? "GET";
+  const url = new URL(req.url ?? "/", `http://localhost:${PORT}`);
+  const path = url.pathname;
+
+  // Root: a small info blob so the base URL isn't a bare 404.
+  if (method === "GET" && path === "/") {
+    sendJson(res, 200, {
+      name: "sapiom mock x402 demo server",
+      x402Mode: X402_ENABLED ? "on (paid endpoints emit 402 until paid)" : "off (paid endpoints return 200)",
+      endpoints: [
+        "GET /api/public/time",
+        "GET /api/public/status",
+        "GET /api/crm/customers",
+        "POST /api/sms",
+        "POST /api/campaigns/analytics",
+      ],
+    });
+    return;
+  }
+
+  if (method === "GET" && path === "/api/public/time") {
+    sendJson(res, 200, { time: new Date().toISOString(), timezone: "UTC" });
+    return;
+  }
+
+  if (method === "GET" && path === "/api/public/status") {
+    sendJson(res, 200, {
+      status: "ok",
+      version: "1.0.0",
+      uptime: (Date.now() - STARTED_AT) / 1000,
+    });
+    return;
+  }
+
+  if (method === "GET" && path === "/api/crm/customers") {
+    const segment = url.searchParams.get("segment");
+    const limit = Number(url.searchParams.get("limit")) || CUSTOMERS.length;
+    const customers = CUSTOMERS.filter((c) => !segment || c.segment === segment).slice(0, limit);
+    sendJson(res, 200, { customers });
+    return;
+  }
+
+  if (method === "POST" && path === "/api/sms") {
+    if (!paymentGate(req, res, path)) return;
+    const body = await readJsonBody(req);
+    sendJson(res, 200, {
+      messageId: `sms_${Math.random().toString(36).slice(2, 10)}`,
+      status: "sent",
+      price: PRICES[path],
+      to: body.phone ?? null,
+      campaignId: body.campaignId ?? null,
+    });
+    return;
+  }
+
+  if (method === "POST" && path === "/api/campaigns/analytics") {
+    if (!paymentGate(req, res, path)) return;
+    const body = await readJsonBody(req);
+    const sent = 3;
+    const delivered = 3;
+    sendJson(res, 200, {
+      name: (body.campaignId as string) ?? "campaign",
+      status: "completed",
+      price: PRICES[path],
+      metrics: { sent, delivered, openRate: 42.5 },
+    });
+    return;
+  }
+
+  sendJson(res, 404, { error: "not found", method, path });
+}
+
+server.listen(PORT, () => {
+  console.log(`Mock x402 demo server listening on http://localhost:${PORT}`);
+  console.log(`  x402 payment challenge mode: ${X402_ENABLED ? "ON (MOCK_X402)" : "off"}`);
+  console.log("  Point the examples at it with DUMMY_SERVER_URL=http://localhost:" + PORT);
+});

--- a/examples/mock-server/package-lock.json
+++ b/examples/mock-server/package-lock.json
@@ -1,0 +1,566 @@
+{
+  "name": "@sapiom/example-mock-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@sapiom/example-mock-server",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@types/node": "^20.11.30",
+        "tsx": "^4.7.0",
+        "typescript": "^5.4.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/mock-server/package.json
+++ b/examples/mock-server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@sapiom/example-mock-server",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Local mock of the x402 demo server for the axios/fetch/node-http examples",
+  "scripts": {
+    "start": "npx tsx index.ts",
+    "typecheck": "npx tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.2"
+  }
+}

--- a/examples/mock-server/tsconfig.json
+++ b/examples/mock-server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["index.ts"]
+}


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The `axios`, `fetch`, and `node-http` examples send their HTTP requests to
`DUMMY_SERVER_URL`, which `.env.example` and the README default to
`https://x402-demo.sapiom.ai`. That hosted demo now returns **403** for every
path (a Cloudflare WAF block, confirmed on the no-auth public endpoints too), so
running any of the three examples fails immediately with
`✗ Failed: Request failed with status code 403`. Diagnosis in #88. There is no
bundled server to fall back to, so the examples cannot be run at all today.

## Summary and scope

Adds a minimal local mock server and makes it the default target, so the HTTP
examples work out of the box without depending on the hosted demo.

- **`examples/mock-server/`** — a new private example package implementing the
  endpoints the three examples call, with realistic stub JSON, using only Node's
  built-in `http` module (no runtime dependencies):
  `GET /api/public/time`, `GET /api/public/status`,
  `GET /api/crm/customers` (`?limit`, `?segment`), `POST /api/sms`,
  `POST /api/campaigns/analytics`, plus a `/` info route and a `404` fallback.
  Run with `npm start` (listens on `http://localhost:3101`, `PORT`-overridable).
- **x402 mode toggle** — paid endpoints return `200` directly by default so the
  examples "just work" offline; `MOCK_X402=1` makes them emit a real x402 `402`
  payment challenge (matching `X402ResponseV2` from `@sapiom/core`) until the SDK
  retries with a payment header (`PAYMENT-SIGNATURE` / `X-PAYMENT`).
- **`examples/.env.example`** — default `DUMMY_SERVER_URL=http://localhost:3101`,
  with a comment that the hosted demo may be unavailable (links #88).
- **`examples/README.md`** — makes running the local mock server the primary path,
  documents the hosted demo as a fallback, and updates Troubleshooting.

Out of scope: the CRM and paid endpoints are still gated by the SDK's Sapiom
**authorization** layer (`SAPIOM_API_URL`), which is separate from
`DUMMY_SERVER_URL` and unchanged here — the two `/api/public/*` endpoints work
with no Sapiom backend, the rest additionally need a Sapiom API as before. Also
out of scope: restoring the hosted `x402-demo.sapiom.ai` server (infra, owned
elsewhere).

## Related work

Related issue or discussion: #88

## Validation

```text
cd examples/mock-server && npm install                 — ok (0 vulnerabilities)
cd examples/mock-server && npm run typecheck           — ok (tsc --noEmit)
run server (default) + curl all endpoints              — GET /, time, status, crm → 200; POST sms, analytics → 200 with expected JSON
run server (MOCK_X402=1) + curl paid endpoints         — no payment header → 402 x402 challenge; PAYMENT-SIGNATURE header → 200; public endpoints still 200
pnpm examples:check                                    — OK (registry valid, terminology-checked)
pnpm terminology:check                                 — passed (972 files)
pnpm provider-copy:check                               — passed (122 files)
```

### Tests and documentation

Tests: N/A — the examples are runnable demos with no unit-test harness; validated
by starting the server and curling every endpoint in both default and `MOCK_X402`
modes (results above). Documentation: added `examples/mock-server/README.md`
(endpoints + x402 mode) and updated `examples/README.md` and
`examples/.env.example` to default to and document the local mock server.

## Compatibility and release impact

- Breaking or externally visible changes: The default `DUMMY_SERVER_URL` in the
  example env/README changes from `https://x402-demo.sapiom.ai` to
  `http://localhost:3101`. This only affects the example projects (not any
  published package); it is documented, and the hosted URL still works as an
  opt-in override if/when it is restored.
- Changeset: N/A — all touched packages are private, non-published example
  projects (`@sapiom/example-*`); nothing in a released package changed.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Authored with Claude Code (Opus 4.8). It diagnosed #88 (Cloudflare 403 on the
hosted demo), traced exactly which endpoints and response shapes the three
examples consume and the x402 V2 challenge/header contract from `@sapiom/core`
and `@sapiom/axios`, then wrote the mock server and the env/README updates.
Verified by running the server and curling every endpoint in both modes and by
running `examples:check` / `terminology:check` / `provider-copy:check`.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
