### PR TITLE
feat(opencode): package Studio-authenticated model and MCP access [SAP-3289]

### DIFF
--- a/.changeset/sanitize-opencode-startup-errors.md
+++ b/.changeset/sanitize-opencode-startup-errors.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/opencode": patch
+---
+
+Expose stable, retry-aware OpenCode startup failure codes without leaking native output, paths, configuration, or underlying causes.

--- a/.changeset/studio-opencode-runtime.md
+++ b/.changeset/studio-opencode-runtime.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/opencode": minor
+"@sapiom/harness": patch
+---
+
+Package a pinned headless OpenCode runtime and configure Sapiom access through Studio's private bridge.

--- a/packages/harness/src/server/opencode-bridge.ts
+++ b/packages/harness/src/server/opencode-bridge.ts
@@ -164,6 +164,7 @@ export class OpenCodeBridge {
       const upstream = assistantUpstreams(grant.environment)[service];
       const key = grant.environment.credentials!.apiKey;
       const headers = new Headers({
+        "Accept-Encoding": "identity",
         Accept: req.header("Accept") ?? "application/json",
         "Content-Type": "application/json",
         ...(service === "llm"

--- a/packages/opencode/.eslintrc.cjs
+++ b/packages/opencode/.eslintrc.cjs
@@ -1,0 +1,22 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+  },
+  ignorePatterns: ['.eslintrc.js', 'vitest.config.ts', 'dist', 'node_modules'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  },
+};

--- a/packages/opencode/LICENSE
+++ b/packages/opencode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Sapiom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -1,0 +1,28 @@
+# @sapiom/opencode
+
+Pinned OpenCode 1.18.29, started directly through `startOpenCodeServer()` without
+an installation command at runtime. Studio owns authorization, working directory,
+state directory, credentials, and shutdown. OpenCode owns conversations and agent
+execution.
+
+```ts
+const config = createSapiomOpenCodeConfig({ bridgeUrl, runtimeToken });
+const server = await startOpenCodeServer({ cwd, stateRoot, config, signal });
+// Only call this after Studio has authorized the selected workspace and user.
+await server.close();
+```
+
+The bridge URL must be loopback. Only its revocable credential enters the model
+and remote MCP configuration. The runtime inherits an allowlist of platform
+environment variables; provider keys and the Electron esbuild pin are excluded
+from tool processes. Project/global Claude configuration and external skills are
+disabled. Runtime state stays below the supplied directory.
+
+Startup and shutdown have deadlines. POSIX shutdown signals the owned process
+group; Windows process-tree hardening and packaged-platform validation remain
+tracked by SAP-3297. Binary paths inside `app.asar` resolve to their unpacked
+counterparts; the desktop packager must include the native binary there.
+
+`pnpm` must allow the `opencode-ai` install script so the platform binary exists
+before Studio starts. The workspace allowlist includes it. No UI is bundled in
+this package.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@sapiom/opencode",
+  "version": "0.0.1",
+  "description": "Studio-managed headless OpenCode runtime with a private credential bridge.",
+  "license": "MIT",
+  "author": "Sapiom",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sapiom/sapiom-js.git",
+    "directory": "packages/opencode"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc --project tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src --ext .ts",
+    "prepublishOnly": "pnpm build"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "opencode-ai": "1.18.29"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@typescript-eslint/eslint-plugin": "^7.3.1",
+    "@typescript-eslint/parser": "^7.3.1",
+    "eslint": "^8.57.0",
+    "typescript": "^5.4.2",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/opencode/src/__fixtures__/server.mjs
+++ b/packages/opencode/src/__fixtures__/server.mjs
@@ -1,0 +1,44 @@
+import { createServer } from "node:http";
+import { writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+
+const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT);
+writeFileSync("runtime.pid", String(process.pid));
+if (config.crash) {
+  console.error("private provider diagnostic");
+  process.exit(1);
+}
+const authorization = `Basic ${Buffer.from(`opencode:${process.env.OPENCODE_SERVER_PASSWORD}`).toString("base64")}`;
+createServer((req, res) => {
+  if (req.headers.authorization !== authorization) {
+    res.writeHead(401).end();
+    return;
+  }
+  if (req.url === "/global/health") {
+    if (!config.stall)
+      res.end(JSON.stringify({ healthy: true, version: "fixture" }));
+  } else if (req.url === "/inspect") {
+    const tool = spawn(process.execPath, [
+      "-e",
+      "console.log(JSON.stringify(Object.keys(process.env)))",
+    ]);
+    let output = "";
+    tool.stdout.on("data", (chunk) => {
+      output += chunk;
+    });
+    tool.on("exit", () =>
+      res.end(
+        JSON.stringify({
+          cwd: process.cwd(),
+          config,
+          keys: JSON.parse(output),
+        }),
+      ),
+    );
+  } else {
+    res.writeHead(404).end("private diagnostic");
+  }
+}).listen(
+  Number(process.argv[process.argv.indexOf("--port") + 1]),
+  "127.0.0.1",
+);

--- a/packages/opencode/src/config.ts
+++ b/packages/opencode/src/config.ts
@@ -1,0 +1,51 @@
+export interface SapiomOpenCodeConfigOptions {
+  bridgeUrl: string;
+  runtimeToken: string;
+  model?: string;
+}
+
+/** Only a revocable runtime credential enters OpenCode; Studio holds the key. */
+export function createSapiomOpenCodeConfig(
+  options: SapiomOpenCodeConfigOptions,
+): Record<string, unknown> {
+  const bridge = new URL(options.bridgeUrl);
+  if (
+    bridge.protocol !== "http:" ||
+    !["127.0.0.1", "[::1]"].includes(bridge.hostname) ||
+    bridge.username ||
+    bridge.password ||
+    bridge.search ||
+    bridge.hash ||
+    !options.runtimeToken
+  ) {
+    throw new Error("OpenCode requires a private loopback credential bridge");
+  }
+  const base = bridge.href.replace(/\/+$/, "");
+  const model = options.model ?? "smart";
+  return {
+    $schema: "https://opencode.ai/config.json",
+    model: `sapiom/${model}`,
+    enabled_providers: ["sapiom"],
+    plugin: [],
+    provider: {
+      sapiom: {
+        npm: "@ai-sdk/openai-compatible",
+        name: "Sapiom",
+        options: {
+          apiKey: options.runtimeToken,
+          baseURL: `${base}/llm/v2/openai/v1`,
+        },
+        models: { [model]: { name: `Sapiom · ${model}` } },
+      },
+    },
+    mcp: {
+      sapiom: {
+        type: "remote",
+        url: `${base}/mcp`,
+        enabled: true,
+        oauth: false,
+        headers: { Authorization: `Bearer ${options.runtimeToken}` },
+      },
+    },
+  };
+}

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -4,6 +4,8 @@ export {
 } from "./config.js";
 export {
   startOpenCodeServer,
+  OpenCodeStartupError,
   type OpenCodeServer,
+  type OpenCodeStartupFailureCode,
   type StartOpenCodeServerOptions,
 } from "./server.js";

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1,0 +1,9 @@
+export {
+  createSapiomOpenCodeConfig,
+  type SapiomOpenCodeConfigOptions,
+} from "./config.js";
+export {
+  startOpenCodeServer,
+  type OpenCodeServer,
+  type StartOpenCodeServerOptions,
+} from "./server.js";

--- a/packages/opencode/src/server.test.ts
+++ b/packages/opencode/src/server.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { startOpenCodeServer, type OpenCodeServer } from "./server.js";
+import { createSapiomOpenCodeConfig } from "./config.js";
+
+let directory: string;
+let server: OpenCodeServer | undefined;
+const command = {
+  executable: process.execPath,
+  prefixArgs: [
+    fileURLToPath(new URL("./__fixtures__/server.mjs", import.meta.url)),
+  ],
+};
+beforeEach(async () => {
+  directory = await mkdtemp(join(tmpdir(), "opencode-runtime-"));
+});
+afterEach(async () => {
+  await server?.close();
+  server = undefined;
+  await rm(directory, { recursive: true, force: true });
+});
+const options = (config: Record<string, unknown> = {}) => ({
+  command,
+  config,
+  cwd: directory,
+  stateRoot: join(directory, "state"),
+});
+
+describe("packaged OpenCode runtime", () => {
+  it("uses the bridge for model and MCP authentication and strips host secrets from tool environments", async () => {
+    const config = createSapiomOpenCodeConfig({
+      bridgeUrl: "http://127.0.0.1:1234/opencode-runtime/runtime",
+      runtimeToken: "scoped-token",
+    });
+    server = await startOpenCodeServer({
+      ...options(config),
+      environment: {
+        ...process.env,
+        SAPIOM_API_KEY: "sk_private",
+        ANTHROPIC_API_KEY: "private",
+        ESBUILD_BINARY_PATH: "/app.asar/private",
+      },
+    });
+    const inspected = await server.fetchJson<{
+      cwd: string;
+      config: Record<string, unknown>;
+      keys: string[];
+    }>("/inspect");
+    expect(inspected.cwd).toBe(directory);
+    expect(inspected.config).toEqual(config);
+    expect(JSON.stringify(inspected)).not.toContain("sk_private");
+    for (const key of [
+      "SAPIOM_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "ESBUILD_BINARY_PATH",
+    ])
+      expect(inspected.keys).not.toContain(key);
+    expect(JSON.stringify(config)).toContain("/llm/v2/openai/v1");
+    expect(JSON.stringify(config)).toContain("/mcp");
+    await expect(server.fetch("https://other.example/private")).rejects.toThrow(
+      "Invalid",
+    );
+    await expect(server.fetch("//other.example/private")).rejects.toThrow(
+      "Invalid",
+    );
+    await expect(server.fetchJson("/missing")).rejects.toThrow(
+      "OpenCode request failed",
+    );
+    const pid = server.pid;
+    await Promise.all([server.close(), server.close()]);
+    expect(() => process.kill(pid, 0)).toThrow();
+  });
+
+  it("bounds hung startup, cleans up the child, and allows another startup", async () => {
+    await expect(
+      startOpenCodeServer({
+        ...options({ stall: true }),
+        startupTimeoutMs: 400,
+      }),
+    ).rejects.toThrow("could not start");
+    const pid = Number(await readFile(join(directory, "runtime.pid"), "utf8"));
+    expect(() => process.kill(pid, 0)).toThrow();
+    server = await startOpenCodeServer(options());
+    expect(server.pid).not.toBe(pid);
+  });
+
+  it("honors revocation during startup and sanitizes child diagnostics", async () => {
+    const abort = new AbortController();
+    const starting = startOpenCodeServer({
+      ...options({ stall: true }),
+      signal: abort.signal,
+    });
+    const timer = setTimeout(() => abort.abort(), 100);
+    try {
+      await expect(starting).rejects.toThrow();
+    } finally {
+      clearTimeout(timer);
+    }
+    await expect(startOpenCodeServer(options({ crash: true }))).rejects.toThrow(
+      "OpenCode could not start. Please retry.",
+    );
+  });
+
+  it.each([
+    "https://remote.example",
+    "http://remote.example",
+    "http://user:password@127.0.0.1",
+    "http://127.0.0.1/?secret=yes",
+  ])("refuses a non-private bridge: %s", (bridgeUrl) => {
+    expect(() =>
+      createSapiomOpenCodeConfig({ bridgeUrl, runtimeToken: "token" }),
+    ).toThrow("private loopback");
+  });
+});

--- a/packages/opencode/src/server.test.ts
+++ b/packages/opencode/src/server.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { startOpenCodeServer, type OpenCodeServer } from "./server.js";
+import {
+  OpenCodeStartupError,
+  startOpenCodeServer,
+  type OpenCodeServer,
+} from "./server.js";
 import { createSapiomOpenCodeConfig } from "./config.js";
 
 let directory: string;
@@ -80,7 +84,12 @@ describe("packaged OpenCode runtime", () => {
         ...options({ stall: true }),
         startupTimeoutMs: 400,
       }),
-    ).rejects.toThrow("could not start");
+    ).rejects.toMatchObject({
+      name: "OpenCodeStartupError",
+      code: "timed-out",
+      retryable: true,
+      message: "OpenCode took too long to start. Retry the connection.",
+    });
     const pid = Number(await readFile(join(directory, "runtime.pid"), "utf8"));
     expect(() => process.kill(pid, 0)).toThrow();
     server = await startOpenCodeServer(options());
@@ -95,13 +104,47 @@ describe("packaged OpenCode runtime", () => {
     });
     const timer = setTimeout(() => abort.abort(), 100);
     try {
-      await expect(starting).rejects.toThrow();
+      await expect(starting).rejects.toMatchObject({
+        code: "cancelled",
+        retryable: true,
+      });
     } finally {
       clearTimeout(timer);
     }
-    await expect(startOpenCodeServer(options({ crash: true }))).rejects.toThrow(
-      "OpenCode could not start. Please retry.",
-    );
+    await expect(
+      startOpenCodeServer(options({ crash: true })),
+    ).rejects.toMatchObject({
+      code: "exited",
+      exitCode: 1,
+      retryable: true,
+      message:
+        "OpenCode exited before it became ready. Retry, then update or reinstall Studio if the problem continues.",
+    });
+  });
+
+  it("classifies real executable path and permission failures without raw details", async () => {
+    const missing = join(directory, "private-provider-token-missing");
+    await expect(
+      startOpenCodeServer({
+        ...options(),
+        command: { executable: missing },
+      }),
+    ).rejects.toEqual(new OpenCodeStartupError("executable-not-found"));
+    if (process.platform !== "win32") {
+      const blocked = join(directory, "private-provider-token-blocked");
+      await writeFile(blocked, "#!/bin/sh\nexit 0\n", { mode: 0o600 });
+      await expect(
+        startOpenCodeServer({
+          ...options(),
+          command: { executable: blocked },
+        }),
+      ).rejects.toEqual(new OpenCodeStartupError("permission-denied"));
+    }
+    expect(
+      (await readdir(join(directory, "state"))).filter((entry) =>
+        entry.startsWith("launch-"),
+      ),
+    ).toEqual([]);
   });
 
   it.each([

--- a/packages/opencode/src/server.ts
+++ b/packages/opencode/src/server.ts
@@ -23,6 +23,53 @@ export interface OpenCodeServer {
   close(): Promise<void>;
 }
 
+export type OpenCodeStartupFailureCode =
+  | "executable-not-found"
+  | "permission-denied"
+  | "launch-failed"
+  | "exited"
+  | "timed-out"
+  | "cancelled";
+
+const startupMessages: Record<OpenCodeStartupFailureCode, string> = {
+  "executable-not-found":
+    "Studio's OpenCode runtime is missing. Update or reinstall Studio, then retry.",
+  "permission-denied":
+    "Studio cannot launch its OpenCode runtime because the executable is not permitted. Check the installation permissions or reinstall Studio, then retry.",
+  "launch-failed":
+    "Studio could not launch its OpenCode runtime. Retry, then update or reinstall Studio if the problem continues.",
+  exited:
+    "OpenCode exited before it became ready. Retry, then update or reinstall Studio if the problem continues.",
+  "timed-out": "OpenCode took too long to start. Retry the connection.",
+  cancelled: "OpenCode startup was cancelled.",
+};
+
+const permanentlyBlocked = new Set<OpenCodeStartupFailureCode>([
+  "executable-not-found",
+  "permission-denied",
+]);
+
+/** A credential-free, stable reason for a native runtime startup failure. */
+export class OpenCodeStartupError extends Error {
+  readonly retryable: boolean;
+  readonly exitCode?: number;
+  readonly signal?: NodeJS.Signals;
+
+  constructor(
+    readonly code: OpenCodeStartupFailureCode,
+    termination?: { exitCode: number | null; signal: NodeJS.Signals | null },
+  ) {
+    super(startupMessages[code]);
+    this.name = "OpenCodeStartupError";
+    this.retryable = !permanentlyBlocked.has(code);
+    if (code === "exited") {
+      if (typeof termination?.exitCode === "number")
+        this.exitCode = termination.exitCode;
+      if (termination?.signal) this.signal = termination.signal;
+    }
+  }
+}
+
 /** Tools receive platform necessities, never the host's provider/auth variables. */
 function platformEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const result: NodeJS.ProcessEnv = {};
@@ -52,7 +99,7 @@ function platformEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
 export async function startOpenCodeServer(
   options: StartOpenCodeServerOptions,
 ): Promise<OpenCodeServer> {
-  options.signal?.throwIfAborted();
+  if (options.signal?.aborted) throw new OpenCodeStartupError("cancelled");
   const command = options.command ?? {
     executable: join(
       dirname(
@@ -77,49 +124,69 @@ export async function startOpenCodeServer(
       mkdir(path, { recursive: true, mode: 0o700 }),
     ),
   );
-  options.signal?.throwIfAborted();
-  const child = spawn(
-    command.executable,
-    [
-      ...(command.prefixArgs ?? []),
-      "serve",
-      "--hostname",
-      "127.0.0.1",
-      "--port",
-      String(port),
-      "--pure",
-    ],
-    {
-      cwd: options.cwd,
-      env: {
-        ...platformEnvironment(options.environment ?? process.env),
-        ...directories,
-        OPENCODE_CONFIG_CONTENT: JSON.stringify(options.config),
-        OPENCODE_SERVER_USERNAME: "opencode",
-        OPENCODE_SERVER_PASSWORD: password,
-        OPENCODE_DISABLE_CLAUDE_CODE: "1",
-        OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: "1",
-        OPENCODE_DISABLE_DEFAULT_PLUGINS: "1",
-        OPENCODE_DISABLE_EXTERNAL_SKILLS: "1",
-        OPENCODE_DISABLE_PROJECT_CONFIG: "1",
-        OPENCODE_DISABLE_AUTOUPDATE: "1",
+  if (options.signal?.aborted) throw new OpenCodeStartupError("cancelled");
+  let child: ChildProcess;
+  try {
+    child = spawn(
+      command.executable,
+      [
+        ...(command.prefixArgs ?? []),
+        "serve",
+        "--hostname",
+        "127.0.0.1",
+        "--port",
+        String(port),
+        "--pure",
+      ],
+      {
+        cwd: options.cwd,
+        env: {
+          ...platformEnvironment(options.environment ?? process.env),
+          ...directories,
+          OPENCODE_CONFIG_CONTENT: JSON.stringify(options.config),
+          OPENCODE_SERVER_USERNAME: "opencode",
+          OPENCODE_SERVER_PASSWORD: password,
+          OPENCODE_DISABLE_CLAUDE_CODE: "1",
+          OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: "1",
+          OPENCODE_DISABLE_DEFAULT_PLUGINS: "1",
+          OPENCODE_DISABLE_EXTERNAL_SKILLS: "1",
+          OPENCODE_DISABLE_PROJECT_CONFIG: "1",
+          OPENCODE_DISABLE_AUTOUPDATE: "1",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        detached: process.platform !== "win32",
       },
-      stdio: ["ignore", "pipe", "pipe"],
-      windowsHide: true,
-      detached: process.platform !== "win32",
-    },
-  );
+    );
+  } catch (error) {
+    throw startupLaunchError(error);
+  }
   // Raw diagnostics can contain configuration or provider credentials.
   child.stdout?.resume();
   child.stderr?.resume();
   let exited = false;
+  let termination:
+    | {
+        exitCode: number | null;
+        signal: NodeJS.Signals | null;
+        spawnErrorCode?: string;
+      }
+    | undefined;
   const exit = new Promise<void>((resolve) => {
-    const done = () => {
+    const done = (next: typeof termination) => {
+      if (exited) return;
       exited = true;
+      termination = next;
       resolve();
     };
-    child.once("exit", done);
-    child.once("error", done);
+    child.once("exit", (exitCode, signal) => done({ exitCode, signal }));
+    child.once("error", (error) =>
+      done({
+        exitCode: null,
+        signal: null,
+        spawnErrorCode: (error as NodeJS.ErrnoException).code,
+      }),
+    );
   });
   let closing: Promise<void> | undefined;
   const close = () =>
@@ -177,10 +244,37 @@ export async function startOpenCodeServer(
         return (await response.json()) as T;
       },
     };
-  } catch {
+  } catch (error) {
+    let startupError: OpenCodeStartupError;
+    if (options.signal?.aborted) {
+      startupError = new OpenCodeStartupError("cancelled");
+    } else if (timeout.aborted) {
+      startupError = new OpenCodeStartupError("timed-out");
+    } else if (exited) {
+      startupError = termination?.spawnErrorCode
+        ? startupLaunchError(termination.spawnErrorCode)
+        : new OpenCodeStartupError("exited", termination);
+    } else {
+      startupError =
+        error instanceof OpenCodeStartupError
+          ? error
+          : new OpenCodeStartupError("launch-failed");
+    }
     await close();
-    throw new Error("OpenCode could not start. Please retry.");
+    throw startupError;
   }
+}
+
+function startupLaunchError(error: unknown): OpenCodeStartupError {
+  const code =
+    typeof error === "string"
+      ? error
+      : (error as NodeJS.ErrnoException | undefined)?.code;
+  if (code === "ENOENT" || code === "ENOTDIR")
+    return new OpenCodeStartupError("executable-not-found");
+  if (code === "EACCES" || code === "EPERM")
+    return new OpenCodeStartupError("permission-denied");
+  return new OpenCodeStartupError("launch-failed");
 }
 
 function signalChild(child: ChildProcess, signal: NodeJS.Signals): void {

--- a/packages/opencode/src/server.ts
+++ b/packages/opencode/src/server.ts
@@ -1,0 +1,205 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { createServer } from "node:net";
+import { dirname, join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+export interface StartOpenCodeServerOptions {
+  cwd: string;
+  stateRoot: string;
+  config: Record<string, unknown>;
+  signal?: AbortSignal;
+  environment?: NodeJS.ProcessEnv;
+  command?: { executable: string; prefixArgs?: string[] };
+  startupTimeoutMs?: number;
+  shutdownTimeoutMs?: number;
+}
+export interface OpenCodeServer {
+  pid: number;
+  fetch(path: string, init?: RequestInit): Promise<Response>;
+  fetchJson<T>(path: string, init?: RequestInit): Promise<T>;
+  close(): Promise<void>;
+}
+
+/** Tools receive platform necessities, never the host's provider/auth variables. */
+function platformEnvironment(source: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const result: NodeJS.ProcessEnv = {};
+  const allowed = new Set([
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "TMPDIR",
+    "TEMP",
+    "TMP",
+    "SYSTEMROOT",
+    "WINDIR",
+    "PATHEXT",
+    "COMSPEC",
+    "LANG",
+    "LC_ALL",
+    "TERM",
+    "COLORTERM",
+  ]);
+  for (const [key, value] of Object.entries(source))
+    if (allowed.has(key.toUpperCase())) result[key] = value;
+  return result;
+}
+
+export async function startOpenCodeServer(
+  options: StartOpenCodeServerOptions,
+): Promise<OpenCodeServer> {
+  options.signal?.throwIfAborted();
+  const command = options.command ?? {
+    executable: join(
+      dirname(
+        createRequire(import.meta.url).resolve("opencode-ai/package.json"),
+      ),
+      "bin",
+      "opencode.exe",
+    ).replace(/([/\\])app\.asar([/\\])/, "$1app.asar.unpacked$2"),
+  };
+  const port = await reservePort();
+  const origin = `http://127.0.0.1:${port}`;
+  const password = randomBytes(32).toString("hex");
+  const authorization = `Basic ${Buffer.from(`opencode:${password}`).toString("base64")}`;
+  const directories = Object.fromEntries(
+    ["config", "data", "cache", "state"].map((name) => [
+      `XDG_${name.toUpperCase()}_HOME`,
+      join(options.stateRoot, name),
+    ]),
+  );
+  await Promise.all(
+    Object.values(directories).map((path) =>
+      mkdir(path, { recursive: true, mode: 0o700 }),
+    ),
+  );
+  options.signal?.throwIfAborted();
+  const child = spawn(
+    command.executable,
+    [
+      ...(command.prefixArgs ?? []),
+      "serve",
+      "--hostname",
+      "127.0.0.1",
+      "--port",
+      String(port),
+      "--pure",
+    ],
+    {
+      cwd: options.cwd,
+      env: {
+        ...platformEnvironment(options.environment ?? process.env),
+        ...directories,
+        OPENCODE_CONFIG_CONTENT: JSON.stringify(options.config),
+        OPENCODE_SERVER_USERNAME: "opencode",
+        OPENCODE_SERVER_PASSWORD: password,
+        OPENCODE_DISABLE_CLAUDE_CODE: "1",
+        OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: "1",
+        OPENCODE_DISABLE_DEFAULT_PLUGINS: "1",
+        OPENCODE_DISABLE_EXTERNAL_SKILLS: "1",
+        OPENCODE_DISABLE_PROJECT_CONFIG: "1",
+        OPENCODE_DISABLE_AUTOUPDATE: "1",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      detached: process.platform !== "win32",
+    },
+  );
+  // Raw diagnostics can contain configuration or provider credentials.
+  child.stdout?.resume();
+  child.stderr?.resume();
+  let exited = false;
+  const exit = new Promise<void>((resolve) => {
+    const done = () => {
+      exited = true;
+      resolve();
+    };
+    child.once("exit", done);
+    child.once("error", done);
+  });
+  let closing: Promise<void> | undefined;
+  const close = () =>
+    (closing ??= (async () => {
+      signalChild(child, "SIGTERM");
+      if (!exited)
+        await Promise.race([exit, delay(options.shutdownTimeoutMs ?? 2000)]);
+      signalChild(child, "SIGKILL");
+      if (!exited) await Promise.race([exit, delay(2000)]);
+      if (!exited)
+        throw new Error("OpenCode did not exit within the shutdown deadline");
+    })());
+  const authenticatedFetch = async (
+    path: string,
+    init: RequestInit = {},
+  ): Promise<Response> => {
+    const url = new URL(path, origin);
+    if (!path.startsWith("/") || url.origin !== origin)
+      throw new Error("Invalid OpenCode request path");
+    const headers = new Headers(init.headers);
+    headers.set("Authorization", authorization);
+    headers.set("Accept-Encoding", "identity");
+    return fetch(url, { ...init, headers, redirect: "error" });
+  };
+  const timeout = AbortSignal.timeout(options.startupTimeoutMs ?? 15000);
+  const signal = options.signal
+    ? AbortSignal.any([options.signal, timeout])
+    : timeout;
+  try {
+    for (;;) {
+      signal.throwIfAborted();
+      if (exited) throw new Error("OpenCode exited during startup");
+      try {
+        const response = await authenticatedFetch("/global/health", {
+          signal: AbortSignal.any([signal, AbortSignal.timeout(1000)]),
+        });
+        if (
+          response.ok &&
+          ((await response.json()) as { healthy?: boolean }).healthy === true
+        )
+          break;
+      } catch {
+        signal.throwIfAborted();
+      }
+      await delay(50, undefined, { signal });
+    }
+    if (!child.pid || exited) throw new Error("OpenCode exited during startup");
+    return {
+      pid: child.pid,
+      fetch: authenticatedFetch,
+      close,
+      async fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+        const response = await authenticatedFetch(path, init);
+        if (!response.ok) throw new Error("OpenCode request failed");
+        return (await response.json()) as T;
+      },
+    };
+  } catch {
+    await close();
+    throw new Error("OpenCode could not start. Please retry.");
+  }
+}
+
+function signalChild(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (!child.pid) return;
+  try {
+    if (process.platform === "win32") child.kill(signal);
+    else process.kill(-child.pid, signal);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+  }
+}
+
+async function reservePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as { port: number }).port;
+      server.close((error) => (error ? reject(error) : resolve(port)));
+    });
+  });
+}

--- a/packages/opencode/tsconfig.build.json
+++ b/packages/opencode/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
+}

--- a/packages/opencode/tsconfig.json
+++ b/packages/opencode/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -693,6 +693,31 @@ importers:
         specifier: ^5.4.2
         version: 5.9.3
 
+  packages/opencode:
+    dependencies:
+      opencode-ai:
+        specifier: 1.18.29
+        version: 1.18.29
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.30
+        version: 20.19.43
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^7.3.1
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: ^7.3.1
+        version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      eslint:
+        specifier: ^8.57.0
+        version: 8.57.1
+      typescript:
+        specifier: ^5.4.2
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@20.19.43)(tsx@4.23.0)
+
   packages/sandbox:
     dependencies:
       '@sapiom/fetch':
@@ -1135,7 +1160,7 @@ packages:
     engines: {node: '>=12'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -4498,6 +4523,75 @@ packages:
         optional: true
       zod:
         optional: true
+
+  opencode-ai@1.18.29:
+    resolution: {integrity: sha512-syIDVwlrYTgTOXzZe9SkInJWethbq6l3SNC762UeXyO0a9V0wGfd+U4yACvppwNBnhIsl0j2QPYYCyLpNaSomg==}
+    cpu: [arm64, x64]
+    os: [darwin, linux, win32]
+    hasBin: true
+
+  opencode-darwin-arm64@1.18.29:
+    resolution: {integrity: sha512-EU0qma5GPJXcDp5rENvedSfqJjqxatQW/Qzjs71pR2YdbrSh7YmBwtvnIb2/KIvfQr0DErX4ST14sbBQI2mQdg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  opencode-darwin-x64-baseline@1.18.29:
+    resolution: {integrity: sha512-LJAQWZd4Tixo/IYCM3qYDk+h+OydkcZY6ywL99K67acJzfiAmfzqDKUi7WuQkMrlTCSPoOxkyz3yTPd0GzVeXw==}
+    cpu: [x64]
+    os: [darwin]
+
+  opencode-darwin-x64@1.18.29:
+    resolution: {integrity: sha512-Soyw5WI5kRI3Wbk5eeuSkMw4x+ScXi3SqzITMsi6rnVX0hsAbFCOmKOieYcd8BKJ1aUTrrG0Vv556CFzekk5Bw==}
+    cpu: [x64]
+    os: [darwin]
+
+  opencode-linux-arm64-musl@1.18.29:
+    resolution: {integrity: sha512-9lNhNvW3FdwbI+BDy/y+0bwIQkbz36u/RVQoZH2tYvWjHkOaf8D+mSuDKbKcFqpLFIbbQona01oYSQZzncZIcQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  opencode-linux-arm64@1.18.29:
+    resolution: {integrity: sha512-Lr7XXik5wPJZBV5RW+aR6Uogf1n5GogpB565m+D/jiO/vRXr9LhvCpixgAr1tiwuH1ZfMsqOOlbFQz5jgH3Tqg==}
+    cpu: [arm64]
+    os: [linux]
+
+  opencode-linux-x64-baseline-musl@1.18.29:
+    resolution: {integrity: sha512-A60ew2Xu0gXPwjPYbXoYtkzpUYaLKpgp8dVU5RJpGhT2NBMWBaEyY8O/pcZJFvhPOoEFP9IYmcF2k8Pj4mjDfA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  opencode-linux-x64-baseline@1.18.29:
+    resolution: {integrity: sha512-AnPvoVjeLC6qBYSeDwmj8fIVeJxspkrh1xAPow5NMSdH7IZZd0auiI2PHIW+0/3B+xfar1Zx1a6yvDd4Wd74Wg==}
+    cpu: [x64]
+    os: [linux]
+
+  opencode-linux-x64-musl@1.18.29:
+    resolution: {integrity: sha512-bGAZ9NFzNOzrXVN9oczd1H+vzLH1aGyYg1ZZNtuZiszxKr8+vTjLnNcjzGJIuc6jtjvlWbfp8l+S5fxCVuQo2A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  opencode-linux-x64@1.18.29:
+    resolution: {integrity: sha512-X8/wS/8mzL7Ko0zYYF6RzKax39KkxXDRoimhmzXuo0gPrZX4DQjqBNpPAByBwUjFapk73ZGSVsjDGvoNapBa1Q==}
+    cpu: [x64]
+    os: [linux]
+
+  opencode-windows-arm64@1.18.29:
+    resolution: {integrity: sha512-LwDli4EeZIGNnq8vJ9/uLIvsxAY0zLi6+54KsmOk8E1w7121axXpJ/5TpCg4LvmsNXwRKenKJgWzqoDBhy/2mw==}
+    cpu: [arm64]
+    os: [win32]
+
+  opencode-windows-x64-baseline@1.18.29:
+    resolution: {integrity: sha512-rUqqp8zbHq5bc3yWPymQxCHgS2Fax07GoEq/KX1R+FE4XNDgL6R+Q1PFqqVDneLd3l0h5qPb+qqsiiWGGEORlA==}
+    cpu: [x64]
+    os: [win32]
+
+  opencode-windows-x64@1.18.29:
+    resolution: {integrity: sha512-xtWiZNMiwFtBl7q9yMG+XK/BTYGfgFoHLDx4ruWVYCoxjV0NYwjJi6rB9B3xIVbTclzu81YLKNFcT3kNBEG9Yw==}
+    cpu: [x64]
+    os: [win32]
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -9865,6 +9959,57 @@ snapshots:
     optionalDependencies:
       ws: 8.21.0
       zod: 4.4.3
+    optional: true
+
+  opencode-ai@1.18.29:
+    optionalDependencies:
+      opencode-darwin-arm64: 1.18.29
+      opencode-darwin-x64: 1.18.29
+      opencode-darwin-x64-baseline: 1.18.29
+      opencode-linux-arm64: 1.18.29
+      opencode-linux-arm64-musl: 1.18.29
+      opencode-linux-x64: 1.18.29
+      opencode-linux-x64-baseline: 1.18.29
+      opencode-linux-x64-baseline-musl: 1.18.29
+      opencode-linux-x64-musl: 1.18.29
+      opencode-windows-arm64: 1.18.29
+      opencode-windows-x64: 1.18.29
+      opencode-windows-x64-baseline: 1.18.29
+
+  opencode-darwin-arm64@1.18.29:
+    optional: true
+
+  opencode-darwin-x64-baseline@1.18.29:
+    optional: true
+
+  opencode-darwin-x64@1.18.29:
+    optional: true
+
+  opencode-linux-arm64-musl@1.18.29:
+    optional: true
+
+  opencode-linux-arm64@1.18.29:
+    optional: true
+
+  opencode-linux-x64-baseline-musl@1.18.29:
+    optional: true
+
+  opencode-linux-x64-baseline@1.18.29:
+    optional: true
+
+  opencode-linux-x64-musl@1.18.29:
+    optional: true
+
+  opencode-linux-x64@1.18.29:
+    optional: true
+
+  opencode-windows-arm64@1.18.29:
+    optional: true
+
+  opencode-windows-x64-baseline@1.18.29:
+    optional: true
+
+  opencode-windows-x64@1.18.29:
     optional: true
 
   optionator@0.9.4:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ onlyBuiltDependencies:
   - electron
   - esbuild
   - "@electron/rebuild"
+  - opencode-ai
 
 # Upgrade the @electron/rebuild that electron-builder bundles (app-builder-lib
 # pins 3.6.1, which drags node-gyp@9.4.1 — its VS detection can't parse recent


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Studio needs a pinned OpenCode runtime that can authenticate through the host and report startup failures without exposing process diagnostics.

## Summary and scope

Package the controlled OpenCode runtime, its sole generated plugin seam, and a public sanitized startup error API. Startup codes remain a fixed allowlist and omit child output, paths, configuration, and causes. Credential/HOME isolation is deliberately delivered in the following retained correction layer.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `studio-opencode-bridge`. Actual-parent size: **861 additions + 1 deletions = 862 changed lines**. This is above the 600-line target and below the 1,000-line hard maximum; the source and tests stay together to preserve a compiling, independently reviewable boundary.

Absorbed reviewed provenance: #932 sanitized startup error API; original packaged OpenCode runtime.

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3289](https://linear.app/sapiom/issue/SAP-3289). This PR keeps its existing number and review history within the main-rooted native GitHub stack.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check ec252d3e3e031ffa215960281e1419e3322e5a4e...d516895e43bc1c43ffc3568a2c6f2a440d1be582` — passed.
- `pnpm --filter @sapiom/opencode build` and `pnpm --filter @sapiom/opencode typecheck` — passed at this API boundary.

### Tests and documentation

Runtime configuration, startup success/failure, timeout, cancellation, exit, missing executable, and permission-denied behavior are covered with package documentation and Changesets.

## Compatibility and release impact

- Breaking or externally visible changes: Adds the `@sapiom/opencode` workspace package and exported sanitized startup error types. No installed-platform certification is claimed.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/900" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
