### PR TITLE
feat(studio): refresh internal Assistant access in the host [SAP-3288]

### DIFF
--- a/.changeset/retain-assistant-access.md
+++ b/.changeset/retain-assistant-access.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Retain unchanged verified Assistant access through bounded transient outages while revoking principal crossovers and exposing an opaque browser authority barrier for draft isolation.

--- a/.changeset/studio-assistant-access.md
+++ b/.changeset/studio-assistant-access.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": minor
+---
+
+Resolve and refresh internal Assistant access using trusted Studio user credentials.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -46,7 +46,15 @@ The Studio host refreshes the internal Assistant capability at most every 30
 seconds and expires an enabled decision within 60 seconds. Missing identity,
 offline startup, unsupported backends, and unavailable flags leave it off.
 These access checks are independent of optional telemetry and never prevent
-ordinary Terminal startup. Only the resolved boolean is exposed to the browser.
+ordinary Terminal startup. The browser receives only the resolved boolean and a
+random, process-memory `authorityRevision`; it never receives principal fields,
+credentials, identity hashes, or grant diagnostics. The revision stays stable
+through polling, reconnects, transient retention, and renewed leases for the
+same authority. A verified principal crossover or actual revocation, denial,
+expiry, or sign-out rotates it before the new state is observable. Disabled
+responses carry the current retirement barrier, and repeated disabled polls do
+not rotate it. Browser draft stores use this opaque boundary to prevent text
+from crossing authorities without persisting it.
 
 The rail's cloud icon marks an agent as deployed once Studio confirms a ready
 hosted build. Failed checks silently retain the last confirmed indicator, and changing

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -42,6 +42,12 @@ Terminal; sign out and sign in again to obtain the user credential. It stays in
 the shared local credential store and is never returned by Studio's browser auth
 API. Sign-out clears it locally and attempts to revoke its token family remotely.
 
+The Studio host refreshes the internal Assistant capability at most every 30
+seconds and expires an enabled decision within 60 seconds. Missing identity,
+offline startup, unsupported backends, and unavailable flags leave it off.
+These access checks are independent of optional telemetry and never prevent
+ordinary Terminal startup. Only the resolved boolean is exposed to the browser.
+
 The rail's cloud icon marks an agent as deployed once Studio confirms a ready
 hosted build. Failed checks silently retain the last confirmed indicator, and changing
 accounts clears this evidence. Retained indicators do not enable cloud runs.

--- a/packages/harness/src/core/assistant-access.test.ts
+++ b/packages/harness/src/core/assistant-access.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ResolvedEnvironment } from "@sapiom/mcp/auth";
+import { AssistantAccess } from "./assistant-access.js";
+
+let access: AssistantAccess;
+let env: ResolvedEnvironment;
+let key: string | null;
+const request = vi.fn();
+const load = vi.fn();
+const pair = {
+  accessToken: "sat_user",
+  refreshToken: "srt_user",
+  expiresAt: "2030-01-01T00:00:00Z",
+};
+const enabled = {
+  protocol: 1,
+  assistant: true,
+  userId: "user-one",
+  tenantId: "tenant",
+  identityRevision: "identity-one",
+  maxAgeMs: 60000,
+  refreshAfterMs: 30000,
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-09-09T00:00:00Z"));
+  key = "sk_private";
+  env = {
+    name: "staging",
+    apiURL: "https://api.sapiom.dev",
+    appURL: "https://app.sapiom.dev",
+    services: {},
+    credentials: {
+      apiKey: key,
+      tenantId: "tenant",
+      organizationName: "Org",
+      apiKeyId: "key",
+      studioCredentials: pair,
+    },
+  };
+  load.mockReset().mockImplementation(async () => structuredClone(env));
+  request.mockReset().mockImplementation(async () => Response.json(enabled));
+  access = new AssistantAccess({
+    enabled: true,
+    harnessVersion: "0.16.0",
+    getApiKey: () => key,
+    loadEnvironment: load,
+    refreshCredentials: async (environment) =>
+      environment.credentials!.studioCredentials!,
+    fetch: request,
+  });
+});
+afterEach(() => {
+  access.close();
+  vi.useRealTimers();
+});
+
+describe("Assistant access", () => {
+  it("starts off and uses the trusted user token, never the org key, for evaluation", async () => {
+    expect(access.get()).toBeNull();
+    await access.refresh();
+    expect(access.get()).toMatchObject({
+      userId: "user-one",
+      tenantId: "tenant",
+    });
+    expect(request).toHaveBeenCalledWith(
+      "https://api.sapiom.dev/v1/studio/capabilities",
+      expect.objectContaining({
+        headers: {
+          Authorization: "Bearer sat_user",
+          "X-Studio-Capability-Version": "1",
+          "X-Studio-Harness-Version": "0.16.0",
+        },
+        redirect: "error",
+      }),
+    );
+    expect(JSON.stringify(request.mock.calls)).not.toContain("sk_private");
+  });
+
+  it.each([
+    {},
+    { ...enabled, assistant: false },
+    { ...enabled, assistant: "true" },
+    { ...enabled, protocol: 2 },
+    { ...enabled, tenantId: "other" },
+    { ...enabled, maxAgeMs: 0 },
+    { ...enabled, userId: 123 },
+    { ...enabled, identityRevision: {} },
+  ])("denies invalid or ineligible responses", async (result) => {
+    request.mockResolvedValue(Response.json(result));
+    await access.refresh();
+    expect(access.get()).toBeNull();
+  });
+
+  it("does no network work in no-auth mode or without trusted user credentials", async () => {
+    access.close();
+    access = new AssistantAccess({
+      enabled: false,
+      harnessVersion: "0.16.0",
+      getApiKey: () => key,
+      loadEnvironment: load,
+      fetch: request,
+    });
+    await access.refresh();
+    expect(load).not.toHaveBeenCalled();
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("refreshes independently of analytics, and remote disable removes a running grant", async () => {
+    const changed = vi.fn();
+    access.subscribe(changed);
+    await access.refresh();
+    request.mockImplementation(async () => Response.json({ assistant: false }));
+    await vi.advanceTimersByTimeAsync(30000);
+    expect(access.get()).toBeNull();
+    expect(changed).toHaveBeenCalledTimes(2);
+  });
+
+  it("expires within 60 seconds even when a refresh is stuck", async () => {
+    await access.refresh();
+    load.mockImplementation(() => new Promise(() => {}));
+    await vi.advanceTimersByTimeAsync(60001);
+    expect(access.get()).toBeNull();
+  });
+
+  it("revokes when another credential in the same organization resolves off", async () => {
+    await access.refresh();
+    env.credentials!.studioCredentials = {
+      ...pair,
+      accessToken: "sat_other",
+      refreshToken: "srt_other",
+    };
+    request.mockImplementation(async () => {
+      return Response.json({ assistant: false });
+    });
+    await access.refresh();
+    expect(access.get()).toBeNull();
+  });
+
+  it("keeps running access through another host's normal token rotation", async () => {
+    const changed = vi.fn();
+    access.subscribe(changed);
+    await access.refresh();
+    env.credentials!.studioCredentials = {
+      ...pair,
+      accessToken: "sat_rotated",
+      refreshToken: "srt_rotated",
+    };
+    await access.refresh();
+    expect(access.get()?.identityRevision).toBe("identity-one");
+    expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("fences an older response when a newer credential observation is queued", async () => {
+    await access.refresh();
+    const expiry = access.get()!.expiresAt;
+    let complete!: (response: Response) => void;
+    request.mockImplementationOnce(
+      () =>
+        new Promise<Response>((resolve) => {
+          complete = resolve;
+        }),
+    );
+    const old = access.refresh();
+    await vi.advanceTimersByTimeAsync(0);
+    const latest = access.refresh();
+    complete(Response.json({ ...enabled, identityRevision: "stale" }));
+    await old;
+    expect(access.get()?.identityRevision).toBe("identity-one");
+    expect(access.get()?.expiresAt).toBe(expiry);
+    await latest;
+  });
+
+  it("does not adopt a late response after sign-out or shutdown", async () => {
+    let complete!: (response: Response) => void;
+    request.mockImplementation(
+      () =>
+        new Promise<Response>((resolve) => {
+          complete = resolve;
+        }),
+    );
+    const refresh = access.refresh();
+    await vi.advanceTimersByTimeAsync(0);
+    access.clear();
+    complete(Response.json(enabled));
+    await refresh;
+    expect(access.get()).toBeNull();
+  });
+
+  it("invalidates on a key change, offline evaluation, and unreadable credentials", async () => {
+    await access.refresh();
+    key = null;
+    expect(access.get()).toBeNull();
+    key = "sk_private";
+    request.mockRejectedValue(new Error("offline"));
+    await access.refresh();
+    expect(access.get()).toBeNull();
+    load.mockRejectedValue(new Error("unreadable"));
+    await access.refresh();
+    expect(access.get()).toBeNull();
+  });
+
+  it("does not extend the lease by slow response delivery", async () => {
+    request.mockImplementation(async () => {
+      vi.setSystemTime(Date.now() + 4000);
+      return Response.json({ ...enabled, maxAgeMs: 1000 });
+    });
+    await access.refresh();
+    expect(access.get()).toBeNull();
+  });
+});

--- a/packages/harness/src/core/assistant-access.test.ts
+++ b/packages/harness/src/core/assistant-access.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedEnvironment } from "@sapiom/mcp/auth";
 import { AssistantAccess } from "./assistant-access.js";
+import { StudioCredentialRefreshError } from "./studio-credentials.js";
 
 let access: AssistantAccess;
 let env: ResolvedEnvironment;
@@ -78,6 +79,78 @@ describe("Assistant access", () => {
     expect(JSON.stringify(request.mock.calls)).not.toContain("sk_private");
   });
 
+  it("projects only an opaque authority revision and keeps it for same-principal renewals and outages", async () => {
+    const disabled = access.getBrowserState();
+    expect(disabled).toEqual({
+      enabled: false,
+      authorityRevision: expect.any(String),
+    });
+    expect(JSON.stringify(disabled)).not.toMatch(/user-one|tenant|sk_private/);
+
+    await access.refresh();
+    const verified = access.getBrowserState();
+    expect(verified.enabled).toBe(true);
+    expect(verified.authorityRevision).not.toBe(disabled.authorityRevision);
+
+    request.mockResolvedValueOnce(
+      Response.json({ ...enabled, maxAgeMs: 45_000 }),
+    );
+    await access.refresh();
+    expect(access.getBrowserState()).toEqual(verified);
+
+    request.mockRejectedValueOnce(new TypeError("offline"));
+    await access.refresh();
+    expect(access.getBrowserState()).toEqual(verified);
+  });
+
+  it("rotates the browser authority before notifying a principal crossover or retirement", async () => {
+    const observed: string[] = [];
+    access.subscribe(() => {
+      observed.push(access.getBrowserState().authorityRevision);
+    });
+    await access.refresh();
+    const first = access.getBrowserState().authorityRevision;
+    expect(observed).toEqual([first]);
+
+    request.mockResolvedValueOnce(
+      Response.json({ ...enabled, userId: "user-two" }),
+    );
+    await access.refresh();
+    const second = access.getBrowserState().authorityRevision;
+    expect(second).not.toBe(first);
+    expect(observed.at(-1)).toBe(second);
+
+    request.mockResolvedValue(Response.json({ assistant: false }));
+    await access.refresh();
+    const retired = access.getBrowserState();
+    expect(retired.enabled).toBe(false);
+    expect(retired.authorityRevision).not.toBe(second);
+    expect(observed.at(-1)).toBe(retired.authorityRevision);
+
+    await access.refresh();
+    expect(access.getBrowserState()).toEqual(retired);
+
+    request.mockResolvedValue(Response.json(enabled));
+    await access.refresh();
+    const readmitted = access.getBrowserState();
+    expect(readmitted.enabled).toBe(true);
+    expect(readmitted.authorityRevision).not.toBe(retired.authorityRevision);
+  });
+
+  it("rotates once when clear retires a grant and keeps that retired barrier", async () => {
+    await access.refresh();
+    const initial = access.getBrowserState().authorityRevision;
+    access.clear();
+    const retired = access.getBrowserState();
+    expect(retired).toEqual({
+      enabled: false,
+      authorityRevision: expect.any(String),
+    });
+    expect(retired.authorityRevision).not.toBe(initial);
+    access.clear();
+    expect(access.getBrowserState()).toEqual(retired);
+  });
+
   it.each([
     {},
     { ...enabled, assistant: false },
@@ -114,7 +187,74 @@ describe("Assistant access", () => {
     request.mockImplementation(async () => Response.json({ assistant: false }));
     await vi.advanceTimersByTimeAsync(30000);
     expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("access_denied");
     expect(changed).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains an unchanged verified grant through successive network and 5xx failures only until its original expiry", async () => {
+    const changed = vi.fn();
+    access.subscribe(changed);
+    await access.refresh();
+    const grant = access.get()!;
+    request.mockRejectedValueOnce(new TypeError("offline"));
+    await access.refresh();
+    expect(access.get()).toBe(grant);
+    request.mockResolvedValueOnce(new Response("", { status: 503 }));
+    await access.refresh();
+    expect(access.get()).toBe(grant);
+    expect(access.get()!.expiresAt).toBe(grant.expiresAt);
+    expect(changed).toHaveBeenCalledOnce();
+    vi.setSystemTime(grant.expiresAt + 1);
+    expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("access_expired");
+    expect(changed).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains a grant through a classified credential-refresh outage without extending it", async () => {
+    await access.refresh();
+    const grant = access.get()!;
+    env.credentials!.studioCredentials = {
+      ...pair,
+      expiresAt: new Date(Date.now() + 30_000).toISOString(),
+    };
+    access.close();
+    access = new AssistantAccess({
+      enabled: true,
+      harnessVersion: "0.16.0",
+      getApiKey: () => key,
+      loadEnvironment: load,
+      refreshCredentials: async () => {
+        throw new StudioCredentialRefreshError("transient", "offline");
+      },
+      fetch: request,
+    });
+    // A new host must never invent eligibility from an outage.
+    await access.refresh();
+    expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("transport_unavailable");
+
+    access.close();
+    env.credentials!.studioCredentials = pair;
+    let fail = false;
+    access = new AssistantAccess({
+      enabled: true,
+      harnessVersion: "0.16.0",
+      getApiKey: () => key,
+      loadEnvironment: load,
+      refreshCredentials: async (environment) => {
+        if (fail)
+          throw new StudioCredentialRefreshError("transient", "offline");
+        return environment.credentials!.studioCredentials!;
+      },
+      fetch: request,
+    });
+    await access.refresh();
+    const verified = access.get()!;
+    fail = true;
+    await access.refresh();
+    expect(access.get()).toBe(verified);
+    expect(access.get()!.expiresAt).toBe(verified.expiresAt);
+    expect(verified.expiresAt).toBe(grant.expiresAt);
   });
 
   it("expires within 60 seconds even when a refresh is stuck", async () => {
@@ -150,6 +290,18 @@ describe("Assistant access", () => {
     await access.refresh();
     expect(access.get()?.identityRevision).toBe("identity-one");
     expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("notifies hosts when the verified user changes even if an identity revision is reused", async () => {
+    const changed = vi.fn();
+    access.subscribe(changed);
+    await access.refresh();
+    request.mockResolvedValue(
+      Response.json({ ...enabled, userId: "user-two" }),
+    );
+    await access.refresh();
+    expect(access.get()?.userId).toBe("user-two");
+    expect(changed).toHaveBeenCalledTimes(2);
   });
 
   it("fences an older response when a newer credential observation is queued", async () => {
@@ -188,17 +340,42 @@ describe("Assistant access", () => {
     expect(access.get()).toBeNull();
   });
 
-  it("invalidates on a key change, offline evaluation, and unreadable credentials", async () => {
+  it("invalidates on a key change, unreadable credentials, and expired credentials", async () => {
     await access.refresh();
     key = null;
     expect(access.get()).toBeNull();
     key = "sk_private";
-    request.mockRejectedValue(new Error("offline"));
-    await access.refresh();
-    expect(access.get()).toBeNull();
     load.mockRejectedValue(new Error("unreadable"));
     await access.refresh();
     expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("access_denied");
+    load.mockImplementation(async () => structuredClone(env));
+    env.credentials!.studioCredentials = {
+      ...pair,
+      expiresAt: new Date(Date.now() - 1).toISOString(),
+    };
+    await access.refresh();
+    expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("authentication_required");
+  });
+
+  it("revokes the old authority before evaluating an identity or tenant crossover", async () => {
+    const changed = vi.fn();
+    access.subscribe(changed);
+    await access.refresh();
+    let finish!: (response: Response) => void;
+    env.credentials!.tenantId = "other-tenant";
+    request.mockImplementationOnce(
+      () => new Promise<Response>((resolve) => (finish = resolve)),
+    );
+    const pending = access.refresh();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("access_denied");
+    expect(changed).toHaveBeenCalledTimes(2);
+    finish(Response.json({ ...enabled, tenantId: "other-tenant" }));
+    await pending;
+    expect(access.get()).toMatchObject({ tenantId: "other-tenant" });
   });
 
   it("does not extend the lease by slow response delivery", async () => {

--- a/packages/harness/src/core/assistant-access.ts
+++ b/packages/harness/src/core/assistant-access.ts
@@ -1,0 +1,227 @@
+import { createHash } from "node:crypto";
+import {
+  resolveEnvironment,
+  readCredentialsOrThrow,
+  type ResolvedEnvironment,
+} from "@sapiom/mcp/auth";
+import { refreshStudioCredentials } from "./studio-credentials.js";
+
+/** Private host state. Only `enabled` is projected to the browser. */
+export interface AssistantGrant {
+  userId: string;
+  tenantId: string;
+  identityRevision: string;
+  expiresAt: number;
+  environment: ResolvedEnvironment;
+}
+
+interface CapabilityResponse {
+  protocol?: number;
+  assistant?: boolean;
+  userId?: string;
+  tenantId?: string;
+  identityRevision?: string;
+  maxAgeMs?: number;
+  refreshAfterMs?: number;
+}
+
+export interface AssistantAccessOptions {
+  enabled: boolean;
+  harnessVersion: string;
+  getApiKey: () => string | null;
+  environment?: string;
+  loadEnvironment?: () => Promise<ResolvedEnvironment>;
+  refreshCredentials?: typeof refreshStudioCredentials;
+  fetch?: typeof globalThis.fetch;
+}
+
+const fingerprint = (env: ResolvedEnvironment): string =>
+  createHash("sha256")
+    .update(
+      JSON.stringify([
+        env.name,
+        env.apiURL,
+        env.services,
+        env.credentials?.apiKey,
+        env.credentials?.tenantId,
+      ]),
+    )
+    .digest("hex");
+
+/** Bounded, revocable eligibility; no analytics opt-in or persisted enabled cache. */
+export class AssistantAccess {
+  private grant: AssistantGrant | null = null;
+  private credentialFingerprint: string | null = null;
+  private epoch = 0;
+  private closed = false;
+  private queue: Promise<void> = Promise.resolve();
+  private refreshTimer?: ReturnType<typeof setTimeout>;
+  private expiryTimer?: ReturnType<typeof setTimeout>;
+  private listeners = new Set<() => void>();
+
+  constructor(private readonly options: AssistantAccessOptions) {}
+
+  get(): AssistantGrant | null {
+    if (
+      this.grant &&
+      (this.grant.expiresAt <= Date.now() ||
+        this.options.getApiKey() !== this.grant.environment.credentials?.apiKey)
+    )
+      this.adopt(null);
+    return this.grant;
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  clear(): void {
+    this.epoch++;
+    this.credentialFingerprint = null;
+    this.adopt(null);
+  }
+
+  refresh(): Promise<void> {
+    if (this.closed || !this.options.enabled) return Promise.resolve();
+    // A newer credential observation fences any older response, without
+    // revoking a running grant just because another host rotated its token.
+    const epoch = ++this.epoch;
+    const run = this.queue.then(() => this.evaluate(epoch));
+    this.queue = run.catch(() => {
+      this.adopt(null);
+    });
+    return this.queue;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.clear();
+    clearTimeout(this.refreshTimer);
+    this.listeners.clear();
+  }
+
+  private adopt(grant: AssistantGrant | null): void {
+    const changed =
+      this.grant?.identityRevision !== grant?.identityRevision ||
+      this.grant?.environment.name !== grant?.environment.name ||
+      this.grant?.environment.apiURL !== grant?.environment.apiURL ||
+      this.grant?.environment.credentials?.apiKey !==
+        grant?.environment.credentials?.apiKey;
+    this.grant = grant;
+    clearTimeout(this.expiryTimer);
+    if (grant) {
+      this.expiryTimer = setTimeout(
+        () => this.adopt(null),
+        Math.max(0, grant.expiresAt - Date.now()),
+      );
+      this.expiryTimer.unref?.();
+    }
+    if (changed) for (const listener of this.listeners) listener();
+  }
+
+  private async evaluate(epoch: number): Promise<void> {
+    if (this.closed || epoch !== this.epoch) return;
+    clearTimeout(this.refreshTimer);
+    let refreshAfterMs = 30_000;
+    const current = () => !this.closed && epoch === this.epoch;
+    try {
+      const env = this.options.loadEnvironment
+        ? await this.options.loadEnvironment()
+        : await resolveEnvironment(
+            this.options.environment ?? process.env.SAPIOM_ENVIRONMENT,
+          );
+      if (!this.options.loadEnvironment)
+        env.credentials = await readCredentialsOrThrow(env.name);
+      if (!current()) return;
+      const before = fingerprint(env);
+      if (before !== this.credentialFingerprint) this.adopt(null);
+      this.credentialFingerprint = before;
+      if (
+        !env.credentials?.studioCredentials ||
+        !env.credentials.apiKey ||
+        env.credentials.apiKey !== this.options.getApiKey()
+      ) {
+        this.adopt(null);
+        return;
+      }
+      const credentials = await (
+        this.options.refreshCredentials ?? refreshStudioCredentials
+      )(env);
+      if (!current()) return;
+      if (!credentials) {
+        this.adopt(null);
+        return;
+      }
+      env.credentials = { ...env.credentials, studioCredentials: credentials };
+      const startedAt = Date.now();
+      const response = await (this.options.fetch ?? fetch)(
+        `${env.apiURL}/v1/studio/capabilities`,
+        {
+          headers: {
+            Authorization: `Bearer ${credentials.accessToken}`,
+            "X-Studio-Capability-Version": "1",
+            "X-Studio-Harness-Version": this.options.harnessVersion,
+          },
+          signal: AbortSignal.timeout(5000),
+          redirect: "error",
+        },
+      );
+      if (!current()) return;
+      if (!response.ok) {
+        this.adopt(null);
+        return;
+      }
+      const result = (await response.json()) as CapabilityResponse;
+      if (!current()) return;
+      if (
+        result.protocol !== 1 ||
+        result.assistant !== true ||
+        typeof result.userId !== "string" ||
+        !result.userId ||
+        typeof result.identityRevision !== "string" ||
+        !result.identityRevision ||
+        result.tenantId !== env.credentials.tenantId ||
+        typeof result.maxAgeMs !== "number" ||
+        !Number.isFinite(result.maxAgeMs) ||
+        result.maxAgeMs <= 0
+      ) {
+        this.adopt(null);
+        return;
+      }
+      const expiresAt = Math.min(
+        startedAt + Math.min(result.maxAgeMs, 60_000),
+        Date.parse(credentials.expiresAt),
+      );
+      if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
+        this.adopt(null);
+        return;
+      }
+      this.credentialFingerprint = fingerprint(env);
+      this.adopt({
+        userId: result.userId,
+        tenantId: result.tenantId,
+        identityRevision: result.identityRevision,
+        expiresAt,
+        environment: env,
+      });
+      if (
+        typeof result.refreshAfterMs === "number" &&
+        Number.isFinite(result.refreshAfterMs)
+      )
+        refreshAfterMs = Math.max(
+          1000,
+          Math.min(result.refreshAfterMs, 30_000),
+        );
+    } catch {
+      if (current()) this.adopt(null);
+    } finally {
+      if (current()) {
+        this.refreshTimer = setTimeout(() => {
+          void this.refresh();
+        }, refreshAfterMs);
+        this.refreshTimer.unref?.();
+      }
+    }
+  }
+}

--- a/packages/harness/src/core/assistant-access.ts
+++ b/packages/harness/src/core/assistant-access.ts
@@ -1,18 +1,36 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   resolveEnvironment,
   readCredentialsOrThrow,
   type ResolvedEnvironment,
 } from "@sapiom/mcp/auth";
-import { refreshStudioCredentials } from "./studio-credentials.js";
+import {
+  refreshStudioCredentials,
+  StudioCredentialRefreshError,
+} from "./studio-credentials.js";
+import type { OpenCodeTransportErrorCode } from "../shared/opencode-errors.js";
 
-/** Private host state. Only `enabled` is projected to the browser. */
+export type AssistantAccessFailureCode = Extract<
+  OpenCodeTransportErrorCode,
+  | "access_denied"
+  | "access_expired"
+  | "authentication_required"
+  | "transport_unavailable"
+>;
+
+/** Private host state. Principal fields are never projected to the browser. */
 export interface AssistantGrant {
   userId: string;
   tenantId: string;
   identityRevision: string;
   expiresAt: number;
   environment: ResolvedEnvironment;
+}
+
+/** Browser-safe access state. The revision is opaque and process-memory only. */
+export interface AssistantAccessProjection {
+  enabled: boolean;
+  authorityRevision: string;
 }
 
 interface CapabilityResponse {
@@ -51,7 +69,11 @@ const fingerprint = (env: ResolvedEnvironment): string =>
 /** Bounded, revocable eligibility; no analytics opt-in or persisted enabled cache. */
 export class AssistantAccess {
   private grant: AssistantGrant | null = null;
+  private failure: AssistantAccessFailureCode = this.options.enabled
+    ? "authentication_required"
+    : "access_denied";
   private credentialFingerprint: string | null = null;
+  private authorityRevision = randomUUID();
   private epoch = 0;
   private closed = false;
   private queue: Promise<void> = Promise.resolve();
@@ -62,13 +84,26 @@ export class AssistantAccess {
   constructor(private readonly options: AssistantAccessOptions) {}
 
   get(): AssistantGrant | null {
-    if (
+    if (this.grant?.expiresAt && this.grant.expiresAt <= Date.now())
+      this.adopt(null, "access_expired");
+    else if (
       this.grant &&
-      (this.grant.expiresAt <= Date.now() ||
-        this.options.getApiKey() !== this.grant.environment.credentials?.apiKey)
+      this.options.getApiKey() !== this.grant.environment.credentials?.apiKey
     )
-      this.adopt(null);
+      this.adopt(null, "authentication_required");
     return this.grant;
+  }
+
+  getFailureCode(): AssistantAccessFailureCode {
+    this.get();
+    return this.failure;
+  }
+
+  getBrowserState(): AssistantAccessProjection {
+    return {
+      enabled: this.get() !== null,
+      authorityRevision: this.authorityRevision,
+    };
   }
 
   subscribe(listener: () => void): () => void {
@@ -79,7 +114,7 @@ export class AssistantAccess {
   clear(): void {
     this.epoch++;
     this.credentialFingerprint = null;
-    this.adopt(null);
+    this.adopt(null, "authentication_required");
   }
 
   refresh(): Promise<void> {
@@ -89,7 +124,8 @@ export class AssistantAccess {
     const epoch = ++this.epoch;
     const run = this.queue.then(() => this.evaluate(epoch));
     this.queue = run.catch(() => {
-      this.adopt(null);
+      if (!this.closed && epoch === this.epoch)
+        this.adopt(null, "access_denied");
     });
     return this.queue;
   }
@@ -101,18 +137,25 @@ export class AssistantAccess {
     this.listeners.clear();
   }
 
-  private adopt(grant: AssistantGrant | null): void {
+  private adopt(
+    grant: AssistantGrant | null,
+    failure: AssistantAccessFailureCode = this.failure,
+  ): void {
     const changed =
+      this.grant?.userId !== grant?.userId ||
+      this.grant?.tenantId !== grant?.tenantId ||
       this.grant?.identityRevision !== grant?.identityRevision ||
       this.grant?.environment.name !== grant?.environment.name ||
       this.grant?.environment.apiURL !== grant?.environment.apiURL ||
       this.grant?.environment.credentials?.apiKey !==
         grant?.environment.credentials?.apiKey;
+    if (changed) this.authorityRevision = randomUUID();
     this.grant = grant;
+    this.failure = failure;
     clearTimeout(this.expiryTimer);
     if (grant) {
       this.expiryTimer = setTimeout(
-        () => this.adopt(null),
+        () => this.adopt(null, "access_expired"),
         Math.max(0, grant.expiresAt - Date.now()),
       );
       this.expiryTimer.unref?.();
@@ -126,53 +169,113 @@ export class AssistantAccess {
     let refreshAfterMs = 30_000;
     const current = () => !this.closed && epoch === this.epoch;
     try {
-      const env = this.options.loadEnvironment
-        ? await this.options.loadEnvironment()
-        : await resolveEnvironment(
-            this.options.environment ?? process.env.SAPIOM_ENVIRONMENT,
-          );
-      if (!this.options.loadEnvironment)
-        env.credentials = await readCredentialsOrThrow(env.name);
+      let env: ResolvedEnvironment;
+      try {
+        env = this.options.loadEnvironment
+          ? await this.options.loadEnvironment()
+          : await resolveEnvironment(
+              this.options.environment ?? process.env.SAPIOM_ENVIRONMENT,
+            );
+        if (!this.options.loadEnvironment)
+          env.credentials = await readCredentialsOrThrow(env.name);
+      } catch {
+        if (current()) this.adopt(null, "access_denied");
+        return;
+      }
       if (!current()) return;
       const before = fingerprint(env);
-      if (before !== this.credentialFingerprint) this.adopt(null);
+      if (
+        this.credentialFingerprint !== null &&
+        before !== this.credentialFingerprint
+      )
+        this.adopt(null, "access_denied");
       this.credentialFingerprint = before;
       if (
         !env.credentials?.studioCredentials ||
         !env.credentials.apiKey ||
         env.credentials.apiKey !== this.options.getApiKey()
       ) {
-        this.adopt(null);
+        this.adopt(null, "authentication_required");
         return;
       }
-      const credentials = await (
-        this.options.refreshCredentials ?? refreshStudioCredentials
-      )(env);
+      const observedCredentialExpiry = Date.parse(
+        env.credentials.studioCredentials.expiresAt,
+      );
+      if (
+        !Number.isFinite(observedCredentialExpiry) ||
+        observedCredentialExpiry <= Date.now()
+      ) {
+        this.adopt(null, "authentication_required");
+        return;
+      }
+      let credentials;
+      try {
+        credentials = await (
+          this.options.refreshCredentials ?? refreshStudioCredentials
+        )(env);
+      } catch (error) {
+        if (!current()) return;
+        if (
+          error instanceof StudioCredentialRefreshError &&
+          error.kind === "transient"
+        )
+          this.retainTransient(before, observedCredentialExpiry);
+        else this.adopt(null, "authentication_required");
+        return;
+      }
       if (!current()) return;
       if (!credentials) {
-        this.adopt(null);
+        this.adopt(null, "authentication_required");
+        return;
+      }
+      const credentialExpiry = Date.parse(credentials.expiresAt);
+      if (
+        !Number.isFinite(credentialExpiry) ||
+        credentialExpiry <= Date.now()
+      ) {
+        this.adopt(null, "authentication_required");
         return;
       }
       env.credentials = { ...env.credentials, studioCredentials: credentials };
       const startedAt = Date.now();
-      const response = await (this.options.fetch ?? fetch)(
-        `${env.apiURL}/v1/studio/capabilities`,
-        {
-          headers: {
-            Authorization: `Bearer ${credentials.accessToken}`,
-            "X-Studio-Capability-Version": "1",
-            "X-Studio-Harness-Version": this.options.harnessVersion,
+      let response: Response;
+      try {
+        response = await (this.options.fetch ?? fetch)(
+          `${env.apiURL}/v1/studio/capabilities`,
+          {
+            headers: {
+              Authorization: `Bearer ${credentials.accessToken}`,
+              "X-Studio-Capability-Version": "1",
+              "X-Studio-Harness-Version": this.options.harnessVersion,
+            },
+            signal: AbortSignal.timeout(5000),
+            redirect: "error",
           },
-          signal: AbortSignal.timeout(5000),
-          redirect: "error",
-        },
-      );
-      if (!current()) return;
-      if (!response.ok) {
-        this.adopt(null);
+        );
+      } catch {
+        if (current()) this.retainTransient(before, credentialExpiry);
         return;
       }
-      const result = (await response.json()) as CapabilityResponse;
+      if (!current()) return;
+      if (!response.ok) {
+        if (response.status >= 500)
+          this.retainTransient(before, credentialExpiry);
+        else
+          this.adopt(
+            null,
+            [401, 403].includes(response.status)
+              ? "authentication_required"
+              : "access_denied",
+          );
+        return;
+      }
+      let result: CapabilityResponse;
+      try {
+        result = (await response.json()) as CapabilityResponse;
+      } catch {
+        this.adopt(null, "access_denied");
+        return;
+      }
       if (!current()) return;
       if (
         result.protocol !== 1 ||
@@ -186,15 +289,15 @@ export class AssistantAccess {
         !Number.isFinite(result.maxAgeMs) ||
         result.maxAgeMs <= 0
       ) {
-        this.adopt(null);
+        this.adopt(null, "access_denied");
         return;
       }
       const expiresAt = Math.min(
         startedAt + Math.min(result.maxAgeMs, 60_000),
-        Date.parse(credentials.expiresAt),
+        credentialExpiry,
       );
       if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
-        this.adopt(null);
+        this.adopt(null, "authentication_required");
         return;
       }
       this.credentialFingerprint = fingerprint(env);
@@ -214,7 +317,7 @@ export class AssistantAccess {
           Math.min(result.refreshAfterMs, 30_000),
         );
     } catch {
-      if (current()) this.adopt(null);
+      if (current()) this.adopt(null, "access_denied");
     } finally {
       if (current()) {
         this.refreshTimer = setTimeout(() => {
@@ -223,5 +326,23 @@ export class AssistantAccess {
         this.refreshTimer.unref?.();
       }
     }
+  }
+
+  private retainTransient(
+    fingerprintAtFailure: string,
+    credentialExpiry: number,
+  ): void {
+    const grant = this.get();
+    if (!grant) {
+      if (this.failure !== "access_denied" && this.failure !== "access_expired")
+        this.adopt(null, "transport_unavailable");
+      return;
+    }
+    if (
+      this.credentialFingerprint !== fingerprintAtFailure ||
+      credentialExpiry <= Date.now() ||
+      grant.environment.credentials?.apiKey !== this.options.getApiKey()
+    )
+      this.adopt(null, "transport_unavailable");
   }
 }

--- a/packages/harness/src/server/auth-mcp-wiring.test.ts
+++ b/packages/harness/src/server/auth-mcp-wiring.test.ts
@@ -303,7 +303,15 @@ describe("Agent Studio MCP authentication wiring", () => {
       headers: { "X-Harness-Token": "test-token" },
     });
     expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(await response.json()).toEqual({ enabled: false });
+    const first = (await response.json()) as Record<string, unknown>;
+    expect(first).toEqual({
+      enabled: false,
+      authorityRevision: expect.any(String),
+    });
+    const repeated = await fetch(url, {
+      headers: { "X-Harness-Token": "test-token" },
+    });
+    expect(await repeated.json()).toEqual(first);
   });
 
   async function waitForAuthenticated(): Promise<void> {

--- a/packages/harness/src/server/auth-mcp-wiring.test.ts
+++ b/packages/harness/src/server/auth-mcp-wiring.test.ts
@@ -245,6 +245,17 @@ describe("Agent Studio MCP authentication wiring", () => {
     });
   }
 
+  it("gates the capability projection with the boot token and stays off without user credentials", async () => {
+    const host = await boot({ authMode: "disabled" });
+    const url = `http://127.0.0.1:${host.port}/api/assistant/access`;
+    expect((await fetch(url)).status).toBe(401);
+    const response = await fetch(url, {
+      headers: { "X-Harness-Token": "test-token" },
+    });
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(await response.json()).toEqual({ enabled: false });
+  });
+
   async function waitForAuthenticated(): Promise<void> {
     await vi.waitFor(() => expect(writeCredentials).toHaveBeenCalled());
     await Promise.resolve(

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -3549,7 +3549,7 @@ export const startServer = async (
   );
   app.get("/api/assistant/access", (_req, res) => {
     res.setHeader("Cache-Control", "no-store");
-    res.json({ enabled: assistantAccess.get() !== null });
+    res.json(assistantAccess.getBrowserState());
   });
   app.use(
     "/api",

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -209,6 +209,7 @@ import {
   ProjectBootstrapCoordinatorClosedError,
 } from "../core/project-bootstrap.js";
 import { IngestCredentialRegistry } from "../core/ingest-credentials.js";
+import { AssistantAccess } from "../core/assistant-access.js";
 import { createStaticRouter } from "./static.js";
 import { createTerminalWebSocketHandler } from "./terminal-ws.js";
 import { createEventsWebSocketHandler } from "./events-ws.js";
@@ -712,6 +713,12 @@ export const startServer = async (
         onKeyChanged: deploymentAuthChanged,
       })
     : staticApiKeyProvider(null);
+
+  const assistantAccess = new AssistantAccess({
+    enabled: authEnabled,
+    harnessVersion: readVersion(),
+    getApiKey: () => apiKeyProvider.getKey(),
+  });
 
   // Mutable auth state — seeded from the boot-time identity and updated by the
   // in-app auth routes (POST /api/auth/start, POST /api/auth/disconnect). The
@@ -1884,7 +1891,10 @@ export const startServer = async (
     if (!authEnabled || credentialStoreObserver) return;
     credentialStoreObserver = observeCredentialStore(
       credentialsFilePath(),
-      () => apiKeyProvider.refresh().then(() => {}),
+      async () => {
+        await apiKeyProvider.refresh();
+        await assistantAccess.refresh();
+      },
       {
         onError: (error) => {
           if ((error as NodeJS.ErrnoException)?.code !== "ENOENT") {
@@ -1901,6 +1911,8 @@ export const startServer = async (
   };
   const unsubscribeCredentialChanges = apiKeyProvider.subscribe(
     ({ apiKey, generation }) => {
+      assistantAccess.clear();
+      void assistantAccess.refresh();
       sessionManager.reconcileMcpCredentialGeneration(generation);
       if (apiKey !== null) {
         // First-run sign-in creates the directory after the boot-time watch
@@ -3920,6 +3932,10 @@ export const startServer = async (
     createBootTokenMiddleware(options.bootToken),
     express.json({ limit: JSON_BODY_LIMIT_BYTES }),
   );
+  app.get("/api/assistant/access", (_req, res) => {
+    res.setHeader("Cache-Control", "no-store");
+    res.json({ enabled: assistantAccess.get() !== null });
+  });
   app.use(
     "/api",
     createRestRouter({
@@ -4373,6 +4389,8 @@ export const startServer = async (
       authEnabled,
       environment: process.env.SAPIOM_ENVIRONMENT,
       onProjectUserChanged: (userId) => {
+        assistantAccess.clear();
+        void assistantAccess.refresh();
         deploymentAuthChanged();
         projectUserId = userId;
         for (const session of sessionManager.list()) {
@@ -4682,6 +4700,7 @@ export const startServer = async (
 
       credentialStoreObserver?.close();
       unsubscribeCredentialChanges();
+      assistantAccess.close();
       await settle(() => sessionManager.beginShutdown());
       const bootstrapClosing = settle(() => projectBootstrap?.close());
       const registrationClosing = settle(() => createdAgentRegistration.close());
@@ -4804,6 +4823,7 @@ export const startServer = async (
     actualPort =
       typeof address === "object" && address ? address.port : options.port;
     agentMapMcpUrl = `http://${host}:${actualPort}/mcp/agent-map`;
+    void assistantAccess.refresh();
     // Covers the ephemeral `port: 0` case where only the bound address is real.
     portDetector.addExcludedPort(actualPort);
     await options.projectBootstrapTestHooks?.afterListenBeforeRecovery?.(


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Assistant eligibility must survive bounded transient refresh failures without crossing a verified principal or leaking drafts between authorities.

## Summary and scope

Retain only a previously verified unchanged grant through classified transient failures, retire it on denial, expiry, sign-out, or authority crossover, and expose the exact no-store `{ enabled, authorityRevision }` endpoint shared by CLI and Electron. The opaque revision is memory-only and rotates once at authority retirement/replacement.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `yashnadge/sap-3288-studio-user-access`. Actual-parent size: **801 additions + 1 deletions = 802 changed lines**. This is above the 600-line target and below the 1,000-line hard maximum; the source and tests stay together to preserve a compiling, independently reviewable boundary.

Absorbed reviewed provenance: #934 verified access retention portion; opaque authorityRevision lifecycle and literal access endpoint.

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3288](https://linear.app/sapiom/issue/SAP-3288). This PR keeps its existing number and review history within the main-rooted native GitHub stack.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check 9c921df81f65d8f03cec8b6151dce2669af5bdde...f618e7e789042429418070aabb02e0d80d73c42d` — passed.
- Focused access/credential/server coverage on the corrected access tree — 45 tests passed.

### Tests and documentation

Access lease, original-expiry, direct user/tenant crossover, retirement/readmission, duplicate clear, and boot-token-gated route coverage are included with README and Changesets.

## Compatibility and release impact

- Breaking or externally visible changes: No breaking public credential shape. The authenticated Assistant access endpoint gains the browser-safe `authorityRevision` field required by later UI consumers.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added trusted Studio user credential checks for Assistant access.
  * Assistant access now refreshes automatically and expires or revokes promptly when eligibility changes.
  * Access remains disabled when identity, backend support, or required settings are unavailable. Connectivity failures remain disabled without a prior verified grant; an unchanged previously verified grant may be retained only within its original bounded expiry window.
  * Added a capability status endpoint for reporting whether Assistant access is enabled.

* **Documentation**
  * Documented Assistant access refresh timing, expiration behavior, and conditions that keep it disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/897" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
