### PR TITLE
feat(studio): add a gated native Assistant conversation [SAP-3290]

### DIFF
--- a/.changeset/studio-opencode-chat.md
+++ b/.changeset/studio-opencode-chat.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": minor
+---
+
+Add the internally gated Terminal/Assistant switch and a Studio-native streaming OpenCode conversation with connection recovery.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -65,6 +65,13 @@ malformed/ambiguous response revokes the grant. Thus an offline first launch
 cannot invent eligibility, while a short outage does not interrupt an unchanged
 verified principal before the server-issued lease ends.
 
+Eligible internal users see a **Terminal | Assistant** switch, with Terminal
+selected initially. Assistant sends prompts and streams Sapiom responses in the
+selected project. Returning to a session reopens its OpenCode conversation;
+switching views detaches the display while execution continues. Connection errors
+offer **Reconnect**, which reloads history without resending accepted prompts.
+This first slice includes basic tool status; richer controls arrive separately.
+
 The Assistant's model and remote MCP requests use a Studio-owned local bridge.
 Its short-lived runtime credential is separate from browser authentication;
 Studio adds the Sapiom key only when forwarding to the configured services.

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -1,0 +1,360 @@
+import { expect, test, type Page } from "@playwright/test";
+import express, { type Response } from "express";
+import type { Server } from "node:http";
+
+// Exercise the pinned adapter over actual incremental HTTP SSE, without a model.
+test.describe.configure({ mode: "serial" });
+type Conversation = {
+  id: string;
+  turns: Array<{
+    info: Record<string, any>;
+    parts: Array<Record<string, any>>;
+  }>;
+  streams: Set<Response>;
+  prompts: string[];
+};
+let server: Server;
+let origin: string;
+let enabled: boolean;
+let failAttach: boolean;
+let failMetadata: boolean;
+let holdHistory: boolean;
+let failEvents: boolean;
+const historyReplies: Array<() => void> = [];
+let routeCalls: number;
+const conversations = new Map<string, Conversation>();
+const emit = (c: Conversation, type: string, properties: object) => {
+  for (const stream of c.streams)
+    stream.write(`data: ${JSON.stringify({ type, properties })}\n\n`);
+};
+function finish(id: string, suffix: string) {
+  const c = conversations.get(id)!;
+  const turn = c.turns.at(-1)!;
+  turn.parts[0].text += suffix;
+  turn.info.time.completed = Date.now();
+  turn.info.finish = "stop";
+  emit(c, "message.part.delta", {
+    sessionID: id,
+    messageID: turn.info.id,
+    partID: turn.parts[0].id,
+    field: "text",
+    delta: suffix,
+  });
+  emit(c, "message.updated", { info: turn.info });
+  emit(c, "session.status", { sessionID: id, status: { type: "idle" } });
+}
+test.beforeEach(async ({ page }) => {
+  conversations.clear();
+  enabled = true;
+  failAttach = false;
+  failMetadata = false;
+  holdHistory = false;
+  failEvents = false;
+  historyReplies.length = 0;
+  routeCalls = 0;
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    res.set({
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Headers": "*",
+    });
+    if (req.method === "OPTIONS") {
+      res.end();
+      return;
+    }
+    next();
+  });
+  app.all("/opencode/:studioId/*", (req, res) => {
+    routeCalls++;
+    if (req.header("X-Harness-Token") !== "chat-test-boot") {
+      res.status(401).end();
+      return;
+    }
+    const id = `ses_${req.params.studioId.replaceAll("-", "_")}`;
+    let c = conversations.get(id);
+    if (!c) {
+      c = { id, turns: [], streams: new Set(), prompts: [] };
+      conversations.set(id, c);
+    }
+    const path = req.params[0];
+    const session = {
+      id,
+      title: "Studio conversation",
+      time: { created: 1, updated: 1 },
+    };
+    if (path === "attach") {
+      res.status(failAttach ? 502 : 200).json({ conversationId: id });
+      return;
+    }
+    if (path === "experimental/session") {
+      res.json([session]);
+      return;
+    }
+    if (path === `session/${id}`) {
+      res.status(failMetadata ? 503 : 200).json(session);
+      return;
+    }
+    if (path === `session/${id}/message`) {
+      if (holdHistory) historyReplies.push(() => res.json(c!.turns));
+      else res.json(c.turns);
+      return;
+    }
+    if (path === "permission" || path === "question") {
+      res.json([]);
+      return;
+    }
+    if (path === "session/status") {
+      res.json({ [id]: { type: "idle" } });
+      return;
+    }
+    if (path === "event") {
+      if (failEvents) {
+        res.status(503).end();
+        return;
+      }
+      res.type("text/event-stream").flushHeaders();
+      c.streams.add(res);
+      res.write('data: {"type":"server.connected","properties":{}}\n\n');
+      res.once("close", () => c!.streams.delete(res));
+      return;
+    }
+    if (path === `session/${id}/prompt_async`) {
+      c.prompts.push(req.body.parts[0].text);
+      const userId = `msg_user_${c.prompts.length}`,
+        assistantId = `msg_assistant_${c.prompts.length}`;
+      const user = {
+        info: {
+          id: userId,
+          sessionID: id,
+          role: "user",
+          time: { created: Date.now() },
+        },
+        parts: [
+          {
+            id: `prt_${userId}`,
+            sessionID: id,
+            messageID: userId,
+            type: "text",
+            text: req.body.parts[0].text,
+          },
+        ],
+      };
+      const assistant = {
+        info: {
+          id: assistantId,
+          sessionID: id,
+          role: "assistant",
+          parentID: userId,
+          time: { created: Date.now() },
+          modelID: "smart",
+          providerID: "sapiom",
+        },
+        parts: [
+          {
+            id: `prt_${assistantId}`,
+            sessionID: id,
+            messageID: assistantId,
+            type: "text",
+            text: "",
+          },
+        ],
+      };
+      c.turns.push(user, assistant);
+      res.status(204).end();
+      emit(c, "session.status", { sessionID: id, status: { type: "busy" } });
+      for (const turn of [user, assistant]) {
+        emit(c, "message.updated", { info: turn.info });
+        emit(c, "message.part.updated", { part: turn.parts[0] });
+      }
+      assistant.parts[0].text = "First chunk";
+      emit(c, "message.part.delta", {
+        sessionID: id,
+        messageID: assistantId,
+        partID: assistant.parts[0].id,
+        field: "text",
+        delta: "First chunk",
+      });
+      return;
+    }
+    res.status(404).end();
+  });
+  server = app.listen(0, "127.0.0.1");
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  origin = `http://127.0.0.1:${(server.address() as { port: number }).port}`;
+  await page.addInitScript(() => {
+    (window as any).__HARNESS__ = { token: "chat-test-boot" };
+  });
+  await page.route("**/api/assistant/access", (route) =>
+    route.fulfill({ json: { enabled } }),
+  );
+  await page.route("**/opencode/**", (route) =>
+    route.continue({
+      url: `${origin}${new URL(route.request().url()).pathname}${new URL(route.request().url()).search}`,
+    }),
+  );
+});
+test.afterEach(async () => {
+  server.closeAllConnections();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+async function openAssistant(page: Page) {
+  await page.goto("/?seed=0");
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(
+    page.getByRole("textbox", { name: "Message Assistant" }),
+  ).toBeEnabled();
+}
+
+test("defaults to Terminal and keeps Assistant unavailable when access is off", async ({
+  page,
+}) => {
+  enabled = false;
+  await page.goto("/?seed=0");
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+  await expect(
+    page.getByRole("group", { name: "Conversation view" }),
+  ).toHaveCount(0);
+  expect(routeCalls).toBe(0);
+});
+
+test("streams, disposes the old tab's connection, restores history, and sends a follow-up", async ({
+  page,
+}) => {
+  await openAssistant(page);
+  const input = page.getByRole("textbox", { name: "Message Assistant" });
+  await input.fill("First request");
+  await input.press("Enter");
+  await expect(
+    page.locator(".studio-chat-assistant").filter({ hasText: "First chunk" }),
+  ).toContainText("First chunk");
+  await expect(
+    page.getByRole("button", { name: "Send message" }),
+  ).toBeDisabled();
+  const tabs = page.getByRole("tablist", { name: "Sessions" }).getByRole("tab");
+  await tabs.nth(1).click();
+  await expect
+    .poll(() => conversations.get("ses_sess_boot")!.streams.size)
+    .toBe(0);
+  finish("ses_sess_boot", " finished in background");
+  await expect(page.locator(".studio-chat-assistant")).toHaveCount(0);
+  await tabs.nth(0).click();
+  await expect(page.locator(".studio-chat-assistant")).toContainText(
+    "finished in background",
+  );
+  await input.fill("Follow-up");
+  await input.press("Enter");
+  await expect
+    .poll(() => conversations.get("ses_sess_boot")!.prompts.length)
+    .toBe(2);
+  finish("ses_sess_boot", " completed follow-up");
+  await expect(page.locator(".studio-chat-assistant").last()).toContainText(
+    "completed follow-up",
+  );
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  await page.getByRole("button", { name: "Terminal", exact: true }).click();
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+});
+
+test("waits for the associated history before enabling the composer", async ({
+  page,
+}) => {
+  holdHistory = true;
+  await page.goto("/?seed=0");
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect.poll(() => historyReplies.length).toBeGreaterThan(0);
+  await expect(
+    page.getByRole("textbox", { name: "Message Assistant" }),
+  ).toBeDisabled();
+  await expect(
+    page.getByRole("button", { name: "Send message" }),
+  ).toBeDisabled();
+  holdHistory = false;
+  for (const reply of historyReplies) reply();
+  await expect(
+    page.getByRole("textbox", { name: "Message Assistant" }),
+  ).toBeEnabled();
+  expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
+});
+
+test("surfaces initial metadata failures and retries the same association", async ({
+  page,
+}) => {
+  failMetadata = true;
+  await page.goto("/?seed=0");
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(page.getByRole("alert")).toContainText("Could not load or send");
+  await expect(
+    page.getByRole("button", { name: "Send message" }),
+  ).toBeDisabled();
+  failMetadata = false;
+  await page.getByRole("button", { name: "Reconnect" }).click();
+  await expect(
+    page.getByRole("textbox", { name: "Message Assistant" }),
+  ).toBeEnabled();
+  expect(conversations.size).toBe(1);
+  expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
+});
+
+test("keeps a native run error visible when idle immediately follows it", async ({
+  page,
+}) => {
+  await openAssistant(page);
+  const c = conversations.get("ses_sess_boot")!;
+  emit(c, "session.error", {
+    sessionID: c.id,
+    error: { name: "UnknownError", data: { message: "controlled failure" } },
+  });
+  emit(c, "session.status", { sessionID: c.id, status: { type: "idle" } });
+  await expect(page.getByRole("alert")).toContainText(
+    "Assistant could not finish",
+  );
+  await expect(
+    page.getByRole("button", { name: "Send message" }),
+  ).toBeDisabled();
+  await page.getByRole("button", { name: "Reconnect" }).click();
+  await expect(
+    page.getByRole("textbox", { name: "Message Assistant" }),
+  ).toBeEnabled();
+  expect(c.prompts).toEqual([]);
+});
+
+test("shows startup failure and reconnects without sending a prompt", async ({
+  page,
+}) => {
+  failAttach = true;
+  await page.goto("/?seed=0");
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(page.getByRole("alert")).toContainText(
+    "Assistant could not open",
+  );
+  failAttach = false;
+  await page.getByRole("button", { name: "Reconnect" }).click();
+  await expect(
+    page.getByRole("textbox", { name: "Message Assistant" }),
+  ).toBeEnabled();
+  expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
+});
+
+test("shows stream loss and reconnects without replaying an accepted prompt", async ({
+  page,
+}) => {
+  await openAssistant(page);
+  const input = page.getByRole("textbox", { name: "Message Assistant" });
+  await input.fill("A single request");
+  await input.press("Enter");
+  const c = conversations.get("ses_sess_boot")!;
+  await expect.poll(() => c.prompts.length).toBe(1);
+  failEvents = true;
+  for (const stream of c.streams) stream.end();
+  await expect(page.getByRole("alert")).toContainText("Connection lost");
+  finish(c.id, " recovered");
+  failEvents = false;
+  await page.getByRole("button", { name: "Reconnect" }).click();
+  await expect(page.locator(".studio-chat-assistant")).toContainText(
+    "First chunk recovered",
+  );
+  await expect(input).toBeEnabled();
+  expect(c.prompts).toEqual(["A single request"]);
+});

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -84,6 +84,7 @@ import { RunSheet } from "./components/RunSheet";
 import { TelemetryNotice } from "./components/TelemetryNotice";
 import { TemplatesPanel } from "./components/TemplatesPanel";
 import { Terminal } from "./components/Terminal";
+import { AssistantPane } from "./components/AssistantPane";
 import { Toast } from "./components/Toast";
 import { TooltipLayer } from "./components/TooltipLayer";
 import { NewSessionComposer } from "./components/NewSessionComposer";
@@ -3380,11 +3381,17 @@ export const App = (): JSX.Element => {
               ) : showWorkbench && conversationSession ? (
                 <div className="agent-view" data-testid="agent-view">
                   <div className="agent-view-panel" id="agent-panel-terminal">
-                    <Terminal
+                    <AssistantPane
                       sessionId={conversationSession.id}
-                      token={harness.bootToken}
-                      cwd={conversationSession.cwd}
-                    />
+                      bootToken={harness.bootToken}
+                      authRevision={harness.authRevision}
+                    >
+                      <Terminal
+                        sessionId={conversationSession.id}
+                        token={harness.bootToken}
+                        cwd={conversationSession.cwd}
+                      />
+                    </AssistantPane>
                   </div>
                 </div>
               ) : (

--- a/packages/harness/web/src/components/AssistantPane.tsx
+++ b/packages/harness/web/src/components/AssistantPane.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState, type ReactNode } from "react";
+import { OpenCodeChat } from "./OpenCodeChat";
+
+/** The server owns eligibility; this is only its short-lived UI projection. */
+export function AssistantPane({
+  sessionId,
+  bootToken,
+  authRevision,
+  children,
+}: {
+  sessionId: string;
+  bootToken: string;
+  authRevision: number;
+  children: ReactNode;
+}) {
+  const [enabled, setEnabled] = useState(false);
+  const [mode, setMode] = useState<"Terminal" | "Assistant">("Terminal");
+  useEffect(() => {
+    const abort = new AbortController();
+    let timer: ReturnType<typeof setTimeout>;
+    setEnabled(false);
+    setMode("Terminal");
+    const refresh = async () => {
+      let allowed = false;
+      try {
+        const response = await fetch("/api/assistant/access", {
+          headers: { "X-Harness-Token": bootToken },
+          credentials: "omit",
+          cache: "no-store",
+          signal: AbortSignal.any([abort.signal, AbortSignal.timeout(5000)]),
+        });
+        allowed = response.ok && (await response.json()).enabled === true;
+      } catch {
+        /* Missing identity or host access stays off. */
+      }
+      if (abort.signal.aborted) return;
+      setEnabled(allowed);
+      if (!allowed) setMode("Terminal");
+      timer = setTimeout(() => {
+        void refresh();
+      }, 15000);
+    };
+    void refresh();
+    return () => {
+      abort.abort();
+      clearTimeout(timer);
+    };
+  }, [bootToken, authRevision]);
+
+  return (
+    <div className="studio-conversation">
+      {enabled && (
+        <div
+          className="studio-conversation-switch"
+          role="group"
+          aria-label="Conversation view"
+        >
+          {(["Terminal", "Assistant"] as const).map((view) => (
+            <button
+              key={view}
+              type="button"
+              className="btn-ghost"
+              aria-pressed={mode === view}
+              onClick={() => setMode(view)}
+            >
+              {view}
+            </button>
+          ))}
+        </div>
+      )}
+      <div className="studio-conversation-body">
+        {enabled && mode === "Assistant" ? (
+          <OpenCodeChat
+            key={sessionId}
+            harnessSessionId={sessionId}
+            bootToken={bootToken}
+          />
+        ) : (
+          children
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/harness/web/src/components/OpenCodeChat.tsx
+++ b/packages/harness/web/src/components/OpenCodeChat.tsx
@@ -1,0 +1,339 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  AssistantRuntimeProvider,
+  ComposerPrimitive,
+  ErrorPrimitive,
+  MessagePrimitive,
+  ThreadPrimitive,
+  useAuiState,
+  type TextMessagePartProps,
+  type ToolCallMessagePartProps,
+} from "@assistant-ui/react";
+import {
+  createOpencodeClient,
+  useOpenCodeRuntime,
+  useOpenCodeThreadState,
+} from "@assistant-ui/react-opencode";
+import { Icon } from "./Icon";
+import { Markdown } from "./Markdown";
+
+interface Props {
+  harnessSessionId: string;
+  bootToken: string;
+}
+const connectionError =
+  "Connection lost. Reconnect to see the latest response.";
+const runError =
+  "Assistant could not finish. Reconnect and check the conversation before sending again.";
+
+export function OpenCodeChat({ harnessSessionId, bootToken }: Props) {
+  const [conversationId, setConversationId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [attempt, setAttempt] = useState(0);
+  const baseUrl = new URL(
+    `/opencode/${encodeURIComponent(harnessSessionId)}`,
+    window.location.origin,
+  ).toString();
+  useEffect(() => {
+    const abort = new AbortController();
+    setConversationId(null);
+    setError(null);
+    void fetch(`${baseUrl}/attach`, {
+      method: "POST",
+      headers: { "X-Harness-Token": bootToken },
+      credentials: "omit",
+      signal: abort.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error("attach failed");
+        const data = await response.json();
+        if (
+          typeof data.conversationId !== "string" ||
+          !data.conversationId.startsWith("ses_")
+        )
+          throw new Error("invalid association");
+        if (!abort.signal.aborted) setConversationId(data.conversationId);
+      })
+      .catch(() => {
+        if (!abort.signal.aborted)
+          setError(
+            "Assistant could not open. Check Studio sign-in and workspace access, then retry.",
+          );
+      });
+    return () => abort.abort();
+  }, [baseUrl, bootToken, attempt]);
+  const retry = useCallback(() => {
+    setConversationId(null);
+    setError(null);
+    setAttempt((value) => value + 1);
+  }, []);
+  return conversationId ? (
+    <RuntimeChat
+      key={`${conversationId}:${attempt}`}
+      baseUrl={baseUrl}
+      bootToken={bootToken}
+      conversationId={conversationId}
+      retry={retry}
+    />
+  ) : (
+    <div className="studio-chat-start">
+      {error ? (
+        <Recovery message={error} retry={retry} />
+      ) : (
+        <span role="status">Opening Assistant…</span>
+      )}
+    </div>
+  );
+}
+
+function RuntimeChat({
+  baseUrl,
+  bootToken,
+  conversationId,
+  retry,
+}: {
+  baseUrl: string;
+  bootToken: string;
+  conversationId: string;
+  retry: () => void;
+}) {
+  const [transportError, setTransportError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [connected, setConnected] = useState(false);
+  const onError = useCallback(
+    () =>
+      setActionError(
+        "Could not load or send the message. Reconnect and check the conversation before sending again.",
+      ),
+    [],
+  );
+  const client = useMemo(() => {
+    const client = createOpencodeClient({
+      baseUrl,
+      headers: { "X-Harness-Token": bootToken },
+      credentials: "omit",
+      fetch: async (input, init) => {
+        const request = new Request(input, init);
+        const path = new URL(request.url).pathname;
+        const root = new URL(`${baseUrl}/session/${conversationId}`).pathname;
+        const required =
+          path === root ||
+          path === `${root}/message` ||
+          path.endsWith("/experimental/session");
+        try {
+          const response = await globalThis.fetch(request);
+          if (!response.ok && required) onError();
+          return response;
+        } catch (error) {
+          if (required && !request.signal.aborted) onError();
+          throw error;
+        }
+      },
+    });
+    const subscribe = client.event.subscribe.bind(client.event);
+    client.event.subscribe = async (parameters, options) => {
+      const result = await subscribe(parameters, {
+        ...options,
+        onSseError(error) {
+          options?.onSseError?.(error);
+          if (!options?.signal?.aborted) {
+            setConnected(false);
+            setTransportError(connectionError);
+          }
+        },
+        onSseEvent(event) {
+          options?.onSseEvent?.(event);
+          if (!options?.signal?.aborted) {
+            const data = event.data as { type?: string };
+            if (data.type === "session.error") setActionError(runError);
+            setConnected(true);
+            setTransportError(null);
+          }
+        },
+      });
+      return {
+        ...result,
+        stream: (async function* () {
+          try {
+            yield* result.stream;
+          } finally {
+            if (!options?.signal?.aborted) {
+              setConnected(false);
+              setTransportError(connectionError);
+            }
+          }
+        })(),
+      };
+    };
+    // This pinned adapter's title hook invokes compaction. OpenCode already
+    // generates titles; suppress that unrelated model action, as in the POC.
+    client.session.summarize = async () => ({ data: true }) as never;
+    return client;
+  }, [baseUrl, bootToken, conversationId, onError]);
+  const runtime = useOpenCodeRuntime({
+    client,
+    initialSessionId: conversationId,
+    onError,
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ChatSurface
+        conversationId={conversationId}
+        connected={connected}
+        error={transportError ?? actionError}
+        retry={retry}
+      />
+    </AssistantRuntimeProvider>
+  );
+}
+
+const AssistantText = ({ text }: TextMessagePartProps) => (
+  <Markdown text={text} />
+);
+const UserText = ({ text }: TextMessagePartProps) => (
+  <p className="studio-chat-user-text">{text}</p>
+);
+const ToolProgress = ({
+  toolName,
+  status,
+  isError,
+}: ToolCallMessagePartProps) => (
+  <div className="studio-chat-meta">
+    {toolName} ·{" "}
+    {isError
+      ? "Failed"
+      : status.type === "running"
+        ? "Working…"
+        : status.type === "requires-action"
+          ? "Waiting"
+          : status.type === "incomplete"
+            ? "Interrupted"
+            : "Complete"}
+  </div>
+);
+
+function ChatSurface({
+  conversationId,
+  connected,
+  error,
+  retry,
+}: {
+  conversationId: string;
+  connected: boolean;
+  error: string | null;
+  retry: () => void;
+}) {
+  const loading = useAuiState((s) => s.thread.isLoading);
+  const running = useAuiState((s) => s.thread.isRunning);
+  const disabled = useAuiState((s) => s.thread.isDisabled);
+  const ready = useOpenCodeThreadState(
+    (s) => s.sessionId === conversationId && s.loadState.type === "ready",
+  );
+  const hasText = useAuiState((s) => {
+    for (let i = s.thread.messages.length - 1; i >= 0; i--) {
+      const message = s.thread.messages[i];
+      if (message.role === "user") return false;
+      if (
+        message.content.some(
+          (part) => part.type === "text" && part.text.length > 0,
+        )
+      )
+        return true;
+    }
+    return false;
+  });
+  const failed = useOpenCodeThreadState(
+    (s) => s.loadState.type === "error" || s.runState.type === "error",
+  );
+  const visibleError = error ?? (failed ? runError : null);
+  return (
+    <ThreadPrimitive.Root
+      className="studio-chat"
+      aria-label="Assistant conversation"
+    >
+      <ThreadPrimitive.Viewport
+        className="studio-chat-viewport"
+        scrollToBottomOnRunStart={false}
+      >
+        <div className="studio-chat-feed">
+          <ThreadPrimitive.Empty>
+            <p className="studio-chat-meta">
+              Describe the change you want to make in this project.
+            </p>
+          </ThreadPrimitive.Empty>
+          <ThreadPrimitive.Messages>
+            {({ message }) => (
+              <MessagePrimitive.Root
+                className={
+                  message.role === "user"
+                    ? "studio-chat-user"
+                    : "studio-chat-assistant"
+                }
+              >
+                <MessagePrimitive.Parts
+                  components={{
+                    Text: message.role === "user" ? UserText : AssistantText,
+                    tools: { Fallback: ToolProgress },
+                  }}
+                />
+                <MessagePrimitive.Error>
+                  <ErrorPrimitive.Root className="studio-chat-error">
+                    <ErrorPrimitive.Message />
+                  </ErrorPrimitive.Root>
+                </MessagePrimitive.Error>
+              </MessagePrimitive.Root>
+            )}
+          </ThreadPrimitive.Messages>
+          {(!connected || !ready || loading || (running && !hasText)) &&
+            !visibleError && (
+              <div role="status" className="studio-chat-meta">
+                {!connected
+                  ? "Connecting…"
+                  : loading || !ready
+                    ? "Loading conversation…"
+                    : "Assistant is working…"}
+              </div>
+            )}
+          {visibleError && <Recovery message={visibleError} retry={retry} />}
+        </div>
+      </ThreadPrimitive.Viewport>
+      <div className="studio-chat-dock">
+        <ComposerPrimitive.Root className="studio-chat-composer">
+          <ComposerPrimitive.Input
+            className="studio-chat-input"
+            aria-label="Message Assistant"
+            placeholder="Describe the change you want"
+            minRows={1}
+            maxRows={6}
+            submitMode="enter"
+            cancelOnEscape={false}
+            addAttachmentOnPaste={false}
+            disabled={
+              !connected || !ready || loading || disabled || !!visibleError
+            }
+          />
+          <div className="studio-chat-actions">
+            <ComposerPrimitive.Send
+              className="composer-send"
+              aria-label="Send message"
+              disabled={!connected || !ready || !!visibleError}
+            >
+              <Icon name="ArrowUp" size={14} />
+            </ComposerPrimitive.Send>
+          </div>
+        </ComposerPrimitive.Root>
+      </div>
+    </ThreadPrimitive.Root>
+  );
+}
+
+function Recovery({ message, retry }: { message: string; retry: () => void }) {
+  return (
+    <div className="studio-chat-error" role="alert">
+      <p>{message}</p>
+      <button type="button" className="btn-ghost" onClick={retry}>
+        Reconnect
+      </button>
+    </div>
+  );
+}

--- a/packages/harness/web/src/main.tsx
+++ b/packages/harness/web/src/main.tsx
@@ -8,6 +8,7 @@ import "./styles.css";
 import "./styles/refine.css";
 // After refine.css, which owns the shared block/surface model this layers on.
 import "./styles/secrets.css";
+import "./styles/opencode-chat.css";
 
 // In mock mode, intercept /api/track calls so Playwright tests can assert
 // that track() events fire without a real server. No-op in real mode.

--- a/packages/harness/web/src/styles/opencode-chat.css
+++ b/packages/harness/web/src/styles/opencode-chat.css
@@ -1,0 +1,145 @@
+.studio-conversation,
+.studio-chat {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.studio-conversation-switch {
+  display: flex;
+  gap: var(--sp1);
+  padding: var(--sp2) var(--sp3);
+  border-bottom: 1px solid var(--line);
+}
+.studio-conversation-switch button[aria-pressed="true"] {
+  background: var(--active-shade);
+  color: var(--text);
+}
+.studio-conversation-body {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+}
+.studio-chat {
+  background: var(--surface-base);
+  color: var(--text);
+  font-size: var(--type-body);
+}
+.studio-chat-start {
+  height: 100%;
+  display: grid;
+  place-items: center;
+  padding: var(--sp4);
+  color: var(--text-dim);
+}
+.studio-chat-viewport {
+  flex: 1;
+  overflow-y: auto;
+  min-height: 0;
+}
+.studio-chat-feed {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp5);
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: var(--sp5) var(--sp4);
+  overflow-wrap: anywhere;
+}
+.studio-chat-user {
+  align-self: flex-end;
+  max-width: 85%;
+  background: var(--active-shade);
+  border-radius: var(--radius);
+  padding: var(--sp2) var(--sp3);
+}
+.studio-chat-user-text {
+  margin: 0;
+  white-space: pre-wrap;
+}
+.studio-chat-assistant {
+  line-height: 1.65;
+  min-width: 0;
+}
+.studio-chat-assistant:empty {
+  display: none;
+}
+.studio-chat-assistant .chat-paragraph:first-child {
+  margin-top: 0;
+}
+.studio-chat-assistant .chat-paragraph:last-child {
+  margin-bottom: 0;
+}
+.studio-chat-meta {
+  font-size: var(--type-meta);
+  color: var(--text-dim);
+}
+.studio-chat-error {
+  color: var(--text-dim);
+  font-size: var(--type-meta);
+}
+.studio-chat-error p {
+  margin: 0 0 var(--sp2);
+}
+.studio-chat-dock {
+  flex-shrink: 0;
+  width: 100%;
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: var(--sp3) var(--sp4) var(--sp4);
+}
+.studio-chat-composer {
+  background: var(--surface-raised);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-md);
+  padding: var(--sp2) var(--sp3);
+}
+.studio-chat-input {
+  display: block;
+  width: 100%;
+  resize: none;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  line-height: 1.5;
+  padding: var(--sp1) 0;
+}
+.studio-chat-composer:has(:focus-visible) {
+  outline: 2px solid var(--focus);
+  outline-offset: 2px;
+  border-radius: var(--radius);
+}
+.studio-chat-input:focus-visible {
+  outline: none;
+}
+.studio-chat-assistant .chat-heading {
+  font-size: var(--type-body);
+  font-weight: 600;
+  margin: var(--sp4) 0 var(--sp2);
+}
+.studio-chat-assistant .chat-code-block {
+  max-width: 100%;
+  overflow-x: auto;
+  white-space: pre;
+  padding: var(--sp3);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  font-size: var(--type-meta);
+}
+.studio-chat-assistant .chat-inline-code {
+  font-size: 0.95em;
+}
+.studio-chat-assistant .chat-list,
+.studio-chat-assistant .chat-blockquote {
+  margin: var(--sp3) 0;
+  padding-left: var(--sp5);
+}
+.studio-chat-input::placeholder {
+  color: var(--text-faint);
+}
+.studio-chat-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: var(--sp2);
+}

--- a/packages/harness/web/vite.config.ts
+++ b/packages/harness/web/vite.config.ts
@@ -147,6 +147,7 @@ export default defineConfig({
         ? undefined
         : {
             "/api": { target: HARNESS_SERVER },
+            "/opencode": { target: HARNESS_SERVER },
             "/canvas": { target: HARNESS_SERVER },
             "/ws": { target: "ws://localhost:4100", ws: true },
           },


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Eligible Studio users need a native Assistant conversation surface without replacing Terminal as the default or exposing unavailable access.

## Summary and scope

Add the gated Assistant pane and OpenCode chat adapter, retain Terminal as the initial view, and keep both CLI and Electron on the shared server-built SPA. Draft lifetime, typed recovery actions, and authority fencing remain in later layers.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `studio-opencode-chat`. Actual-parent size: **953 additions + 4 deletions = 957 changed lines**. This is above the 600-line target and below the 1,000-line hard maximum; the source and tests stay together to preserve a compiling, independently reviewable boundary.

Absorbed reviewed provenance: original gated Assistant conversation UI; ancestry propagation only.

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3290](https://linear.app/sapiom/issue/SAP-3290). This PR keeps its existing number and review history within the main-rooted native GitHub stack.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check 90095ebca55b0aeb3e73e32904c534cb7594a3fe...db36dbf3f690d9e70fdafb89f4e270b55369a8c8` — passed.
- Exact final Assistant browser command with one Chromium worker — 31 passed (1.1m).

### Tests and documentation

Component-level Playwright coverage exercises streaming, tab disposal, history restoration, follow-up sends, and unavailable access. README and a Changeset describe the gated surface.

## Compatibility and release impact

- Breaking or externally visible changes: Adds an internal access-gated Assistant view; Terminal remains the default and backup path.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
