### PR TITLE
feat(studio): scope OpenCode conversations and event streams [SAP-3290]

### DIFF
--- a/.changeset/route-assistant-recovery-errors.md
+++ b/.changeset/route-assistant-recovery-errors.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Route strictly scoped Assistant runtime, authentication, and missing-history failures as actionable sanitized errors while preserving saved session associations and preventing replay.

--- a/.changeset/studio-opencode-sessions.md
+++ b/.changeset/studio-opencode-sessions.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/harness": minor
+"@sapiom/opencode": patch
+---
+
+Associate Studio sessions with distinct OpenCode conversations and expose authenticated, session-scoped actions and incremental events.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -56,6 +56,15 @@ responses carry the current retirement barrier, and repeated disabled polls do
 not rotate it. Browser draft stores use this opaque boundary to prevent text
 from crossing authorities without persisting it.
 
+After a successful check, timeout, network, or HTTP 5xx failures from credential
+or capability refresh may retain that exact grant only while its original lease
+and observed user credential remain unexpired. A transient failure never moves
+either expiry. Sign-out, credential expiry, API key/environment/tenant/user
+change, an authentication rejection, an explicit `assistant: false`, or a
+malformed/ambiguous response revokes the grant. Thus an offline first launch
+cannot invent eligibility, while a short outage does not interrupt an unchanged
+verified principal before the server-issued lease ends.
+
 The Assistant's model and remote MCP requests use a Studio-owned local bridge.
 Its short-lived runtime credential is separate from browser authentication;
 Studio adds the Sapiom key only when forwarding to the configured services.
@@ -68,6 +77,30 @@ directory. Browser detachment leaves it running; sign-out, access revocation,
 and Studio shutdown stop it. Runtime state is isolated by user, organization,
 session, and directory under `~/.sapiom/harness/opencode`. A process lock prevents
 two Studio hosts from opening the same runtime state concurrently.
+
+Transport failures use fixed, credential-free codes and copy. HTTP responses
+carry a nested typed error; an already-open event stream receives the same error
+as a host-generated `studio.error` before closing when possible. Native events
+cannot claim that host-only type. Ordinary native events require matching
+session IDs, including every nested ID. The only session-less native failure
+converted to a terminal Studio error is a Sapiom provider-auth error received
+from the currently bound runtime and authority with an exact authorized-directory
+envelope; unknown, conflicting, stale-runtime, and differently scoped events are
+dropped. Reconnect reattaches and reloads history; it never replays an accepted
+prompt or tool call.
+
+The Studio session record remains authoritative for session identity, project,
+and working directory. Its authority-scoped runtime directory owns a versioned
+`association.json` sidecar that maps that Studio session to one native
+conversation. The host serializes creation and atomic commit under the same
+lifecycle that owns the native runtime; browser mounts do not own the mapping.
+Retirement, sign-out, missing native history, and transient lookup failures do
+not delete or replace it. A native 404 is reported as confirmed unavailable,
+while network and other transport failures remain retryable; neither path
+creates a second conversation. There is no implicit legacy scan or cleanup in
+this correction: a future migration adapter must validate both identities,
+commit a versioned mapping atomically, preserve the old history until verified,
+and make cleanup an explicit post-migration operation.
 
 The rail's cloud icon marks an agent as deployed once Studio confirms a ready
 hosted build. Failed checks silently retain the last confirmed indicator, and changing

--- a/packages/harness/src/core/opencode-host.test.ts
+++ b/packages/harness/src/core/opencode-host.test.ts
@@ -253,6 +253,7 @@ describe("Studio-owned OpenCode lifecycle", () => {
     finish();
     await rejected;
   });
+
   it("retires a confirmed exited process so retry can reopen the same persistent state", async () => {
     let exit!: () => void;
     const exited = new Promise<void>((resolve) => {

--- a/packages/harness/src/core/opencode-host.ts
+++ b/packages/harness/src/core/opencode-host.ts
@@ -209,14 +209,16 @@ export class OpenCodeHost {
   private async workspace(id: string): Promise<OpenCodeWorkspace> {
     const workspace = await this.options.authorize(id);
     if (!workspace || workspace.harnessSessionId !== id)
-      throw new Error("This Studio workspace is unavailable");
+      throw new OpenCodeAccessError("This Studio workspace is unavailable");
     return { harnessSessionId: id, cwd: await realpath(workspace.cwd) };
   }
 
   private async validate(entry: Managed): Promise<void> {
     const workspace = await this.workspace(entry.workspace.harnessSessionId);
     if (workspace.cwd !== entry.workspace.cwd)
-      throw new Error("This Studio workspace changed. Please retry.");
+      throw new OpenCodeAccessError(
+        "This Studio workspace changed. Please retry.",
+      );
     const grant = this.options.access.get();
     if (
       this.closed ||

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -159,6 +159,7 @@ import {
   resolveManifestName,
 } from "../core/definition-name.js";
 import { createBootTokenMiddleware } from "./auth.js";
+import { createOpenCodeRouter } from "./opencode.js";
 import {
   createApiKeyProvider,
   staticApiKeyProvider,
@@ -3548,6 +3549,7 @@ export const startServer = async (
   const app: Express = express();
   app.disable("x-powered-by");
   app.use("/opencode-runtime", openCodeBridge.router);
+  app.use("/opencode", createOpenCodeRouter(openCodeHost, options.bootToken));
 
   // Everything under /api requires the boot token; mounted as middleware
   // (not a router) so it also gates the workflows/macros routers below,

--- a/packages/harness/src/server/opencode-events.ts
+++ b/packages/harness/src/server/opencode-events.ts
@@ -1,6 +1,10 @@
 import { once } from "node:events";
 import type { Response } from "express";
-import type { OpenCodeServer } from "@sapiom/opencode";
+import {
+  OpenCodeTransportError,
+  type HostedOpenCode,
+} from "../core/opencode-host.js";
+import { openCodeTransportFailure } from "../shared/opencode-errors.js";
 
 const record = (value: unknown): Record<string, unknown> =>
   value && typeof value === "object" && !Array.isArray(value)
@@ -11,10 +15,20 @@ const record = (value: unknown): Record<string, unknown> =>
 export function scopedOpenCodeEvent(
   value: unknown,
   id: string,
+  scope?: { cwd: string; isCurrent: () => boolean },
 ): Record<string, unknown> | null {
   const envelope = record(value);
   const event = record(envelope.payload ?? value);
   const properties = record(event.properties);
+  if (scope && !scope.isCurrent()) return null;
+  if (
+    scope &&
+    envelope.payload !== undefined &&
+    envelope.directory !== undefined &&
+    envelope.directory !== scope.cwd
+  )
+    return null;
+  if (event.type === "studio.error") return null;
   if (event.type === "server.connected" || event.type === "server.heartbeat")
     return { type: event.type, properties: {} };
   const info = record(properties.info);
@@ -30,6 +44,20 @@ export function scopedOpenCodeEvent(
   )
     ids.push(info.id);
   const present = ids.filter((value) => value !== undefined);
+  if (
+    event.type === "session.error" &&
+    record(properties.error).name === "ProviderAuthError" &&
+    record(record(properties.error).data).providerID === "sapiom" &&
+    ((present.length > 0 && present.every((value) => value === id)) ||
+      (present.length === 0 &&
+        scope &&
+        envelope.payload !== undefined &&
+        envelope.directory === scope.cwd))
+  )
+    return {
+      type: "studio.error",
+      properties: openCodeTransportFailure("authentication_required"),
+    };
   return present.length > 0 && present.every((value) => value === id)
     ? event
     : null;
@@ -37,12 +65,12 @@ export function scopedOpenCodeEvent(
 
 /** Buffer at most one incomplete frame; never collect the complete response. */
 export async function streamOpenCodeEvents(
-  server: OpenCodeServer,
+  hosted: HostedOpenCode,
   id: string,
   res: Response,
   signal: AbortSignal,
 ): Promise<void> {
-  const upstream = await server.fetch("/event", {
+  const upstream = await hosted.server.fetch("/event", {
     signal,
     headers: { Accept: "text/event-stream" },
   });
@@ -64,7 +92,7 @@ export async function streamOpenCodeEvents(
   };
   let statusSeen = false;
   // Start after subscribing; never overwrite a newer native status with this snapshot.
-  void server
+  void hosted.server
     .fetchJson<Record<string, unknown>>("/session/status", {
       signal: AbortSignal.any([signal, AbortSignal.timeout(3000)]),
     })
@@ -103,16 +131,48 @@ export async function streamOpenCodeEvents(
           .map((line) => line.slice(5).trimStart())
           .join("\n");
         if (!data) continue;
-        const event = scopedOpenCodeEvent(JSON.parse(data), id);
+        const event = scopedOpenCodeEvent(JSON.parse(data), id, hosted);
         if (!event) continue;
         if (event.type === "session.status" || event.type === "session.idle")
           statusSeen = true;
         await write(event);
+        if (event.type === "studio.error") {
+          res.end();
+          return;
+        }
       }
       if (pending.length > maxFrame)
         throw new Error("Assistant event is too large");
     }
+    if (
+      signal.reason instanceof OpenCodeTransportError &&
+      !res.destroyed &&
+      !res.writableEnded
+    ) {
+      res.write(
+        `data: ${JSON.stringify({
+          type: "studio.error",
+          properties: signal.reason.failure,
+        })}\n\n`,
+      );
+    }
     res.end();
+  } catch (error) {
+    if (
+      signal.reason instanceof OpenCodeTransportError &&
+      !res.destroyed &&
+      !res.writableEnded
+    ) {
+      res.write(
+        `data: ${JSON.stringify({
+          type: "studio.error",
+          properties: signal.reason.failure,
+        })}\n\n`,
+      );
+      res.end();
+      return;
+    }
+    throw error;
   } finally {
     await reader.cancel().catch(() => {});
   }

--- a/packages/harness/src/server/opencode-events.ts
+++ b/packages/harness/src/server/opencode-events.ts
@@ -1,0 +1,119 @@
+import { once } from "node:events";
+import type { Response } from "express";
+import type { OpenCodeServer } from "@sapiom/opencode";
+
+const record = (value: unknown): Record<string, unknown> =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+
+/** Scope before sending any bytes to the browser, including conflicting nested IDs. */
+export function scopedOpenCodeEvent(
+  value: unknown,
+  id: string,
+): Record<string, unknown> | null {
+  const envelope = record(value);
+  const event = record(envelope.payload ?? value);
+  const properties = record(event.properties);
+  if (event.type === "server.connected" || event.type === "server.heartbeat")
+    return { type: event.type, properties: {} };
+  const info = record(properties.info);
+  const ids = [
+    properties.sessionID,
+    info.sessionID,
+    record(properties.part).sessionID,
+  ];
+  if (
+    ["session.created", "session.updated", "session.deleted"].includes(
+      String(event.type),
+    )
+  )
+    ids.push(info.id);
+  const present = ids.filter((value) => value !== undefined);
+  return present.length > 0 && present.every((value) => value === id)
+    ? event
+    : null;
+}
+
+/** Buffer at most one incomplete frame; never collect the complete response. */
+export async function streamOpenCodeEvents(
+  server: OpenCodeServer,
+  id: string,
+  res: Response,
+  signal: AbortSignal,
+): Promise<void> {
+  const upstream = await server.fetch("/event", {
+    signal,
+    headers: { Accept: "text/event-stream" },
+  });
+  if (
+    !upstream.ok ||
+    !upstream.body ||
+    !upstream.headers.get("content-type")?.includes("text/event-stream")
+  ) {
+    await upstream.body?.cancel();
+    throw new Error("Assistant event connection failed");
+  }
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("X-Accel-Buffering", "no");
+  res.flushHeaders();
+  const write = async (event: Record<string, unknown>) => {
+    signal.throwIfAborted();
+    if (!res.write(`data: ${JSON.stringify(event)}\n\n`))
+      await once(res, "drain", { signal });
+  };
+  let statusSeen = false;
+  // Start after subscribing; never overwrite a newer native status with this snapshot.
+  void server
+    .fetchJson<Record<string, unknown>>("/session/status", {
+      signal: AbortSignal.any([signal, AbortSignal.timeout(3000)]),
+    })
+    .then(async (statuses) => {
+      if (!statusSeen && !signal.aborted && !res.writableEnded)
+        await write({
+          type: "session.status",
+          properties: {
+            sessionID: id,
+            status: statuses[id] ?? { type: "idle" },
+          },
+        });
+    })
+    .catch(() => {});
+  const reader = upstream.body.getReader();
+  const decoder = new TextDecoder();
+  let pending = "";
+  const maxFrame = 2 * 1024 * 1024;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      pending = (pending + decoder.decode(value, { stream: true })).replace(
+        /\r\n/g,
+        "\n",
+      );
+      let boundary: number;
+      while ((boundary = pending.indexOf("\n\n")) >= 0) {
+        if (boundary > maxFrame)
+          throw new Error("Assistant event is too large");
+        const frame = pending.slice(0, boundary);
+        pending = pending.slice(boundary + 2);
+        const data = frame
+          .split("\n")
+          .filter((line) => line.startsWith("data:"))
+          .map((line) => line.slice(5).trimStart())
+          .join("\n");
+        if (!data) continue;
+        const event = scopedOpenCodeEvent(JSON.parse(data), id);
+        if (!event) continue;
+        if (event.type === "session.status" || event.type === "session.idle")
+          statusSeen = true;
+        await write(event);
+      }
+      if (pending.length > maxFrame)
+        throw new Error("Assistant event is too large");
+    }
+    res.end();
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+}

--- a/packages/harness/src/server/opencode.test.ts
+++ b/packages/harness/src/server/opencode.test.ts
@@ -6,9 +6,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   OpenCodeAccessError,
+  OpenCodeTransportError,
   type HostedOpenCode,
 } from "../core/opencode-host.js";
 import { createOpenCodeRouter } from "./opencode.js";
+import { openCodeTransportFailure } from "../shared/opencode-errors.js";
+import { scopedOpenCodeEvent } from "./opencode-events.js";
 
 let root: string;
 let origin: string;
@@ -98,6 +101,7 @@ beforeEach(async () => {
       cwd: root,
       stateRoot,
       signal: abort.signal,
+      isCurrent: () => !abort.signal.aborted,
       server: {
         pid: 123,
         exited: new Promise<void>(() => {}),
@@ -314,15 +318,163 @@ describe("Studio-scoped OpenCode transport", () => {
     sessions.delete(id);
     router = createOpenCodeRouter({ ensure }, "boot-token");
     const missing = await request("studio-a/attach", { method: "POST" });
-    expect(missing.status).toBe(502);
-    expect(await missing.text()).not.toContain("private native diagnostics");
+    expect(missing.status).toBe(410);
+    expect(await missing.json()).toEqual({
+      error: openCodeTransportFailure("native_history_missing"),
+    });
     await writeFile(
       join(hosts.get("studio-a")!.stateRoot, "association.json"),
       '{"version":1,"conversationId":"studio-a"}',
     );
-    expect((await request("studio-a/attach", { method: "POST" })).status).toBe(
-      502,
-    );
+    const corrupt = await request("studio-a/attach", { method: "POST" });
+    expect(corrupt.status).toBe(410);
+    expect(await corrupt.json()).toEqual({
+      error: openCodeTransportFailure("native_history_missing"),
+    });
     expect(created).toBe(1);
+  });
+
+  it("returns exact typed access and startup failures without exposing diagnostics", async () => {
+    ensure.mockRejectedValueOnce(
+      new OpenCodeAccessError(
+        "private credential detail",
+        "authentication_required",
+      ),
+    );
+    const authentication = await request("studio-a/attach", {
+      method: "POST",
+    });
+    expect(authentication.status).toBe(401);
+    expect(await authentication.json()).toEqual({
+      error: openCodeTransportFailure("authentication_required"),
+    });
+    ensure.mockRejectedValueOnce(
+      new OpenCodeAccessError("private authority detail", "access_expired"),
+    );
+    const expired = await request("studio-a/attach", { method: "POST" });
+    expect(expired.status).toBe(403);
+    expect(await expired.json()).toEqual({
+      error: openCodeTransportFailure("access_expired"),
+    });
+    ensure.mockRejectedValueOnce(
+      new OpenCodeTransportError(
+        openCodeTransportFailure(
+          "runtime_start_failed",
+          "executable-not-found",
+        ),
+      ),
+    );
+    const startup = await request("studio-a/attach", { method: "POST" });
+    expect(startup.status).toBe(503);
+    expect(await startup.json()).toEqual({
+      error: openCodeTransportFailure(
+        "runtime_start_failed",
+        "executable-not-found",
+      ),
+    });
+    expect(created).toBe(0);
+  });
+
+  it.each(["access_expired", "runtime_exited"] as const)(
+    "emits a typed terminal event on %s and never submits work",
+    async (code) => {
+      await attach();
+      const response = await request("studio-a/event");
+      const reader = response.body!.getReader();
+      await readUntil(reader, '"busy"');
+      aborts
+        .get("studio-a")!
+        .abort(
+          new OpenCodeTransportError(
+            code === "access_expired"
+              ? openCodeTransportFailure("access_expired")
+              : openCodeTransportFailure("runtime_exited"),
+          ),
+        );
+      const terminal = await readUntil(reader, '"studio.error"');
+      expect(terminal).toContain(`"code":"${code}"`);
+      expect(await reader.read()).toEqual({ done: true, value: undefined });
+      expect(
+        requests.filter((item) =>
+          /prompt_async|final-response/.test(item.path),
+        ),
+      ).toHaveLength(0);
+    },
+  );
+
+  it("drops native-spoofed, conflicting, unscoped, and stale terminal events", async () => {
+    const id = await attach();
+    const response = await request("studio-a/event");
+    const reader = response.body!.getReader();
+    await readUntil(reader, '"busy"');
+    const auth = {
+      type: "session.error",
+      properties: {
+        error: {
+          name: "ProviderAuthError",
+          data: { providerID: "sapiom", message: "private" },
+        },
+      },
+    };
+    const scope = { cwd: root, isCurrent: () => true };
+    for (const event of [
+      {
+        type: "studio.error",
+        properties: openCodeTransportFailure("access_denied"),
+      },
+      auth,
+      { directory: "/different", payload: auth },
+      {
+        ...auth,
+        properties: {
+          ...auth.properties,
+          sessionID: id,
+          part: { sessionID: "ses_secret" },
+        },
+      },
+      {
+        directory: root,
+        payload: {
+          ...auth,
+          properties: {
+            ...auth.properties,
+            sessionID: "ses_foreign",
+          },
+        },
+      },
+      {
+        directory: root,
+        payload: {
+          ...auth,
+          properties: {
+            ...auth.properties,
+            sessionID: id,
+            info: { sessionID: "ses_foreign" },
+          },
+        },
+      },
+    ])
+      expect(scopedOpenCodeEvent(event, id, scope)).toBeNull();
+    expect(
+      scopedOpenCodeEvent({ directory: root, payload: auth }, id, {
+        cwd: root,
+        isCurrent: () => false,
+      }),
+    ).toBeNull();
+    streams[0].write(
+      `data: ${JSON.stringify({
+        type: "message.part.delta",
+        properties: { sessionID: id, delta: "still-scoped" },
+      })}\n\n`,
+    );
+    const visible = await readUntil(reader, "still-scoped");
+    expect(visible).not.toContain("studio.error");
+    streams[0].write(
+      `data: ${JSON.stringify({ directory: root, payload: auth })}\n\n`,
+    );
+    const terminal = await readUntil(reader, "studio.error");
+    expect(terminal).toContain('"code":"authentication_required"');
+    expect(terminal).not.toContain("private");
+    expect(await reader.read()).toEqual({ done: true, value: undefined });
   });
 });

--- a/packages/harness/src/server/opencode.test.ts
+++ b/packages/harness/src/server/opencode.test.ts
@@ -1,0 +1,328 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import express, { type Response, type Router } from "express";
+import { createServer, type Server } from "node:http";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  OpenCodeAccessError,
+  type HostedOpenCode,
+} from "../core/opencode-host.js";
+import { createOpenCodeRouter } from "./opencode.js";
+
+let root: string;
+let origin: string;
+let router: Router;
+let enabled: boolean;
+let created: number;
+const hosts = new Map<string, HostedOpenCode>();
+const aborts = new Map<string, AbortController>();
+const sessions = new Map<string, { id: string; title: string }>();
+const streams: Response[] = [];
+const servers: Server[] = [];
+const requests: {
+  path: string;
+  headers: Record<string, unknown>;
+  body: unknown;
+}[] = [];
+const ensure = vi.fn();
+const close = vi.fn();
+async function listen(app: express.Express): Promise<string> {
+  const server = createServer(app);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  return `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+}
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "studio-opencode-route-"));
+  enabled = true;
+  created = 0;
+  requests.length = streams.length = 0;
+  sessions.clear();
+  hosts.clear();
+  aborts.clear();
+  close.mockReset();
+  const engine = express();
+  engine.use(express.json());
+  engine.use((req, _res, next) => {
+    requests.push({ path: req.path, headers: req.headers, body: req.body });
+    next();
+  });
+  engine.post("/session", (_req, res) => {
+    const session = { id: `ses_${++created}`, title: "Conversation" };
+    sessions.set(session.id, session);
+    res.json(session);
+  });
+  engine.get("/session/status", (_req, res) => {
+    res.json({
+      ses_1: { type: "busy" },
+      ses_2: { type: "idle" },
+      ses_secret: { type: "busy" },
+    });
+  });
+  engine.get("/session/:id", (req, res) => {
+    const session = sessions.get(req.params.id);
+    if (session) res.json(session);
+    else res.status(404).json({ error: "private native diagnostics" });
+  });
+  engine.get("/session/:id/message", (_req, res) => {
+    res.json([]);
+  });
+  engine.post("/session/:id/prompt_async", (_req, res) => {
+    res.status(204).end();
+  });
+  engine.get(["/permission", "/question"], (_req, res) => {
+    res.json([
+      { sessionID: "ses_1", id: "own" },
+      { sessionID: "ses_secret", id: "private" },
+    ]);
+  });
+  engine.get("/event", (_req, res) => {
+    res.setHeader("Content-Type", "text/event-stream");
+    res.flushHeaders();
+    streams.push(res);
+  });
+  const nativeOrigin = await listen(engine);
+  for (const id of ["studio-a", "studio-b"]) {
+    const stateRoot = join(root, id);
+    await mkdir(stateRoot);
+    const abort = new AbortController();
+    aborts.set(id, abort);
+    const nativeFetch = (path: string, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      headers.set("Authorization", "Basic native-only");
+      return fetch(`${nativeOrigin}${path}`, { ...init, headers });
+    };
+    hosts.set(id, {
+      harnessSessionId: id,
+      cwd: root,
+      stateRoot,
+      signal: abort.signal,
+      server: {
+        pid: 123,
+        exited: new Promise<void>(() => {}),
+        fetch: nativeFetch,
+        close,
+        async fetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+          const response = await nativeFetch(path, init);
+          if (!response.ok) throw new Error("private native diagnostics");
+          return response.json();
+        },
+      },
+    });
+  }
+  ensure.mockReset().mockImplementation(async (id) => {
+    if (!enabled || !hosts.has(id))
+      throw new OpenCodeAccessError("unavailable");
+    return hosts.get(id)!;
+  });
+  router = createOpenCodeRouter({ ensure }, "boot-token");
+  const app = express();
+  app.use("/opencode", (req, res, next) => router(req, res, next));
+  origin = await listen(app);
+});
+afterEach(async () => {
+  for (const abort of aborts.values()) abort.abort();
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+          server.closeAllConnections();
+        }),
+    ),
+  );
+  await rm(root, { recursive: true, force: true });
+});
+function request(path: string, init: RequestInit = {}) {
+  return fetch(`${origin}/opencode/${path}`, {
+    headers: {
+      "X-Harness-Token": "boot-token",
+      "Content-Type": "application/json",
+    },
+    ...init,
+  });
+}
+async function attach(id = "studio-a") {
+  const response = await request(`${id}/attach`, { method: "POST" });
+  expect(response.status).toBe(200);
+  return (await response.json()).conversationId as string;
+}
+async function readUntil(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  includes: string,
+) {
+  let text = "";
+  while (!text.includes(includes)) {
+    const next = await reader.read();
+    if (next.done) throw new Error("stream ended early");
+    text += new TextDecoder().decode(next.value);
+  }
+  return text;
+}
+
+describe("Studio-scoped OpenCode transport", () => {
+  it("authenticates before startup and rejects flag-off or unauthorized workspaces", async () => {
+    expect(
+      (await request("studio-a/attach", { method: "POST", headers: {} }))
+        .status,
+    ).toBe(401);
+    expect(ensure).not.toHaveBeenCalled();
+    enabled = false;
+    expect((await request("studio-a/attach", { method: "POST" })).status).toBe(
+      403,
+    );
+    enabled = true;
+    expect((await request("unknown/attach", { method: "POST" })).status).toBe(
+      403,
+    );
+    expect(created).toBe(0);
+  });
+
+  it("coalesces attach and restores the same separate conversation after remount and host restart", async () => {
+    const [a, again] = await Promise.all([attach(), attach()]);
+    expect(a).toBe(again);
+    expect(a).not.toBe("studio-a");
+    expect(await attach("studio-b")).not.toBe(a);
+    expect(created).toBe(2);
+    hosts.set("studio-a", { ...hosts.get("studio-a")! });
+    router = createOpenCodeRouter({ ensure }, "boot-token");
+    expect(await attach()).toBe(a);
+    expect(created).toBe(2);
+  });
+
+  it("rejects cross-session IDs and scope/configuration overrides before forwarding", async () => {
+    const a = await attach();
+    const b = await attach("studio-b");
+    expect((await request(`studio-a/session/${b}/message`)).status).toBe(403);
+    for (const path of [
+      "config",
+      "provider",
+      "session",
+      "global/event",
+      `session/${a}/message?directory=/private`,
+      `session/${a}/message?workspace=other`,
+    ])
+      expect((await request(`studio-a/${path}`)).status).toBe(400);
+    for (const body of [
+      { parts: [{ type: "file", url: "file:///private" }] },
+      { parts: [{ type: "text", text: "hi" }], model: {} },
+      { parts: [{ type: "text", text: "hi" }], system: "override" },
+    ])
+      expect(
+        (
+          await request(`studio-a/session/${a}/prompt_async`, {
+            method: "POST",
+            body: JSON.stringify(body),
+          })
+        ).status,
+      ).toBe(400);
+    expect(requests.some((req) => req.path.endsWith("/prompt_async"))).toBe(
+      false,
+    );
+  });
+
+  it("sends text without forwarding browser credentials and scopes all collection responses", async () => {
+    const id = await attach();
+    const body = { parts: [{ type: "text", text: "Make the change" }] };
+    const response = await request(`studio-a/session/${id}/prompt_async`, {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: {
+        "X-Harness-Token": "boot-token",
+        "Content-Type": "application/json",
+        Authorization: "Bearer browser",
+        Cookie: "private-cookie",
+        "X-Opencode-Directory": "/forged",
+      },
+    });
+    expect(response.status).toBe(204);
+    const native = requests.at(-1)!;
+    expect(native.body).toEqual(body);
+    expect(native.headers.authorization).toBe("Basic native-only");
+    for (const name of ["x-harness-token", "cookie", "x-opencode-directory"])
+      expect(native.headers[name]).toBeUndefined();
+    expect(
+      await (
+        await request("studio-a/experimental/session?roots=true&archived=true")
+      ).json(),
+    ).toEqual([{ id, title: "Conversation" }]);
+    expect(await (await request("studio-a/session/status")).json()).toEqual({
+      [id]: { type: "busy" },
+    });
+    for (const path of ["permission", "question"])
+      expect(await (await request(`studio-a/${path}`)).json()).toEqual([
+        { sessionID: id, id: "own" },
+      ]);
+  });
+
+  it("streams complete scoped frames immediately, filters conflicting IDs, and detaches without aborting execution", async () => {
+    const id = await attach();
+    const abort = new AbortController();
+    const response = await request("studio-a/event", { signal: abort.signal });
+    expect(response.headers.get("x-accel-buffering")).toBe("no");
+    const reader = response.body!.getReader();
+    await readUntil(reader, '"busy"');
+    const events = [
+      {
+        type: "message.part.delta",
+        properties: { sessionID: "ses_secret", delta: "private" },
+      },
+      {
+        type: "message.part.updated",
+        properties: {
+          sessionID: id,
+          part: { sessionID: "ses_secret", text: "conflict" },
+        },
+      },
+      {
+        payload: {
+          type: "message.part.delta",
+          properties: { sessionID: id, delta: "first" },
+        },
+      },
+    ];
+    for (const event of events)
+      streams[0].write(`data: ${JSON.stringify(event)}\r\n\r\n`);
+    const first = await readUntil(reader, "first");
+    expect(first).not.toMatch(/private|conflict|ses_secret/);
+    expect(streams[0].writableEnded).toBe(false);
+    streams[0].write(
+      'data: {"type":"message.part.delta","properties":{"sessionID":"ses_1","delta":"next"}}\r',
+    );
+    streams[0].write("\n\r\n");
+    expect(await readUntil(reader, "next")).toContain("next");
+    abort.abort();
+    await vi.waitFor(() => expect(streams[0].destroyed).toBe(true));
+    expect(close).not.toHaveBeenCalled();
+    expect(aborts.get("studio-a")!.signal.aborted).toBe(false);
+    expect(await attach()).toBe(id);
+  });
+
+  it("closes a live event stream when the host revokes execution access", async () => {
+    await attach();
+    const response = await request("studio-a/event");
+    const reader = response.body!.getReader();
+    await readUntil(reader, '"busy"');
+    aborts.get("studio-a")!.abort();
+    await expect(reader.read()).rejects.toThrow();
+    await vi.waitFor(() => expect(streams[0].destroyed).toBe(true));
+  });
+
+  it("preserves a missing or corrupt association as a visible error instead of replacing history", async () => {
+    const id = await attach();
+    sessions.delete(id);
+    router = createOpenCodeRouter({ ensure }, "boot-token");
+    const missing = await request("studio-a/attach", { method: "POST" });
+    expect(missing.status).toBe(502);
+    expect(await missing.text()).not.toContain("private native diagnostics");
+    await writeFile(
+      join(hosts.get("studio-a")!.stateRoot, "association.json"),
+      '{"version":1,"conversationId":"studio-a"}',
+    );
+    expect((await request("studio-a/attach", { method: "POST" })).status).toBe(
+      502,
+    );
+    expect(created).toBe(1);
+  });
+});

--- a/packages/harness/src/server/opencode.ts
+++ b/packages/harness/src/server/opencode.ts
@@ -1,0 +1,171 @@
+import express, { type Request, type Response, type Router } from "express";
+import {
+  OpenCodeAssociations,
+  isConversationId,
+} from "../core/opencode-association.js";
+import {
+  OpenCodeAccessError,
+  type OpenCodeHost,
+} from "../core/opencode-host.js";
+import { createBootTokenMiddleware } from "./auth.js";
+import { streamOpenCodeEvents } from "./opencode-events.js";
+
+export function createOpenCodeRouter(
+  host: Pick<OpenCodeHost, "ensure">,
+  bootToken: string,
+): Router {
+  const router = express.Router();
+  const associations = new OpenCodeAssociations();
+  router.use(
+    createBootTokenMiddleware(bootToken),
+    express.json({ limit: "1mb" }),
+  );
+  router.all("/:harnessSessionId/*", (req, res) => {
+    void forward(req, res);
+  });
+  router.use((_req, res) => {
+    res.status(404).json({ error: "Unknown Assistant route" });
+  });
+
+  async function forward(req: Request, res: Response): Promise<void> {
+    const path = req.params[0] ?? "";
+    const id = req.params.harnessSessionId!;
+    const read = req.method === "GET";
+    const conversation =
+      /^session\/(ses_[A-Za-z0-9_-]+)(\/message|\/prompt_async)?$/.exec(path);
+    const collection = [
+      "experimental/session",
+      "session/status",
+      "permission",
+      "question",
+    ].includes(path);
+    const prompt =
+      !read && req.method === "POST" && conversation?.[2] === "/prompt_async";
+    const attach = req.method === "POST" && path === "attach";
+    const allowed =
+      attach ||
+      prompt ||
+      (read &&
+        (path === "event" ||
+          collection ||
+          (conversation && conversation[2] !== "/prompt_async")));
+    const queryAllowed = Object.entries(req.query).every(
+      ([key, value]) =>
+        path === "experimental/session" &&
+        ["roots", "archived"].includes(key) &&
+        value === "true",
+    );
+    if (
+      !allowed ||
+      !/^[A-Za-z0-9_-]{1,128}$/.test(id) ||
+      !queryAllowed ||
+      (conversation && !isConversationId(conversation[1]))
+    ) {
+      res.status(400).json({ error: "Unsupported Assistant request" });
+      return;
+    }
+    if (prompt && !validPrompt(req.body)) {
+      res
+        .status(400)
+        .json({
+          error: "Send a text message without model or workspace overrides",
+        });
+      return;
+    }
+    const disconnected = new AbortController();
+    const cancel = () => disconnected.abort();
+    res.once("close", cancel);
+    res.setHeader("Cache-Control", "no-store");
+    try {
+      const hosted = await host.ensure(id);
+      const nativeId = await associations.ensure(hosted);
+      const signal = AbortSignal.any([hosted.signal, disconnected.signal]);
+      signal.throwIfAborted();
+      if (conversation && conversation[1] !== nativeId) {
+        res
+          .status(403)
+          .json({
+            error: "Conversation does not belong to this Studio session",
+          });
+        return;
+      }
+      if (attach) {
+        res.json({ conversationId: nativeId });
+        return;
+      }
+      if (path === "event") {
+        await streamOpenCodeEvents(hosted.server, nativeId, res, signal);
+        return;
+      }
+      const nativePath =
+        path === "experimental/session" ? `session/${nativeId}` : path;
+      const upstream = await hosted.server.fetch(`/${nativePath}`, {
+        method: req.method,
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        ...(prompt ? { body: JSON.stringify(req.body) } : {}),
+        signal: AbortSignal.any([signal, AbortSignal.timeout(30000)]),
+      });
+      if (!upstream.ok) {
+        await upstream.body?.cancel();
+        res
+          .status(upstream.status === 404 ? 404 : 502)
+          .json({
+            error:
+              "Assistant request failed. Refresh the conversation and retry.",
+          });
+        return;
+      }
+      if (upstream.status === 204) {
+        res.status(204).end();
+        return;
+      }
+      const data = await upstream.json();
+      signal.throwIfAborted();
+      if (path === "experimental/session") res.json([data]);
+      else if (path === "session/status")
+        res.json({ [nativeId]: data[nativeId] ?? { type: "idle" } });
+      else if (path === "permission" || path === "question")
+        res.json(
+          data.filter(
+            (item: { sessionID?: string }) => item.sessionID === nativeId,
+          ),
+        );
+      else res.json(data);
+    } catch (error) {
+      if (!res.headersSent && !res.destroyed)
+        res
+          .status(error instanceof OpenCodeAccessError ? 403 : 502)
+          .json({
+            error:
+              "Assistant is unavailable. Check Studio sign-in and workspace access, then retry.",
+          });
+      else res.destroy();
+    } finally {
+      disconnected.abort();
+      res.off("close", cancel);
+    }
+  }
+  return router;
+}
+
+function validPrompt(value: unknown): boolean {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const body = value as Record<string, unknown>;
+  return (
+    Object.keys(body).every((key) => key === "parts") &&
+    Array.isArray(body.parts) &&
+    body.parts.length > 0 &&
+    body.parts.length <= 32 &&
+    body.parts.every(
+      (part) =>
+        part &&
+        part.type === "text" &&
+        typeof part.text === "string" &&
+        part.text.trim().length > 0 &&
+        Object.keys(part).every((key) => ["type", "text"].includes(key)),
+    )
+  );
+}

--- a/packages/harness/src/server/opencode.ts
+++ b/packages/harness/src/server/opencode.ts
@@ -4,11 +4,15 @@ import {
   isConversationId,
 } from "../core/opencode-association.js";
 import {
-  OpenCodeAccessError,
+  OpenCodeTransportError,
   type OpenCodeHost,
 } from "../core/opencode-host.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { streamOpenCodeEvents } from "./opencode-events.js";
+import {
+  openCodeTransportFailure,
+  type OpenCodeTransportFailure,
+} from "../shared/opencode-errors.js";
 
 export function createOpenCodeRouter(
   host: Pick<OpenCodeHost, "ensure">,
@@ -94,7 +98,7 @@ export function createOpenCodeRouter(
         return;
       }
       if (path === "event") {
-        await streamOpenCodeEvents(hosted.server, nativeId, res, signal);
+        await streamOpenCodeEvents(hosted, nativeId, res, signal);
         return;
       }
       const nativePath =
@@ -110,12 +114,14 @@ export function createOpenCodeRouter(
       });
       if (!upstream.ok) {
         await upstream.body?.cancel();
-        res
-          .status(upstream.status === 404 ? 404 : 502)
-          .json({
-            error:
-              "Assistant request failed. Refresh the conversation and retry.",
-          });
+        sendFailure(
+          res,
+          openCodeTransportFailure(
+            upstream.status === 404 && conversation
+              ? "native_history_missing"
+              : "transport_unavailable",
+          ),
+        );
         return;
       }
       if (upstream.status === 204) {
@@ -136,12 +142,12 @@ export function createOpenCodeRouter(
       else res.json(data);
     } catch (error) {
       if (!res.headersSent && !res.destroyed)
-        res
-          .status(error instanceof OpenCodeAccessError ? 403 : 502)
-          .json({
-            error:
-              "Assistant is unavailable. Check Studio sign-in and workspace access, then retry.",
-          });
+        sendFailure(
+          res,
+          error instanceof OpenCodeTransportError
+            ? error.failure
+            : openCodeTransportFailure("transport_unavailable"),
+        );
       else res.destroy();
     } finally {
       disconnected.abort();
@@ -149,6 +155,18 @@ export function createOpenCodeRouter(
     }
   }
   return router;
+}
+
+function sendFailure(res: Response, failure: OpenCodeTransportFailure): void {
+  const status =
+    failure.code === "authentication_required"
+      ? 401
+      : failure.code === "access_denied" || failure.code === "access_expired"
+        ? 403
+        : failure.code === "native_history_missing"
+          ? 410
+          : 503;
+  res.status(status).json({ error: failure });
 }
 
 function validPrompt(value: unknown): boolean {


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Assistant session actions and native events must be scoped to the current runtime, authority, directory, and exact session identities.

## Summary and scope

Expose authenticated session-scoped OpenCode routes and incremental SSE events, convert only strict current-scope failures, suppress conflicting native session IDs, and preserve associations when native history is confirmed missing. The session/router Changeset lives here because these endpoints first exist in this layer.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `studio-opencode-lifecycle`. Actual-parent size: **895 additions + 0 deletions = 895 changed lines**. This is above the 600-line target and below the 1,000-line hard maximum; the source and tests stay together to preserve a compiling, independently reviewable boundary.

Absorbed reviewed provenance: #935 authenticated session router/event transport portion; native conflicting-session identity suppression; session route/event Changeset moved from #901.

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3290](https://linear.app/sapiom/issue/SAP-3290). This PR keeps its existing number and review history within the main-rooted native GitHub stack.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check 6a333454d39b30d2417f40b7eece516c798ac332...bf417539c68d518ced3472d9c333a9c3bf1e40dc` — passed.
- Harness typecheck plus focused shared/access/credential/host/association/server/auth wiring tests — 78/78 passed.

### Tests and documentation

Router, event, host, access, association, and conflicting-session fixtures cover current/stale runtime scope, exact directory fallback, spoof suppression, 404 history ownership, and retryable transport failures.

## Compatibility and release impact

- Breaking or externally visible changes: Adds authenticated internal session routes and typed event failures. Missing native history remains an honest terminal state and does not create, adopt, or delete a native conversation.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
