### PR TITLE
feat(harness): add a project with the OS folder browser on desktop [SAP-3143]

### DIFF
--- a/.changeset/native-folder-step.md
+++ b/.changeset/native-folder-step.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Add a project with the OS folder browser on desktop. The rail's Add-a-project button opened a dialog wrapping a text field, offering Finder or Explorer as a button inside it; on the desktop app it now opens the folder browser directly. The typed-path dialog remains the web fallback, and "Add existing agents" is unchanged.

--- a/packages/harness/web/e2e/folder-field.spec.ts
+++ b/packages/harness/web/e2e/folder-field.spec.ts
@@ -5,6 +5,11 @@
  * browser is the picker, and the `npx` browser host — which is what every other
  * spec here runs as — falls back to the field plus a native `<datalist>`.
  *
+ * On desktop the bridge now decides whether our dialog opens AT ALL, not just
+ * what renders inside it, so the two hosts no longer share one entrance: "Add
+ * a project" asks the OS directly, while "Add existing agents" keeps the dialog
+ * because it has to show what it found under the folder.
+ *
  * The desktop half is covered by INJECTING the bridge the Electron preload
  * exposes (`window.sapiomDesktop`). That is the same shape
  * `harness-desktop/src/preload/desktop.mts` publishes and the desktop smoke run
@@ -71,7 +76,7 @@ test.describe("browser host (npx)", () => {
 });
 
 test.describe("desktop host", () => {
-  test("Choose opens the OS folder browser at the current folder, and takes its answer", async ({
+  test("Add a project skips our dialog and asks the OS, at the current root", async ({
     page,
   }) => {
     await installDesktopBridge(page, "/Users/demo/blank-slate");
@@ -79,35 +84,52 @@ test.describe("desktop host", () => {
     await expect(page.locator(".rail-workflows")).toBeVisible();
     await page.getByTestId("rail-add-project").click();
 
-    const input = page.getByTestId("folder-field-input");
-    await expect(input).toHaveValue("/Users/demo/acme-app/projects");
-    // No datalist on desktop: the OS dialog IS the completion there.
-    await expect(page.getByTestId("folder-field-options")).toHaveCount(0);
-
-    await page.getByTestId("folder-field-choose").click();
+    // THE DIALOG NEVER OPENS on this host. Asserted first and asserted at all
+    // because the failure this guards is showing BOTH — our modal wrapping a
+    // text field, with the OS browser as a button inside it.
+    await expect(page.locator(".modal-start")).toHaveCount(0);
     // Opened where the user already is, rather than at some default root.
     expect(await chooseCalls(page)).toEqual(["/Users/demo/acme-app/projects"]);
-    await expect(input).toHaveValue("/Users/demo/blank-slate");
-
-    // And the choice drives the dialog, not just the field.
-    await expect(page.getByTestId("open-project")).toBeEnabled();
-    await page.getByTestId("open-project").click();
+    // And the answer is the whole interaction: the project is added, with no
+    // confirm step, because picking a folder in Finder already was the confirm.
     await expect(page.getByTestId("project-row-blank-slate")).toBeVisible();
   });
 
-  test("cancelling the OS dialog leaves the folder alone", async ({ page }) => {
-    // `showOpenDialog` resolves null on cancel (harness-desktop/main/dialogs.ts),
-    // and null must never be written into the field — a cancelled pick is not a
-    // choice of "nothing".
+  test("cancelling the OS dialog adds nothing and opens nothing", async ({
+    page,
+  }) => {
+    // `showOpenDialog` resolves null on cancel (harness-desktop/main/dialogs.ts).
+    // A cancelled pick must not fall back into our dialog: the user declined
+    // the question, not the way it was asked.
     await installDesktopBridge(page, null);
     await page.goto("/");
     await expect(page.locator(".rail-workflows")).toBeVisible();
     await page.getByTestId("rail-add-project").click();
 
+    expect(await chooseCalls(page)).toHaveLength(1);
+    await expect(page.locator(".modal-start")).toHaveCount(0);
+    await expect(page.getByTestId("project-row-blank-slate")).toHaveCount(0);
+  });
+
+  test("the field's own Choose still serves the entrance that keeps a dialog", async ({
+    page,
+  }) => {
+    // "Add existing agents" has to show what it found under the folder, so the
+    // picker is only its first step and the dialog stays on both hosts. That
+    // keeps `FolderField`'s desktop branch reachable, so it is still covered
+    // here rather than deleted with the entrance that stopped using it.
+    await installDesktopBridge(page, "/Users/demo/blank-slate");
+    await page.goto("/");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+    await page.getByTestId("add-existing-agents").click();
+    await expect(page.locator(".modal-start")).toBeVisible();
+
     const input = page.getByTestId("folder-field-input");
+    // No datalist on desktop: the OS dialog IS the completion there.
+    await expect(page.getByTestId("folder-field-options")).toHaveCount(0);
+
     await page.getByTestId("folder-field-choose").click();
     expect(await chooseCalls(page)).toHaveLength(1);
-    await expect(input).toHaveValue("/Users/demo/acme-app/projects");
-    await expect(page.getByTestId("open-project")).toBeEnabled();
+    await expect(input).toHaveValue("/Users/demo/blank-slate");
   });
 });

--- a/packages/harness/web/e2e/folder-field.spec.ts
+++ b/packages/harness/web/e2e/folder-field.spec.ts
@@ -111,6 +111,51 @@ test.describe("desktop host", () => {
     await expect(page.getByTestId("project-row-blank-slate")).toHaveCount(0);
   });
 
+  test("a slow open does not yank the view off a project chosen while waiting", async ({
+    page,
+  }) => {
+    /* THE DIALOG USED TO BE THE LOCK. While it was open the rail was behind a
+       modal, so "add a folder" could not overlap "select a project". Opening
+       the OS picker instead hands the rail back the moment it closes, and the
+       scan behind it is the slow part — so the two DO overlap now, and the
+       later choice has to win.
+
+       Not a contrived window: the mock's scan takes 250ms, and a real one
+       walks a tree. */
+    await installDesktopBridge(page, "/Users/demo/blank-slate");
+    // `mockStudioProjects=present` because the competing choice has to be a
+    // durable project — a selectable map is what the finishing scan overrides.
+    await page.goto("/?mockStudioProjects=present");
+    await expect(page.locator(".rail-workflows")).toBeVisible();
+
+    const other = page.getByTestId("project-select-acme-app");
+    await expect(other).toBeVisible();
+
+    // No awaits between these two: the second click has to land inside the
+    // first one's scan, which is the whole point.
+    await page.getByTestId("rail-add-project").click();
+    await other.click();
+
+    // The open still COMPLETES — the folder is added, because the user did ask
+    // for it. Only the navigation to it is dropped.
+    await expect(page.getByTestId("project-row-blank-slate")).toBeVisible();
+
+    /* SETTLE FIRST, THEN ASSERT, and that ordering is the test.
+       `toHaveAttribute` retries until it matches and returns on the first
+       pass, so asserting straight after the row appears is satisfied by the
+       state BEFORE the stale navigation lands — it passed against the
+       unfixed build. The override arrives a few frames later, after the
+       preference read that follows the scan, so the wait is what gives it
+       the chance to happen. */
+    await page.waitForTimeout(1500);
+    await expect(other).toHaveAttribute("aria-pressed", "true");
+    // Stated from the other side too: the late arrival must not have taken
+    // the selection for itself.
+    await expect(
+      page.getByTestId("project-select-blank-slate"),
+    ).toHaveAttribute("aria-pressed", "false");
+  });
+
   test("the field's own Choose still serves the entrance that keeps a dialog", async ({
     page,
   }) => {

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -2905,13 +2905,28 @@ export const App = (): JSX.Element => {
               await harness.removeProject(root);
             }}
             onOpenProject={async (requestedRoot) => {
+              // CLAIMED BEFORE THE SCAN, not after it. The scan is the slow
+              // part, and this generation is what a later user choice
+              // invalidates (`handleSelectWorkspace` bumps the same ref). Taken
+              // afterwards it claimed a NEWER generation than the selection the
+              // user made while waiting, so a slow open would win a race it had
+              // already lost and yank the view back to the folder just added.
+              //
+              // The open itself is NOT conditional — the project is still added
+              // either way. Only the navigation to it is dropped, because the
+              // user has since said where they want to be.
+              const generation = ++studioRestoreGenerationRef.current;
+              const stale = (): boolean =>
+                generation !== studioRestoreGenerationRef.current;
               const openedRoot = await harness.openProject(requestedRoot);
+              if (stale()) return;
               let restoringProject: {
                 projectId: StudioProjectId;
                 cwd: string;
               } | null = null;
               try {
                 const refreshed = await harness.api.getState();
+                if (stale()) return;
                 const scope = refreshed.workspaceScopes?.find((candidate) =>
                   samePath(candidate.cwd, openedRoot),
                 );
@@ -2924,11 +2939,10 @@ export const App = (): JSX.Element => {
                   cwd: scope.cwd,
                 };
                 restoredStudioProjectsRef.current.add(project.projectId);
-                const generation = ++studioRestoreGenerationRef.current;
                 const current = await harness.api.getStudioCurrentWorkspace(
                   project.projectId,
                 );
-                if (generation !== studioRestoreGenerationRef.current) return;
+                if (stale()) return;
                 const restoredSelection = current.selection;
                 if (restoredSelection.kind === "agent") {
                   const workflow = refreshed.workflows.find((candidate) =>
@@ -2953,11 +2967,17 @@ export const App = (): JSX.Element => {
                 setFocusedAgentPath(scope.cwd);
                 if (isMobile) setRightCollapsed(true);
               } catch {
-                if (restoringProject) {
+                if (restoringProject && !stale()) {
                   // Preference restoration is best-effort. The project itself
                   // opened successfully, so fall back to its stable map rather
                   // than leaving the previous workspace selected. Keep the
                   // restore guard so later session frames cannot repeat it.
+                  //
+                  // Staleness gates the FALLBACK too: a failure to read the
+                  // preference is not a reason to override a choice the user
+                  // made while waiting. Bumping is inside the guard as well,
+                  // or a stale failure would invalidate the newer selection's
+                  // own pending restore.
                   studioRestoreGenerationRef.current += 1;
                   setStudioSelection({
                     kind: "agent-map",

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -1021,7 +1021,14 @@ export function WorkflowsRail({
                 // last one sent the OS picker to its default folder in the
                 // case the dialog handled best: no project open, nothing
                 // pinned, but somewhere the user was working recently.
-                startingAt: projectRoot ?? launchDir ?? recentDirs[0],
+                //
+                // `||` between the tiers, where `StartDialog` writes `??`.
+                // An empty `launchDir` is not an answer to "which folder", and
+                // `??` treats it as one — it would stop the chain there and
+                // then be discarded downstream, losing the recent folder to
+                // the OS default. Each tier has to fall through when it is
+                // empty, not merely when it is absent.
+                startingAt: projectRoot || launchDir || recentDirs[0],
                 openDialog: () => setStartMode("open"),
                 onPicked: (root) => {
                   void onOpenProject(root).catch((err: unknown) => {

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -1016,8 +1016,12 @@ export function WorkflowsRail({
               // folder — and Finder answers it better than we do.
               void chooseProjectFolder({
                 chooseDirectory: getDesktopBridge()?.chooseDirectory ?? null,
-                // The dialog's own precedence for where to start.
-                startingAt: projectRoot ?? launchDir,
+                // The dialog's own precedence for where to start, all three
+                // tiers of it (`StartDialog`'s initial `cwd`). Dropping the
+                // last one sent the OS picker to its default folder in the
+                // case the dialog handled best: no project open, nothing
+                // pinned, but somewhere the user was working recently.
+                startingAt: projectRoot ?? launchDir ?? recentDirs[0],
                 openDialog: () => setStartMode("open"),
                 onPicked: (root) => {
                   void onOpenProject(root).catch((err: unknown) => {

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -36,6 +36,7 @@ import { PlanCard } from "./PlanCard";
 import { UpdateCard } from "./UpdateCard";
 import { SettingsPopover } from "./SettingsPopover";
 import { describeUpdateOutcome, getDesktopBridge } from "../lib/desktop";
+import { chooseProjectFolder } from "../lib/folder-step";
 import {
   LiveMark,
   ProjectRow,
@@ -1006,7 +1007,28 @@ export function WorkflowsRail({
             data-tooltip="Add a project"
             onClick={() => {
               setHistoryOpen(false);
-              setStartMode("open");
+              // THE BRIDGE DECIDES WHETHER OUR DIALOG OPENS AT ALL, not what
+              // renders inside it. `FolderField` already feature-detects
+              // `chooseDirectory`, but one level too deep: it used the answer
+              // to swap a `<datalist>`, so a desktop user still got a modal
+              // wrapping a text input with the OS browser offered as a button
+              // inside it. In `open` mode this dialog asks one question — which
+              // folder — and Finder answers it better than we do.
+              void chooseProjectFolder({
+                chooseDirectory: getDesktopBridge()?.chooseDirectory ?? null,
+                // The dialog's own precedence for where to start.
+                startingAt: projectRoot ?? launchDir,
+                openDialog: () => setStartMode("open"),
+                onPicked: (root) => {
+                  void onOpenProject(root).catch((err: unknown) => {
+                    onToast(
+                      err instanceof Error
+                        ? err.message
+                        : "Couldn't open that folder.",
+                    );
+                  });
+                },
+              });
             }}
           >
             <Icon name="FolderPlus" size={14} />

--- a/packages/harness/web/src/lib/folder-step.test.ts
+++ b/packages/harness/web/src/lib/folder-step.test.ts
@@ -60,7 +60,11 @@ describe("the folder step", () => {
     expect(openDialog).not.toHaveBeenCalled();
   });
 
-  it("swallows a failed native pick without falling back", async () => {
+  it("falls back to the dialog when the native pick FAILS", async () => {
+    // The one case that is not a decline. A broken bridge used to be swallowed
+    // exactly like a cancel, which left Add a project doing nothing at all on
+    // a desktop build whose picker was unavailable — a dead control with no
+    // way through. Cancelling still does nothing; failing offers the fallback.
     const openDialog = vi.fn();
     const onPicked = vi.fn();
 
@@ -73,7 +77,7 @@ describe("the folder step", () => {
     ).resolves.toBeUndefined();
 
     expect(onPicked).not.toHaveBeenCalled();
-    expect(openDialog).not.toHaveBeenCalled();
+    expect(openDialog).toHaveBeenCalledTimes(1);
   });
 
   it("omits the starting folder rather than passing an empty one", async () => {

--- a/packages/harness/web/src/lib/folder-step.test.ts
+++ b/packages/harness/web/src/lib/folder-step.test.ts
@@ -88,4 +88,20 @@ describe("the folder step", () => {
 
     expect(chooseDirectory).toHaveBeenCalledWith(undefined);
   });
+
+  it("omits an EMPTY starting folder too, not just a missing one", async () => {
+    // `launchDir` reaches callers through `?? null`, which lets `""` past, so
+    // the two cases are not the same value arriving twice — an empty string
+    // would be forwarded as an empty `defaultPath` by `??`.
+    const chooseDirectory = vi.fn().mockResolvedValue(null);
+
+    await chooseProjectFolder({
+      chooseDirectory,
+      startingAt: "",
+      openDialog: vi.fn(),
+      onPicked: vi.fn(),
+    });
+
+    expect(chooseDirectory).toHaveBeenCalledWith(undefined);
+  });
 });

--- a/packages/harness/web/src/lib/folder-step.test.ts
+++ b/packages/harness/web/src/lib/folder-step.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { chooseProjectFolder } from "./folder-step";
+
+/**
+ * The desktop branch cannot be reached by the e2e tier — there is no Electron
+ * here, and the Playwright suite is the browser host by definition, so it can
+ * only ever prove the fallback. These are the desktop half's only proof, which
+ * is why they assert the NEGATIVE too: that the dialog never opens when the
+ * bridge is there. A test that only checked `chooseDirectory` was called would
+ * still pass on a build that opened both.
+ */
+describe("the folder step", () => {
+  it("goes straight to the OS picker when the bridge is there", async () => {
+    const chooseDirectory = vi.fn().mockResolvedValue("/Users/demo/acme-app");
+    const openDialog = vi.fn();
+    const onPicked = vi.fn();
+
+    await chooseProjectFolder({
+      chooseDirectory,
+      startingAt: "/Users/demo",
+      openDialog,
+      onPicked,
+    });
+
+    expect(chooseDirectory).toHaveBeenCalledWith("/Users/demo");
+    expect(onPicked).toHaveBeenCalledWith("/Users/demo/acme-app");
+    // The whole point: our dialog is not also shown.
+    expect(openDialog).not.toHaveBeenCalled();
+  });
+
+  it("opens the folder dialog when there is no bridge", async () => {
+    const openDialog = vi.fn();
+    const onPicked = vi.fn();
+
+    await chooseProjectFolder({
+      chooseDirectory: null,
+      startingAt: "/Users/demo",
+      openDialog,
+      onPicked,
+    });
+
+    expect(openDialog).toHaveBeenCalledTimes(1);
+    expect(onPicked).not.toHaveBeenCalled();
+  });
+
+  it("treats a cancelled native pick as nothing happening", async () => {
+    const openDialog = vi.fn();
+    const onPicked = vi.fn();
+
+    await chooseProjectFolder({
+      chooseDirectory: vi.fn().mockResolvedValue(null),
+      openDialog,
+      onPicked,
+    });
+
+    expect(onPicked).not.toHaveBeenCalled();
+    // Dismissing a folder browser must not fall back into our dialog: the user
+    // said no to the question, not to the way it was asked.
+    expect(openDialog).not.toHaveBeenCalled();
+  });
+
+  it("swallows a failed native pick without falling back", async () => {
+    const openDialog = vi.fn();
+    const onPicked = vi.fn();
+
+    await expect(
+      chooseProjectFolder({
+        chooseDirectory: vi.fn().mockRejectedValue(new Error("no window")),
+        openDialog,
+        onPicked,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(onPicked).not.toHaveBeenCalled();
+    expect(openDialog).not.toHaveBeenCalled();
+  });
+
+  it("omits the starting folder rather than passing an empty one", async () => {
+    const chooseDirectory = vi.fn().mockResolvedValue(null);
+
+    await chooseProjectFolder({
+      chooseDirectory,
+      startingAt: null,
+      openDialog: vi.fn(),
+      onPicked: vi.fn(),
+    });
+
+    expect(chooseDirectory).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/packages/harness/web/src/lib/folder-step.ts
+++ b/packages/harness/web/src/lib/folder-step.ts
@@ -1,0 +1,64 @@
+/**
+ * ASKING FOR A FOLDER: native on desktop, our dialog on the web.
+ *
+ * The split already existed, one level too deep. `FolderField` asks
+ * `getDesktopBridge()?.chooseDirectory` and uses the answer to decide whether
+ * to render a `<datalist>` — so on desktop the app still opened a modal
+ * wrapping a text input, and offered the OS folder browser as a button inside
+ * it. That is backwards. With Finder or Explorer available, our dialog is not a
+ * smaller version of it; it is a different and worse control, and the typed
+ * path is what a browser host is left with when it has nothing better.
+ *
+ * So the bridge decides whether the DIALOG OPENS AT ALL, and that decision
+ * lives here rather than inline at the caller, so the hosts cannot drift apart
+ * as more entrances start asking this same question.
+ *
+ * Only `StartDialog`'s `open` mode is routed through this today, because that
+ * mode asks exactly one question — which folder — and has exactly one action.
+ * `detect` mode still opens the dialog on both hosts: it has to show what it
+ * found under the folder, so the picker is only its first step.
+ *
+ * A FUNCTION RATHER THAN A HOOK, and pure over its inputs, because the desktop
+ * half cannot be exercised in this repo: there is no Electron in the test
+ * environment, and the browser half is the only one an e2e run can reach. A
+ * branch that only one host can run needs a test that does not need that host.
+ * See `folder-step.test.ts`.
+ */
+
+export interface FolderStepHost {
+  /**
+   * The desktop bridge's directory picker, or null in a browser. Feature
+   * detected by the caller, never assumed — an older desktop build without it
+   * reads as a browser and takes the fallback, which is always safe.
+   */
+  chooseDirectory: ((startingAt?: string) => Promise<string | null>) | null;
+  /** Where the OS picker should open. Ignored by the fallback, which has its
+   *  own recents and its own starting folder. */
+  startingAt?: string | null;
+  /** The web fallback: show our own folder dialog. */
+  openDialog: () => void;
+  /** A folder the user settled on. Not called when they cancel. */
+  onPicked: (root: string) => void;
+}
+
+/**
+ * Ask for a folder the best way this host can.
+ *
+ * Resolves once the question has been ASKED, not answered: the dialog path
+ * returns as soon as the dialog is open. Only the native path has an answer to
+ * wait for, and a cancelled or failed pick is a no-op rather than an error —
+ * dismissing a folder browser is not a failure, and there is nothing to report.
+ */
+export async function chooseProjectFolder(host: FolderStepHost): Promise<void> {
+  if (!host.chooseDirectory) {
+    host.openDialog();
+    return;
+  }
+  let picked: string | null = null;
+  try {
+    picked = await host.chooseDirectory(host.startingAt ?? undefined);
+  } catch {
+    return;
+  }
+  if (picked) host.onPicked(picked);
+}

--- a/packages/harness/web/src/lib/folder-step.ts
+++ b/packages/harness/web/src/lib/folder-step.ts
@@ -56,7 +56,10 @@ export async function chooseProjectFolder(host: FolderStepHost): Promise<void> {
   }
   let picked: string | null = null;
   try {
-    picked = await host.chooseDirectory(host.startingAt ?? undefined);
+    // `||`, NOT `??`: an empty string has to be omitted too, not forwarded as
+    // an empty `defaultPath`. `launchDir` reaches callers through `?? null`,
+    // which lets `""` past, and "start at nowhere" is not a starting folder.
+    picked = await host.chooseDirectory(host.startingAt || undefined);
   } catch {
     return;
   }

--- a/packages/harness/web/src/lib/folder-step.ts
+++ b/packages/harness/web/src/lib/folder-step.ts
@@ -46,8 +46,14 @@ export interface FolderStepHost {
  *
  * Resolves once the question has been ASKED, not answered: the dialog path
  * returns as soon as the dialog is open. Only the native path has an answer to
- * wait for, and a cancelled or failed pick is a no-op rather than an error —
- * dismissing a folder browser is not a failure, and there is nothing to report.
+ * wait for.
+ *
+ * CANCELLING AND FAILING ARE DIFFERENT ANSWERS, and they were conflated here.
+ * Cancelling resolves `null` and is a no-op — dismissing a folder browser is
+ * not a failure and there is nothing to report. A REJECTION is not a decline:
+ * it means the bridge is broken, and swallowing it left the only entrance to
+ * adding a project doing nothing at all, with no way through. The typed-path
+ * dialog still works on this host, so a failure falls back to it.
  */
 export async function chooseProjectFolder(host: FolderStepHost): Promise<void> {
   if (!host.chooseDirectory) {
@@ -61,6 +67,8 @@ export async function chooseProjectFolder(host: FolderStepHost): Promise<void> {
     // which lets `""` past, and "start at nowhere" is not a starting folder.
     picked = await host.chooseDirectory(host.startingAt || undefined);
   } catch {
+    // Not a decline — see above. Leave the user a working way to answer.
+    host.openDialog();
     return;
   }
   if (picked) host.onPicked(picked);


### PR DESCRIPTION
## Primary change type

- [x] Feature

## Problem and motivation

Adding a project on the desktop app opened a modal wrapping a text input, with Finder or Explorer offered as a button *inside* it. The desktop/web split already existed but sat one level too deep: `FolderField` feature-detects `getDesktopBridge()?.chooseDirectory` and uses the answer to decide whether to render a `<datalist>`, so the bridge changed what rendered inside our dialog rather than whether the dialog was the right control at all.

With a real OS folder browser available, our dialog is not a smaller version of it — it is a different and worse control. The typed path is what a browser host is left with when it has nothing better.

This is an acceptance item on SAP-3143: "The folder step opens the native picker when the desktop bridge is present; typed path only on web."

## Summary and scope

The rail's Add-a-project `+` now asks `chooseProjectFolder`, and the bridge decides whether our dialog opens at all. On desktop the OS browser opens directly and the chosen folder goes straight to `onOpenProject`. On web, behaviour is unchanged.

The decision lives in `web/src/lib/folder-step.ts` rather than inline at the caller, so hosts cannot drift apart as more entrances start asking this same question.

**Intentionally out of scope:**

- `StartDialog`'s `detect` mode ("Add existing agents") is untouched. It has to show what it found under the folder, so the picker is only its first step there; `open` mode asks one question with one action, which is why only it can be answered outright by the OS browser.
- The rest of SAP-3143 — the create verb's form, removing `composerScaffoldPrompt` (still live at `web/src/App.tsx:1888`), and making the composer project-aware. Those carry open design questions the ticket flags explicitly, including an unresolved question against SAP-2981 about whether any prompt is submitted at all. **SAP-3143 stays open.**

## Related work

Related issue or discussion: SAP-3143.

Salvaged from #803, which is now closed. That PR was stacked on `gwitwer/studio-rail-creation` (its own PR #801 closed unmerged, superseded by #819 + `[Agent Map 01..15/15]`), and its central commit dispatched to `harness.openPlannerSession` — deleted from `main` by `21684912` "feat(harness): activate ordinary bootstrap [Agent Map 07/15]", which is the founder's reversal of the planner session type. This file is the one piece of #803 with no open design question. See the closing comment on #803 for the full accounting of what was and was not carried forward.

## Validation

```text
npx vitest run web/src/lib/folder-step.test.ts    — 6 passed (6)
npx playwright test folder-field.spec.ts          — 6 passed (6)
npx playwright test open-project unrooted-agents \
  project-axis create-agent agent-map-navigation \
  agent-map-initialization smoke                  — 180 passed (180)
npx tsc --noEmit                                  — clean
npx tsc --noEmit -p web/tsconfig.json             — clean
npx eslint src --ext .ts                          — clean
npm run build (tsc + vite web bundle)             — built, no new warnings
npx prettier --check <changed files>              — clean on changed lines
```

`pnpm --filter "@sapiom/harness^..." build` is required before typecheck, or `@sapiom/agent-core` and `@sapiom/mcp` report as missing modules.

Note: `WorkflowsRail.tsx` already fails `prettier --check` on `main` at lines 712-720 and 754-757. Left untouched to keep this diff to one problem.

### Tests and documentation

`web/src/lib/folder-step.test.ts`, 6 cases, plus 4 desktop-host cases in `web/e2e/folder-field.spec.ts`.

The desktop branch is unreachable by both test tiers — no Electron in the unit environment, and Playwright is a browser host by definition — so `chooseProjectFolder` is a pure function over an injected host, and the spec asserts the negatives: that our dialog does **not** also open when the bridge is present, and that a **cancelled** pick does not fall back into it. Dismissing a folder browser is the user declining the question, not declining the way it was asked.

**A failed pick is a different answer, and it does fall back.** Cancelling resolves `null`; only a broken bridge rejects, and swallowing that left Add a project doing nothing at all on a host whose picker was unavailable. Both sides are pinned so they cannot re-converge: the e2e cancel case asserts no dialog opens, the unit failure case asserts one does.

Two gaps, stated rather than papered over: the starting-folder tier selection is a JSX expression with no direct test (the helper's empty-value handling is covered for both `null` and `""`, but "which of the three tiers wins" is not), and `StartDialog.tsx:82` has the same `??`-versus-empty-string gap for those tiers — left alone because it is reachable from other entrances and is not this PR's change.

No user-facing docs cover this control; the behaviour change is in the changeset.

## Compatibility and release impact

- Breaking or externally visible changes: None breaking. Externally visible: on the desktop app, Add a project opens the OS folder browser instead of a typed-path dialog. Web is unchanged.
- Changeset: Added — `.changeset/native-folder-step.md` (patch).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability.

## AI assistance

- [x] I used AI assistance and have described it below.

Claude Code investigated #803's viability, established that its base was abandoned and its core mechanism deleted from main, and selected and adapted this file from that branch. It wrote the caller wiring and the doc comments, and ran the build, typecheck, lint, and test commands quoted above. `folder-step.ts` and its spec are substantially the originals from #803 with the doc comments corrected to describe this narrower change rather than the create-verb redesign, which is not in this PR.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012wSFNBtYuYRA2XQunaVMvV


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop users can open the operating system’s folder picker directly when creating a project.
  * Selected folders open automatically without an additional confirmation step.
  * If the native picker is unavailable, project creation continues to use the existing web dialog.
  * “Add existing agents” continues to use the in-app dialog.

* **Bug Fixes**
  * Cancelled or unsuccessful folder selections leave the current view unchanged.
  * Project selections remain correct when folder scanning and user actions overlap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/915" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
