### PR TITLE
fix(studio): preserve drafts and reveal Terminal work [SAP-3290]

### DIFF
--- a/.changeset/fence-assistant-drafts.md
+++ b/.changeset/fence-assistant-drafts.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Fence in-memory Assistant drafts by the server-issued authority revision so drafts cannot cross account, tenant, denial, or readmission boundaries.

--- a/.changeset/retain-assistant-drafts.md
+++ b/.changeset/retain-assistant-drafts.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Retain unsent Assistant drafts across pane routes, session review, reconnects, and live-to-exited remounts while clearing them at authentication, deletion, and reload boundaries.

--- a/.changeset/studio-opencode-chat-recovery.md
+++ b/.changeset/studio-opencode-chat-recovery.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Preserve Assistant drafts during brief capability-check failures and reveal Terminal when Studio sends it foreground work.

--- a/.changeset/studio-opencode-chat-recovery.md
+++ b/.changeset/studio-opencode-chat-recovery.md
@@ -2,4 +2,4 @@
 "@sapiom/harness": patch
 ---
 
-Preserve Assistant drafts during brief capability-check failures and reveal Terminal when Studio sends it foreground work.
+Preserve Assistant drafts across view changes and brief capability-check failures. Reveal Terminal after foreground work is accepted, and show rejected inspector sends without changing the view.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -76,14 +76,15 @@ rejected send shows its error and keeps the selected view. Unsent chat text is
 keyed by authenticated principal and Studio session above the centre pane, so it
 survives Terminal/Assistant and session switches, reconnects, exited-session
 views, and temporary New Session or past-session review navigation. It is never
-persisted: sign-out/account change, session deletion, and page/app reload clear
-the applicable in-memory draft. Conversation view is a separate, unpersisted
-mount-local preference: Terminal is the initial/reset view, while a foreground
-CLI prompt accepted by Studio explicitly reveals it. Background actions keep
-the selected view. A failed UI
-access poll retains the open draft for at most 60 seconds after the last success;
-explicit revocation/sign-out takes effect immediately when observed. The host
-continues enforcing its own capability expiry independently.
+persisted: actual Assistant-access retirement, authority crossover, sign-out,
+session deletion, and page/app reload clear the applicable in-memory draft.
+Same-authority renewals, polls, and reconnects retain it. Conversation view is
+a separate, unpersisted mount-local preference: Terminal is the initial/reset
+view, while a foreground CLI prompt accepted by Studio explicitly reveals it.
+Background actions keep the selected view. A failed UI access poll retains the
+open draft for at most 60 seconds after the last success; explicit
+revocation/sign-out takes effect immediately when observed. The host continues
+enforcing its own capability expiry independently.
 
 The Assistant's model and remote MCP requests use a Studio-owned local bridge.
 Its short-lived runtime credential is separate from browser authentication;

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -71,8 +71,10 @@ selected project. Returning to a session reopens its OpenCode conversation;
 switching views detaches the display while execution continues. Connection errors
 offer **Reconnect**, which reloads history without resending accepted prompts.
 This first slice includes basic tool status; richer controls arrive separately.
-Studio actions that send a foreground prompt to the CLI reveal Terminal so its
-response stays visible. Background actions keep the selected view. A failed UI
+Studio actions reveal Terminal after a foreground CLI prompt is accepted; a
+rejected send shows its error and keeps the selected view. Unsent chat text stays
+in memory per session across view/tab switches and reconnects until sign-out or
+reload. Background actions keep the selected view. A failed UI
 access poll retains the open draft for at most 60 seconds after the last success;
 explicit revocation/sign-out takes effect immediately when observed. The host
 continues enforcing its own capability expiry independently.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -71,6 +71,11 @@ selected project. Returning to a session reopens its OpenCode conversation;
 switching views detaches the display while execution continues. Connection errors
 offer **Reconnect**, which reloads history without resending accepted prompts.
 This first slice includes basic tool status; richer controls arrive separately.
+Studio actions that send a foreground prompt to the CLI reveal Terminal so its
+response stays visible. Background actions keep the selected view. A failed UI
+access poll retains the open draft for at most 60 seconds after the last success;
+explicit revocation/sign-out takes effect immediately when observed. The host
+continues enforcing its own capability expiry independently.
 
 The Assistant's model and remote MCP requests use a Studio-owned local bridge.
 Its short-lived runtime credential is separate from browser authentication;

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -72,9 +72,15 @@ switching views detaches the display while execution continues. Connection error
 offer **Reconnect**, which reloads history without resending accepted prompts.
 This first slice includes basic tool status; richer controls arrive separately.
 Studio actions reveal Terminal after a foreground CLI prompt is accepted; a
-rejected send shows its error and keeps the selected view. Unsent chat text stays
-in memory per session across view/tab switches and reconnects until sign-out or
-reload. Background actions keep the selected view. A failed UI
+rejected send shows its error and keeps the selected view. Unsent chat text is
+keyed by authenticated principal and Studio session above the centre pane, so it
+survives Terminal/Assistant and session switches, reconnects, exited-session
+views, and temporary New Session or past-session review navigation. It is never
+persisted: sign-out/account change, session deletion, and page/app reload clear
+the applicable in-memory draft. Conversation view is a separate, unpersisted
+mount-local preference: Terminal is the initial/reset view, while a foreground
+CLI prompt accepted by Studio explicitly reveals it. Background actions keep
+the selected view. A failed UI
 access poll retains the open draft for at most 60 seconds after the last success;
 explicit revocation/sign-out takes effect immediately when observed. The host
 continues enforcing its own capability expiry independently.

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -16,6 +16,7 @@ type Conversation = {
 let server: Server;
 let origin: string;
 let enabled: boolean;
+let accessAuthorityRevision: string;
 let failAttach: boolean;
 let failMetadata: boolean;
 let holdHistory: boolean;
@@ -49,6 +50,7 @@ function finish(id: string, suffix: string) {
 test.beforeEach(async ({ page }) => {
   conversations.clear();
   enabled = true;
+  accessAuthorityRevision = "authority-a";
   failAttach = false;
   failMetadata = false;
   holdHistory = false;
@@ -197,7 +199,10 @@ test.beforeEach(async ({ page }) => {
   });
   await page.route("**/api/assistant/access", (route) => {
     accessCalls++;
-    return route.fulfill({ status: failAccess ? 503 : 200, json: { enabled } });
+    return route.fulfill({
+      status: failAccess ? 503 : 200,
+      json: { enabled, authorityRevision: accessAuthorityRevision },
+    });
   });
   await page.route("**/opencode/**", (route) =>
     route.continue({
@@ -475,13 +480,19 @@ test("surfaces a rejected prompt POST and reconnects without replaying it", asyn
   expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
 });
 
-test("retains the draft during a failed access poll but applies explicit revocation", async ({
+test("retains the draft across stable and failed access polls but clears it at a disabled authority barrier", async ({
   page,
 }) => {
   await page.clock.install();
   await openAssistant(page);
   const input = page.getByRole("textbox", { name: "Message Assistant" });
   await input.fill("An unsent draft");
+
+  const beforeStablePoll = accessCalls;
+  await page.clock.fastForward(16000);
+  await expect.poll(() => accessCalls).toBeGreaterThan(beforeStablePoll);
+  await expect(input).toHaveValue("An unsent draft");
+
   const before = accessCalls;
   failAccess = true;
   await page.clock.fastForward(16000);
@@ -490,11 +501,42 @@ test("retains the draft during a failed access poll but applies explicit revocat
   expect(conversations.get("ses_sess_boot")!.streams.size).toBe(1);
   failAccess = false;
   enabled = false;
+  accessAuthorityRevision = "authority-retired";
   await page.clock.fastForward(16000);
   await expect(
     page.getByRole("group", { name: "Conversation view" }),
   ).toHaveCount(0);
   await expect(page.locator(".harness-terminal")).toBeVisible();
+
+  // Repeated disabled observations retain the same barrier. Readmission uses
+  // a new authority epoch, and neither can recover the retired draft.
+  const beforeDisabledPoll = accessCalls;
+  await page.clock.fastForward(16000);
+  await expect.poll(() => accessCalls).toBeGreaterThan(beforeDisabledPoll);
+  enabled = true;
+  accessAuthorityRevision = "authority-readmitted";
+  await page.clock.fastForward(16000);
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(input).toHaveValue("");
+});
+
+test("clears a draft on a direct enabled authority crossover without an auth event", async ({
+  page,
+}) => {
+  await page.clock.install();
+  await openAssistant(page);
+  const input = page.getByRole("textbox", { name: "Message Assistant" });
+  await input.fill("Principal A private draft");
+
+  const before = accessCalls;
+  accessAuthorityRevision = "authority-b";
+  await page.clock.fastForward(16000);
+  await expect.poll(() => accessCalls).toBeGreaterThan(before);
+
+  // authRevision is deliberately unchanged: the access epoch alone must swap
+  // the App-owned store before the enabled Principal B chat can mount.
+  await expect(input).toHaveValue("");
+  expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
 });
 
 test("expires the cached UI capability after sixty seconds without a successful poll", async ({

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -20,6 +20,9 @@ let failAttach: boolean;
 let failMetadata: boolean;
 let holdHistory: boolean;
 let failEvents: boolean;
+let failPrompt: boolean;
+let failAccess: boolean;
+let accessCalls: number;
 const historyReplies: Array<() => void> = [];
 let routeCalls: number;
 const conversations = new Map<string, Conversation>();
@@ -50,6 +53,9 @@ test.beforeEach(async ({ page }) => {
   failMetadata = false;
   holdHistory = false;
   failEvents = false;
+  failPrompt = false;
+  failAccess = false;
+  accessCalls = 0;
   historyReplies.length = 0;
   routeCalls = 0;
   const app = express();
@@ -120,6 +126,10 @@ test.beforeEach(async ({ page }) => {
       return;
     }
     if (path === `session/${id}/prompt_async`) {
+      if (failPrompt) {
+        res.status(502).json({ error: "Controlled send failure" });
+        return;
+      }
       c.prompts.push(req.body.parts[0].text);
       const userId = `msg_user_${c.prompts.length}`,
         assistantId = `msg_assistant_${c.prompts.length}`;
@@ -185,9 +195,10 @@ test.beforeEach(async ({ page }) => {
   await page.addInitScript(() => {
     (window as any).__HARNESS__ = { token: "chat-test-boot" };
   });
-  await page.route("**/api/assistant/access", (route) =>
-    route.fulfill({ json: { enabled } }),
-  );
+  await page.route("**/api/assistant/access", (route) => {
+    accessCalls++;
+    return route.fulfill({ status: failAccess ? 503 : 200, json: { enabled } });
+  });
   await page.route("**/opencode/**", (route) =>
     route.continue({
       url: `${origin}${new URL(route.request().url()).pathname}${new URL(route.request().url()).search}`,
@@ -357,4 +368,110 @@ test("shows stream loss and reconnects without replaying an accepted prompt", as
   );
   await expect(input).toBeEnabled();
   expect(c.prompts).toEqual(["A single request"]);
+});
+
+test("surfaces a rejected prompt POST and reconnects without replaying it", async ({
+  page,
+}) => {
+  await openAssistant(page);
+  failPrompt = true;
+  const input = page.getByRole("textbox", { name: "Message Assistant" });
+  await input.fill("A rejected request");
+  await input.press("Enter");
+  await expect(page.getByRole("alert")).toContainText("Could not load or send");
+  await expect(input).toBeDisabled();
+  failPrompt = false;
+  await page.getByRole("button", { name: "Reconnect" }).click();
+  await expect(input).toBeEnabled();
+  expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
+});
+
+test("retains the draft during a failed access poll but applies explicit revocation", async ({
+  page,
+}) => {
+  await page.clock.install();
+  await openAssistant(page);
+  const input = page.getByRole("textbox", { name: "Message Assistant" });
+  await input.fill("An unsent draft");
+  const before = accessCalls;
+  failAccess = true;
+  await page.clock.fastForward(16000);
+  await expect.poll(() => accessCalls).toBeGreaterThan(before);
+  await expect(input).toHaveValue("An unsent draft");
+  expect(conversations.get("ses_sess_boot")!.streams.size).toBe(1);
+  failAccess = false;
+  enabled = false;
+  await page.clock.fastForward(16000);
+  await expect(
+    page.getByRole("group", { name: "Conversation view" }),
+  ).toHaveCount(0);
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+});
+
+test("expires the cached UI capability after sixty seconds without a successful poll", async ({
+  page,
+}) => {
+  await page.clock.install();
+  await openAssistant(page);
+  failAccess = true;
+  await page.clock.fastForward(61000);
+  await expect(
+    page.getByRole("group", { name: "Conversation view" }),
+  ).toHaveCount(0);
+  await expect
+    .poll(() => conversations.get("ses_sess_boot")!.streams.size)
+    .toBe(0);
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+});
+
+test("reveals foreground Terminal input and preserves Assistant for background actions", async ({
+  page,
+}) => {
+  await openAssistant(page);
+  await page.evaluate(() => {
+    (window as any).__HARNESS_TEST__.publish({
+      type: "canvas.reload",
+      harnessSessionId: "sess-boot",
+    });
+  });
+  await expect(page.locator(".canvas-frame-wrap")).toHaveAttribute(
+    "data-view",
+    "board",
+  );
+  page.on("dialog", (dialog) => void dialog.accept());
+  await page.getByTestId("canvas-describe-ai").click();
+  await expect
+    .poll(() =>
+      page.evaluate(() => (window as any).__HARNESS_TEST__?.lastMacroRun?.id),
+    )
+    .toBe("describe");
+  const assistant = page.getByRole("button", {
+    name: "Assistant",
+    exact: true,
+  });
+  await expect(assistant).toHaveAttribute("aria-pressed", "true");
+  expect(conversations.get("ses_sess_boot")!.streams.size).toBe(1);
+  await page.getByTestId("canvas-chat-toggle").click();
+  await page.getByTestId("canvas-freeform-input").fill("Explain this agent");
+  await expect(assistant).toHaveAttribute("aria-pressed", "true");
+  await page.getByTestId("canvas-freeform-ask").click();
+  await expect(
+    page.getByRole("button", { name: "Terminal", exact: true }),
+  ).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as any).__HARNESS_TEST__?.lastInjectInput?.req.text ?? "",
+      ),
+    )
+    .toContain("Explain this agent");
+  await expect
+    .poll(() => conversations.get("ses_sess_boot")!.streams.size)
+    .toBe(0);
+  await assistant.click();
+  const tabs = page.getByRole("tablist", { name: "Sessions" }).getByRole("tab");
+  await tabs.nth(1).click();
+  await tabs.nth(0).click();
+  await expect(assistant).toHaveAttribute("aria-pressed", "true");
 });

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -268,6 +268,93 @@ test("streams, disposes the old tab's connection, restores history, and sends a 
   await expect(page.locator(".harness-terminal")).toBeVisible();
 });
 
+test("keeps principal-scoped session drafts across centre-pane routes and exited-session remounts", async ({
+  page,
+}) => {
+  await openAssistant(page);
+  const input = page.getByRole("textbox", { name: "Message Assistant" });
+  await input.fill("First session draft");
+
+  const tabs = page.getByRole("tablist", { name: "Sessions" }).getByRole("tab");
+  await tabs.nth(1).click();
+  await input.fill("Second session draft");
+
+  // The create-new destination unmounts the whole conversation branch.
+  await page.getByTestId("rail-create-new").click();
+  await expect(page.getByTestId("new-session-composer")).toBeVisible();
+  await page.getByTestId("composer-back").click();
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(input).toHaveValue("Second session draft");
+
+  // A transcript-only review is another centre-pane owner. Closing it returns
+  // to the same live Studio session without making the review adopt/resume.
+  await page.getByTestId("history-trigger").click();
+  await page.getByTestId("past-sessions-trigger").hover();
+  await page
+    .getByTestId("history-2b6d9e10-7711-4c2a-8b0a-9e4f2d1c5a33")
+    .click();
+  await expect(page.getByTestId("past-session-pane")).toBeVisible();
+  await page.getByTestId("past-session-close").click();
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(input).toHaveValue("Second session draft");
+
+  await tabs.nth(0).click();
+  await expect(input).toHaveValue("First session draft");
+
+  // Natural Terminal exit swaps the live workbench for the dead-session pane.
+  // The remounted Assistant still owns the same session-keyed draft.
+  await page.evaluate(() =>
+    (window as any).__HARNESS_TEST__.publish({
+      type: "session.status",
+      session: {
+        id: "sess-boot",
+        agentSessionId: null,
+        boundWorkflowPath: "/Users/demo/acme-app/leasing",
+        harness: "claude-code",
+        cwd: "/Users/demo/acme-app",
+        title: "acme-app",
+        status: "exited",
+        ready: false,
+        exitCode: 0,
+        createdAt: new Date().toISOString(),
+        lastActiveAt: new Date().toISOString(),
+      },
+    }),
+  );
+  await expect(page.getByTestId("dead-session-pane")).toBeVisible();
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(input).toHaveValue("First session draft");
+
+  // An auth barrier replaces the whole store. A newly verified principal can
+  // use Assistant, but never inherits either prior principal's unsent text.
+  enabled = false;
+  await page.evaluate(() =>
+    (window as any).__HARNESS_TEST__.publish({
+      type: "auth.changed",
+      authenticated: false,
+      organizationName: null,
+    }),
+  );
+  await expect(
+    page.getByRole("group", { name: "Conversation view" }),
+  ).toHaveCount(0);
+  enabled = true;
+  await page.evaluate(() =>
+    (window as any).__HARNESS_TEST__.publish({
+      type: "auth.changed",
+      authenticated: true,
+      organizationName: "Another organization",
+    }),
+  );
+  await expect(
+    page.getByRole("button", { name: "Assistant", exact: true }),
+  ).toBeVisible();
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(input).toHaveValue("");
+});
+
 test("waits for the associated history before enabling the composer", async ({
   page,
 }) => {

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -357,6 +357,7 @@ test("shows stream loss and reconnects without replaying an accepted prompt", as
   await input.press("Enter");
   const c = conversations.get("ses_sess_boot")!;
   await expect.poll(() => c.prompts.length).toBe(1);
+  await input.fill("An unsent follow-up");
   failEvents = true;
   for (const stream of c.streams) stream.end();
   await expect(page.getByRole("alert")).toContainText("Connection lost");
@@ -367,6 +368,7 @@ test("shows stream loss and reconnects without replaying an accepted prompt", as
     "First chunk recovered",
   );
   await expect(input).toBeEnabled();
+  await expect(input).toHaveValue("An unsent follow-up");
   expect(c.prompts).toEqual(["A single request"]);
 });
 
@@ -428,6 +430,8 @@ test("reveals foreground Terminal input and preserves Assistant for background a
   page,
 }) => {
   await openAssistant(page);
+  const input = page.getByRole("textbox", { name: "Message Assistant" });
+  await input.fill("Keep this unsent draft");
   await page.evaluate(() => {
     (window as any).__HARNESS_TEST__.publish({
       type: "canvas.reload",
@@ -470,8 +474,55 @@ test("reveals foreground Terminal input and preserves Assistant for background a
     .poll(() => conversations.get("ses_sess_boot")!.streams.size)
     .toBe(0);
   await assistant.click();
+  await expect(input).toHaveValue("Keep this unsent draft");
   const tabs = page.getByRole("tablist", { name: "Sessions" }).getByRole("tab");
   await tabs.nth(1).click();
+  await expect(input).toHaveValue("");
+  await input.fill("A different tab's draft");
   await tabs.nth(0).click();
   await expect(assistant).toHaveAttribute("aria-pressed", "true");
+  await expect(input).toHaveValue("Keep this unsent draft");
+  await input.press("Enter");
+  await expect
+    .poll(() => conversations.get("ses_sess_boot")!.prompts)
+    .toEqual(["Keep this unsent draft"]);
+  finish("ses_sess_boot", " complete");
+  await page.getByRole("button", { name: "Terminal", exact: true }).click();
+  await assistant.click();
+  await expect(input).toHaveValue("");
+});
+
+test("shows a rejected inspector command without leaving Assistant or losing its draft", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+  await openAssistant(page);
+  await page.evaluate(() => {
+    (window as any).__HARNESS_TEST__.publish({
+      type: "canvas.reload",
+      harnessSessionId: "sess-boot",
+    });
+  });
+  await expect(page.locator(".canvas-frame-wrap")).toHaveAttribute(
+    "data-view",
+    "board",
+  );
+  const input = page.getByRole("textbox", { name: "Message Assistant" });
+  await input.fill("Keep this draft after failure");
+  await page.getByTestId("canvas-chat-toggle").click();
+  await page.getByTestId("canvas-freeform-input").fill("Explain this agent");
+  await page.evaluate(() => {
+    (window as any).__MOCK_INJECT_FAIL_ONCE__ = true;
+  });
+  await page.getByTestId("canvas-freeform-ask").click();
+  await expect(page.getByTestId("toast")).toContainText(
+    "Session is still initialising",
+  );
+  await expect(input).toHaveValue("Keep this draft after failure");
+  await expect(
+    page.getByRole("button", { name: "Assistant", exact: true }),
+  ).toHaveAttribute("aria-pressed", "true");
+  expect(conversations.get("ses_sess_boot")!.streams.size).toBe(1);
+  expect(errors).toEqual([]);
 });

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -85,6 +85,7 @@ import { TelemetryNotice } from "./components/TelemetryNotice";
 import { TemplatesPanel } from "./components/TemplatesPanel";
 import { Terminal } from "./components/Terminal";
 import { AssistantPane } from "./components/AssistantPane";
+import type { ChatDraftStore } from "./components/OpenCodeChat";
 import { Toast } from "./components/Toast";
 import { TooltipLayer } from "./components/TooltipLayer";
 import { NewSessionComposer } from "./components/NewSessionComposer";
@@ -296,6 +297,23 @@ export const App = (): JSX.Element => {
     createGraphViewportStore,
     [harness.authRevision],
   );
+  // Draft text belongs to a principal + Studio session, not to whichever
+  // centre-pane branch happens to be mounted. An auth barrier replaces this
+  // whole store; an app reload intentionally drops it rather than persisting
+  // sensitive, unsent text.
+  const assistantDrafts = useMemo<ChatDraftStore>(
+    () => new Map(),
+    [harness.authRevision, harness.bootToken],
+  );
+  // Successful session deletion removes its keyed draft. Exited sessions stay
+  // in state (and keep their draft) until the user actually closes them.
+  useEffect(() => {
+    if (!harness.state) return;
+    const sessionIds = new Set(harness.state.sessions.map(({ id }) => id));
+    for (const id of assistantDrafts.keys()) {
+      if (!sessionIds.has(id)) assistantDrafts.delete(id);
+    }
+  }, [assistantDrafts, harness.state]);
   const [selectedHarness, setSelectedHarness] = useState<HarnessKind>(
     () => loadUiPrefs().preferredHarness ?? DEFAULT_HARNESS,
   );
@@ -3300,24 +3318,35 @@ export const App = (): JSX.Element => {
                   onClose={() => setReviewSummary(null)}
                 />
               ) : showDead && conversationSession ? (
-                <DeadSessionPane
-                  session={conversationSession}
-                  resumeMode={deadResumeMode}
-                  loadRecord={harness.sessionRecord}
-                  onResume={() =>
-                    void harness.resumeSession(conversationSession.id)
+                <AssistantPane
+                  sessionId={conversationSession.id}
+                  bootToken={harness.bootToken}
+                  authRevision={harness.authRevision}
+                  drafts={assistantDrafts}
+                  terminalRevision={
+                    harness.terminalRevealBySession.get(conversationSession.id) ??
+                    0
                   }
-                  onContinue={() =>
-                    void harness.rehydrateSession({
-                      cwd: conversationSession.cwd,
-                      harness: conversationSession.harness,
-                      from: conversationSession.id,
-                    })
-                  }
-                  onClose={() =>
-                    void harness.closeSession(conversationSession.id)
-                  }
-                />
+                >
+                  <DeadSessionPane
+                    session={conversationSession}
+                    resumeMode={deadResumeMode}
+                    loadRecord={harness.sessionRecord}
+                    onResume={() =>
+                      void harness.resumeSession(conversationSession.id)
+                    }
+                    onContinue={() =>
+                      void harness.rehydrateSession({
+                        cwd: conversationSession.cwd,
+                        harness: conversationSession.harness,
+                        from: conversationSession.id,
+                      })
+                    }
+                    onClose={() =>
+                      void harness.closeSession(conversationSession.id)
+                    }
+                  />
+                </AssistantPane>
               ) : showAgentEmpty && focusedWorkflow ? (
                 /* Honest absence: no session that can WORK on this agent — its
                    board still draws on the right, from the workflow-keyed route
@@ -3385,7 +3414,12 @@ export const App = (): JSX.Element => {
                       sessionId={conversationSession.id}
                       bootToken={harness.bootToken}
                       authRevision={harness.authRevision}
-                      terminalRevision={harness.terminalRevealBySession.get(conversationSession.id) ?? 0}
+                      drafts={assistantDrafts}
+                      terminalRevision={
+                        harness.terminalRevealBySession.get(
+                          conversationSession.id,
+                        ) ?? 0
+                      }
                     >
                       <Terminal
                         sessionId={conversationSession.id}

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -3385,6 +3385,7 @@ export const App = (): JSX.Element => {
                       sessionId={conversationSession.id}
                       bootToken={harness.bootToken}
                       authRevision={harness.authRevision}
+                      terminalRevision={harness.terminalRevealBySession.get(conversationSession.id) ?? 0}
                     >
                       <Terminal
                         sessionId={conversationSession.id}

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -3830,7 +3830,13 @@ export const App = (): JSX.Element => {
                   }
                   onInjectPrompt={(text) => {
                     if (harness.activeSessionId)
-                      void harness.injectInput(harness.activeSessionId, text);
+                      void harness
+                        .injectInput(harness.activeSessionId, text)
+                        .catch((err) =>
+                          harness.showToast(
+                            errorMessage(err, "Could not send the prompt to Terminal."),
+                          ),
+                        );
                   }}
                   onDescribeWorkflow={handleDescribeWithAI}
                 />

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -297,13 +297,16 @@ export const App = (): JSX.Element => {
     createGraphViewportStore,
     [harness.authRevision],
   );
+  const [assistantAuthorityRevision, setAssistantAuthorityRevision] = useState<
+    string | null
+  >(null);
   // Draft text belongs to a principal + Studio session, not to whichever
   // centre-pane branch happens to be mounted. An auth barrier replaces this
   // whole store; an app reload intentionally drops it rather than persisting
   // sensitive, unsent text.
   const assistantDrafts = useMemo<ChatDraftStore>(
     () => new Map(),
-    [harness.authRevision, harness.bootToken],
+    [assistantAuthorityRevision, harness.authRevision, harness.bootToken],
   );
   // Successful session deletion removes its keyed draft. Exited sessions stay
   // in state (and keep their draft) until the user actually closes them.
@@ -3323,6 +3326,8 @@ export const App = (): JSX.Element => {
                   bootToken={harness.bootToken}
                   authRevision={harness.authRevision}
                   drafts={assistantDrafts}
+                  authorityRevision={assistantAuthorityRevision}
+                  onAuthorityRevision={setAssistantAuthorityRevision}
                   terminalRevision={
                     harness.terminalRevealBySession.get(conversationSession.id) ??
                     0
@@ -3415,6 +3420,8 @@ export const App = (): JSX.Element => {
                       bootToken={harness.bootToken}
                       authRevision={harness.authRevision}
                       drafts={assistantDrafts}
+                      authorityRevision={assistantAuthorityRevision}
+                      onAuthorityRevision={setAssistantAuthorityRevision}
                       terminalRevision={
                         harness.terminalRevealBySession.get(
                           conversationSession.id,

--- a/packages/harness/web/src/components/AssistantPane.tsx
+++ b/packages/harness/web/src/components/AssistantPane.tsx
@@ -12,6 +12,8 @@ export function AssistantPane({
   authRevision,
   terminalRevision,
   drafts,
+  authorityRevision,
+  onAuthorityRevision,
   children,
 }: {
   sessionId: string;
@@ -19,9 +21,18 @@ export function AssistantPane({
   authRevision: number;
   terminalRevision: number;
   drafts: ChatDraftStore;
+  authorityRevision: string | null;
+  onAuthorityRevision: (revision: string) => void;
   children: ReactNode;
 }) {
-  const [enabled, setEnabled] = useState(false);
+  const [access, setAccess] = useState<{
+    enabled: boolean;
+    authorityRevision: string;
+  } | null>(null);
+  // An enabled response cannot mount chat until App has adopted the same
+  // opaque authority barrier and replaced the principal-scoped draft map.
+  const enabled =
+    access?.enabled === true && access.authorityRevision === authorityRevision;
   const [mode, setMode] = useState<"Terminal" | "Assistant">("Terminal");
   const draft = useMemo(() => {
     const entry = drafts.get(sessionId) ?? { text: "" };
@@ -41,10 +52,12 @@ export function AssistantPane({
     let expiry: ReturnType<typeof setTimeout>;
     const disable = () => {
       clearTimeout(expiry);
-      setEnabled(false);
+      setAccess((current) =>
+        current ? { ...current, enabled: false } : current,
+      );
       setMode("Terminal");
     };
-    setEnabled(false);
+    setAccess(null);
     setMode("Terminal");
     const refresh = async () => {
       try {
@@ -57,12 +70,21 @@ export function AssistantPane({
         if (abort.signal.aborted) return;
         if (response.status === 401 || response.status === 403) disable();
         if (!response.ok) throw new Error("Access check unavailable");
-        const { enabled: allowed } = await response.json();
+        const { enabled: allowed, authorityRevision: nextAuthorityRevision } =
+          await response.json();
         if (abort.signal.aborted) return;
-        if (typeof allowed !== "boolean")
+        if (
+          typeof allowed !== "boolean" ||
+          typeof nextAuthorityRevision !== "string" ||
+          nextAuthorityRevision.length === 0
+        )
           throw new Error("Invalid access check");
         clearTimeout(expiry);
-        setEnabled(allowed);
+        onAuthorityRevision(nextAuthorityRevision);
+        setAccess({
+          enabled: allowed,
+          authorityRevision: nextAuthorityRevision,
+        });
         if (allowed) expiry = setTimeout(disable, 60000);
         else setMode("Terminal");
       } catch {
@@ -80,7 +102,7 @@ export function AssistantPane({
       clearTimeout(timer);
       clearTimeout(expiry);
     };
-  }, [bootToken, authRevision]);
+  }, [bootToken, authRevision, onAuthorityRevision]);
 
   return (
     <div className="studio-conversation">
@@ -106,7 +128,7 @@ export function AssistantPane({
       <div className="studio-conversation-body">
         {enabled && mode === "Assistant" ? (
           <OpenCodeChat
-            key={sessionId}
+            key={`${authorityRevision}:${sessionId}`}
             harnessSessionId={sessionId}
             bootToken={bootToken}
             draft={draft}

--- a/packages/harness/web/src/components/AssistantPane.tsx
+++ b/packages/harness/web/src/components/AssistantPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { OpenCodeChat } from "./OpenCodeChat";
 
 /** The server owns eligibility; this is only its short-lived UI projection. */
@@ -6,22 +6,36 @@ export function AssistantPane({
   sessionId,
   bootToken,
   authRevision,
+  terminalRevision,
   children,
 }: {
   sessionId: string;
   bootToken: string;
   authRevision: number;
+  terminalRevision: number;
   children: ReactNode;
 }) {
   const [enabled, setEnabled] = useState(false);
   const [mode, setMode] = useState<"Terminal" | "Assistant">("Terminal");
+  const revealed = useRef(new Map<string, number>());
+  useEffect(() => {
+    if (terminalRevision > (revealed.current.get(sessionId) ?? 0)) {
+      revealed.current.set(sessionId, terminalRevision);
+      setMode("Terminal");
+    }
+  }, [sessionId, terminalRevision]);
   useEffect(() => {
     const abort = new AbortController();
     let timer: ReturnType<typeof setTimeout>;
+    let expiry: ReturnType<typeof setTimeout>;
+    const disable = () => {
+      clearTimeout(expiry);
+      setEnabled(false);
+      setMode("Terminal");
+    };
     setEnabled(false);
     setMode("Terminal");
     const refresh = async () => {
-      let allowed = false;
       try {
         const response = await fetch("/api/assistant/access", {
           headers: { "X-Harness-Token": bootToken },
@@ -29,13 +43,22 @@ export function AssistantPane({
           cache: "no-store",
           signal: AbortSignal.any([abort.signal, AbortSignal.timeout(5000)]),
         });
-        allowed = response.ok && (await response.json()).enabled === true;
+        if (abort.signal.aborted) return;
+        if (response.status === 401 || response.status === 403) disable();
+        if (!response.ok) throw new Error("Access check unavailable");
+        const { enabled: allowed } = await response.json();
+        if (abort.signal.aborted) return;
+        if (typeof allowed !== "boolean")
+          throw new Error("Invalid access check");
+        clearTimeout(expiry);
+        setEnabled(allowed);
+        if (allowed) expiry = setTimeout(disable, 60000);
+        else setMode("Terminal");
       } catch {
-        /* Missing identity or host access stays off. */
+        // A transient poll failure must not discard an open draft. This UI
+        // projection expires within 60s; the host enforces its own grant.
       }
       if (abort.signal.aborted) return;
-      setEnabled(allowed);
-      if (!allowed) setMode("Terminal");
       timer = setTimeout(() => {
         void refresh();
       }, 15000);
@@ -44,6 +67,7 @@ export function AssistantPane({
     return () => {
       abort.abort();
       clearTimeout(timer);
+      clearTimeout(expiry);
     };
   }, [bootToken, authRevision]);
 

--- a/packages/harness/web/src/components/AssistantPane.tsx
+++ b/packages/harness/web/src/components/AssistantPane.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef, useState, type ReactNode } from "react";
-import { OpenCodeChat } from "./OpenCodeChat";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { OpenCodeChat, type ChatDraft } from "./OpenCodeChat";
 
 /** The server owns eligibility; this is only its short-lived UI projection. */
 export function AssistantPane({
@@ -17,6 +17,16 @@ export function AssistantPane({
 }) {
   const [enabled, setEnabled] = useState(false);
   const [mode, setMode] = useState<"Terminal" | "Assistant">("Terminal");
+  // Preserve only unsent text across runtime disposal, scoped to this sign-in.
+  const drafts = useMemo(
+    () => new Map<string, ChatDraft>(),
+    [authRevision, bootToken],
+  );
+  const draft = useMemo(() => {
+    const entry = drafts.get(sessionId) ?? { text: "" };
+    drafts.set(sessionId, entry);
+    return entry;
+  }, [drafts, sessionId]);
   const revealed = useRef(new Map<string, number>());
   useEffect(() => {
     if (terminalRevision > (revealed.current.get(sessionId) ?? 0)) {
@@ -98,6 +108,7 @@ export function AssistantPane({
             key={sessionId}
             harnessSessionId={sessionId}
             bootToken={bootToken}
+            draft={draft}
           />
         ) : (
           children

--- a/packages/harness/web/src/components/AssistantPane.tsx
+++ b/packages/harness/web/src/components/AssistantPane.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
-import { OpenCodeChat, type ChatDraft } from "./OpenCodeChat";
+import {
+  OpenCodeChat,
+  type ChatDraft,
+  type ChatDraftStore,
+} from "./OpenCodeChat";
 
 /** The server owns eligibility; this is only its short-lived UI projection. */
 export function AssistantPane({
@@ -7,21 +11,18 @@ export function AssistantPane({
   bootToken,
   authRevision,
   terminalRevision,
+  drafts,
   children,
 }: {
   sessionId: string;
   bootToken: string;
   authRevision: number;
   terminalRevision: number;
+  drafts: ChatDraftStore;
   children: ReactNode;
 }) {
   const [enabled, setEnabled] = useState(false);
   const [mode, setMode] = useState<"Terminal" | "Assistant">("Terminal");
-  // Preserve only unsent text across runtime disposal, scoped to this sign-in.
-  const drafts = useMemo(
-    () => new Map<string, ChatDraft>(),
-    [authRevision, bootToken],
-  );
   const draft = useMemo(() => {
     const entry = drafts.get(sessionId) ?? { text: "" };
     drafts.set(sessionId, entry);

--- a/packages/harness/web/src/components/OpenCodeChat.tsx
+++ b/packages/harness/web/src/components/OpenCodeChat.tsx
@@ -7,6 +7,7 @@ import {
   ThreadPrimitive,
   useAuiState,
   type TextMessagePartProps,
+  type ThreadComposerRuntime,
   type ToolCallMessagePartProps,
 } from "@assistant-ui/react";
 import {
@@ -18,16 +19,20 @@ import { Icon } from "./Icon";
 import { Markdown } from "./Markdown";
 import { EmptyState } from "./EmptyState";
 
+export interface ChatDraft {
+  text: string;
+}
 interface Props {
   harnessSessionId: string;
   bootToken: string;
+  draft: ChatDraft;
 }
 const connectionError =
   "Connection lost. Reconnect to see the latest response.";
 const runError =
   "Assistant could not finish. Reconnect and check the conversation before sending again.";
 
-export function OpenCodeChat({ harnessSessionId, bootToken }: Props) {
+export function OpenCodeChat({ harnessSessionId, bootToken, draft }: Props) {
   const [conversationId, setConversationId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [attempt, setAttempt] = useState(0);
@@ -75,6 +80,7 @@ export function OpenCodeChat({ harnessSessionId, bootToken }: Props) {
       bootToken={bootToken}
       conversationId={conversationId}
       retry={retry}
+      draft={draft}
     />
   ) : (
     <div className="studio-chat-start">
@@ -92,11 +98,13 @@ function RuntimeChat({
   bootToken,
   conversationId,
   retry,
+  draft,
 }: {
   baseUrl: string;
   bootToken: string;
   conversationId: string;
   retry: () => void;
+  draft: ChatDraft;
 }) {
   const [transportError, setTransportError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -183,6 +191,8 @@ function RuntimeChat({
         connected={connected}
         error={transportError ?? actionError}
         retry={retry}
+        composer={runtime.thread.composer}
+        draft={draft}
       />
     </AssistantRuntimeProvider>
   );
@@ -218,11 +228,15 @@ function ChatSurface({
   connected,
   error,
   retry,
+  composer,
+  draft,
 }: {
   conversationId: string;
   connected: boolean;
   error: string | null;
   retry: () => void;
+  composer: ThreadComposerRuntime;
+  draft: ChatDraft;
 }) {
   const loading = useAuiState((s) => s.thread.isLoading);
   const running = useAuiState((s) => s.thread.isRunning);
@@ -230,6 +244,13 @@ function ChatSurface({
   const ready = useOpenCodeThreadState(
     (s) => s.sessionId === conversationId && s.loadState.type === "ready",
   );
+  useEffect(() => {
+    if (!ready) return;
+    composer.setText(draft.text);
+    return composer.subscribe(() => {
+      draft.text = composer.getState().text;
+    });
+  }, [composer, draft, ready]);
   const hasText = useAuiState((s) => {
     for (let i = s.thread.messages.length - 1; i >= 0; i--) {
       const message = s.thread.messages[i];

--- a/packages/harness/web/src/components/OpenCodeChat.tsx
+++ b/packages/harness/web/src/components/OpenCodeChat.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   AssistantRuntimeProvider,
   ComposerPrimitive,
@@ -246,7 +252,7 @@ function ChatSurface({
   const ready = useOpenCodeThreadState(
     (s) => s.sessionId === conversationId && s.loadState.type === "ready",
   );
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!ready) return;
     composer.setText(draft.text);
     return composer.subscribe(() => {

--- a/packages/harness/web/src/components/OpenCodeChat.tsx
+++ b/packages/harness/web/src/components/OpenCodeChat.tsx
@@ -16,6 +16,7 @@ import {
 } from "@assistant-ui/react-opencode";
 import { Icon } from "./Icon";
 import { Markdown } from "./Markdown";
+import { EmptyState } from "./EmptyState";
 
 interface Props {
   harnessSessionId: string;
@@ -257,9 +258,10 @@ function ChatSurface({
       >
         <div className="studio-chat-feed">
           <ThreadPrimitive.Empty>
-            <p className="studio-chat-meta">
-              Describe the change you want to make in this project.
-            </p>
+            <EmptyState
+              title="Start a conversation"
+              body="Describe the change you want to make in this project."
+            />
           </ThreadPrimitive.Empty>
           <ThreadPrimitive.Messages>
             {({ message }) => (

--- a/packages/harness/web/src/components/OpenCodeChat.tsx
+++ b/packages/harness/web/src/components/OpenCodeChat.tsx
@@ -22,6 +22,8 @@ import { EmptyState } from "./EmptyState";
 export interface ChatDraft {
   text: string;
 }
+/** In-memory only: App owns one store for the current authenticated principal. */
+export type ChatDraftStore = Map<string, ChatDraft>;
 interface Props {
   harnessSessionId: string;
   bootToken: string;

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -39,6 +39,7 @@ import {
   type WorkflowScanOutcome,
 } from "./api";
 import { unavailableWorkflowDeployment } from "./workflow-deployment";
+import { macroNeedsReadySession } from "./macro-actions";
 import { type ConnectivityErrorInput } from "./connectivity";
 import { isWithinDir, samePath } from "./paths";
 import { projectToOpen } from "./project-tree";
@@ -2120,10 +2121,14 @@ export function useHarnessState(): HarnessStateHook {
   const runMacro = useCallback(
     async (id: string, req: RunMacroRequest): Promise<void> => {
       const macro = state?.macros.find((candidate) => candidate.id === id);
-      if (macro?.action.kind === "inject" && macro.execution !== "background")
-        revealTerminal(req.harnessSessionId);
       try {
         await api.runMacro(id, req);
+        if (
+          macro &&
+          macroNeedsReadySession(macro) &&
+          macro.execution !== "background"
+        )
+          revealTerminal(req.harnessSessionId);
       } catch (err) {
         // App.tsx fires this without awaiting — surface failures as a toast
         // instead of an invisible unhandled rejection (which is exactly how
@@ -2363,8 +2368,8 @@ export function useHarnessState(): HarnessStateHook {
   // generic toast message.
   const injectInput = useCallback(
     async (sessionId: string, text: string): Promise<void> => {
-      revealTerminal(sessionId);
       await api.injectInput(sessionId, { text, submit: true });
+      revealTerminal(sessionId);
     },
     [revealTerminal],
   );

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -345,6 +345,8 @@ export interface HarnessStateHook {
    * by showing the reason inline rather than as a toast.
    */
   injectInput: (sessionId: string, text: string) => Promise<void>;
+  /** Reveal app-driven foreground PTY work in the matching conversation pane. */
+  terminalRevealBySession: Map<string, number>;
   /** Expose the toast setter so panels can push their own toasts. Defaults
    *  to the "error" tone; callers announcing a result opt into "info". */
   showToast: (message: string, tone?: ToastTone) => void;
@@ -474,6 +476,14 @@ export function useHarnessState(): HarnessStateHook {
     new WorkflowProjectionOrder<WorkflowInfo>(),
   ).current;
   const [authRevision, setAuthRevision] = useState(0);
+  const [terminalRevealBySession, setTerminalRevealBySession] = useState(
+    () => new Map<string, number>(),
+  );
+  const revealTerminal = useCallback((sessionId: string) => {
+    setTerminalRevealBySession((previous) =>
+      new Map(previous).set(sessionId, (previous.get(sessionId) ?? 0) + 1),
+    );
+  }, []);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Boot-error facts (HTTP status / network-throw flag), shaped for the
@@ -2109,6 +2119,9 @@ export function useHarnessState(): HarnessStateHook {
 
   const runMacro = useCallback(
     async (id: string, req: RunMacroRequest): Promise<void> => {
+      const macro = state?.macros.find((candidate) => candidate.id === id);
+      if (macro?.action.kind === "inject" && macro.execution !== "background")
+        revealTerminal(req.harnessSessionId);
       try {
         await api.runMacro(id, req);
       } catch (err) {
@@ -2125,7 +2138,7 @@ export function useHarnessState(): HarnessStateHook {
         );
       }
     },
-    [],
+    [revealTerminal, state?.macros],
   );
 
   // Deploy via the direct route: stream build status to the toast, then refresh
@@ -2350,9 +2363,10 @@ export function useHarnessState(): HarnessStateHook {
   // generic toast message.
   const injectInput = useCallback(
     async (sessionId: string, text: string): Promise<void> => {
+      revealTerminal(sessionId);
       await api.injectInput(sessionId, { text, submit: true });
     },
-    [],
+    [revealTerminal],
   );
 
   const showToast = useCallback(
@@ -2424,6 +2438,7 @@ export function useHarnessState(): HarnessStateHook {
     startProdRun,
     runLocal,
     injectInput,
+    terminalRevealBySession,
     showToast,
     lastDeployErrorFor,
     deployStateByPath,


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Assistant drafts must survive expected pane/session remounts without crossing an authority, deleted session, account, or reload boundary.

## Summary and scope

Keep per-session drafts in an App-owned memory map, replace it atomically when the server's opaque authorityRevision changes, fail closed until parent/child epochs agree, and preserve Terminal reveal behavior for accepted foreground input. This absorbs the reviewed draft-lifetime and authority-consumer correction PRs.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `studio-opencode-chat-ui`. Actual-parent size: **522 additions + 39 deletions = 561 changed lines**.

Absorbed reviewed provenance: #936 draft lifetime; #938 opaque authority draft fence.

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3290](https://linear.app/sapiom/issue/SAP-3290). This PR keeps its existing number and review history within the main-rooted native GitHub stack.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check db36dbf3f690d9e70fdafb89f4e270b55369a8c8...d1a205d787724d1bec02d0aa19088201a45fa03d` — passed.
- Exact final Assistant browser command with one Chromium worker — 31 passed (1.1m), including stable/failed polls and direct authority crossover.

### Tests and documentation

Browser coverage includes two sessions, route and exited-session remounts, reconnect/poll retention, deletion/id reuse, disabled retirement/readmission, and direct enabled A-to-B crossover with unchanged authRevision.

## Compatibility and release impact

- Breaking or externally visible changes: No persistence or principal identifiers are added. Drafts clear on authority retirement/crossover, session deletion, auth barriers, and reload.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/911" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
