### PR TITLE
feat(studio): own OpenCode lifecycle for authorized workspaces [SAP-3290]

### DIFF
--- a/.changeset/studio-opencode-lifecycle.md
+++ b/.changeset/studio-opencode-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/harness": minor
+"@sapiom/opencode": patch
+---
+
+Own OpenCode startup, authorized workspace state, access revocation, and shutdown in the shared Studio host.

--- a/.changeset/studio-opencode-sessions.md
+++ b/.changeset/studio-opencode-sessions.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/harness": minor
+"@sapiom/opencode": patch
+---
+
+Associate Studio sessions with distinct OpenCode conversations and expose authenticated, session-scoped actions and incremental events.

--- a/.changeset/studio-opencode-sessions.md
+++ b/.changeset/studio-opencode-sessions.md
@@ -1,6 +1,0 @@
----
-"@sapiom/harness": minor
-"@sapiom/opencode": patch
----
-
-Associate Studio sessions with distinct OpenCode conversations and expose authenticated, session-scoped actions and incremental events.

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -10,7 +10,7 @@ name: Harness
 # status checks). Keep the paths list in sync if the harness gains a new
 # workspace dependency; the current closure is:
 #   harness -> agent, agent-core, agent-runtime, analytics-core, mcp,
-#              sandbox-preview, tools
+#              sandbox-preview, tools, opencode
 on:
   pull_request:
     types: [opened, synchronize, reopened, stacked]
@@ -23,6 +23,7 @@ on:
       - "packages/agent-runtime/**"
       - "packages/analytics-core/**"
       - "packages/mcp/**"
+      - "packages/opencode/**"
       - "packages/sandbox-preview/**"
       - "packages/tools/**"
       - "pnpm-lock.yaml"
@@ -40,6 +41,7 @@ on:
       - "packages/agent-runtime/**"
       - "packages/analytics-core/**"
       - "packages/mcp/**"
+      - "packages/opencode/**"
       - "packages/sandbox-preview/**"
       - "packages/tools/**"
       - "pnpm-lock.yaml"

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -63,6 +63,12 @@ Production uses the Sapiom LLM gateway. Other environments must explicitly set
 `services.llm` to their gateway origin in the matching credentials-file environment
 entry; Studio never falls back from a custom environment to production.
 
+Studio owns each Assistant runtime for the authorized session and working
+directory. Browser detachment leaves it running; sign-out, access revocation,
+and Studio shutdown stop it. Runtime state is isolated by user, organization,
+session, and directory under `~/.sapiom/harness/opencode`. A process lock prevents
+two Studio hosts from opening the same runtime state concurrently.
+
 The rail's cloud icon marks an agent as deployed once Studio confirms a ready
 hosted build. Failed checks silently retain the last confirmed indicator, and changing
 accounts clears this evidence. Retained indicators do not enable cloud runs.

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -63,11 +63,12 @@
     "e2e:live": "tsx scripts/e2e-live.ts"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@sapiom/agent": "workspace:^",
     "@sapiom/agent-core": "workspace:^",
     "@sapiom/analytics-core": "workspace:^",
     "@sapiom/mcp": "workspace:^",
-    "@modelcontextprotocol/sdk": "^1.26.0",
+    "@sapiom/opencode": "workspace:^",
     "ajv": "^8.12.0",
     "express": "^4.21.0",
     "express-rate-limit": "^7.4.0",

--- a/packages/harness/src/core/opencode-association.test.ts
+++ b/packages/harness/src/core/opencode-association.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { mkdtemp, readFile, rename, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { OpenCodeAssociations } from "./opencode-association.js";
+import type { HostedOpenCode } from "./opencode-host.js";
+
+vi.mock("node:fs/promises", async (original) => {
+  const fs = await original<typeof import("node:fs/promises")>();
+  return { ...fs, rename: vi.fn(fs.rename) };
+});
+let root: string;
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+it("serializes association commits across runtime retirement, including an already pending rename", async () => {
+  root = await mkdtemp(join(tmpdir(), "studio-association-"));
+  const original =
+    await vi.importActual<typeof import("node:fs/promises")>(
+      "node:fs/promises",
+    );
+  let commit!: () => void;
+  let entered!: () => void;
+  const writing = new Promise<void>((resolve) => {
+    entered = resolve;
+  });
+  vi.mocked(rename).mockImplementationOnce(async (from, to) => {
+    entered();
+    await new Promise<void>((resolve) => {
+      commit = resolve;
+    });
+    await original.rename(from, to);
+  });
+  let created = 0;
+  const abort = new AbortController();
+  const hosted: HostedOpenCode = {
+    harnessSessionId: "studio-one",
+    cwd: root,
+    stateRoot: root,
+    signal: abort.signal,
+    server: {
+      pid: 123,
+      exited: new Promise<void>(() => {}),
+      close: vi.fn(),
+      fetch: vi.fn(),
+      async fetchJson<T>(path: string): Promise<T> {
+        return {
+          id: path === "/session" ? `ses_${++created}` : path.split("/").at(-1),
+        } as T;
+      },
+    },
+  };
+  const associations = new OpenCodeAssociations();
+  const old = associations.ensure(hosted);
+  await writing;
+  abort.abort();
+  const replacement = { ...hosted, signal: new AbortController().signal };
+  const next = associations.ensure(replacement);
+  try {
+    expect(created).toBe(1);
+    commit();
+    const [oldId, newId] = await Promise.all([old, next]);
+    expect(newId).toBe(oldId);
+    expect(created).toBe(1);
+    expect(
+      JSON.parse(await readFile(join(root, "association.json"), "utf8"))
+        .conversationId,
+    ).toBe(newId);
+    expect(await associations.ensure(replacement)).toBe(newId);
+  } finally {
+    commit();
+    await Promise.allSettled([old, next]);
+  }
+});

--- a/packages/harness/src/core/opencode-association.test.ts
+++ b/packages/harness/src/core/opencode-association.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, it, vi } from "vitest";
-import { mkdtemp, readFile, rename, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { OpenCodeAssociations } from "./opencode-association.js";
@@ -39,11 +39,14 @@ it("serializes association commits across runtime retirement, including an alrea
     cwd: root,
     stateRoot: root,
     signal: abort.signal,
+    isCurrent: () => !abort.signal.aborted,
     server: {
       pid: 123,
       exited: new Promise<void>(() => {}),
       close: vi.fn(),
-      fetch: vi.fn(),
+      fetch: vi.fn(async (path: string) =>
+        Response.json({ id: path.split("/").at(-1) }),
+      ),
       async fetchJson<T>(path: string): Promise<T> {
         return {
           id: path === "/session" ? `ses_${++created}` : path.split("/").at(-1),
@@ -55,7 +58,12 @@ it("serializes association commits across runtime retirement, including an alrea
   const old = associations.ensure(hosted);
   await writing;
   abort.abort();
-  const replacement = { ...hosted, signal: new AbortController().signal };
+  const replacementAbort = new AbortController();
+  const replacement = {
+    ...hosted,
+    signal: replacementAbort.signal,
+    isCurrent: () => !replacementAbort.signal.aborted,
+  };
   const next = associations.ensure(replacement);
   try {
     expect(created).toBe(1);
@@ -72,4 +80,47 @@ it("serializes association commits across runtime retirement, including an alrea
     commit();
     await Promise.allSettled([old, next]);
   }
+});
+
+it("distinguishes confirmed missing history from transient lookup failure without creating a replacement", async () => {
+  root = await mkdtemp(join(tmpdir(), "studio-association-"));
+  const conversationId = "ses_saved";
+  await writeFile(
+    join(root, "association.json"),
+    JSON.stringify({ version: 1, conversationId }),
+  );
+  const abort = new AbortController();
+  const fetch = vi
+    .fn()
+    .mockResolvedValueOnce(new Response("private missing", { status: 404 }))
+    .mockRejectedValueOnce(new TypeError("private network diagnostic"))
+    .mockResolvedValueOnce(Response.json({ id: conversationId }));
+  const create = vi.fn();
+  const hosted: HostedOpenCode = {
+    harnessSessionId: "studio-one",
+    cwd: root,
+    stateRoot: root,
+    signal: abort.signal,
+    isCurrent: () => !abort.signal.aborted,
+    server: {
+      pid: 123,
+      exited: new Promise<void>(() => {}),
+      close: vi.fn(),
+      fetch,
+      fetchJson: create,
+    },
+  };
+  const associations = new OpenCodeAssociations();
+  await expect(associations.ensure(hosted)).rejects.toMatchObject({
+    failure: { code: "native_history_missing", retryable: false },
+  });
+  await expect(associations.ensure(hosted)).rejects.toMatchObject({
+    failure: { code: "transport_unavailable", retryable: true },
+  });
+  await expect(associations.ensure(hosted)).resolves.toBe(conversationId);
+  expect(fetch).toHaveBeenCalledTimes(3);
+  expect(create).not.toHaveBeenCalled();
+  expect(
+    JSON.parse(await readFile(join(root, "association.json"), "utf8")),
+  ).toEqual({ version: 1, conversationId });
 });

--- a/packages/harness/src/core/opencode-association.ts
+++ b/packages/harness/src/core/opencode-association.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { readFile, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { HostedOpenCode } from "./opencode-host.js";
+import {
+  OpenCodeTransportError,
+  type HostedOpenCode,
+} from "./opencode-host.js";
+import { openCodeTransportFailure } from "../shared/opencode-errors.js";
 import { DurableFileLock } from "./durable-file-lock.js";
 
 export const isConversationId = (id: unknown): id is string =>
@@ -52,14 +56,45 @@ export class OpenCodeAssociations {
         !isConversationId(saved.conversationId) ||
         saved.conversationId === hosted.harnessSessionId
       )
-        throw new Error("Assistant conversation association is invalid");
+        throw new OpenCodeTransportError(
+          openCodeTransportFailure("native_history_missing"),
+        );
       // Missing history is an error, never permission to silently replace it.
-      const session = await hosted.server.fetchJson<{ id: string }>(
-        `/session/${saved.conversationId}`,
-        { signal },
-      );
+      let response: Response;
+      try {
+        response = await hosted.server.fetch(
+          `/session/${saved.conversationId}`,
+          { signal },
+        );
+      } catch {
+        if (signal.reason instanceof OpenCodeTransportError)
+          throw signal.reason;
+        throw new OpenCodeTransportError(
+          openCodeTransportFailure("transport_unavailable"),
+        );
+      }
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new OpenCodeTransportError(
+          openCodeTransportFailure(
+            response.status === 404
+              ? "native_history_missing"
+              : "transport_unavailable",
+          ),
+        );
+      }
+      let session: { id?: unknown };
+      try {
+        session = (await response.json()) as { id?: unknown };
+      } catch {
+        throw new OpenCodeTransportError(
+          openCodeTransportFailure("transport_unavailable"),
+        );
+      }
       if (session.id !== saved.conversationId)
-        throw new Error("Assistant conversation is unavailable");
+        throw new OpenCodeTransportError(
+          openCodeTransportFailure("transport_unavailable"),
+        );
       return saved.conversationId;
     }
     const session = await hosted.server.fetchJson<{ id: string }>("/session", {

--- a/packages/harness/src/core/opencode-association.ts
+++ b/packages/harness/src/core/opencode-association.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from "node:crypto";
+import { readFile, rename, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { HostedOpenCode } from "./opencode-host.js";
+import { DurableFileLock } from "./durable-file-lock.js";
+
+export const isConversationId = (id: unknown): id is string =>
+  typeof id === "string" && /^ses_[A-Za-z0-9_-]{1,128}$/.test(id);
+
+/** One native conversation per Studio session; the host holds the owner lock. */
+export class OpenCodeAssociations {
+  private pending = new WeakMap<HostedOpenCode, Promise<string>>();
+
+  ensure(hosted: HostedOpenCode): Promise<string> {
+    const existing = this.pending.get(hosted);
+    if (existing) return existing;
+    const pending = this.load(hosted).catch((error) => {
+      this.pending.delete(hosted);
+      throw error;
+    });
+    this.pending.set(hosted, pending);
+    return pending;
+  }
+
+  private async load(hosted: HostedOpenCode): Promise<string> {
+    const file = join(hosted.stateRoot, "association.json");
+    // Held through commit even if the runtime retires during filesystem I/O.
+    // A replacement host must finish this transaction before reading a mapping.
+    const unlock = await new DurableFileLock(file).acquire();
+    try {
+      hosted.signal.throwIfAborted();
+      return await this.readOrCreate(hosted, file);
+    } finally {
+      await unlock();
+    }
+  }
+
+  private async readOrCreate(
+    hosted: HostedOpenCode,
+    file: string,
+  ): Promise<string> {
+    const signal = AbortSignal.any([hosted.signal, AbortSignal.timeout(15000)]);
+    let saved: { version?: unknown; conversationId?: unknown } | undefined;
+    try {
+      saved = JSON.parse(await readFile(file, "utf8"));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    if (saved !== undefined) {
+      if (
+        saved?.version !== 1 ||
+        !isConversationId(saved.conversationId) ||
+        saved.conversationId === hosted.harnessSessionId
+      )
+        throw new Error("Assistant conversation association is invalid");
+      // Missing history is an error, never permission to silently replace it.
+      const session = await hosted.server.fetchJson<{ id: string }>(
+        `/session/${saved.conversationId}`,
+        { signal },
+      );
+      if (session.id !== saved.conversationId)
+        throw new Error("Assistant conversation is unavailable");
+      return saved.conversationId;
+    }
+    const session = await hosted.server.fetchJson<{ id: string }>("/session", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+      signal,
+    });
+    if (!isConversationId(session.id) || session.id === hosted.harnessSessionId)
+      throw new Error("Assistant returned an invalid conversation");
+    const temporary = `${file}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(
+        temporary,
+        JSON.stringify({ version: 1, conversationId: session.id }),
+        { mode: 0o600, flag: "wx" },
+      );
+      hosted.signal.throwIfAborted();
+      await rename(temporary, file);
+    } finally {
+      await rm(temporary, { force: true });
+    }
+    return session.id;
+  }
+}

--- a/packages/harness/src/core/opencode-host.test.ts
+++ b/packages/harness/src/core/opencode-host.test.ts
@@ -3,7 +3,7 @@ import { access, mkdtemp, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AssistantGrant } from "./assistant-access.js";
-import { OpenCodeHost } from "./opencode-host.js";
+import { OpenCodeHost, OpenCodeTransportError } from "./opencode-host.js";
 
 let root: string;
 let cwd: string;
@@ -16,6 +16,7 @@ const start = vi.fn();
 const revoke = vi.fn();
 const close = vi.fn();
 const issue = vi.fn();
+const neverExited = new Promise<void>(() => {});
 beforeEach(async () => {
   expectShutdownFailure = false;
   root = await mkdtemp(join(tmpdir(), "studio-opencode-host-"));
@@ -45,12 +46,18 @@ beforeEach(async () => {
   close.mockReset().mockResolvedValue(undefined);
   revoke.mockReset();
   issue.mockReset().mockReturnValue({ id: "runtime", token: "scoped", revoke });
-  start
-    .mockReset()
-    .mockResolvedValue({ pid: 123, fetch: vi.fn(), fetchJson: vi.fn(), close });
+  start.mockReset().mockResolvedValue({
+    pid: 123,
+    exited: neverExited,
+    fetch: vi.fn(),
+    fetchJson: vi.fn(),
+    close,
+  });
   host = new OpenCodeHost({
     access: {
       get: () => grant,
+      getFailureCode: () =>
+        grant ? "transport_unavailable" : "authentication_required",
       subscribe: (listener) => {
         changed = listener;
         return () => {};
@@ -112,7 +119,9 @@ describe("Studio-owned OpenCode lifecycle", () => {
 
   it("releases failed startup so retry can acquire the same state", async () => {
     start.mockRejectedValueOnce(new Error("startup failed"));
-    await expect(host.ensure("studio-one")).rejects.toThrow("startup failed");
+    await expect(host.ensure("studio-one")).rejects.toMatchObject({
+      failure: { code: "runtime_start_failed" },
+    });
     expect(revoke).toHaveBeenCalledOnce();
     await host.ensure("studio-one");
     expect(start).toHaveBeenCalledTimes(2);
@@ -137,7 +146,7 @@ describe("Studio-owned OpenCode lifecycle", () => {
       await new Promise<void>((resolve) => {
         finish = resolve;
       });
-      return { pid: 123, close };
+      return { pid: 123, exited: neverExited, close };
     });
     const pending = host.ensure("studio-one");
     const rejected = expect(pending).rejects.toThrow("access changed");
@@ -152,12 +161,15 @@ describe("Studio-owned OpenCode lifecycle", () => {
     expect(revoke).toHaveBeenCalled();
   });
 
-  it("keeps attachment alive without a browser, revokes on identity changes, and closes idempotently", async () => {
+  it("keeps attachment alive without a browser, revokes on verified-user changes, and closes idempotently", async () => {
     const attachment = await host.ensure("studio-one");
     expect(close).not.toHaveBeenCalled();
-    grant = { ...grant!, identityRevision: "new-user" };
+    grant = { ...grant!, userId: "new-user" };
     changed();
     expect(attachment.signal.aborted).toBe(true);
+    expect(attachment.signal.reason).toMatchObject({
+      failure: { code: "access_denied" },
+    });
     await Promise.all([host.close(), host.close()]);
     expect(close).toHaveBeenCalledOnce();
     await expect(host.ensure("studio-one")).rejects.toThrow("unavailable");
@@ -179,16 +191,16 @@ describe("Studio-owned OpenCode lifecycle", () => {
     grant = null;
     changed();
     close.mockRejectedValue(new Error("still alive"));
-    finish({ pid: 123, close });
+    finish({ pid: 123, exited: neverExited, close });
     await rejected;
     await expect(
       access(join(start.mock.calls[0][0].stateRoot, "..", "runtime.lock")),
     ).resolves.toBeUndefined();
     grant = saved;
     changed();
-    await expect(host.ensure("studio-one")).rejects.toThrow(
-      "another Studio window",
-    );
+    await expect(host.ensure("studio-one")).rejects.toMatchObject({
+      failure: { code: "transport_unavailable" },
+    });
     expect(start).toHaveBeenCalledOnce();
   });
 
@@ -213,7 +225,7 @@ describe("Studio-owned OpenCode lifecycle", () => {
     authorize.mockImplementation(async (id) => ({ harnessSessionId: id, cwd }));
     start.mockImplementationOnce(async () => {
       authorize.mockResolvedValue(null);
-      return { pid: 456, close };
+      return { pid: 456, exited: neverExited, close };
     });
     await expect(host.ensure("studio-two")).rejects.toThrow("workspace");
     expect(close).toHaveBeenCalledTimes(2);
@@ -240,5 +252,43 @@ describe("Studio-owned OpenCode lifecycle", () => {
     expect(settled).toBe(false);
     finish();
     await rejected;
+  });
+  it("retires a confirmed exited process so retry can reopen the same persistent state", async () => {
+    let exit!: () => void;
+    const exited = new Promise<void>((resolve) => {
+      exit = resolve;
+    });
+    start.mockResolvedValueOnce({ pid: 123, exited, close });
+    const first = await host.ensure("studio-one");
+    exit();
+    await vi.waitFor(() => expect(first.signal.aborted).toBe(true));
+    const restored = await host.ensure("studio-one");
+    expect(restored.stateRoot).toBe(first.stateRoot);
+    expect(start).toHaveBeenCalledTimes(2);
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("maps only the bounded native startup reason and suppresses expected cancellation", async () => {
+    start.mockRejectedValueOnce({
+      code: "permission-denied",
+      message: "/private/runtime/path",
+    });
+    await expect(host.ensure("studio-one")).rejects.toMatchObject({
+      failure: {
+        code: "runtime_start_failed",
+        reason: "permission-denied",
+        retryable: false,
+        action: "open_settings",
+      },
+    });
+    start.mockImplementationOnce(async ({ signal }) => {
+      grant = null;
+      changed();
+      signal.throwIfAborted();
+      throw new OpenCodeTransportError({} as never);
+    });
+    await expect(host.ensure("studio-one")).rejects.toMatchObject({
+      failure: { code: "authentication_required" },
+    });
   });
 });

--- a/packages/harness/src/core/opencode-host.test.ts
+++ b/packages/harness/src/core/opencode-host.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { access, mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AssistantGrant } from "./assistant-access.js";
+import { OpenCodeHost } from "./opencode-host.js";
+
+let root: string;
+let cwd: string;
+let host: OpenCodeHost;
+let grant: AssistantGrant | null;
+let changed: () => void;
+let expectShutdownFailure = false;
+const authorize = vi.fn();
+const start = vi.fn();
+const revoke = vi.fn();
+const close = vi.fn();
+const issue = vi.fn();
+beforeEach(async () => {
+  expectShutdownFailure = false;
+  root = await mkdtemp(join(tmpdir(), "studio-opencode-host-"));
+  cwd = join(root, "project");
+  await mkdir(cwd);
+  grant = {
+    userId: "user",
+    tenantId: "tenant",
+    identityRevision: "revision",
+    expiresAt: Date.now() + 60000,
+    environment: {
+      name: "production",
+      appURL: "https://app.sapiom.ai",
+      apiURL: "https://api.sapiom.ai",
+      services: {},
+      credentials: {
+        apiKey: "sk_private",
+        apiKeyId: "key",
+        tenantId: "tenant",
+        organizationName: "Org",
+      },
+    },
+  };
+  authorize
+    .mockReset()
+    .mockImplementation(async (id) => ({ harnessSessionId: id, cwd }));
+  close.mockReset().mockResolvedValue(undefined);
+  revoke.mockReset();
+  issue.mockReset().mockReturnValue({ id: "runtime", token: "scoped", revoke });
+  start
+    .mockReset()
+    .mockResolvedValue({ pid: 123, fetch: vi.fn(), fetchJson: vi.fn(), close });
+  host = new OpenCodeHost({
+    access: {
+      get: () => grant,
+      subscribe: (listener) => {
+        changed = listener;
+        return () => {};
+      },
+    },
+    bridge: { issue, model: "smart" },
+    origin: () => "http://127.0.0.1:1234",
+    stateRoot: root,
+    authorize,
+    start,
+  });
+});
+afterEach(async () => {
+  if (expectShutdownFailure)
+    await expect(host.close()).rejects.toThrow("shutdown");
+  else await host.close();
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("Studio-owned OpenCode lifecycle", () => {
+  it("coalesces attachments and uses only the authorized cwd and private state", async () => {
+    const [first, second] = await Promise.all([
+      host.ensure("studio-one"),
+      host.ensure("studio-one"),
+    ]);
+    expect(first).toBe(second);
+    expect(start).toHaveBeenCalledOnce();
+    expect(first.cwd).toBe(cwd);
+    expect(first.harnessSessionId).toBe("studio-one");
+    expect(first.stateRoot.startsWith(join(root, "opencode"))).toBe(true);
+    expect(JSON.stringify(start.mock.calls)).not.toContain("sk_private");
+    expect(start.mock.calls[0][0].config.model).toBe("sapiom/smart");
+    await host.ensure("studio-two");
+    expect(start).toHaveBeenCalledTimes(2);
+    expect(start.mock.calls[0][0].stateRoot).not.toBe(
+      start.mock.calls[1][0].stateRoot,
+    );
+  });
+
+  it("does not inspect workspaces or start a process when access is off", async () => {
+    grant = null;
+    await expect(host.ensure("studio-one")).rejects.toThrow("unavailable");
+    expect(authorize).not.toHaveBeenCalled();
+    expect(start).not.toHaveBeenCalled();
+    expect(issue).not.toHaveBeenCalled();
+  });
+
+  it("rejects unauthorized workspaces and changing authority during authorization", async () => {
+    authorize.mockResolvedValueOnce(null);
+    await expect(host.ensure("studio-one")).rejects.toThrow("workspace");
+    authorize.mockImplementationOnce(async (id) => {
+      grant = null;
+      changed();
+      return { harnessSessionId: id, cwd };
+    });
+    await expect(host.ensure("studio-one")).rejects.toThrow("access changed");
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("releases failed startup so retry can acquire the same state", async () => {
+    start.mockRejectedValueOnce(new Error("startup failed"));
+    await expect(host.ensure("studio-one")).rejects.toThrow("startup failed");
+    expect(revoke).toHaveBeenCalledOnce();
+    await host.ensure("studio-one");
+    expect(start).toHaveBeenCalledTimes(2);
+  });
+
+  it("retires an existing runtime when workspace authorization is withdrawn", async () => {
+    const attached = await host.ensure("studio-one");
+    authorize.mockResolvedValue(null);
+    await expect(host.ensure("studio-one")).rejects.toThrow("workspace");
+    expect(attached.signal.aborted).toBe(true);
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("aborts and closes a late startup after access revocation", async () => {
+    let finish!: () => void;
+    let started!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    start.mockImplementationOnce(async () => {
+      started();
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      return { pid: 123, close };
+    });
+    const pending = host.ensure("studio-one");
+    const rejected = expect(pending).rejects.toThrow("access changed");
+    await entered;
+    grant = null;
+    changed();
+    finish();
+    await rejected;
+    await host.close();
+    expect(start.mock.calls[0][0].signal.aborted).toBe(true);
+    expect(close).toHaveBeenCalledOnce();
+    expect(revoke).toHaveBeenCalled();
+  });
+
+  it("keeps attachment alive without a browser, revokes on identity changes, and closes idempotently", async () => {
+    const attachment = await host.ensure("studio-one");
+    expect(close).not.toHaveBeenCalled();
+    grant = { ...grant!, identityRevision: "new-user" };
+    changed();
+    expect(attachment.signal.aborted).toBe(true);
+    await Promise.all([host.close(), host.close()]);
+    expect(close).toHaveBeenCalledOnce();
+    await expect(host.ensure("studio-one")).rejects.toThrow("unavailable");
+  });
+
+  it("retains the owner lock if a revoked late startup cannot be stopped", async () => {
+    expectShutdownFailure = true;
+    const saved = grant;
+    let finish!: (server: unknown) => void;
+    start.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const pending = host.ensure("studio-one");
+    const rejected = expect(pending).rejects.toThrow("shutdown");
+    await vi.waitFor(() => expect(start).toHaveBeenCalledOnce());
+    grant = null;
+    changed();
+    close.mockRejectedValue(new Error("still alive"));
+    finish({ pid: 123, close });
+    await rejected;
+    await expect(
+      access(join(start.mock.calls[0][0].stateRoot, "..", "runtime.lock")),
+    ).resolves.toBeUndefined();
+    grant = saved;
+    changed();
+    await expect(host.ensure("studio-one")).rejects.toThrow(
+      "another Studio window",
+    );
+    expect(start).toHaveBeenCalledOnce();
+  });
+
+  it("rechecks workspace authorization after retirement and after native startup", async () => {
+    await host.ensure("studio-one");
+    let finish!: () => void;
+    close.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    const retiring = host.retire("studio-one");
+    const pending = host.ensure("studio-two");
+    const rejected = expect(pending).rejects.toThrow("workspace");
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+    authorize.mockResolvedValue(null);
+    finish();
+    await retiring;
+    await rejected;
+    expect(start).toHaveBeenCalledOnce();
+    authorize.mockImplementation(async (id) => ({ harnessSessionId: id, cwd }));
+    start.mockImplementationOnce(async () => {
+      authorize.mockResolvedValue(null);
+      return { pid: 456, close };
+    });
+    await expect(host.ensure("studio-two")).rejects.toThrow("workspace");
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it("waits for every runtime cleanup even when one shutdown fails", async () => {
+    expectShutdownFailure = true;
+    await host.ensure("studio-one");
+    await host.ensure("studio-two");
+    let finish!: () => void;
+    close.mockRejectedValueOnce(new Error("still alive"));
+    close.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    let settled = false;
+    const shutdown = host.close().finally(() => {
+      settled = true;
+    });
+    const rejected = expect(shutdown).rejects.toThrow("shutdown");
+    await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(2));
+    expect(settled).toBe(false);
+    finish();
+    await rejected;
+  });
+});

--- a/packages/harness/src/core/opencode-host.ts
+++ b/packages/harness/src/core/opencode-host.ts
@@ -7,7 +7,17 @@ import {
   startOpenCodeServer,
   type OpenCodeServer,
 } from "@sapiom/opencode";
-import type { AssistantAccess, AssistantGrant } from "./assistant-access.js";
+import type {
+  AssistantAccess,
+  AssistantAccessFailureCode,
+  AssistantGrant,
+} from "./assistant-access.js";
+import {
+  openCodeStartupReasons,
+  openCodeTransportFailure,
+  type OpenCodeStartupReason,
+  type OpenCodeTransportFailure,
+} from "../shared/opencode-errors.js";
 import { DurableFileLock } from "./durable-file-lock.js";
 import type {
   OpenCodeBridge,
@@ -22,6 +32,7 @@ export interface HostedOpenCode extends OpenCodeWorkspace {
   stateRoot: string;
   server: OpenCodeServer;
   signal: AbortSignal;
+  isCurrent: () => boolean;
 }
 interface Managed {
   workspace: OpenCodeWorkspace;
@@ -33,17 +44,34 @@ interface Managed {
   cleanupFailed?: boolean;
 }
 interface Options {
-  access: Pick<AssistantAccess, "get" | "subscribe">;
+  access: Pick<AssistantAccess, "get" | "getFailureCode" | "subscribe">;
   bridge: Pick<OpenCodeBridge, "issue" | "model">;
   origin: () => string;
   stateRoot: string;
   authorize: (id: string) => Promise<OpenCodeWorkspace | null>;
   start?: typeof startOpenCodeServer;
 }
+export class OpenCodeTransportError extends Error {
+  constructor(readonly failure: OpenCodeTransportFailure) {
+    super(failure.message);
+  }
+}
+export class OpenCodeAccessError extends OpenCodeTransportError {
+  constructor(
+    message: string,
+    code: AssistantAccessFailureCode = "access_denied",
+  ) {
+    const failure = openCodeTransportFailure(code);
+    super(failure);
+    this.message = message;
+  }
+}
 const authority = (grant: AssistantGrant) =>
   createHash("sha256")
     .update(
       JSON.stringify([
+        grant.userId,
+        grant.tenantId,
         grant.identityRevision,
         grant.environment.name,
         grant.environment.apiURL,
@@ -66,10 +94,12 @@ export class OpenCodeHost {
         void this.workspace(id)
           .then(async (workspace) => {
             if (this.entries.get(id) !== entry) return;
-            if (workspace.cwd !== entry.workspace.cwd) await this.retire(id);
+            if (workspace.cwd !== entry.workspace.cwd)
+              await this.retire(id, openCodeTransportFailure("access_denied"));
           })
           .catch(() => {
-            if (this.entries.get(id) === entry) void this.retire(id);
+            if (this.entries.get(id) === entry)
+              void this.retire(id, openCodeTransportFailure("access_denied"));
           });
       }
     }, 30000);
@@ -78,7 +108,12 @@ export class OpenCodeHost {
       const grant = options.access.get();
       for (const [id, entry] of this.entries) {
         if (!grant || authority(grant) !== entry.authority)
-          void this.retire(id);
+          void this.retire(
+            id,
+            grant
+              ? openCodeTransportFailure("access_denied")
+              : this.accessFailure(),
+          );
       }
     });
   }
@@ -86,15 +121,23 @@ export class OpenCodeHost {
   async ensure(id: string): Promise<HostedOpenCode> {
     const grant = this.options.access.get();
     if (this.closed || !grant)
-      throw new Error("Assistant access is unavailable");
+      throw this.accessError("Assistant access is unavailable");
     const workspace = await this.workspace(id).catch(async (error) => {
-      await this.retire(id);
+      await this.retire(
+        id,
+        error instanceof OpenCodeTransportError
+          ? error.failure
+          : openCodeTransportFailure("access_denied"),
+      );
       throw error;
     });
     const { cwd } = workspace;
     const current = this.options.access.get();
     if (this.closed || !current || authority(current) !== authority(grant))
-      throw new Error("Assistant access changed. Please retry.");
+      throw new OpenCodeAccessError(
+        "Assistant access changed. Please retry.",
+        current ? "access_denied" : this.options.access.getFailureCode(),
+      );
     const existing = this.entries.get(id);
     if (
       existing &&
@@ -102,7 +145,8 @@ export class OpenCodeHost {
       existing.authority === authority(grant)
     )
       return existing.ready!;
-    if (existing) await this.retire(id);
+    if (existing)
+      await this.retire(id, openCodeTransportFailure("access_denied"));
     // A prior retirement must finish before another process uses its database.
     await Promise.all(this.closing);
     const verified = await this.workspace(id);
@@ -124,11 +168,14 @@ export class OpenCodeHost {
     return entry.ready;
   }
 
-  retire(id: string): Promise<void> {
+  retire(
+    id: string,
+    failure = openCodeTransportFailure("transport_unavailable"),
+  ): Promise<void> {
     const entry = this.entries.get(id);
     if (!entry) return Promise.resolve();
     this.entries.delete(id);
-    entry.abort.abort();
+    entry.abort.abort(new OpenCodeTransportError(failure));
     entry.credential?.revoke();
     const closing = (async () => {
       const hosted = await entry.ready?.catch(() => null);
@@ -177,7 +224,10 @@ export class OpenCodeHost {
       !grant ||
       authority(grant) !== entry.authority
     )
-      throw new Error("Assistant access changed. Please retry.");
+      throw new OpenCodeAccessError(
+        "Assistant access changed. Please retry.",
+        grant ? "access_denied" : this.options.access.getFailureCode(),
+      );
   }
 
   private async unlock(entry: Managed): Promise<void> {
@@ -205,6 +255,7 @@ export class OpenCodeHost {
       .digest("hex");
     const stateRoot = join(this.options.stateRoot, "opencode", scope);
     let server: OpenCodeServer | undefined;
+    let startupAttempted = false;
     try {
       entry.unlock = await new DurableFileLock(join(stateRoot, "runtime"), {
         timeoutMs: 1000,
@@ -220,18 +271,38 @@ export class OpenCodeHost {
         runtimeToken: entry.credential.token,
         model: this.options.bridge.model,
       });
+      startupAttempted = true;
       server = await (this.options.start ?? startOpenCodeServer)({
         cwd: entry.workspace.cwd,
         stateRoot: join(stateRoot, "engine"),
         config,
         signal: entry.abort.signal,
       });
+      void server.exited
+        .then(() => {
+          if (this.entries.get(entry.workspace.harnessSessionId) === entry)
+            return this.retire(
+              entry.workspace.harnessSessionId,
+              openCodeTransportFailure("runtime_exited"),
+            );
+        })
+        .catch(() => {});
       await this.validate(entry);
       return {
         ...entry.workspace,
         stateRoot,
         server,
         signal: entry.abort.signal,
+        isCurrent: () => {
+          const current = this.options.access.get();
+          return (
+            !this.closed &&
+            !entry.abort.signal.aborted &&
+            this.entries.get(entry.workspace.harnessSessionId) === entry &&
+            !!current &&
+            authority(current) === entry.authority
+          );
+        },
       };
     } catch (error) {
       if (this.entries.get(entry.workspace.harnessSessionId) === entry)
@@ -246,7 +317,41 @@ export class OpenCodeHost {
         }
       }
       await this.unlock(entry);
-      throw error;
+      if (error instanceof OpenCodeTransportError) throw error;
+      if (
+        entry.abort.signal.aborted &&
+        entry.abort.signal.reason instanceof OpenCodeTransportError
+      )
+        throw entry.abort.signal.reason;
+      throw new OpenCodeTransportError(
+        startupAttempted
+          ? openCodeTransportFailure(
+              "runtime_start_failed",
+              startupReason(error),
+            )
+          : openCodeTransportFailure("transport_unavailable"),
+      );
     }
   }
+
+  private accessFailure(): OpenCodeTransportFailure {
+    return openCodeTransportFailure(this.options.access.getFailureCode());
+  }
+
+  private accessError(message: string): OpenCodeAccessError {
+    return new OpenCodeAccessError(
+      message,
+      this.options.access.getFailureCode(),
+    );
+  }
+}
+
+function startupReason(error: unknown): OpenCodeStartupReason | undefined {
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+  return openCodeStartupReasons.includes(code as OpenCodeStartupReason)
+    ? (code as OpenCodeStartupReason)
+    : undefined;
 }

--- a/packages/harness/src/core/opencode-host.ts
+++ b/packages/harness/src/core/opencode-host.ts
@@ -209,14 +209,16 @@ export class OpenCodeHost {
   private async workspace(id: string): Promise<OpenCodeWorkspace> {
     const workspace = await this.options.authorize(id);
     if (!workspace || workspace.harnessSessionId !== id)
-      throw new Error("This Studio workspace is unavailable");
+      throw new OpenCodeAccessError("This Studio workspace is unavailable");
     return { harnessSessionId: id, cwd: await realpath(workspace.cwd) };
   }
 
   private async validate(entry: Managed): Promise<void> {
     const workspace = await this.workspace(entry.workspace.harnessSessionId);
     if (workspace.cwd !== entry.workspace.cwd)
-      throw new Error("This Studio workspace changed. Please retry.");
+      throw new OpenCodeAccessError(
+        "This Studio workspace changed. Please retry.",
+      );
     const grant = this.options.access.get();
     if (
       this.closed ||

--- a/packages/harness/src/core/opencode-host.ts
+++ b/packages/harness/src/core/opencode-host.ts
@@ -1,0 +1,252 @@
+import { createHash } from "node:crypto";
+import { realpath } from "node:fs/promises";
+import { join } from "node:path";
+import {
+  createSapiomOpenCodeConfig,
+  OpenCodeShutdownError,
+  startOpenCodeServer,
+  type OpenCodeServer,
+} from "@sapiom/opencode";
+import type { AssistantAccess, AssistantGrant } from "./assistant-access.js";
+import { DurableFileLock } from "./durable-file-lock.js";
+import type {
+  OpenCodeBridge,
+  OpenCodeBridgeCredential,
+} from "../server/opencode-bridge.js";
+
+export interface OpenCodeWorkspace {
+  harnessSessionId: string;
+  cwd: string;
+}
+export interface HostedOpenCode extends OpenCodeWorkspace {
+  stateRoot: string;
+  server: OpenCodeServer;
+  signal: AbortSignal;
+}
+interface Managed {
+  workspace: OpenCodeWorkspace;
+  authority: string;
+  abort: AbortController;
+  ready?: Promise<HostedOpenCode>;
+  credential?: OpenCodeBridgeCredential;
+  unlock?: () => Promise<void>;
+  cleanupFailed?: boolean;
+}
+interface Options {
+  access: Pick<AssistantAccess, "get" | "subscribe">;
+  bridge: Pick<OpenCodeBridge, "issue" | "model">;
+  origin: () => string;
+  stateRoot: string;
+  authorize: (id: string) => Promise<OpenCodeWorkspace | null>;
+  start?: typeof startOpenCodeServer;
+}
+const authority = (grant: AssistantGrant) =>
+  createHash("sha256")
+    .update(
+      JSON.stringify([
+        grant.identityRevision,
+        grant.environment.name,
+        grant.environment.apiURL,
+        grant.environment.credentials?.apiKey,
+      ]),
+    )
+    .digest("hex");
+
+/** Owned by startServer, not by React mounts or browser connections. */
+export class OpenCodeHost {
+  private entries = new Map<string, Managed>();
+  private closing = new Set<Promise<void>>();
+  private closed = false;
+  private cleanupFailed = false;
+  private workspaceTimer: ReturnType<typeof setInterval>;
+  private unsubscribe: () => void;
+  constructor(private readonly options: Options) {
+    this.workspaceTimer = setInterval(() => {
+      for (const [id, entry] of this.entries) {
+        void this.workspace(id)
+          .then(async (workspace) => {
+            if (this.entries.get(id) !== entry) return;
+            if (workspace.cwd !== entry.workspace.cwd) await this.retire(id);
+          })
+          .catch(() => {
+            if (this.entries.get(id) === entry) void this.retire(id);
+          });
+      }
+    }, 30000);
+    this.workspaceTimer.unref?.();
+    this.unsubscribe = options.access.subscribe(() => {
+      const grant = options.access.get();
+      for (const [id, entry] of this.entries) {
+        if (!grant || authority(grant) !== entry.authority)
+          void this.retire(id);
+      }
+    });
+  }
+
+  async ensure(id: string): Promise<HostedOpenCode> {
+    const grant = this.options.access.get();
+    if (this.closed || !grant)
+      throw new Error("Assistant access is unavailable");
+    const workspace = await this.workspace(id).catch(async (error) => {
+      await this.retire(id);
+      throw error;
+    });
+    const { cwd } = workspace;
+    const current = this.options.access.get();
+    if (this.closed || !current || authority(current) !== authority(grant))
+      throw new Error("Assistant access changed. Please retry.");
+    const existing = this.entries.get(id);
+    if (
+      existing &&
+      existing.workspace.cwd === cwd &&
+      existing.authority === authority(grant)
+    )
+      return existing.ready!;
+    if (existing) await this.retire(id);
+    // A prior retirement must finish before another process uses its database.
+    await Promise.all(this.closing);
+    const verified = await this.workspace(id);
+    if (
+      this.closed ||
+      this.options.access.get() !== current ||
+      verified.cwd !== cwd
+    )
+      return this.ensure(id);
+    const racing = this.entries.get(id);
+    if (racing) return this.ensure(id);
+    const entry: Managed = {
+      workspace: { harnessSessionId: id, cwd },
+      authority: authority(grant),
+      abort: new AbortController(),
+    };
+    this.entries.set(id, entry);
+    entry.ready = this.start(entry, grant);
+    return entry.ready;
+  }
+
+  retire(id: string): Promise<void> {
+    const entry = this.entries.get(id);
+    if (!entry) return Promise.resolve();
+    this.entries.delete(id);
+    entry.abort.abort();
+    entry.credential?.revoke();
+    const closing = (async () => {
+      const hosted = await entry.ready?.catch(() => null);
+      try {
+        await hosted?.server.close();
+      } catch {
+        entry.cleanupFailed = true;
+      }
+      // Keep the owner lock if shutdown fails, so another runtime cannot
+      // concurrently use a database whose previous owner may still be alive.
+      await this.unlock(entry);
+    })();
+    this.closing.add(closing);
+    void closing.finally(() => this.closing.delete(closing)).catch(() => {});
+    return closing;
+  }
+
+  async close(): Promise<void> {
+    this.closed = true;
+    clearInterval(this.workspaceTimer);
+    this.unsubscribe();
+    for (const id of this.entries.keys()) void this.retire(id);
+    const results = await Promise.allSettled(this.closing);
+    if (
+      this.cleanupFailed ||
+      results.some((result) => result.status === "rejected")
+    )
+      throw new OpenCodeShutdownError();
+  }
+
+  private async workspace(id: string): Promise<OpenCodeWorkspace> {
+    const workspace = await this.options.authorize(id);
+    if (!workspace || workspace.harnessSessionId !== id)
+      throw new Error("This Studio workspace is unavailable");
+    return { harnessSessionId: id, cwd: await realpath(workspace.cwd) };
+  }
+
+  private async validate(entry: Managed): Promise<void> {
+    const workspace = await this.workspace(entry.workspace.harnessSessionId);
+    if (workspace.cwd !== entry.workspace.cwd)
+      throw new Error("This Studio workspace changed. Please retry.");
+    const grant = this.options.access.get();
+    if (
+      this.closed ||
+      entry.abort.signal.aborted ||
+      !grant ||
+      authority(grant) !== entry.authority
+    )
+      throw new Error("Assistant access changed. Please retry.");
+  }
+
+  private async unlock(entry: Managed): Promise<void> {
+    if (entry.cleanupFailed) {
+      this.cleanupFailed = true;
+      throw new OpenCodeShutdownError();
+    }
+    await entry.unlock?.();
+    entry.unlock = undefined;
+  }
+
+  private async start(
+    entry: Managed,
+    grant: AssistantGrant,
+  ): Promise<HostedOpenCode> {
+    const scope = createHash("sha256")
+      .update(
+        JSON.stringify([
+          grant.userId,
+          grant.tenantId,
+          entry.workspace.harnessSessionId,
+          entry.workspace.cwd,
+        ]),
+      )
+      .digest("hex");
+    const stateRoot = join(this.options.stateRoot, "opencode", scope);
+    let server: OpenCodeServer | undefined;
+    try {
+      entry.unlock = await new DurableFileLock(join(stateRoot, "runtime"), {
+        timeoutMs: 1000,
+        storageError: () =>
+          new Error(
+            "Assistant is already open in another Studio window or its state is unavailable",
+          ),
+      }).acquire();
+      await this.validate(entry);
+      entry.credential = this.options.bridge.issue();
+      const config = createSapiomOpenCodeConfig({
+        bridgeUrl: `${this.options.origin()}/opencode-runtime/${entry.credential.id}`,
+        runtimeToken: entry.credential.token,
+        model: this.options.bridge.model,
+      });
+      server = await (this.options.start ?? startOpenCodeServer)({
+        cwd: entry.workspace.cwd,
+        stateRoot: join(stateRoot, "engine"),
+        config,
+        signal: entry.abort.signal,
+      });
+      await this.validate(entry);
+      return {
+        ...entry.workspace,
+        stateRoot,
+        server,
+        signal: entry.abort.signal,
+      };
+    } catch (error) {
+      if (this.entries.get(entry.workspace.harnessSessionId) === entry)
+        this.entries.delete(entry.workspace.harnessSessionId);
+      entry.credential?.revoke();
+      if (error instanceof OpenCodeShutdownError) entry.cleanupFailed = true;
+      if (server) {
+        try {
+          await server.close();
+        } catch {
+          entry.cleanupFailed = true;
+        }
+      }
+      await this.unlock(entry);
+      throw error;
+    }
+  }
+}

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -195,6 +195,7 @@ import {
 } from "../core/project-bootstrap.js";
 import { IngestCredentialRegistry } from "../core/ingest-credentials.js";
 import { AssistantAccess } from "../core/assistant-access.js";
+import { OpenCodeHost } from "../core/opencode-host.js";
 import { OpenCodeBridge } from "./opencode-bridge.js";
 import { createStaticRouter } from "./static.js";
 import { createTerminalWebSocketHandler } from "./terminal-ws.js";
@@ -3529,6 +3530,21 @@ export const startServer = async (
     return { ok: await sessionManager.submitInput(sessionId, text, submit) };
   };
 
+  const openCodeHost = new OpenCodeHost({
+    access: assistantAccess,
+    bridge: openCodeBridge,
+    origin: () => `http://127.0.0.1:${actualPort}`,
+    stateRoot: statePaths.root,
+    authorize: async (id) => {
+      const session = sessionManager.get(id);
+      if (!session || !(await isProjectSessionDispatchAuthorized({
+        session,
+        currentPrincipal: () => localProjectPrincipal(projectUserId, machineId),
+        resolveProject: (projectId) => studioProjectCatalog.resolveIdentity(projectId),
+      }))) return null;
+      return { harnessSessionId: id, cwd: session.cwd };
+    },
+  });
   const app: Express = express();
   app.disable("x-powered-by");
   app.use("/opencode-runtime", openCodeBridge.router);
@@ -4259,6 +4275,7 @@ export const startServer = async (
       credentialStoreObserver?.close();
       unsubscribeCredentialChanges();
       assistantAccess.close();
+      await settle(() => openCodeHost.close());
       openCodeBridge.close();
       await settle(() => sessionManager.beginShutdown());
       const bootstrapClosing = settle(() => projectBootstrap?.close());

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,9 @@ importers:
       '@sapiom/mcp':
         specifier: workspace:^
         version: link:../mcp
+      '@sapiom/opencode':
+        specifier: workspace:^
+        version: link:../opencode
       ajv:
         specifier: ^8.12.0
         version: 8.20.0
@@ -1163,7 +1166,7 @@ packages:
     engines: {node: '>=12'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {gitHosted: true, integrity: sha512-MXgzlTDEEndJB3TBbvd5uFQO/8gaINo1Hfen8vef5rq/VHVPeB63uuv/uO5+8GFsAJ/rauu6XB79S6K4+aXc+w==, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Each authorized workspace needs one managed OpenCode runtime and durable association whose lifetime follows verified Assistant authority.

## Summary and scope

Own runtime startup, bridge credentials, directory-scoped association, post-lock and post-start authority validation, and sanitized host failure propagation. Post-start workspace or authority invalidation cannot adopt a late runtime. Session routes and incremental event delivery remain in #902.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `assistant-runtime-lock-ownership`. Actual-parent size: **939 additions + 3 deletions = 942 changed lines**. This is above the 600-line target and below the 1,000-line hard maximum; the source and tests stay together to preserve a compiling, independently reviewable boundary.

Absorbed reviewed provenance: #935 association and host lifecycle ownership portion; post-start workspace/authority invalidation.

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3290](https://linear.app/sapiom/issue/SAP-3290). This PR keeps its existing number and review history within the main-rooted native GitHub stack.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check 2c61d8d67b9f6bdeb9ef98e8aadf9efc030d6c7c...6a333454d39b30d2417f40b7eece516c798ac332` — passed.
- Harness typecheck plus focused host/association tests — 14/14 passed at this layer.

### Tests and documentation

Host and association tests cover single-runtime ownership, access retirement, workspace invalidation, sanitized startup failures, cleanup behavior, and preservation of saved associations.

## Compatibility and release impact

- Breaking or externally visible changes: Adds internal lifecycle and association ownership behind the existing authenticated Studio server. No full Resume/Continue migration is introduced.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/901" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
