### PR TITLE
docs(agent-core,mcp,tools): point npm-shipped copies of the platform rules at the served text and stamp them [SAP-3181]

### DIFF
--- a/.changeset/pointer-ize-platform-rules.md
+++ b/.changeset/pointer-ize-platform-rules.md
@@ -1,0 +1,40 @@
+---
+"@sapiom/agent-core": minor
+"@sapiom/mcp": minor
+"@sapiom/tools": patch
+"@sapiom/cli": patch
+---
+
+Stop restating the platform rules in npm-shipped files; point at the served copy
+and stamp the pointer (SAP-3181).
+
+The rules that are true of Sapiom regardless of the installed SDK — one-off call
+vs agent, the capability catalog, database lifetime, trigger kinds, App Links,
+which capability calls an LLM, composing deployed agents, platform vocabulary —
+are served by the Sapiom API at `GET /v1/agents/authoring-rules`. Every copy
+this repo used to ship of them was frozen at publish or scaffold time and could
+never be corrected; that is how the 7-day database claim and the two-kind
+trigger list reached customers.
+
+- The `sapiom-agent-authoring` skill's platform chapters are now a short
+  summary plus a pointer to the served section, bracketed by
+  `<!-- section: … -->` markers so a Studio session can splice the served text
+  in. The authoring mechanics (step model, directives, `ctx.shared`,
+  pause/resume, stubs) are unchanged.
+- Every scaffolded `AGENTS.md` (both `@sapiom/agent-core` templates, the
+  `@sapiom/cli` template and all gallery examples) and `examples/AUTHORING.md`
+  carry a one-paragraph pointer and a stamp:
+  `<!-- sapiom-authoring-rules release=… digest=… -->`.
+- `@sapiom/tools`' JSDoc on the `model` field of `llm.run`, `llm.submit`,
+  `models.run` and `models.coding.run` points at the served rule instead of
+  restating it.
+- `sapiom_dev_agents_check` reads the stamps in the project's `AGENTS.md` and
+  skill, makes one best-effort anonymous read of the served endpoint's
+  `X-Sapiom-Content-*` headers, and warns when a stamp differs from the served
+  copy. No stamp means no request; unreachable means no warning. The wording is
+  "differs from", never "older than" — digests do not order.
+- `@sapiom/agent-core` exports the stamp vocabulary
+  (`AUTHORING_RULES_*`, `parseAuthoringRulesStamp`,
+  `renderAuthoringRulesStamp`, `authoringRulesDriftWarning`), and
+  `node scripts/authoring-rules-stamp.mjs --from-served` moves every stamp in
+  the repo to the current release at once.

--- a/examples/AUTHORING.md
+++ b/examples/AUTHORING.md
@@ -18,6 +18,14 @@ The path is five steps:
 If you only remember one thing: **write for the person deciding whether to use this, not
 for the person who built it.** Plain, concrete, second-person. No pitch.
 
+The platform rules a template must respect — which capability calls an LLM, database lifetime,
+trigger kinds, App Link webhooks — are served live at
+<https://api.sapiom.ai/v1/agents/authoring-rules> and are not restated in this guide; where a
+step below touches one, it points at the served section. This guide was
+written against release 1.0 of that text.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->
+
 ---
 
 ## 1. Develop
@@ -256,9 +264,11 @@ run, and secrets are read at step dispatch.
    order.
 5. **Get the capability ids right.** The `capabilities` array and each `steps[].capability`
    must be the exact `ctx.sapiom.*` ids your code actually calls — see
-   [Capability ids](#capability-ids-correctness-not-style). One-shot LLM work uses
-   `llm.run`; managed multi-turn loops use `models.run`, and coding agents use
-   `models.coding`. The runtime path is **not** `llm.generate`.
+   [Capability ids](#capability-ids-correctness-not-style). Which of `llm.run`, `models.run`
+   and `models.coding` a step should call is the served rule
+   ([Calling LLMs from steps](https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface));
+   the manifest names whichever one the code actually calls. The runtime path is **not**
+   `llm.generate`.
 6. **Keep the manifest runnable, not just honest.** The `examples` you list must be real
    `{ input, output }` pairs the code produces — don't invent fields. And `examples[0].input`
    must **produce a terminal run when deployed**: in particular it must not name a resource (a
@@ -466,13 +476,13 @@ A declaration says what a thing **is**, never where it is stored — there is no
 `connectorId`, no `store`, and there never will be. Storage belongs to the resolver, which is what
 lets it change without touching your template.
 
-| Field             | Shows up as                                                                        | Write it as                                                                                                                                                                                                                                                                                                                                                                                                                                         |
-| ----------------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `resources`       | "Sapiom will provision" in the setup panel, and the cost/lifetime line on the card | The managed things a run creates — a Postgres, a sandbox, a repo, an inbox. Each needs a `kind` and a `handle` (the slug your step code passes to `ctx.sapiom.database.get()`; unique within a template). `duration` is postgres-only, caps at **7d, and there is no renew verb** — if your template needs state that outlives that, say so in `notes` and set `ephemeral: false`. `seed` is read-side only; see below.                             |
-| `requiredSecrets` | The credential dialog on "Use this template"                                       | Only credentials **Sapiom cannot broker** — a Slack token, the customer's own DB. Never a Sapiom API key, never a non-secret value. Each needs `key`, `label`, `provider`; `key` follows process-env rules — not `PATH`, not `SAPIOM_*`, not `WORKFLOWS_*`. Mark `optional: true` only when the run still reaches a terminal state without it and says what it skipped.                                                                             |
-| `settings`        | Ordinary form fields, merged into the run input                                    | Non-secret config — a recipient, a lookback window, a row cap. **This is where a `RECIPIENT` belongs, not the vault**, which can't be listed, validated, or prompted for. `default` is required: a setting without one can't support a zero-interaction run, which is the point.                                                                                                                                                                    |
-| `defaultInput`    | The one-click Run path                                                             | The input a run starts with when the user supplies nothing. Merged **under** the user's input and under `settings` defaults, so an explicit value always wins. **Not the same as `examples[0].input`**, which is documentation and may legitimately hold a repo slug or a live URL that won't work on a fresh tenant. It never overrides your code's own defaults.                                                                                  |
-| `zeroSetup`       | The shelf's "runs with no setup" claim                                             | What an unconfigured run actually reaches: a `terminalState`, optional `expect[]` assertions over the terminal artifact (`nonEmptyArray`, `nonEmptyString`, `minLength`, `matches`, `equals`, `absent`), and a one-sentence `narrative`. Assert that the pattern **demonstrably ran and the output is honest about it** — not that the result is production-grade. The narrative renders verbatim, so it must never imply a send that won't happen. |
+| Field             | Shows up as                                                                        | Write it as                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ----------------- | ---------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `resources`       | "Sapiom will provision" in the setup panel, and the cost/lifetime line on the card | The managed things a run creates — a Postgres, a sandbox, a repo, an inbox. Each needs a `kind` and a `handle` (the slug your step code passes to `ctx.sapiom.database.get()`; unique within a template). `duration` is a legacy postgres-only field the platform no longer reads — a Sapiom Postgres is permanent and metered by slot, per the served rule ([Database lifecycle](https://api.sapiom.ai/v1/agents/authoring-rules#database-lifecycle)); omit it in a new template. `seed` is read-side only; see below. |
+| `requiredSecrets` | The credential dialog on "Use this template"                                       | Only credentials **Sapiom cannot broker** — a Slack token, the customer's own DB. Never a Sapiom API key, never a non-secret value. Each needs `key`, `label`, `provider`; `key` follows process-env rules — not `PATH`, not `SAPIOM_*`, not `WORKFLOWS_*`. Mark `optional: true` only when the run still reaches a terminal state without it and says what it skipped.                                                                                                                                                 |
+| `settings`        | Ordinary form fields, merged into the run input                                    | Non-secret config — a recipient, a lookback window, a row cap. **This is where a `RECIPIENT` belongs, not the vault**, which can't be listed, validated, or prompted for. `default` is required: a setting without one can't support a zero-interaction run, which is the point.                                                                                                                                                                                                                                        |
+| `defaultInput`    | The one-click Run path                                                             | The input a run starts with when the user supplies nothing. Merged **under** the user's input and under `settings` defaults, so an explicit value always wins. **Not the same as `examples[0].input`**, which is documentation and may legitimately hold a repo slug or a live URL that won't work on a fresh tenant. It never overrides your code's own defaults.                                                                                                                                                      |
+| `zeroSetup`       | The shelf's "runs with no setup" claim                                             | What an unconfigured run actually reaches: a `terminalState`, optional `expect[]` assertions over the terminal artifact (`nonEmptyArray`, `nonEmptyString`, `minLength`, `matches`, `equals`, `absent`), and a one-sentence `narrative`. Assert that the pattern **demonstrably ran and the output is honest about it** — not that the result is production-grade. The narrative renders verbatim, so it must never imply a send that won't happen.                                                                     |
 
 #### `seed`: only seed what your template READS
 
@@ -592,9 +602,10 @@ The `capabilities` array and each `steps[].capability` **must be the real `ctx.s
 the source calls.** Mismatches make the gallery advertise a capability the deployed run never
 uses, and skew the estimated cost.
 
-- One-shot LLM work uses **`llm.run`**. Use `models.run` only for a managed
-  multi-turn loop, and `models.coding` for a coding agent. None of these runtime
-  paths is `llm.generate`, a catalog id that reads `coming_soon`.
+- Which of `llm.run`, `models.run` and `models.coding` a step should call is the served
+  rule ([Calling LLMs from steps](https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface));
+  name the one the code calls. None of these runtime paths is `llm.generate`, a catalog id that
+  reads `coming_soon`.
 - Cross-check against `index.ts`: grep for `ctx.sapiom.<x>` and list exactly those ids.
 - Don't add a capability to the array that no step calls.
 
@@ -603,6 +614,10 @@ uses, and skew the estimated cost.
 ## Reading a model reply (correctness, not style)
 
 **Need data back from a model? Declare the shape. Never slice JSON out of prose.**
+
+This is the template-authoring view of the served rule
+([Calling LLMs from steps](https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface));
+if the two ever disagree, the served text wins.
 
 ```ts
 const REVIEW_TOOL = "emit_review";

--- a/examples/approval-chain/AGENTS.md
+++ b/examples/approval-chain/AGENTS.md
@@ -108,3 +108,13 @@ forward via the `goto(...)` input or `ctx.shared` rather than recomputing them �
 the ledger uses DB-side `now()` for timestamps to stay deterministic across
 retries. The `correlationId` is `ctx.executionId` (stable across every gate), so a
 resume signal always lands on the right run.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/autonomous-pr/AGENTS.md
+++ b/examples/autonomous-pr/AGENTS.md
@@ -106,3 +106,13 @@ tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
 A step body runs **once** on the happy path; it re-runs only on retry (after a
 throw). Capture non-deterministic values (timestamps, ids, the branch name)
 once and pass them forward via `ctx.shared` rather than recomputing them.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/cold-outreach-engine/AGENTS.md
+++ b/examples/cold-outreach-engine/AGENTS.md
@@ -33,3 +33,13 @@ Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev t
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Every timestamp — contact creation, touch sends, reply time — is captured at the DB boundary via Postgres `now()`, not a per-row JS clock, so retries don't skew the campaign log.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/content-repurposing-pipeline/AGENTS.md
+++ b/examples/content-repurposing-pipeline/AGENTS.md
@@ -130,3 +130,13 @@ Capture non-deterministic values once and pass them forward via the `goto(...)` 
 or `ctx.shared` rather than recomputing them. `graphics` launches and pauses on exactly
 one image job per turn, and `clip` pauses on exactly one launched job, so a resume
 signal always has a paused step to land on.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/dependency-upgrade/AGENTS.md
+++ b/examples/dependency-upgrade/AGENTS.md
@@ -58,3 +58,13 @@ tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
 A step body runs **once** on the happy path; it re-runs only on retry (after a
 throw). Capture non-deterministic values (timestamps, ids) once and pass them
 forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/durable-backfill/AGENTS.md
+++ b/examples/durable-backfill/AGENTS.md
@@ -13,7 +13,7 @@ This project defines exactly one Sapiom agent in `index.ts` — **Durable Backfi
 - **`database.get`** resolves the dataset's connection string, which is injected into the chunk sandbox as `DATABASE_URL`.
 - **`sandboxes.create` / `exec`** run the per-chunk `command` in a fresh, short-TTL sandbox (torn down in a `finally`, so nothing lingers between chunks).
 - **`fileStorage.upload` / `getDownloadUrl` / `list` / `delete`** persist the checkpoint (rotated each chunk), the per-chunk result artifacts, and the final manifest — and read the checkpoint back when resuming.
-- **Capabilities come from the types.** What's on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck. The one-shot LLM path (unused here) is `ctx.sapiom.llm.run`.
+- **Capabilities come from the types.** What's on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck. Which capability calls an LLM (unused here) is the served rule ([Calling LLMs from steps](https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface)).
 
 ## Authoring
 
@@ -49,3 +49,13 @@ Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev t
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). The `correlationId` is `ctx.executionId` (stable across pauses), so every heartbeat lands on the right run. Progress is advanced in `ctx.shared` and checkpointed to file storage after each chunk, so a resumed or restarted run never reprocesses a completed chunk.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/error-triage-digest/AGENTS.md
+++ b/examples/error-triage-digest/AGENTS.md
@@ -44,3 +44,13 @@ Keep the same `dryRun` guard around it. Memory needs no recipient.
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). The dedup timestamp is captured once at the DB boundary via Postgres `now()` rather than a per-row JS clock, so retries don't skew `last_seen`.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/eval-gate/AGENTS.md
+++ b/examples/eval-gate/AGENTS.md
@@ -117,3 +117,13 @@ A step body runs **once** on the happy path; it re-runs only on retry (after a
 throw). Capture non-deterministic values (timestamps, ids, the draft text
 itself) once and pass them forward via the `goto(...)` input or `ctx.shared`
 rather than recomputing them.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/fan-out-and-combine/AGENTS.md
+++ b/examples/fan-out-and-combine/AGENTS.md
@@ -40,3 +40,13 @@ off-ramp. Inside a step's `run`, Sapiom capabilities are pre-auth'd on `ctx.sapi
   offline, and honest.
 - Deployed, a run with `{}` fans a sample goal into three parallel child runs of
   itself and returns one combined answer.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/fintech-exec-radar/AGENTS.md
+++ b/examples/fintech-exec-radar/AGENTS.md
@@ -66,3 +66,13 @@ Run `npm run typecheck`, then use the Sapiom developer MCP:
 Require `unusedStubs` and `stubWarnings` to both be empty. A production E2E is
 link → deploy → run with all default companies → inspect to terminal. Run it
 twice to prove the second run suppresses the first run's source keys.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/hello-agent/AGENTS.md
+++ b/examples/hello-agent/AGENTS.md
@@ -22,3 +22,13 @@ Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev t
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/human-in-the-loop/AGENTS.md
+++ b/examples/human-in-the-loop/AGENTS.md
@@ -86,3 +86,13 @@ throw). Capture non-deterministic values (timestamps, ids) once and pass them
 forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.
 The `correlationId` is `ctx.executionId` (stable across both pauses), so a resume
 signal always lands on the right run.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/logged-in-screenshots/AGENTS.md
+++ b/examples/logged-in-screenshots/AGENTS.md
@@ -46,3 +46,13 @@ capabilities are pre-auth'd on `ctx.sapiom` (here: `ctx.sapiom.search.scrape`,
   so `search.scrape` and `session.screenshot` return stub content.
 - Deployed, a run with `{}` crawls `https://sapiom.ai` and produces a QA
   report.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/meeting-notes-crm/AGENTS.md
+++ b/examples/meeting-notes-crm/AGENTS.md
@@ -44,3 +44,13 @@ Keep the same `dryRun` guard around it. Memory needs no recipient.
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Row timestamps are captured once at the DB boundary via Postgres `now()` rather than a per-row JS clock, so retries don't skew `updated_at` / `last_meeting_at`.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/news-roundup/AGENTS.md
+++ b/examples/news-roundup/AGENTS.md
@@ -48,3 +48,13 @@ return pauseUntilSignal(run, { resumeStep: "finalize" });                       
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Don't rely on a value being recomputed identically across a pause/resume — capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared`.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/newsletter-autopilot/AGENTS.md
+++ b/examples/newsletter-autopilot/AGENTS.md
@@ -62,3 +62,13 @@ Keep the same `dryRun` guard around it. Memory needs no recipients. Recall past 
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/nl-db-query-endpoint/AGENTS.md
+++ b/examples/nl-db-query-endpoint/AGENTS.md
@@ -61,3 +61,13 @@ Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev t
 A step body runs **once** on the happy path; it re-runs only on retry (after a
 throw). Capture non-deterministic values (timestamps, ids) once and pass them
 forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/personalized-media-at-scale/AGENTS.md
+++ b/examples/personalized-media-at-scale/AGENTS.md
@@ -33,3 +33,13 @@ Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev t
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/pr-review-bot/AGENTS.md
+++ b/examples/pr-review-bot/AGENTS.md
@@ -78,3 +78,13 @@ Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev t
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them. The `correlationId` is `ctx.executionId` (stable across the pause), so the resume signal always lands on the right run.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/proposal-generator/AGENTS.md
+++ b/examples/proposal-generator/AGENTS.md
@@ -101,3 +101,13 @@ throw). Capture non-deterministic values once and pass them forward via the
 is derived from `ctx.executionId` (stable across retries and the pause), and
 `correlationId` is `ctx.executionId`, so a resume signal always lands on the right
 run.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/research-to-microsite/AGENTS.md
+++ b/examples/research-to-microsite/AGENTS.md
@@ -95,3 +95,13 @@ tools (`sapiom_dev_agents_*`). See `README.md` for the full lifecycle.
 A step body runs **once** on the happy path; it re-runs only on retry (after a
 throw). Capture non-deterministic values (timestamps, ids) once and pass them
 forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/scene-to-video/AGENTS.md
+++ b/examples/scene-to-video/AGENTS.md
@@ -24,7 +24,7 @@ decompose ─▶ keyframe ⇄ collectKeyframe ─▶ animate ⇄ collect ─▶ 
 ## Authoring
 
 - An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run, ... })`. Keep exactly one `defineAgent(...)` export.
-- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck. One-shot LLM work uses `ctx.sapiom.llm.run({ request: { system, messages, max_tokens } })` through the gateway.
+- **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck. This template's one-shot LLM work is `ctx.sapiom.llm.run({ request: { system, messages, max_tokens } })`; which capability a step should call is the served rule ([Calling LLMs from steps](https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface)).
 - **Async pause/resume.** A launched capability (`images.launch`, `video.launch`) returns a dispatch handle; `return pauseUntilSignal(handle, { resumeStep })` suspends the step until the job's signal arrives. The step must also **declare** the edge: `pause: { signal, resumeStep }`. The resumed step receives an `ImageResultPayload` / `VideoResultPayload` (`{ outputs: [{ fileId?, downloadUrl?, generationError? }] }` — the signal fires on either terminal outcome, so check `generationError` before treating a missing `fileId` as a storage problem).
 - **Why `keyframe`/`animate` are sequential, not one paused step per job at once.** A paused step waits on a single `(signal, correlationId)` pair. Launching every job up front and then draining would risk one finishing before we've paused on it — its resume signal would have nowhere to land. Launching shot `i` only after shot `i-1` resumes keeps a paused step always waiting before its job can complete. This is also why keyframes use `images.launch` rather than a concurrent `Promise.all` of `images.create`: the synchronous routed call holds its request open for the full generate+store, which meets Core's 30s router cap under fan-out — `launch` submits and returns as soon as the job is enqueued, so it never does.
 
@@ -48,3 +48,13 @@ This is the priciest template in the gallery once you go past one shot: a full r
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them. The `keyframe ⇄ collectKeyframe` loop advances a `keyframeIndex` counter and the `animate ⇄ collect` loop advances a separate `animateIndex` counter, both in `ctx.shared`.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/scheduled-compliance-audit/AGENTS.md
+++ b/examples/scheduled-compliance-audit/AGENTS.md
@@ -81,3 +81,13 @@ A step body runs **once** on the happy path; it re-runs only on retry (after a
 throw). The audit timestamp is captured once in `collect` and carried forward via
 `ctx.shared` rather than recomputed downstream — do the same for any id or clock
 value a later step depends on.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/scheduled-db-insight-report/AGENTS.md
+++ b/examples/scheduled-db-insight-report/AGENTS.md
@@ -48,3 +48,13 @@ A step body runs **once** on the happy path; it re-runs only on retry (after a
 throw). The snapshot timestamp is captured once server-side via Postgres `now()`
 and passed forward via `ctx.shared`, rather than recomputed per step. Capture other
 non-deterministic values (ids, timestamps) the same way.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/scheduled-research-brief/AGENTS.md
+++ b/examples/scheduled-research-brief/AGENTS.md
@@ -42,3 +42,13 @@ Keep the same `dryRun` guard around it. Memory needs no recipient. Recall past b
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/slack-notifier/AGENTS.md
+++ b/examples/slack-notifier/AGENTS.md
@@ -59,3 +59,13 @@ throw). Slack's `chat.postMessage` has no idempotency key, so a retry after a
 successful post but failed ack could double-post — keep the post in its own step
 so a retry re-runs only the post, and capture any non-deterministic values
 (timestamps, ids) once, passing them forward via `goto(...)` or `ctx.shared`.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/template.schema.json
+++ b/examples/template.schema.json
@@ -126,7 +126,7 @@
           },
           "duration": {
             "enum": ["15m", "1h", "4h", "24h", "7d"],
-            "description": "postgres only. 7d is the maximum and there is NO renew verb — a managed Postgres is scratch space, not a datastore. A template that needs durable state must say so in `notes`."
+            "description": "postgres only, and legacy: the platform no longer reads it. A Sapiom Postgres is permanent and metered by slot — see the served rule at https://api.sapiom.ai/v1/agents/authoring-rules#database-lifecycle. Omit it in a new template; existing declarations still parse."
           },
           "seed": {
             "type": "string",
@@ -135,7 +135,7 @@
           "ephemeral": {
             "type": "boolean",
             "default": true,
-            "description": "True when the resource is disposable per run. False signals the 7-day TTL problem applies and the template needs a durability story in `notes`."
+            "description": "True when the resource is disposable per run. False signals the template keeps state across runs and needs a durability story in `notes`."
           },
           "reuse": {
             "type": "object",

--- a/examples/the-brain/AGENTS.md
+++ b/examples/the-brain/AGENTS.md
@@ -79,3 +79,13 @@ A step body runs **once** on the happy path; it re-runs only on retry (after a
 throw). Capture non-deterministic values (timestamps, ids) once and pass them
 forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.
 The `now` input pins the clock for deterministic testing.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/wait-for-webhook/AGENTS.md
+++ b/examples/wait-for-webhook/AGENTS.md
@@ -45,3 +45,13 @@ Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev t
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them. The `correlationId` is `ctx.executionId` (stable across the pause), so the resume signal always lands on the right run.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/examples/web-research-digest/AGENTS.md
+++ b/examples/web-research-digest/AGENTS.md
@@ -24,3 +24,13 @@ Drive `check` / `run_local` / `link` / `deploy` / `run` via the Sapiom MCP dev t
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Capture non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared` rather than recomputing them.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "pr-labeler:check": "node --test scripts/pr-label-classifier.test.mjs && prettier --check .github/labeler.yml .github/workflows/pr-labeler.yml .github/workflows/test.yml .github/pull_request_template.md package.json scripts/pr-label-classifier.mjs scripts/pr-label-classifier.test.mjs",
     "pr-ci-security:check": "node --test scripts/pr-ci-security.test.mjs && prettier --check .github/workflows/test.yml .github/workflows/harness.yml scripts/pr-ci-security.test.mjs",
     "examples:sort": "node scripts/examples-sort.mjs",
-    "examples:sync-setup": "node scripts/examples-sync-setup.mjs"
+    "examples:sync-setup": "node scripts/examples-sync-setup.mjs",
+    "authoring-rules:stamp": "node scripts/authoring-rules-stamp.mjs"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -31,7 +31,9 @@ Sapiom regardless of your SDK version: one-off call vs agent, the capability cat
 lifetime, trigger kinds, App Links, which capability calls an LLM, composing deployed agents,
 vocabulary — are **served live** from <https://api.sapiom.ai/v1/agents/authoring-rules> and
 only summarized here; each such chapter is bracketed by `section:` markers naming the served
-section it points at. When a summary below and the served text disagree, the served text wins.
+section it points at. A pointer's `#name` fragment names that section's marker (an HTML
+comment, `section: name`) in the served text — the endpoint serves raw Markdown, so search for
+the marker rather than expecting a browser to jump to it. When a summary below and the served text disagree, the served text wins.
 This copy was written against release 1.0 of it; `sapiom_dev_agents_check` warns when the
 served copy differs.
 

--- a/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/skills/sapiom-agent-authoring/SKILL.md
@@ -24,10 +24,26 @@ dashboard required.
 **Load this skill before scaffolding — it drives the whole lifecycle from zero.** Inside a
 scaffolded project, `AGENTS.md` is the quick reference; this skill is the deep guide.
 
-## If the Sapiom dev MCP isn't connected yet
+**Two kinds of content live here, and they update differently.** The authoring _mechanics_ —
+the step model, directives, `ctx.shared`, pause/resume, local stubs — describe the
+`@sapiom/agent` in your `node_modules` and ship with it. The _platform rules_ — what is true of
+Sapiom regardless of your SDK version: one-off call vs agent, the capability catalog, database
+lifetime, trigger kinds, App Links, which capability calls an LLM, composing deployed agents,
+vocabulary — are **served live** from <https://api.sapiom.ai/v1/agents/authoring-rules> and
+only summarized here; each such chapter is bracketed by `section:` markers naming the served
+section it points at. When a summary below and the served text disagree, the served text wins.
+This copy was written against release 1.0 of it; `sapiom_dev_agents_check` warns when the
+served copy differs.
 
-The lifecycle below runs through the **sapiom-dev** MCP server (`@sapiom/mcp`). If its tools
-(`sapiom_authenticate`, `sapiom_dev_agents_*`) aren't available, add the server first:
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->
+
+<!-- section: one-off-vs-agent -->
+
+## If the local authoring server isn't connected yet
+
+The lifecycle below runs through **the local authoring server** — the `@sapiom/mcp` package,
+stdio. If its tools (`sapiom_authenticate`, `sapiom_dev_agents_*`) aren't available, add it
+first:
 
 ```bash
 claude mcp add sapiom -- npx -y @sapiom/mcp
@@ -35,6 +51,12 @@ claude mcp add sapiom -- npx -y @sapiom/mcp
 
 Other clients: run `npx -y @sapiom/mcp` as a local (stdio) MCP server — see
 [docs.sapiom.ai](https://docs.sapiom.ai/integration/mcp-servers/setup) for per-client config.
+Sapiom's other server, **the hosted capability server** (`https://api.sapiom.ai/v1/mcp`), is
+for a one-off call with no automation to keep; which server a task belongs to, and what local
+work does and does not spend, is the served section
+[One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent).
+
+<!-- /section: one-off-vs-agent -->
 
 ## Lifecycle from Zero
 
@@ -71,7 +93,9 @@ filesystem, process, environment, network, and third-party services.
 
 Run `sapiom_authenticate` — it opens a browser login and caches an API key in
 `~/.sapiom/credentials.json`. Confirm with `sapiom_status`. This makes your coding agent an
-API-key principal; link, deploy, and cloud run require it.
+API-key principal; link, deploy, and cloud run require it. Which server's `sapiom_authenticate` that is (the one
+alongside the `sapiom_dev_agents_*` tools) and why local work needs no account: served section
+[One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent).
 
 ### 4. Link → deploy → run → inspect
 
@@ -276,25 +300,34 @@ reference instead.
 | `ctx.organizationId` | `string \| null`                 | Tenant org                                                                                                                                                |
 | `ctx.tenantId`       | `string \| null`                 | Tenant id                                                                                                                                                 |
 
+<!-- section: capability-catalog -->
+
 ## Capabilities from Steps
 
-Steps call Sapiom's paid capabilities through `ctx.sapiom.*` — sandboxes, repositories,
-coding models (`ctx.sapiom.models.coding`), file storage, content generation, search,
-databases, email, domains, memory, and more as they land. **Do not memorize the catalog:
-types are the source of truth.** The full surface is the `Sapiom` interface in `@sapiom/tools`
-— installed in your project's `node_modules`, so its types match the exact version you're on.
-`ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
-catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
+Steps call Sapiom's paid capabilities through the typed `ctx.sapiom.*` client. **Do not
+memorize the catalog: types are the source of truth.** The full surface is the `Sapiom`
+interface in `@sapiom/tools` — installed in your project's `node_modules`, so its types match
+the exact version you're on. `ctx.sapiom.` autocompletes what exists, `npm run typecheck`
+rejects what doesn't, and the catalog with pricing lives at
+[docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities). What the catalog spans, how
+per-agent secrets and the read-only Vault reach a step, and why triggers are cloud objects
+rather than `ctx.sapiom` calls: served section
+[Capabilities from steps](https://api.sapiom.ai/v1/agents/authoring-rules#capability-catalog).
+Database lifetime and metering: served section
+[Database lifecycle](https://api.sapiom.ai/v1/agents/authoring-rules#database-lifecycle).
+
+<!-- /section: capability-catalog -->
 
 ### Secrets, `agents.launch`, receipts, App Link webhooks
 
-Taught once, in the served `sapiom-dev` primer (in your context from the moment the MCP
-connects) and on docs.sapiom.ai — not restated here. Per-agent secrets and the read-only
-Vault: [Credentials and
-configuration](https://docs.sapiom.ai/reference/credentials-and-configuration). Fire-and-forget
-dispatch with `ctx.sapiom.agents.launch`: "Composing Deployed Agents" below and
-[Authoring](https://docs.sapiom.ai/agents/authoring). Receipts and manual replay of inbound
-events: the primer's REST pointers. App Link `/hook/*` webhooks:
+Taught once, in the served text — not restated here. Per-agent secrets and the read-only Vault:
+[Capabilities from steps](https://api.sapiom.ai/v1/agents/authoring-rules#capability-catalog) and
+[Credentials and configuration](https://docs.sapiom.ai/reference/credentials-and-configuration).
+Fire-and-forget dispatch with `ctx.sapiom.agents.launch`: "Composing Deployed Agents" below and
+[Composing deployed agents](https://api.sapiom.ai/v1/agents/authoring-rules#agent-composition).
+Receipts and manual replay of inbound events: the local authoring server's served primer (in
+your context from the moment it connects) and its REST pointers. App Link `/hook/*` webhooks:
+[App Links and third-party webhooks](https://api.sapiom.ai/v1/agents/authoring-rules#app-links) and
 [App Links](https://docs.sapiom.ai/capabilities/app-links#webhooks).
 
 ### Coding Repository Errors
@@ -327,157 +360,56 @@ try {
 }
 ```
 
+<!-- section: llm-call-surface -->
+
 ## Calling LLMs from Steps
 
-Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the
-job is the most common mistake in authored agents:
+Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the job is
+the most common mistake in authored agents. In one line each: `ctx.sapiom.llm.run` is ONE call
+(summarize, extract, classify, one-shot generate); `ctx.sapiom.models.run` is a platform-driven
+multi-turn reasoning + tool-calling loop (never for a one-shot — it loops and overthinks);
+`ctx.sapiom.agents.run` dispatches a DEPLOYED agent by slug. You never pick a model: omit
+`model` and let the platform route it — a raw provider model id is never honored on any surface.
 
-| Capability              | Use for                                                                                                                            | Never for                                                        |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `ctx.sapiom.llm.run`    | ONE LLM call — summarize, extract, classify, one-shot generate                                                                     | A multi-turn task, or anything needing its own tool-calling loop |
-| `ctx.sapiom.models.run` | A platform-driven multi-turn reasoning + tool-calling loop (minutes, not seconds). `models.coding.run` for sandboxed coding tasks. | A one-shot completion — it will loop and overthink               |
-| `ctx.sapiom.agents.run` | Dispatching a DEPLOYED agent by slug — composing systems from small deployed agents                                                | Anything that isn't itself a deployed agent                      |
+The full rule — the worked example (`llm.run` with `output`, read back with `structuredOf`;
+`textOf` for plain text; never `content[0]`), why `max_tokens` must budget for thinking as well
+as output, the label rule and the result's `servedClass`/`lane` disclosure, and how to debug a
+run in the Run Inspector — is the served section
+[Calling LLMs from steps](https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface).
+Read it before the first `llm.*` / `models.run` / `agents.run` call. Customer guide:
+[Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
 
-**⚠️ The mistake to never repeat:** sending single-shot, fixed-shape intent through
-`models.run`'s multi-turn loop instead of one `llm.run` call. The symptom: the run takes
-far longer than the task needs, "overthinks" a trivial extraction, and — if the caller just
-grabs the first content block hoping it's the answer — returns a `thinking` block instead.
+<!-- /section: llm-call-surface -->
 
-### Worked example: a trivial fixed-shape-JSON task
-
-**Wrong** — one-shot intent sent through the multi-turn loop, then the answer string-parsed
-out of free text:
-
-```typescript
-// DON'T: models.run for a one-shot extraction — it loops and overthinks, and
-// "reply with only JSON" is brittle (prose, invalid JSON, or a leading
-// `thinking` block all break a naive `JSON.parse(content[0])`).
-const run = await ctx.sapiom.models.run({
-  prompt: `Reply with ONLY JSON: {"priority": "...", "category": "..."} for: ${input.text}`,
-});
-const parsed = JSON.parse(run.output ?? "{}"); // brittle, and pays for a reasoning loop
-```
-
-**Right** — `llm.run` with `output` for the fixed shape, read back with `structuredOf`
-(forced tool-use output has no `text` block — the result lives in `tool_use`, never
-`content[0]`):
-
-```typescript
-const response = await ctx.sapiom.llm.run({
-  request: {
-    messages: [
-      { role: "user", content: `Classify this support ticket: ${input.text}` },
-    ],
-    max_tokens: 256,
-  },
-  // No `model` — omit it and let the platform choose (recommended; passing
-  // "smart" would be a no-op — it already is the default — and a raw provider
-  // model id is never honored).
-  output: {
-    name: "classify_ticket",
-    schema: {
-      type: "object",
-      properties: {
-        priority: { type: "string", enum: ["low", "medium", "high"] },
-        category: { type: "string" },
-      },
-      required: ["priority", "category"],
-    },
-  },
-});
-
-const { priority, category } = ctx.sapiom.llm.structuredOf<{
-  priority: string;
-  category: string;
-}>(response)!;
-```
-
-`output` automates the forced tool call and its `tool_choice` wiring; `structuredOf` reads
-the result back out. For a **plain-text** reply instead, use
-`ctx.sapiom.llm.textOf(response)` — it reads only the `type === 'text'` block, skipping a
-`thinking` block that may precede it.
-
-### The label rule
-
-**You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
-`models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
-against its configured label set — never a raw provider model id (never honored, on any
-surface). Omit it entirely to let the platform choose (the recommended default) — passing
-`"smart"` is a no-op: it already is the default. The result discloses what actually served, in the platform's own
-vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
-lane it executed in) — never a model or provider id.
-
-### Debugging a run
-
-Find the run in the dashboard's run detail view, find the suspicious step's row id, then
-open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
-
-Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+<!-- section: agent-composition -->
 
 ## Composing Deployed Agents (System Design)
 
 **One agent per project — but a system is several projects.** The "keep exactly one
-`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system. A
-multi-stage system ("research → write script → voiceover → assemble → post") is not one
-big agent with five steps: it is several small agents, each its own project, deployed
-separately, composed by a thin coordinator that dispatches them by slug. A small deployed
-agent is independently testable, versioned, and reusable from more than one caller; a
-monolith couples every stage into a single deploy unit and step graph, so any stage change
-redeploys — and risks — all of them.
+`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system: a
+multi-stage system is several small agents, each its own project, deployed separately, composed
+by a thin coordinator that dispatches them by slug with `ctx.sapiom.agents.run`. `agents.run`
+resolves on ANY terminal status and does NOT throw — branch on
+`research.status !== "completed"` or a failed stage silently feeds `null` downstream. For a
+long-running child use `ctx.sapiom.agents.launch` and pause the calling step on the handle
+(`pauseUntilSignal`, below) so the coordinator's step doesn't time out. Deploy bottom-up —
+children first, the coordinator last, since it dispatches them by their slugs. The worked
+example is the served section
+[Composing deployed agents](https://api.sapiom.ai/v1/agents/authoring-rules#agent-composition).
 
-**Wrong** — one project inlining every stage as a step:
+<!-- /section: agent-composition -->
 
-```typescript
-// DON'T: video-pipeline/index.ts with research, script, voiceover, assemble,
-// post as five steps of ONE defineAgent. No stage is reusable or
-// independently testable, and every stage change redeploys all five.
-```
-
-**Right** — each stage its own deployed project; a coordinator composes them:
-
-```typescript
-// research-topic/, write-script/, generate-voiceover/, assemble-video/,
-// post-video/: five small projects, each deployed on its own slug.
-// video-pipeline/ is then just the coordinator:
-const research = await ctx.sapiom.agents.run({
-  definition: "research-topic", // the deployed child's slug
-  input: { topic: input.topic },
-});
-// agents.run resolves on ANY terminal status (completed | failed | cancelled)
-// and does NOT throw — a non-completed child is data the coordinator must
-// branch on, or a failed stage silently feeds `null` downstream.
-if (research.status !== "completed") {
-  // (fail() requires this step to declare canFail: true)
-  return fail(`research-topic ${research.status}: ${String(research.error)}`);
-}
-const script = await ctx.sapiom.agents.run({
-  definition: "write-script",
-  input: { research: research.output },
-});
-// …and so on. Use agents.launch + pauseUntilSignal for a long-running child
-// so the coordinator's step doesn't time out.
-```
-
-Building a system in one session? Scaffold the stages as separate projects and deploy
-bottom-up — children first, the coordinator last (it dispatches them by their slugs).
+<!-- section: platform-vocabulary -->
 
 ## Naming Conventions
 
-Several words are overloaded across this platform. Know which meaning a given context
-uses — conflating two costs you a wrong capability choice, not just a wrong word:
+"agent", "run", "task", "session", "dispatch" and "label" each carry several meanings on this
+platform, and conflating two costs you a wrong capability choice, not just a wrong word. The
+glossary — and the rule for new capabilities: don't re-overload "agent" or "run", give a new
+verb its own name — is the served section
+[Platform vocabulary](https://api.sapiom.ai/v1/agents/authoring-rules#platform-vocabulary).
 
-| Term         | Meaning(s) on this platform                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **agent**    | (1) `@sapiom/agent` — this authoring framework (`defineAgent`, this skill). (2) A **deployed agent** — one project's compiled definition, dispatched by `ctx.sapiom.agents.run`/`launch` (addressed by its slug via `AgentRunSpec.definition`) — the customer-facing name is always "agent." (3) `ctx.sapiom.models.run`'s managed multi-turn loop — a managed loop the platform runs for you; you call it, you never author it. (4) A **Claude Code subagent** — an unrelated feature of the coding tool itself, not part of the Sapiom SDK. |
-| **run**      | (1) `ctx.sapiom.llm.run` — one synchronous LLM call. (2) `ctx.sapiom.models.run` / `agents.run` — `launch()` + `wait()`, blocking until terminal (vs. `launch()` alone, which returns a pausable handle). (3) An execution instance/row of any of the above — the thing you inspect/debug. (4) The dashboard's Run button / Local Run / Prod Run (Studio UI actions, not an API call).                                                                                                                                                        |
-| **task**     | `CodingRunSpec.task` — the coding agent's prompt-equivalent field. Deliberately not called `prompt`: it's handed to a sandboxed coding agent, not a bare LLM call.                                                                                                                                                                                                                                                                                                                                                                            |
-| **session**  | (1) `ctx.sapiom.llm.createSession`/`callSession` — reserved LLM capacity accepting repeated drop-in calls until its TTL/budget ends it (replacing the deferred `submit`/`redeem` lane). (2) A Studio harness terminal session — unrelated, no LLM-capacity semantics.                                                                                                                                                                                                                                                                         |
-| **dispatch** | The structural contract (`DispatchHandle`) a long-running capability's `launch()` handle satisfies so a step can `pauseUntilSignal(handle, …)` and resume on completion. Every dispatched capability (coding, `models.run`, `agents.run`, more later) shares this ONE contract — "dispatch" always means this pattern, never anything else.                                                                                                                                                                                                   |
-| **label**    | The author-facing term for a `model:`/`label:` _input_ value (e.g. `"smart"`) — never a raw provider model id (never honored, on any surface). Not a contradiction that a result's `servedClass` field says "class": that field _reports_ the billing class the platform resolved your label to — it's a disclosure field, not author-facing input vocabulary. You still write `label`; the platform still reports back `servedClass`.                                                                                                        |
-
-**The rule new capabilities must follow:** don't re-overload "agent" or "run" further. If a
-new capability needs its own verb, name it something else (`dispatch`, `launch`, `submit`,
-`create*`) rather than adding a sixth meaning to a word that already has five.
+<!-- /section: platform-vocabulary -->
 
 ## Failure Handling & Retries
 
@@ -604,38 +536,22 @@ Under `run_local`, a dispatch pause auto-resumes with the stub result; a manual 
 auto-resumes with `{}`. There is no manual-signal payload override in the local runner, so
 type the resumed step's input with optional fields accordingly.
 
+<!-- section: trigger-kinds -->
+
 ## Triggers — Run a Deployed Agent Without a Human
 
-A trigger is a persisted cloud object attached to a **deployed** agent by slug; each fire starts an
-independent production run. Create one with `sapiom_dev_agents_schedule` — `kind` picks the shape:
+A trigger is a persisted cloud object attached to a **deployed** agent by slug; each fire starts
+an independent production run. Create one with `sapiom_dev_agents_schedule` — `kind` is one of
+`schedule_cron`, `schedule_once`, `event`, `webhook` (the `event`/`webhook` kinds and
+`sapiom_dev_agents_schedule_secret` need `@sapiom/mcp` >= 0.15). "Run this agent when an
+external system POSTs to us" is a `webhook` trigger, not a hand-built HTTP server. The required
+field per kind, the signing scheme a webhook sender must follow, secret rotation, and why a
+Slack / Stripe / GitHub / Meta sender needs an App Link `/hook/*` receiver instead of our HMAC:
+served sections [Trigger kinds](https://api.sapiom.ai/v1/agents/authoring-rules#trigger-kinds)
+and [App Links and third-party webhooks](https://api.sapiom.ai/v1/agents/authoring-rules#app-links).
+Full guide: [Triggers](https://docs.sapiom.ai/guides/triggers).
 
-| `kind`          | Fires when                                                                                                                    | Required field                                          |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `schedule_cron` | on a recurring cron (validate it first with `sapiom_dev_agents_cron_preview`)                                                 | `cron` (optional `timezone`)                            |
-| `schedule_once` | once, at a future time                                                                                                        | `at` (ISO 8601)                                         |
-| `event`         | every time this tenant emits that event type through the tenant events API (`{ type, payload }`; route in the Triggers guide) | `eventType` (`lead.created`; `sapiom.*` is reserved)    |
-| `webhook`       | every time an external system POSTs to a public hook URL minted for the trigger                                               | none — the result returns the URL + a shown-once secret |
-
-"Run this agent when an external system POSTs to us" is a **`webhook` trigger**, not a hand-built
-HTTP server. The create result carries the hook URL, the secret (shown once — it is derived,
-never stored, and cannot be read back), and the signing scheme every request must follow:
-
-- `X-Sapiom-Signature` = HMAC-SHA256(secret, `<X-Sapiom-Timestamp>.<X-Sapiom-Event-Id>.<raw body>`), lowercase hex
-- `X-Sapiom-Timestamp` = Unix epoch **milliseconds**, accepted within ±5 minutes
-- `X-Sapiom-Event-Id` = sender-chosen delivery id (`[A-Za-z0-9_-]{1,128}`); a repeat is deduplicated, so retries are safe
-- body = a JSON object (≤ 1 MiB) — it becomes the run input, folded over the trigger's stored `input`
-
-Only a sender you control can sign like that. **Slack, Meta (WhatsApp), Stripe, GitHub and other
-third parties sign with their own schemes and cannot produce our HMAC** — give them an
-[App Link](https://docs.sapiom.ai/capabilities/app-links) `/hook/*` receiver (`webhooksEnabled`)
-that verifies _their_ signature and then emits a tenant event or starts the run through the API,
-or a small translator that re-signs into a webhook trigger.
-
-`sapiom_dev_agents_schedule_inspect` and `_schedule_cancel` cover every kind (inspect never shows
-a webhook secret). `sapiom_dev_agents_schedule_secret` rotates a webhook secret (`rotate` → new
-secret, the old one verifies for a 24h grace → `complete_rotation` ends the grace early) or
-`revoke`s it (compromise: the hook dies now). The `event` / `webhook` kinds and the secret tool need
-`@sapiom/mcp` >= 0.15. Full guide: [Triggers](https://docs.sapiom.ai/guides/triggers).
+<!-- /section: trigger-kinds -->
 
 ## Determinism
 
@@ -730,10 +646,9 @@ Write each step the way it should run in production — never weaken logic to sh
 - **One `defineAgent` export per file.** The scaffold wraps a single `index.ts`.
 - **`ctx.shared` for fanout.** When three steps all need the entry input, write it into
   `ctx.shared` in the entry step — don't thread it through every `goto` payload.
-- **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
-  [remote MCP](https://docs.sapiom.ai/integration/mcp-servers/remote) (`https://api.sapiom.ai/v1/mcp`,
-  direct `sapiom_*` tools, `tool_discover` to find the right one) or the typed SDK client
-  ([`@sapiom/tools`](https://www.npmjs.com/package/@sapiom/tools)) instead of scaffolding.
+- **One-off capability call, no automation to keep?** That's not an agent — the served section
+  [One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent)
+  says which server or SDK client to use instead of scaffolding.
 
 ## Troubleshooting
 
@@ -751,11 +666,12 @@ Write each step the way it should run in production — never weaken logic to sh
 
 ## References
 
-| Resource                                                                     | What it covers                                                                |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| [Authoring guide](https://docs.sapiom.ai/agents/authoring)                   | Full step model, failure patterns, pause/resume, determinism                  |
-| [Quickstart](https://docs.sapiom.ai/agents/quick-start)                      | Scaffold → write → test → deploy walkthrough                                  |
-| [Capabilities](https://docs.sapiom.ai/capabilities)                          | The full `ctx.sapiom.*` catalog with pricing                                  |
-| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why             |
-| [Triggers](https://docs.sapiom.ai/guides/triggers)                           | Cron, one-off, event, and webhook triggers; webhook signing + secret rotation |
-| `AGENTS.md` in your scaffold                                                 | The quick in-project reference                                                |
+| Resource                                                                     | What it covers                                                                                                 |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [Platform rules (served)](https://api.sapiom.ai/v1/agents/authoring-rules)   | The live text every platform chapter above summarizes and points at; this copy was written against release 1.0 |
+| [Authoring guide](https://docs.sapiom.ai/agents/authoring)                   | Full step model, failure patterns, pause/resume, determinism                                                   |
+| [Quickstart](https://docs.sapiom.ai/agents/quick-start)                      | Scaffold → write → test → deploy walkthrough                                                                   |
+| [Capabilities](https://docs.sapiom.ai/capabilities)                          | The full `ctx.sapiom.*` catalog with pricing                                                                   |
+| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why                                              |
+| [Triggers](https://docs.sapiom.ai/guides/triggers)                           | Cron, one-off, event, and webhook triggers; webhook signing + secret rotation                                  |
+| `AGENTS.md` in your scaffold                                                 | The quick in-project reference                                                                                 |

--- a/packages/agent-core/src/__tests__/authoring-rules-stamp.test.ts
+++ b/packages/agent-core/src/__tests__/authoring-rules-stamp.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Stamp agreement guard (SAP-3181). Every npm-shipped file that summarizes or
+ * points at the served platform rules records which release it was written
+ * against. Those records have to move together — a file left on an old stamp
+ * would make `sapiom_dev_agents_check` warn about a copy that was in fact
+ * re-read, or stay silent about one that was not — so this holds all of them
+ * to the constants in src/authoring-rules.ts, which the backend's own digest
+ * pin holds to the served body. `scripts/authoring-rules-stamp.mjs` is how
+ * they move.
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+
+import {
+  AUTHORING_RULES_DIGEST,
+  AUTHORING_RULES_RELEASE,
+  AUTHORING_RULES_SECTIONS,
+  AUTHORING_RULES_URL,
+  authoringRulesDriftWarning,
+  parseAuthoringRulesStamp,
+  renderAuthoringRulesStamp,
+} from "../authoring-rules";
+
+const PKG_ROOT = path.resolve(__dirname, "..", "..");
+const REPO_ROOT = path.resolve(PKG_ROOT, "..", "..");
+const CANONICAL_SKILL = path.join(
+  PKG_ROOT,
+  "skills",
+  "sapiom-agent-authoring",
+  "SKILL.md",
+);
+
+/** Markdown files carrying the HTML-comment stamp. */
+function stampedMarkdownFiles(): string[] {
+  const files = [
+    CANONICAL_SKILL,
+    path.join(PKG_ROOT, "templates", "default", "AGENTS.md"),
+    path.join(PKG_ROOT, "templates", "coding-pause", "AGENTS.md"),
+    path.join(REPO_ROOT, "examples", "AUTHORING.md"),
+  ];
+  // The CLI's separately published template — may not exist on every branch.
+  const cliAgentsMd = path.join(
+    REPO_ROOT,
+    "packages",
+    "cli",
+    "templates",
+    "default",
+    "AGENTS.md",
+  );
+  if (existsSync(cliAgentsMd)) files.push(cliAgentsMd);
+  const examples = path.join(REPO_ROOT, "examples");
+  for (const entry of readdirSync(examples, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const agentsMd = path.join(examples, entry.name, "AGENTS.md");
+    if (existsSync(agentsMd)) files.push(agentsMd);
+  }
+  return files;
+}
+
+/** `.ts` files carrying the JSDoc form, `(written against release X)`. */
+const JSDOC_FILES = [
+  path.join(REPO_ROOT, "packages", "tools", "src", "llm", "index.ts"),
+  path.join(REPO_ROOT, "packages", "tools", "src", "models", "index.ts"),
+];
+
+const rel = (file: string) => path.relative(REPO_ROOT, file);
+
+describe("authoring-rules stamp", () => {
+  it("renders and parses round-trip", () => {
+    const stamp = { release: "2.3", digest: "0123456789ab" };
+    expect(parseAuthoringRulesStamp(renderAuthoringRulesStamp(stamp))).toEqual(
+      stamp,
+    );
+    expect(parseAuthoringRulesStamp("# no stamp here\n")).toBeNull();
+  });
+
+  it("the shipped stamp is a well-formed release id and 12-hex digest", () => {
+    expect(AUTHORING_RULES_RELEASE).toMatch(/^\d+\.\d+$/);
+    expect(AUTHORING_RULES_DIGEST).toMatch(/^[0-9a-f]{12}$/);
+  });
+
+  const markdownFiles = stampedMarkdownFiles();
+
+  it("guards the skill, the templates, AUTHORING.md and every example", () => {
+    // 3 templates + skill + AUTHORING.md + the gallery. A missing example is a
+    // gallery change, not a stamp change, but a count this low means the walk broke.
+    expect(markdownFiles.length).toBeGreaterThan(20);
+  });
+
+  for (const file of markdownFiles) {
+    it(`${rel(file)} carries the current stamp`, () => {
+      const markdown = readFileSync(file, "utf8");
+      expect(parseAuthoringRulesStamp(markdown)).toEqual({
+        release: AUTHORING_RULES_RELEASE,
+        digest: AUTHORING_RULES_DIGEST,
+      });
+      // The prose beside the stamp names the same release, so a reader and the
+      // machine see one number.
+      expect(markdown).toContain(
+        `written against release ${AUTHORING_RULES_RELEASE}`,
+      );
+      expect(markdown).not.toMatch(
+        new RegExp(
+          `written against release (?!${AUTHORING_RULES_RELEASE.replace(".", "\\.")}\\b)\\d+\\.\\d+`,
+        ),
+      );
+    });
+  }
+
+  for (const file of JSDOC_FILES) {
+    it(`${rel(file)} JSDoc pointers name the current release`, () => {
+      const source = readFileSync(file, "utf8");
+      const releases = [
+        ...source.matchAll(
+          /authoring-rules#[a-z-]+\s*(?:\*\s*)?\(written against release ([^)\s]+)\)/g,
+        ),
+      ].map((m) => m[1]);
+      expect(releases.length).toBeGreaterThan(0);
+      expect(new Set(releases)).toEqual(new Set([AUTHORING_RULES_RELEASE]));
+    });
+  }
+});
+
+describe("authoring-rules pointers", () => {
+  const anchorsOf = (text: string): string[] =>
+    [...text.matchAll(/authoring-rules#([a-z-]+)/g)].map((m) => m[1]);
+
+  it("every section anchor a shipped file points at exists on the served body", () => {
+    const known = new Set<string>(AUTHORING_RULES_SECTIONS);
+    for (const file of [...stampedMarkdownFiles(), ...JSDOC_FILES]) {
+      for (const anchor of anchorsOf(readFileSync(file, "utf8"))) {
+        expect({
+          file: rel(file),
+          anchor: known.has(anchor) ? anchor : `UNKNOWN:${anchor}`,
+        }).toEqual({ file: rel(file), anchor });
+      }
+    }
+  });
+
+  it("the skill brackets each platform chapter with matching section markers", () => {
+    const skill = readFileSync(CANONICAL_SKILL, "utf8");
+    const opens = [...skill.matchAll(/<!-- section: ([a-z-]+) -->/g)].map(
+      (m) => m[1],
+    );
+    const closes = [...skill.matchAll(/<!-- \/section: ([a-z-]+) -->/g)].map(
+      (m) => m[1],
+    );
+    expect(opens.length).toBeGreaterThan(0);
+    expect(closes).toEqual(opens);
+    expect(new Set(opens).size).toBe(opens.length);
+    for (const name of opens) {
+      expect(AUTHORING_RULES_SECTIONS).toContain(name);
+    }
+    // Every bracketed chapter points at the section it summarizes.
+    for (const name of opens) {
+      const body = skill
+        .split(`<!-- section: ${name} -->`)[1]
+        .split(`<!-- /section: ${name} -->`)[0];
+      expect(body).toContain(`${AUTHORING_RULES_URL}#${name}`);
+    }
+  });
+
+  it("the skill no longer restates the rules it points at", () => {
+    const skill = readFileSync(CANONICAL_SKILL, "utf8");
+    // The worked LLM example, the vocabulary table and the trigger table were
+    // the restatements; each is one pointer now.
+    expect(skill).not.toContain("| `ctx.sapiom.llm.run`    |");
+    expect(skill).not.toContain("| **agent**    |");
+    expect(skill).not.toContain("| `schedule_cron` |");
+    expect(skill).not.toContain("X-Sapiom-Signature");
+  });
+});
+
+describe("authoringRulesDriftWarning", () => {
+  const local = { release: "1.0", digest: "1f3e5cd9648f" };
+
+  it("is null when the digests agree, whatever the release ids say", () => {
+    expect(
+      authoringRulesDriftWarning("AGENTS.md", local, {
+        release: "1.1",
+        digest: local.digest,
+      }),
+    ).toBeNull();
+  });
+
+  it("says 'differs', names both stamps and the URL, and never ranks them", () => {
+    const warning = authoringRulesDriftWarning("AGENTS.md", local, {
+      release: "1.1",
+      digest: "abcdefabcdef",
+    });
+    expect(warning).toContain("AGENTS.md");
+    expect(warning).toContain("release 1.0 (digest 1f3e5cd9648f)");
+    expect(warning).toContain("differs");
+    expect(warning).toContain("release 1.1, digest abcdefabcdef");
+    expect(warning).toContain(AUTHORING_RULES_URL);
+    expect(warning).not.toMatch(/older|newer|outdated|behind/i);
+  });
+});

--- a/packages/agent-core/src/authoring-rules.ts
+++ b/packages/agent-core/src/authoring-rules.ts
@@ -1,0 +1,119 @@
+/**
+ * The served platform rules, and the stamp an npm-shipped copy carries to say
+ * which release of them it was written against (SAP-3181, SAP-2908 §3(d)).
+ *
+ * The rules that are true of Sapiom regardless of the installed `@sapiom/agent`
+ * — one-off call vs agent, the capability catalog, database lifetime, trigger
+ * kinds, App Links, which capability calls an LLM, composing deployed agents,
+ * platform vocabulary — are served by the backend at
+ * `GET /v1/agents/authoring-rules` (SAP-3223) and stamped with a content
+ * release id and a 12-hex sha-256 digest of the body (SAP-3190). Everything
+ * this package ships that used to restate one of those rules — the
+ * `sapiom-agent-authoring` skill's platform chapters, every scaffolded
+ * `AGENTS.md`, `examples/AUTHORING.md` — now carries a short summary, a pointer
+ * to the served section, and this stamp. A copy inside a scaffolded project is
+ * frozen at scaffold time and can never be corrected; the stamp is what lets
+ * `sapiom_dev_agents_check` say "this differs from the served copy" instead of
+ * teaching a stale rule silently.
+ *
+ * The comparison is always "differs from", never "older than": digests do not
+ * order, and content-release ids have collided (three PRs once claimed the same
+ * id with three bodies), so neither can be ranked. `AUTHORING_RULES_DIGEST` is
+ * the first 12 hex of the same sha-256 the backend pins for its bundled-fallback
+ * check, so the two repos agree on one token.
+ *
+ * Bumping: when the backend cuts a new release, run
+ * `node scripts/authoring-rules-stamp.mjs --from-served` at the repo root. It
+ * rewrites these two constants and every stamped file together;
+ * `__tests__/authoring-rules-stamp.test.ts` fails if any of them disagree.
+ */
+
+/** Public URL of the served rules (production). */
+export const AUTHORING_RULES_URL =
+  "https://api.sapiom.ai/v1/agents/authoring-rules";
+
+/** Path of the served rules on any Sapiom API host, for non-production environments. */
+export const AUTHORING_RULES_PATH = "/v1/agents/authoring-rules";
+
+/** The content release the shipped summaries and pointers were written against. */
+export const AUTHORING_RULES_RELEASE = "1.0";
+
+/** First 12 hex of sha-256 over that release's body — what the server reports in `X-Sapiom-Content-Digest`. */
+export const AUTHORING_RULES_DIGEST = "1f3e5cd9648f";
+
+/**
+ * The section anchors the served body carries (`<!-- section: NAME -->`), in
+ * document order. A pointer names one of these as a URL fragment; the backend
+ * treats the set as a contract, so a rename there is a break here.
+ */
+export const AUTHORING_RULES_SECTIONS = [
+  "one-off-vs-agent",
+  "capability-catalog",
+  "database-lifecycle",
+  "trigger-kinds",
+  "app-links",
+  "llm-call-surface",
+  "agent-composition",
+  "platform-vocabulary",
+] as const;
+
+export type AuthoringRulesSection = (typeof AUTHORING_RULES_SECTIONS)[number];
+
+/** What a stamp records: the release id and the body digest it was written against. */
+export interface AuthoringRulesStamp {
+  release: string;
+  digest: string;
+}
+
+/** The stamp the shipped files carry right now. */
+export const AUTHORING_RULES_STAMP: AuthoringRulesStamp = {
+  release: AUTHORING_RULES_RELEASE,
+  digest: AUTHORING_RULES_DIGEST,
+};
+
+/**
+ * The stamp as it appears in a Markdown file — an HTML comment, so it renders
+ * to nothing and survives a reader's edits around it.
+ */
+export function renderAuthoringRulesStamp(
+  stamp: AuthoringRulesStamp = AUTHORING_RULES_STAMP,
+): string {
+  return `<!-- sapiom-authoring-rules release=${stamp.release} digest=${stamp.digest} -->`;
+}
+
+const STAMP_PATTERN =
+  /<!--\s*sapiom-authoring-rules\s+release=(\S+)\s+digest=([0-9a-f]{12})\s*-->/;
+
+/**
+ * Read the stamp out of a Markdown file's contents. `null` when the file carries
+ * none — a project scaffolded before stamps existed, or a hand-written file — in
+ * which case there is nothing to compare and `check` stays silent.
+ */
+export function parseAuthoringRulesStamp(
+  markdown: string,
+): AuthoringRulesStamp | null {
+  const match = STAMP_PATTERN.exec(markdown);
+  return match ? { release: match[1], digest: match[2] } : null;
+}
+
+/**
+ * The warning `check` attaches when a stamped file was written against a
+ * different body than the server currently serves. Worded as "differs", never
+ * "older" (see the module comment), and it names the file, both stamps and the
+ * URL so the reader can go straight to the current text. `null` when the two
+ * agree.
+ */
+export function authoringRulesDriftWarning(
+  file: string,
+  local: AuthoringRulesStamp,
+  served: AuthoringRulesStamp,
+  url: string = AUTHORING_RULES_URL,
+): string | null {
+  if (local.digest === served.digest) return null;
+  return (
+    `${file} was written against Sapiom platform rules release ${local.release} ` +
+    `(digest ${local.digest}); the served copy differs (release ${served.release}, ` +
+    `digest ${served.digest}). Its summaries and pointers may no longer match — ` +
+    `read the current rules at ${url}.`
+  );
+}

--- a/packages/agent-core/src/index.ts
+++ b/packages/agent-core/src/index.ts
@@ -53,6 +53,24 @@ export type {
   ResolvedVersions,
 } from "./scaffold.js";
 
+// The served platform rules' stamp: what a shipped summary/pointer was written
+// against, and the "differs from the served copy" warning `check` attaches (SAP-3181).
+export {
+  AUTHORING_RULES_URL,
+  AUTHORING_RULES_PATH,
+  AUTHORING_RULES_RELEASE,
+  AUTHORING_RULES_DIGEST,
+  AUTHORING_RULES_SECTIONS,
+  AUTHORING_RULES_STAMP,
+  renderAuthoringRulesStamp,
+  parseAuthoringRulesStamp,
+  authoringRulesDriftWarning,
+} from "./authoring-rules.js";
+export type {
+  AuthoringRulesStamp,
+  AuthoringRulesSection,
+} from "./authoring-rules.js";
+
 // Best-effort dependency install + bundle-failure hinting — shared by scaffold,
 // the example seed, and the Canvas/check/run-local bundle paths.
 export { installProjectDependencies } from "./install-deps.js";

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -31,7 +31,9 @@ Sapiom regardless of your SDK version: one-off call vs agent, the capability cat
 lifetime, trigger kinds, App Links, which capability calls an LLM, composing deployed agents,
 vocabulary — are **served live** from <https://api.sapiom.ai/v1/agents/authoring-rules> and
 only summarized here; each such chapter is bracketed by `section:` markers naming the served
-section it points at. When a summary below and the served text disagree, the served text wins.
+section it points at. A pointer's `#name` fragment names that section's marker (an HTML
+comment, `section: name`) in the served text — the endpoint serves raw Markdown, so search for
+the marker rather than expecting a browser to jump to it. When a summary below and the served text disagree, the served text wins.
 This copy was written against release 1.0 of it; `sapiom_dev_agents_check` warns when the
 served copy differs.
 

--- a/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -24,10 +24,26 @@ dashboard required.
 **Load this skill before scaffolding — it drives the whole lifecycle from zero.** Inside a
 scaffolded project, `AGENTS.md` is the quick reference; this skill is the deep guide.
 
-## If the Sapiom dev MCP isn't connected yet
+**Two kinds of content live here, and they update differently.** The authoring _mechanics_ —
+the step model, directives, `ctx.shared`, pause/resume, local stubs — describe the
+`@sapiom/agent` in your `node_modules` and ship with it. The _platform rules_ — what is true of
+Sapiom regardless of your SDK version: one-off call vs agent, the capability catalog, database
+lifetime, trigger kinds, App Links, which capability calls an LLM, composing deployed agents,
+vocabulary — are **served live** from <https://api.sapiom.ai/v1/agents/authoring-rules> and
+only summarized here; each such chapter is bracketed by `section:` markers naming the served
+section it points at. When a summary below and the served text disagree, the served text wins.
+This copy was written against release 1.0 of it; `sapiom_dev_agents_check` warns when the
+served copy differs.
 
-The lifecycle below runs through the **sapiom-dev** MCP server (`@sapiom/mcp`). If its tools
-(`sapiom_authenticate`, `sapiom_dev_agents_*`) aren't available, add the server first:
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->
+
+<!-- section: one-off-vs-agent -->
+
+## If the local authoring server isn't connected yet
+
+The lifecycle below runs through **the local authoring server** — the `@sapiom/mcp` package,
+stdio. If its tools (`sapiom_authenticate`, `sapiom_dev_agents_*`) aren't available, add it
+first:
 
 ```bash
 claude mcp add sapiom -- npx -y @sapiom/mcp
@@ -35,6 +51,12 @@ claude mcp add sapiom -- npx -y @sapiom/mcp
 
 Other clients: run `npx -y @sapiom/mcp` as a local (stdio) MCP server — see
 [docs.sapiom.ai](https://docs.sapiom.ai/integration/mcp-servers/setup) for per-client config.
+Sapiom's other server, **the hosted capability server** (`https://api.sapiom.ai/v1/mcp`), is
+for a one-off call with no automation to keep; which server a task belongs to, and what local
+work does and does not spend, is the served section
+[One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent).
+
+<!-- /section: one-off-vs-agent -->
 
 ## Lifecycle from Zero
 
@@ -71,7 +93,9 @@ filesystem, process, environment, network, and third-party services.
 
 Run `sapiom_authenticate` — it opens a browser login and caches an API key in
 `~/.sapiom/credentials.json`. Confirm with `sapiom_status`. This makes your coding agent an
-API-key principal; link, deploy, and cloud run require it.
+API-key principal; link, deploy, and cloud run require it. Which server's `sapiom_authenticate` that is (the one
+alongside the `sapiom_dev_agents_*` tools) and why local work needs no account: served section
+[One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent).
 
 ### 4. Link → deploy → run → inspect
 
@@ -276,25 +300,34 @@ reference instead.
 | `ctx.organizationId` | `string \| null`                 | Tenant org                                                                                                                                                |
 | `ctx.tenantId`       | `string \| null`                 | Tenant id                                                                                                                                                 |
 
+<!-- section: capability-catalog -->
+
 ## Capabilities from Steps
 
-Steps call Sapiom's paid capabilities through `ctx.sapiom.*` — sandboxes, repositories,
-coding models (`ctx.sapiom.models.coding`), file storage, content generation, search,
-databases, email, domains, memory, and more as they land. **Do not memorize the catalog:
-types are the source of truth.** The full surface is the `Sapiom` interface in `@sapiom/tools`
-— installed in your project's `node_modules`, so its types match the exact version you're on.
-`ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
-catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
+Steps call Sapiom's paid capabilities through the typed `ctx.sapiom.*` client. **Do not
+memorize the catalog: types are the source of truth.** The full surface is the `Sapiom`
+interface in `@sapiom/tools` — installed in your project's `node_modules`, so its types match
+the exact version you're on. `ctx.sapiom.` autocompletes what exists, `npm run typecheck`
+rejects what doesn't, and the catalog with pricing lives at
+[docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities). What the catalog spans, how
+per-agent secrets and the read-only Vault reach a step, and why triggers are cloud objects
+rather than `ctx.sapiom` calls: served section
+[Capabilities from steps](https://api.sapiom.ai/v1/agents/authoring-rules#capability-catalog).
+Database lifetime and metering: served section
+[Database lifecycle](https://api.sapiom.ai/v1/agents/authoring-rules#database-lifecycle).
+
+<!-- /section: capability-catalog -->
 
 ### Secrets, `agents.launch`, receipts, App Link webhooks
 
-Taught once, in the served `sapiom-dev` primer (in your context from the moment the MCP
-connects) and on docs.sapiom.ai — not restated here. Per-agent secrets and the read-only
-Vault: [Credentials and
-configuration](https://docs.sapiom.ai/reference/credentials-and-configuration). Fire-and-forget
-dispatch with `ctx.sapiom.agents.launch`: "Composing Deployed Agents" below and
-[Authoring](https://docs.sapiom.ai/agents/authoring). Receipts and manual replay of inbound
-events: the primer's REST pointers. App Link `/hook/*` webhooks:
+Taught once, in the served text — not restated here. Per-agent secrets and the read-only Vault:
+[Capabilities from steps](https://api.sapiom.ai/v1/agents/authoring-rules#capability-catalog) and
+[Credentials and configuration](https://docs.sapiom.ai/reference/credentials-and-configuration).
+Fire-and-forget dispatch with `ctx.sapiom.agents.launch`: "Composing Deployed Agents" below and
+[Composing deployed agents](https://api.sapiom.ai/v1/agents/authoring-rules#agent-composition).
+Receipts and manual replay of inbound events: the local authoring server's served primer (in
+your context from the moment it connects) and its REST pointers. App Link `/hook/*` webhooks:
+[App Links and third-party webhooks](https://api.sapiom.ai/v1/agents/authoring-rules#app-links) and
 [App Links](https://docs.sapiom.ai/capabilities/app-links#webhooks).
 
 ### Coding Repository Errors
@@ -327,157 +360,56 @@ try {
 }
 ```
 
+<!-- section: llm-call-surface -->
+
 ## Calling LLMs from Steps
 
-Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the
-job is the most common mistake in authored agents:
+Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the job is
+the most common mistake in authored agents. In one line each: `ctx.sapiom.llm.run` is ONE call
+(summarize, extract, classify, one-shot generate); `ctx.sapiom.models.run` is a platform-driven
+multi-turn reasoning + tool-calling loop (never for a one-shot — it loops and overthinks);
+`ctx.sapiom.agents.run` dispatches a DEPLOYED agent by slug. You never pick a model: omit
+`model` and let the platform route it — a raw provider model id is never honored on any surface.
 
-| Capability              | Use for                                                                                                                            | Never for                                                        |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `ctx.sapiom.llm.run`    | ONE LLM call — summarize, extract, classify, one-shot generate                                                                     | A multi-turn task, or anything needing its own tool-calling loop |
-| `ctx.sapiom.models.run` | A platform-driven multi-turn reasoning + tool-calling loop (minutes, not seconds). `models.coding.run` for sandboxed coding tasks. | A one-shot completion — it will loop and overthink               |
-| `ctx.sapiom.agents.run` | Dispatching a DEPLOYED agent by slug — composing systems from small deployed agents                                                | Anything that isn't itself a deployed agent                      |
+The full rule — the worked example (`llm.run` with `output`, read back with `structuredOf`;
+`textOf` for plain text; never `content[0]`), why `max_tokens` must budget for thinking as well
+as output, the label rule and the result's `servedClass`/`lane` disclosure, and how to debug a
+run in the Run Inspector — is the served section
+[Calling LLMs from steps](https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface).
+Read it before the first `llm.*` / `models.run` / `agents.run` call. Customer guide:
+[Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
 
-**⚠️ The mistake to never repeat:** sending single-shot, fixed-shape intent through
-`models.run`'s multi-turn loop instead of one `llm.run` call. The symptom: the run takes
-far longer than the task needs, "overthinks" a trivial extraction, and — if the caller just
-grabs the first content block hoping it's the answer — returns a `thinking` block instead.
+<!-- /section: llm-call-surface -->
 
-### Worked example: a trivial fixed-shape-JSON task
-
-**Wrong** — one-shot intent sent through the multi-turn loop, then the answer string-parsed
-out of free text:
-
-```typescript
-// DON'T: models.run for a one-shot extraction — it loops and overthinks, and
-// "reply with only JSON" is brittle (prose, invalid JSON, or a leading
-// `thinking` block all break a naive `JSON.parse(content[0])`).
-const run = await ctx.sapiom.models.run({
-  prompt: `Reply with ONLY JSON: {"priority": "...", "category": "..."} for: ${input.text}`,
-});
-const parsed = JSON.parse(run.output ?? "{}"); // brittle, and pays for a reasoning loop
-```
-
-**Right** — `llm.run` with `output` for the fixed shape, read back with `structuredOf`
-(forced tool-use output has no `text` block — the result lives in `tool_use`, never
-`content[0]`):
-
-```typescript
-const response = await ctx.sapiom.llm.run({
-  request: {
-    messages: [
-      { role: "user", content: `Classify this support ticket: ${input.text}` },
-    ],
-    max_tokens: 256,
-  },
-  // No `model` — omit it and let the platform choose (recommended; passing
-  // "smart" would be a no-op — it already is the default — and a raw provider
-  // model id is never honored).
-  output: {
-    name: "classify_ticket",
-    schema: {
-      type: "object",
-      properties: {
-        priority: { type: "string", enum: ["low", "medium", "high"] },
-        category: { type: "string" },
-      },
-      required: ["priority", "category"],
-    },
-  },
-});
-
-const { priority, category } = ctx.sapiom.llm.structuredOf<{
-  priority: string;
-  category: string;
-}>(response)!;
-```
-
-`output` automates the forced tool call and its `tool_choice` wiring; `structuredOf` reads
-the result back out. For a **plain-text** reply instead, use
-`ctx.sapiom.llm.textOf(response)` — it reads only the `type === 'text'` block, skipping a
-`thinking` block that may precede it.
-
-### The label rule
-
-**You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
-`models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
-against its configured label set — never a raw provider model id (never honored, on any
-surface). Omit it entirely to let the platform choose (the recommended default) — passing
-`"smart"` is a no-op: it already is the default. The result discloses what actually served, in the platform's own
-vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
-lane it executed in) — never a model or provider id.
-
-### Debugging a run
-
-Find the run in the dashboard's run detail view, find the suspicious step's row id, then
-open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
-
-Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+<!-- section: agent-composition -->
 
 ## Composing Deployed Agents (System Design)
 
 **One agent per project — but a system is several projects.** The "keep exactly one
-`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system. A
-multi-stage system ("research → write script → voiceover → assemble → post") is not one
-big agent with five steps: it is several small agents, each its own project, deployed
-separately, composed by a thin coordinator that dispatches them by slug. A small deployed
-agent is independently testable, versioned, and reusable from more than one caller; a
-monolith couples every stage into a single deploy unit and step graph, so any stage change
-redeploys — and risks — all of them.
+`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system: a
+multi-stage system is several small agents, each its own project, deployed separately, composed
+by a thin coordinator that dispatches them by slug with `ctx.sapiom.agents.run`. `agents.run`
+resolves on ANY terminal status and does NOT throw — branch on
+`research.status !== "completed"` or a failed stage silently feeds `null` downstream. For a
+long-running child use `ctx.sapiom.agents.launch` and pause the calling step on the handle
+(`pauseUntilSignal`, below) so the coordinator's step doesn't time out. Deploy bottom-up —
+children first, the coordinator last, since it dispatches them by their slugs. The worked
+example is the served section
+[Composing deployed agents](https://api.sapiom.ai/v1/agents/authoring-rules#agent-composition).
 
-**Wrong** — one project inlining every stage as a step:
+<!-- /section: agent-composition -->
 
-```typescript
-// DON'T: video-pipeline/index.ts with research, script, voiceover, assemble,
-// post as five steps of ONE defineAgent. No stage is reusable or
-// independently testable, and every stage change redeploys all five.
-```
-
-**Right** — each stage its own deployed project; a coordinator composes them:
-
-```typescript
-// research-topic/, write-script/, generate-voiceover/, assemble-video/,
-// post-video/: five small projects, each deployed on its own slug.
-// video-pipeline/ is then just the coordinator:
-const research = await ctx.sapiom.agents.run({
-  definition: "research-topic", // the deployed child's slug
-  input: { topic: input.topic },
-});
-// agents.run resolves on ANY terminal status (completed | failed | cancelled)
-// and does NOT throw — a non-completed child is data the coordinator must
-// branch on, or a failed stage silently feeds `null` downstream.
-if (research.status !== "completed") {
-  // (fail() requires this step to declare canFail: true)
-  return fail(`research-topic ${research.status}: ${String(research.error)}`);
-}
-const script = await ctx.sapiom.agents.run({
-  definition: "write-script",
-  input: { research: research.output },
-});
-// …and so on. Use agents.launch + pauseUntilSignal for a long-running child
-// so the coordinator's step doesn't time out.
-```
-
-Building a system in one session? Scaffold the stages as separate projects and deploy
-bottom-up — children first, the coordinator last (it dispatches them by their slugs).
+<!-- section: platform-vocabulary -->
 
 ## Naming Conventions
 
-Several words are overloaded across this platform. Know which meaning a given context
-uses — conflating two costs you a wrong capability choice, not just a wrong word:
+"agent", "run", "task", "session", "dispatch" and "label" each carry several meanings on this
+platform, and conflating two costs you a wrong capability choice, not just a wrong word. The
+glossary — and the rule for new capabilities: don't re-overload "agent" or "run", give a new
+verb its own name — is the served section
+[Platform vocabulary](https://api.sapiom.ai/v1/agents/authoring-rules#platform-vocabulary).
 
-| Term         | Meaning(s) on this platform                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **agent**    | (1) `@sapiom/agent` — this authoring framework (`defineAgent`, this skill). (2) A **deployed agent** — one project's compiled definition, dispatched by `ctx.sapiom.agents.run`/`launch` (addressed by its slug via `AgentRunSpec.definition`) — the customer-facing name is always "agent." (3) `ctx.sapiom.models.run`'s managed multi-turn loop — a managed loop the platform runs for you; you call it, you never author it. (4) A **Claude Code subagent** — an unrelated feature of the coding tool itself, not part of the Sapiom SDK. |
-| **run**      | (1) `ctx.sapiom.llm.run` — one synchronous LLM call. (2) `ctx.sapiom.models.run` / `agents.run` — `launch()` + `wait()`, blocking until terminal (vs. `launch()` alone, which returns a pausable handle). (3) An execution instance/row of any of the above — the thing you inspect/debug. (4) The dashboard's Run button / Local Run / Prod Run (Studio UI actions, not an API call).                                                                                                                                                        |
-| **task**     | `CodingRunSpec.task` — the coding agent's prompt-equivalent field. Deliberately not called `prompt`: it's handed to a sandboxed coding agent, not a bare LLM call.                                                                                                                                                                                                                                                                                                                                                                            |
-| **session**  | (1) `ctx.sapiom.llm.createSession`/`callSession` — reserved LLM capacity accepting repeated drop-in calls until its TTL/budget ends it (replacing the deferred `submit`/`redeem` lane). (2) A Studio harness terminal session — unrelated, no LLM-capacity semantics.                                                                                                                                                                                                                                                                         |
-| **dispatch** | The structural contract (`DispatchHandle`) a long-running capability's `launch()` handle satisfies so a step can `pauseUntilSignal(handle, …)` and resume on completion. Every dispatched capability (coding, `models.run`, `agents.run`, more later) shares this ONE contract — "dispatch" always means this pattern, never anything else.                                                                                                                                                                                                   |
-| **label**    | The author-facing term for a `model:`/`label:` _input_ value (e.g. `"smart"`) — never a raw provider model id (never honored, on any surface). Not a contradiction that a result's `servedClass` field says "class": that field _reports_ the billing class the platform resolved your label to — it's a disclosure field, not author-facing input vocabulary. You still write `label`; the platform still reports back `servedClass`.                                                                                                        |
-
-**The rule new capabilities must follow:** don't re-overload "agent" or "run" further. If a
-new capability needs its own verb, name it something else (`dispatch`, `launch`, `submit`,
-`create*`) rather than adding a sixth meaning to a word that already has five.
+<!-- /section: platform-vocabulary -->
 
 ## Failure Handling & Retries
 
@@ -604,38 +536,22 @@ Under `run_local`, a dispatch pause auto-resumes with the stub result; a manual 
 auto-resumes with `{}`. There is no manual-signal payload override in the local runner, so
 type the resumed step's input with optional fields accordingly.
 
+<!-- section: trigger-kinds -->
+
 ## Triggers — Run a Deployed Agent Without a Human
 
-A trigger is a persisted cloud object attached to a **deployed** agent by slug; each fire starts an
-independent production run. Create one with `sapiom_dev_agents_schedule` — `kind` picks the shape:
+A trigger is a persisted cloud object attached to a **deployed** agent by slug; each fire starts
+an independent production run. Create one with `sapiom_dev_agents_schedule` — `kind` is one of
+`schedule_cron`, `schedule_once`, `event`, `webhook` (the `event`/`webhook` kinds and
+`sapiom_dev_agents_schedule_secret` need `@sapiom/mcp` >= 0.15). "Run this agent when an
+external system POSTs to us" is a `webhook` trigger, not a hand-built HTTP server. The required
+field per kind, the signing scheme a webhook sender must follow, secret rotation, and why a
+Slack / Stripe / GitHub / Meta sender needs an App Link `/hook/*` receiver instead of our HMAC:
+served sections [Trigger kinds](https://api.sapiom.ai/v1/agents/authoring-rules#trigger-kinds)
+and [App Links and third-party webhooks](https://api.sapiom.ai/v1/agents/authoring-rules#app-links).
+Full guide: [Triggers](https://docs.sapiom.ai/guides/triggers).
 
-| `kind`          | Fires when                                                                                                                    | Required field                                          |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `schedule_cron` | on a recurring cron (validate it first with `sapiom_dev_agents_cron_preview`)                                                 | `cron` (optional `timezone`)                            |
-| `schedule_once` | once, at a future time                                                                                                        | `at` (ISO 8601)                                         |
-| `event`         | every time this tenant emits that event type through the tenant events API (`{ type, payload }`; route in the Triggers guide) | `eventType` (`lead.created`; `sapiom.*` is reserved)    |
-| `webhook`       | every time an external system POSTs to a public hook URL minted for the trigger                                               | none — the result returns the URL + a shown-once secret |
-
-"Run this agent when an external system POSTs to us" is a **`webhook` trigger**, not a hand-built
-HTTP server. The create result carries the hook URL, the secret (shown once — it is derived,
-never stored, and cannot be read back), and the signing scheme every request must follow:
-
-- `X-Sapiom-Signature` = HMAC-SHA256(secret, `<X-Sapiom-Timestamp>.<X-Sapiom-Event-Id>.<raw body>`), lowercase hex
-- `X-Sapiom-Timestamp` = Unix epoch **milliseconds**, accepted within ±5 minutes
-- `X-Sapiom-Event-Id` = sender-chosen delivery id (`[A-Za-z0-9_-]{1,128}`); a repeat is deduplicated, so retries are safe
-- body = a JSON object (≤ 1 MiB) — it becomes the run input, folded over the trigger's stored `input`
-
-Only a sender you control can sign like that. **Slack, Meta (WhatsApp), Stripe, GitHub and other
-third parties sign with their own schemes and cannot produce our HMAC** — give them an
-[App Link](https://docs.sapiom.ai/capabilities/app-links) `/hook/*` receiver (`webhooksEnabled`)
-that verifies _their_ signature and then emits a tenant event or starts the run through the API,
-or a small translator that re-signs into a webhook trigger.
-
-`sapiom_dev_agents_schedule_inspect` and `_schedule_cancel` cover every kind (inspect never shows
-a webhook secret). `sapiom_dev_agents_schedule_secret` rotates a webhook secret (`rotate` → new
-secret, the old one verifies for a 24h grace → `complete_rotation` ends the grace early) or
-`revoke`s it (compromise: the hook dies now). The `event` / `webhook` kinds and the secret tool need
-`@sapiom/mcp` >= 0.15. Full guide: [Triggers](https://docs.sapiom.ai/guides/triggers).
+<!-- /section: trigger-kinds -->
 
 ## Determinism
 
@@ -730,10 +646,9 @@ Write each step the way it should run in production — never weaken logic to sh
 - **One `defineAgent` export per file.** The scaffold wraps a single `index.ts`.
 - **`ctx.shared` for fanout.** When three steps all need the entry input, write it into
   `ctx.shared` in the entry step — don't thread it through every `goto` payload.
-- **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
-  [remote MCP](https://docs.sapiom.ai/integration/mcp-servers/remote) (`https://api.sapiom.ai/v1/mcp`,
-  direct `sapiom_*` tools, `tool_discover` to find the right one) or the typed SDK client
-  ([`@sapiom/tools`](https://www.npmjs.com/package/@sapiom/tools)) instead of scaffolding.
+- **One-off capability call, no automation to keep?** That's not an agent — the served section
+  [One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent)
+  says which server or SDK client to use instead of scaffolding.
 
 ## Troubleshooting
 
@@ -751,11 +666,12 @@ Write each step the way it should run in production — never weaken logic to sh
 
 ## References
 
-| Resource                                                                     | What it covers                                                                |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| [Authoring guide](https://docs.sapiom.ai/agents/authoring)                   | Full step model, failure patterns, pause/resume, determinism                  |
-| [Quickstart](https://docs.sapiom.ai/agents/quick-start)                      | Scaffold → write → test → deploy walkthrough                                  |
-| [Capabilities](https://docs.sapiom.ai/capabilities)                          | The full `ctx.sapiom.*` catalog with pricing                                  |
-| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why             |
-| [Triggers](https://docs.sapiom.ai/guides/triggers)                           | Cron, one-off, event, and webhook triggers; webhook signing + secret rotation |
-| `AGENTS.md` in your scaffold                                                 | The quick in-project reference                                                |
+| Resource                                                                     | What it covers                                                                                                 |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [Platform rules (served)](https://api.sapiom.ai/v1/agents/authoring-rules)   | The live text every platform chapter above summarizes and points at; this copy was written against release 1.0 |
+| [Authoring guide](https://docs.sapiom.ai/agents/authoring)                   | Full step model, failure patterns, pause/resume, determinism                                                   |
+| [Quickstart](https://docs.sapiom.ai/agents/quick-start)                      | Scaffold → write → test → deploy walkthrough                                                                   |
+| [Capabilities](https://docs.sapiom.ai/capabilities)                          | The full `ctx.sapiom.*` catalog with pricing                                                                   |
+| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why                                              |
+| [Triggers](https://docs.sapiom.ai/guides/triggers)                           | Cron, one-off, event, and webhook triggers; webhook signing + secret rotation                                  |
+| `AGENTS.md` in your scaffold                                                 | The quick in-project reference                                                                                 |

--- a/packages/agent-core/templates/coding-pause/AGENTS.md
+++ b/packages/agent-core/templates/coding-pause/AGENTS.md
@@ -6,7 +6,7 @@ The full authoring guide ships inside this project at `.claude/skills/sapiom-age
 
 ## Authoring
 
-- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export — one agent per project. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (see the sapiom-agent-authoring skill’s "Composing Deployed Agents").
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export — one agent per project. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (the rule and its worked example: [Composing deployed agents](https://api.sapiom.ai/v1/agents/authoring-rules#agent-composition), summarized in the sapiom-agent-authoring skill).
 - **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
 
 ## The entry input contract
@@ -80,3 +80,13 @@ return pauseUntilSignal(run, { resumeStep: "finalize" }); // suspend on the run'
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Don't rely on a value being recomputed identically across a pause/resume — capture compact non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared`; persist bulk state and carry a reference.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -31,7 +31,9 @@ Sapiom regardless of your SDK version: one-off call vs agent, the capability cat
 lifetime, trigger kinds, App Links, which capability calls an LLM, composing deployed agents,
 vocabulary — are **served live** from <https://api.sapiom.ai/v1/agents/authoring-rules> and
 only summarized here; each such chapter is bracketed by `section:` markers naming the served
-section it points at. When a summary below and the served text disagree, the served text wins.
+section it points at. A pointer's `#name` fragment names that section's marker (an HTML
+comment, `section: name`) in the served text — the endpoint serves raw Markdown, so search for
+the marker rather than expecting a browser to jump to it. When a summary below and the served text disagree, the served text wins.
 This copy was written against release 1.0 of it; `sapiom_dev_agents_check` warns when the
 served copy differs.
 

--- a/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
+++ b/packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md
@@ -24,10 +24,26 @@ dashboard required.
 **Load this skill before scaffolding — it drives the whole lifecycle from zero.** Inside a
 scaffolded project, `AGENTS.md` is the quick reference; this skill is the deep guide.
 
-## If the Sapiom dev MCP isn't connected yet
+**Two kinds of content live here, and they update differently.** The authoring _mechanics_ —
+the step model, directives, `ctx.shared`, pause/resume, local stubs — describe the
+`@sapiom/agent` in your `node_modules` and ship with it. The _platform rules_ — what is true of
+Sapiom regardless of your SDK version: one-off call vs agent, the capability catalog, database
+lifetime, trigger kinds, App Links, which capability calls an LLM, composing deployed agents,
+vocabulary — are **served live** from <https://api.sapiom.ai/v1/agents/authoring-rules> and
+only summarized here; each such chapter is bracketed by `section:` markers naming the served
+section it points at. When a summary below and the served text disagree, the served text wins.
+This copy was written against release 1.0 of it; `sapiom_dev_agents_check` warns when the
+served copy differs.
 
-The lifecycle below runs through the **sapiom-dev** MCP server (`@sapiom/mcp`). If its tools
-(`sapiom_authenticate`, `sapiom_dev_agents_*`) aren't available, add the server first:
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->
+
+<!-- section: one-off-vs-agent -->
+
+## If the local authoring server isn't connected yet
+
+The lifecycle below runs through **the local authoring server** — the `@sapiom/mcp` package,
+stdio. If its tools (`sapiom_authenticate`, `sapiom_dev_agents_*`) aren't available, add it
+first:
 
 ```bash
 claude mcp add sapiom -- npx -y @sapiom/mcp
@@ -35,6 +51,12 @@ claude mcp add sapiom -- npx -y @sapiom/mcp
 
 Other clients: run `npx -y @sapiom/mcp` as a local (stdio) MCP server — see
 [docs.sapiom.ai](https://docs.sapiom.ai/integration/mcp-servers/setup) for per-client config.
+Sapiom's other server, **the hosted capability server** (`https://api.sapiom.ai/v1/mcp`), is
+for a one-off call with no automation to keep; which server a task belongs to, and what local
+work does and does not spend, is the served section
+[One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent).
+
+<!-- /section: one-off-vs-agent -->
 
 ## Lifecycle from Zero
 
@@ -71,7 +93,9 @@ filesystem, process, environment, network, and third-party services.
 
 Run `sapiom_authenticate` — it opens a browser login and caches an API key in
 `~/.sapiom/credentials.json`. Confirm with `sapiom_status`. This makes your coding agent an
-API-key principal; link, deploy, and cloud run require it.
+API-key principal; link, deploy, and cloud run require it. Which server's `sapiom_authenticate` that is (the one
+alongside the `sapiom_dev_agents_*` tools) and why local work needs no account: served section
+[One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent).
 
 ### 4. Link → deploy → run → inspect
 
@@ -276,25 +300,34 @@ reference instead.
 | `ctx.organizationId` | `string \| null`                 | Tenant org                                                                                                                                                |
 | `ctx.tenantId`       | `string \| null`                 | Tenant id                                                                                                                                                 |
 
+<!-- section: capability-catalog -->
+
 ## Capabilities from Steps
 
-Steps call Sapiom's paid capabilities through `ctx.sapiom.*` — sandboxes, repositories,
-coding models (`ctx.sapiom.models.coding`), file storage, content generation, search,
-databases, email, domains, memory, and more as they land. **Do not memorize the catalog:
-types are the source of truth.** The full surface is the `Sapiom` interface in `@sapiom/tools`
-— installed in your project's `node_modules`, so its types match the exact version you're on.
-`ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
-catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
+Steps call Sapiom's paid capabilities through the typed `ctx.sapiom.*` client. **Do not
+memorize the catalog: types are the source of truth.** The full surface is the `Sapiom`
+interface in `@sapiom/tools` — installed in your project's `node_modules`, so its types match
+the exact version you're on. `ctx.sapiom.` autocompletes what exists, `npm run typecheck`
+rejects what doesn't, and the catalog with pricing lives at
+[docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities). What the catalog spans, how
+per-agent secrets and the read-only Vault reach a step, and why triggers are cloud objects
+rather than `ctx.sapiom` calls: served section
+[Capabilities from steps](https://api.sapiom.ai/v1/agents/authoring-rules#capability-catalog).
+Database lifetime and metering: served section
+[Database lifecycle](https://api.sapiom.ai/v1/agents/authoring-rules#database-lifecycle).
+
+<!-- /section: capability-catalog -->
 
 ### Secrets, `agents.launch`, receipts, App Link webhooks
 
-Taught once, in the served `sapiom-dev` primer (in your context from the moment the MCP
-connects) and on docs.sapiom.ai — not restated here. Per-agent secrets and the read-only
-Vault: [Credentials and
-configuration](https://docs.sapiom.ai/reference/credentials-and-configuration). Fire-and-forget
-dispatch with `ctx.sapiom.agents.launch`: "Composing Deployed Agents" below and
-[Authoring](https://docs.sapiom.ai/agents/authoring). Receipts and manual replay of inbound
-events: the primer's REST pointers. App Link `/hook/*` webhooks:
+Taught once, in the served text — not restated here. Per-agent secrets and the read-only Vault:
+[Capabilities from steps](https://api.sapiom.ai/v1/agents/authoring-rules#capability-catalog) and
+[Credentials and configuration](https://docs.sapiom.ai/reference/credentials-and-configuration).
+Fire-and-forget dispatch with `ctx.sapiom.agents.launch`: "Composing Deployed Agents" below and
+[Composing deployed agents](https://api.sapiom.ai/v1/agents/authoring-rules#agent-composition).
+Receipts and manual replay of inbound events: the local authoring server's served primer (in
+your context from the moment it connects) and its REST pointers. App Link `/hook/*` webhooks:
+[App Links and third-party webhooks](https://api.sapiom.ai/v1/agents/authoring-rules#app-links) and
 [App Links](https://docs.sapiom.ai/capabilities/app-links#webhooks).
 
 ### Coding Repository Errors
@@ -327,157 +360,56 @@ try {
 }
 ```
 
+<!-- section: llm-call-surface -->
+
 ## Calling LLMs from Steps
 
-Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the
-job is the most common mistake in authored agents:
+Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the job is
+the most common mistake in authored agents. In one line each: `ctx.sapiom.llm.run` is ONE call
+(summarize, extract, classify, one-shot generate); `ctx.sapiom.models.run` is a platform-driven
+multi-turn reasoning + tool-calling loop (never for a one-shot — it loops and overthinks);
+`ctx.sapiom.agents.run` dispatches a DEPLOYED agent by slug. You never pick a model: omit
+`model` and let the platform route it — a raw provider model id is never honored on any surface.
 
-| Capability              | Use for                                                                                                                            | Never for                                                        |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `ctx.sapiom.llm.run`    | ONE LLM call — summarize, extract, classify, one-shot generate                                                                     | A multi-turn task, or anything needing its own tool-calling loop |
-| `ctx.sapiom.models.run` | A platform-driven multi-turn reasoning + tool-calling loop (minutes, not seconds). `models.coding.run` for sandboxed coding tasks. | A one-shot completion — it will loop and overthink               |
-| `ctx.sapiom.agents.run` | Dispatching a DEPLOYED agent by slug — composing systems from small deployed agents                                                | Anything that isn't itself a deployed agent                      |
+The full rule — the worked example (`llm.run` with `output`, read back with `structuredOf`;
+`textOf` for plain text; never `content[0]`), why `max_tokens` must budget for thinking as well
+as output, the label rule and the result's `servedClass`/`lane` disclosure, and how to debug a
+run in the Run Inspector — is the served section
+[Calling LLMs from steps](https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface).
+Read it before the first `llm.*` / `models.run` / `agents.run` call. Customer guide:
+[Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
 
-**⚠️ The mistake to never repeat:** sending single-shot, fixed-shape intent through
-`models.run`'s multi-turn loop instead of one `llm.run` call. The symptom: the run takes
-far longer than the task needs, "overthinks" a trivial extraction, and — if the caller just
-grabs the first content block hoping it's the answer — returns a `thinking` block instead.
+<!-- /section: llm-call-surface -->
 
-### Worked example: a trivial fixed-shape-JSON task
-
-**Wrong** — one-shot intent sent through the multi-turn loop, then the answer string-parsed
-out of free text:
-
-```typescript
-// DON'T: models.run for a one-shot extraction — it loops and overthinks, and
-// "reply with only JSON" is brittle (prose, invalid JSON, or a leading
-// `thinking` block all break a naive `JSON.parse(content[0])`).
-const run = await ctx.sapiom.models.run({
-  prompt: `Reply with ONLY JSON: {"priority": "...", "category": "..."} for: ${input.text}`,
-});
-const parsed = JSON.parse(run.output ?? "{}"); // brittle, and pays for a reasoning loop
-```
-
-**Right** — `llm.run` with `output` for the fixed shape, read back with `structuredOf`
-(forced tool-use output has no `text` block — the result lives in `tool_use`, never
-`content[0]`):
-
-```typescript
-const response = await ctx.sapiom.llm.run({
-  request: {
-    messages: [
-      { role: "user", content: `Classify this support ticket: ${input.text}` },
-    ],
-    max_tokens: 256,
-  },
-  // No `model` — omit it and let the platform choose (recommended; passing
-  // "smart" would be a no-op — it already is the default — and a raw provider
-  // model id is never honored).
-  output: {
-    name: "classify_ticket",
-    schema: {
-      type: "object",
-      properties: {
-        priority: { type: "string", enum: ["low", "medium", "high"] },
-        category: { type: "string" },
-      },
-      required: ["priority", "category"],
-    },
-  },
-});
-
-const { priority, category } = ctx.sapiom.llm.structuredOf<{
-  priority: string;
-  category: string;
-}>(response)!;
-```
-
-`output` automates the forced tool call and its `tool_choice` wiring; `structuredOf` reads
-the result back out. For a **plain-text** reply instead, use
-`ctx.sapiom.llm.textOf(response)` — it reads only the `type === 'text'` block, skipping a
-`thinking` block that may precede it.
-
-### The label rule
-
-**You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
-`models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
-against its configured label set — never a raw provider model id (never honored, on any
-surface). Omit it entirely to let the platform choose (the recommended default) — passing
-`"smart"` is a no-op: it already is the default. The result discloses what actually served, in the platform's own
-vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
-lane it executed in) — never a model or provider id.
-
-### Debugging a run
-
-Find the run in the dashboard's run detail view, find the suspicious step's row id, then
-open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
-
-Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+<!-- section: agent-composition -->
 
 ## Composing Deployed Agents (System Design)
 
 **One agent per project — but a system is several projects.** The "keep exactly one
-`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system. A
-multi-stage system ("research → write script → voiceover → assemble → post") is not one
-big agent with five steps: it is several small agents, each its own project, deployed
-separately, composed by a thin coordinator that dispatches them by slug. A small deployed
-agent is independently testable, versioned, and reusable from more than one caller; a
-monolith couples every stage into a single deploy unit and step graph, so any stage change
-redeploys — and risks — all of them.
+`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system: a
+multi-stage system is several small agents, each its own project, deployed separately, composed
+by a thin coordinator that dispatches them by slug with `ctx.sapiom.agents.run`. `agents.run`
+resolves on ANY terminal status and does NOT throw — branch on
+`research.status !== "completed"` or a failed stage silently feeds `null` downstream. For a
+long-running child use `ctx.sapiom.agents.launch` and pause the calling step on the handle
+(`pauseUntilSignal`, below) so the coordinator's step doesn't time out. Deploy bottom-up —
+children first, the coordinator last, since it dispatches them by their slugs. The worked
+example is the served section
+[Composing deployed agents](https://api.sapiom.ai/v1/agents/authoring-rules#agent-composition).
 
-**Wrong** — one project inlining every stage as a step:
+<!-- /section: agent-composition -->
 
-```typescript
-// DON'T: video-pipeline/index.ts with research, script, voiceover, assemble,
-// post as five steps of ONE defineAgent. No stage is reusable or
-// independently testable, and every stage change redeploys all five.
-```
-
-**Right** — each stage its own deployed project; a coordinator composes them:
-
-```typescript
-// research-topic/, write-script/, generate-voiceover/, assemble-video/,
-// post-video/: five small projects, each deployed on its own slug.
-// video-pipeline/ is then just the coordinator:
-const research = await ctx.sapiom.agents.run({
-  definition: "research-topic", // the deployed child's slug
-  input: { topic: input.topic },
-});
-// agents.run resolves on ANY terminal status (completed | failed | cancelled)
-// and does NOT throw — a non-completed child is data the coordinator must
-// branch on, or a failed stage silently feeds `null` downstream.
-if (research.status !== "completed") {
-  // (fail() requires this step to declare canFail: true)
-  return fail(`research-topic ${research.status}: ${String(research.error)}`);
-}
-const script = await ctx.sapiom.agents.run({
-  definition: "write-script",
-  input: { research: research.output },
-});
-// …and so on. Use agents.launch + pauseUntilSignal for a long-running child
-// so the coordinator's step doesn't time out.
-```
-
-Building a system in one session? Scaffold the stages as separate projects and deploy
-bottom-up — children first, the coordinator last (it dispatches them by their slugs).
+<!-- section: platform-vocabulary -->
 
 ## Naming Conventions
 
-Several words are overloaded across this platform. Know which meaning a given context
-uses — conflating two costs you a wrong capability choice, not just a wrong word:
+"agent", "run", "task", "session", "dispatch" and "label" each carry several meanings on this
+platform, and conflating two costs you a wrong capability choice, not just a wrong word. The
+glossary — and the rule for new capabilities: don't re-overload "agent" or "run", give a new
+verb its own name — is the served section
+[Platform vocabulary](https://api.sapiom.ai/v1/agents/authoring-rules#platform-vocabulary).
 
-| Term         | Meaning(s) on this platform                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **agent**    | (1) `@sapiom/agent` — this authoring framework (`defineAgent`, this skill). (2) A **deployed agent** — one project's compiled definition, dispatched by `ctx.sapiom.agents.run`/`launch` (addressed by its slug via `AgentRunSpec.definition`) — the customer-facing name is always "agent." (3) `ctx.sapiom.models.run`'s managed multi-turn loop — a managed loop the platform runs for you; you call it, you never author it. (4) A **Claude Code subagent** — an unrelated feature of the coding tool itself, not part of the Sapiom SDK. |
-| **run**      | (1) `ctx.sapiom.llm.run` — one synchronous LLM call. (2) `ctx.sapiom.models.run` / `agents.run` — `launch()` + `wait()`, blocking until terminal (vs. `launch()` alone, which returns a pausable handle). (3) An execution instance/row of any of the above — the thing you inspect/debug. (4) The dashboard's Run button / Local Run / Prod Run (Studio UI actions, not an API call).                                                                                                                                                        |
-| **task**     | `CodingRunSpec.task` — the coding agent's prompt-equivalent field. Deliberately not called `prompt`: it's handed to a sandboxed coding agent, not a bare LLM call.                                                                                                                                                                                                                                                                                                                                                                            |
-| **session**  | (1) `ctx.sapiom.llm.createSession`/`callSession` — reserved LLM capacity accepting repeated drop-in calls until its TTL/budget ends it (replacing the deferred `submit`/`redeem` lane). (2) A Studio harness terminal session — unrelated, no LLM-capacity semantics.                                                                                                                                                                                                                                                                         |
-| **dispatch** | The structural contract (`DispatchHandle`) a long-running capability's `launch()` handle satisfies so a step can `pauseUntilSignal(handle, …)` and resume on completion. Every dispatched capability (coding, `models.run`, `agents.run`, more later) shares this ONE contract — "dispatch" always means this pattern, never anything else.                                                                                                                                                                                                   |
-| **label**    | The author-facing term for a `model:`/`label:` _input_ value (e.g. `"smart"`) — never a raw provider model id (never honored, on any surface). Not a contradiction that a result's `servedClass` field says "class": that field _reports_ the billing class the platform resolved your label to — it's a disclosure field, not author-facing input vocabulary. You still write `label`; the platform still reports back `servedClass`.                                                                                                        |
-
-**The rule new capabilities must follow:** don't re-overload "agent" or "run" further. If a
-new capability needs its own verb, name it something else (`dispatch`, `launch`, `submit`,
-`create*`) rather than adding a sixth meaning to a word that already has five.
+<!-- /section: platform-vocabulary -->
 
 ## Failure Handling & Retries
 
@@ -604,38 +536,22 @@ Under `run_local`, a dispatch pause auto-resumes with the stub result; a manual 
 auto-resumes with `{}`. There is no manual-signal payload override in the local runner, so
 type the resumed step's input with optional fields accordingly.
 
+<!-- section: trigger-kinds -->
+
 ## Triggers — Run a Deployed Agent Without a Human
 
-A trigger is a persisted cloud object attached to a **deployed** agent by slug; each fire starts an
-independent production run. Create one with `sapiom_dev_agents_schedule` — `kind` picks the shape:
+A trigger is a persisted cloud object attached to a **deployed** agent by slug; each fire starts
+an independent production run. Create one with `sapiom_dev_agents_schedule` — `kind` is one of
+`schedule_cron`, `schedule_once`, `event`, `webhook` (the `event`/`webhook` kinds and
+`sapiom_dev_agents_schedule_secret` need `@sapiom/mcp` >= 0.15). "Run this agent when an
+external system POSTs to us" is a `webhook` trigger, not a hand-built HTTP server. The required
+field per kind, the signing scheme a webhook sender must follow, secret rotation, and why a
+Slack / Stripe / GitHub / Meta sender needs an App Link `/hook/*` receiver instead of our HMAC:
+served sections [Trigger kinds](https://api.sapiom.ai/v1/agents/authoring-rules#trigger-kinds)
+and [App Links and third-party webhooks](https://api.sapiom.ai/v1/agents/authoring-rules#app-links).
+Full guide: [Triggers](https://docs.sapiom.ai/guides/triggers).
 
-| `kind`          | Fires when                                                                                                                    | Required field                                          |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `schedule_cron` | on a recurring cron (validate it first with `sapiom_dev_agents_cron_preview`)                                                 | `cron` (optional `timezone`)                            |
-| `schedule_once` | once, at a future time                                                                                                        | `at` (ISO 8601)                                         |
-| `event`         | every time this tenant emits that event type through the tenant events API (`{ type, payload }`; route in the Triggers guide) | `eventType` (`lead.created`; `sapiom.*` is reserved)    |
-| `webhook`       | every time an external system POSTs to a public hook URL minted for the trigger                                               | none — the result returns the URL + a shown-once secret |
-
-"Run this agent when an external system POSTs to us" is a **`webhook` trigger**, not a hand-built
-HTTP server. The create result carries the hook URL, the secret (shown once — it is derived,
-never stored, and cannot be read back), and the signing scheme every request must follow:
-
-- `X-Sapiom-Signature` = HMAC-SHA256(secret, `<X-Sapiom-Timestamp>.<X-Sapiom-Event-Id>.<raw body>`), lowercase hex
-- `X-Sapiom-Timestamp` = Unix epoch **milliseconds**, accepted within ±5 minutes
-- `X-Sapiom-Event-Id` = sender-chosen delivery id (`[A-Za-z0-9_-]{1,128}`); a repeat is deduplicated, so retries are safe
-- body = a JSON object (≤ 1 MiB) — it becomes the run input, folded over the trigger's stored `input`
-
-Only a sender you control can sign like that. **Slack, Meta (WhatsApp), Stripe, GitHub and other
-third parties sign with their own schemes and cannot produce our HMAC** — give them an
-[App Link](https://docs.sapiom.ai/capabilities/app-links) `/hook/*` receiver (`webhooksEnabled`)
-that verifies _their_ signature and then emits a tenant event or starts the run through the API,
-or a small translator that re-signs into a webhook trigger.
-
-`sapiom_dev_agents_schedule_inspect` and `_schedule_cancel` cover every kind (inspect never shows
-a webhook secret). `sapiom_dev_agents_schedule_secret` rotates a webhook secret (`rotate` → new
-secret, the old one verifies for a 24h grace → `complete_rotation` ends the grace early) or
-`revoke`s it (compromise: the hook dies now). The `event` / `webhook` kinds and the secret tool need
-`@sapiom/mcp` >= 0.15. Full guide: [Triggers](https://docs.sapiom.ai/guides/triggers).
+<!-- /section: trigger-kinds -->
 
 ## Determinism
 
@@ -730,10 +646,9 @@ Write each step the way it should run in production — never weaken logic to sh
 - **One `defineAgent` export per file.** The scaffold wraps a single `index.ts`.
 - **`ctx.shared` for fanout.** When three steps all need the entry input, write it into
   `ctx.shared` in the entry step — don't thread it through every `goto` payload.
-- **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
-  [remote MCP](https://docs.sapiom.ai/integration/mcp-servers/remote) (`https://api.sapiom.ai/v1/mcp`,
-  direct `sapiom_*` tools, `tool_discover` to find the right one) or the typed SDK client
-  ([`@sapiom/tools`](https://www.npmjs.com/package/@sapiom/tools)) instead of scaffolding.
+- **One-off capability call, no automation to keep?** That's not an agent — the served section
+  [One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent)
+  says which server or SDK client to use instead of scaffolding.
 
 ## Troubleshooting
 
@@ -751,11 +666,12 @@ Write each step the way it should run in production — never weaken logic to sh
 
 ## References
 
-| Resource                                                                     | What it covers                                                                |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| [Authoring guide](https://docs.sapiom.ai/agents/authoring)                   | Full step model, failure patterns, pause/resume, determinism                  |
-| [Quickstart](https://docs.sapiom.ai/agents/quick-start)                      | Scaffold → write → test → deploy walkthrough                                  |
-| [Capabilities](https://docs.sapiom.ai/capabilities)                          | The full `ctx.sapiom.*` catalog with pricing                                  |
-| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why             |
-| [Triggers](https://docs.sapiom.ai/guides/triggers)                           | Cron, one-off, event, and webhook triggers; webhook signing + secret rotation |
-| `AGENTS.md` in your scaffold                                                 | The quick in-project reference                                                |
+| Resource                                                                     | What it covers                                                                                                 |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [Platform rules (served)](https://api.sapiom.ai/v1/agents/authoring-rules)   | The live text every platform chapter above summarizes and points at; this copy was written against release 1.0 |
+| [Authoring guide](https://docs.sapiom.ai/agents/authoring)                   | Full step model, failure patterns, pause/resume, determinism                                                   |
+| [Quickstart](https://docs.sapiom.ai/agents/quick-start)                      | Scaffold → write → test → deploy walkthrough                                                                   |
+| [Capabilities](https://docs.sapiom.ai/capabilities)                          | The full `ctx.sapiom.*` catalog with pricing                                                                   |
+| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why                                              |
+| [Triggers](https://docs.sapiom.ai/guides/triggers)                           | Cron, one-off, event, and webhook triggers; webhook signing + secret rotation                                  |
+| `AGENTS.md` in your scaffold                                                 | The quick in-project reference                                                                                 |

--- a/packages/agent-core/templates/default/AGENTS.md
+++ b/packages/agent-core/templates/default/AGENTS.md
@@ -6,7 +6,7 @@ The full authoring guide ships inside this project at `.claude/skills/sapiom-age
 
 ## Authoring
 
-- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export — one agent per project. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (see the sapiom-agent-authoring skill’s "Composing Deployed Agents").
+- An agent is `defineAgent({ entry, steps })`; each step is `defineStep({ name, next, run })`. Keep exactly one `defineAgent(...)` export — one agent per project. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (the rule and its worked example: [Composing deployed agents](https://api.sapiom.ai/v1/agents/authoring-rules#agent-composition), summarized in the sapiom-agent-authoring skill).
 - **Capabilities come from the types.** What's available on `ctx.sapiom` is defined by `@sapiom/tools` — read the types / use autocomplete rather than guessing. A wrong capability or method name fails typecheck.
 
 ## The entry input contract
@@ -80,3 +80,13 @@ return pauseUntilSignal(run, { resumeStep: "finalize" }); // suspend on the run'
 ## Determinism
 
 A step body runs **once** on the happy path; it re-runs only on retry (after a throw). Don't rely on a value being recomputed identically across a pause/resume — capture compact non-deterministic values (timestamps, ids) once and pass them forward via the `goto(...)` input or `ctx.shared`; persist bulk state and carry a reference.
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/packages/cli/templates/default/AGENTS.md
+++ b/packages/cli/templates/default/AGENTS.md
@@ -12,4 +12,14 @@ This project defines exactly one Sapiom agent in `index.ts`, authored against `@
 
 - Use `npm run check` as the tight feedback loop — prefer it over reasoning about whether the graph is valid.
 - For exact command options, run `sapiom agents --help`, and pass `--json` to any command for machine-readable output. Don't hardcode capability lists or schemas — query them at runtime.
-- Keep exactly one `defineAgent(...)` export in `index.ts` — one agent per project. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (see the sapiom-agent-authoring skill’s "Composing Deployed Agents").
+- Keep exactly one `defineAgent(...)` export in `index.ts` — one agent per project. A multi-stage system is several small projects composed with `ctx.sapiom.agents.run` (the rule and its worked example: [Composing deployed agents](https://api.sapiom.ai/v1/agents/authoring-rules#agent-composition), summarized in the sapiom-agent-authoring skill).
+
+## Platform rules (served, not restated here)
+
+The rules that are true of Sapiom regardless of this project's SDK version — which capability
+calls an LLM, database lifetime, trigger kinds, App Link webhooks, composing deployed agents —
+are served live at <https://api.sapiom.ai/v1/agents/authoring-rules> and summarized in the
+`sapiom-agent-authoring` skill's platform chapters. This file was written against release 1.0 of
+that text; `sapiom_dev_agents_check` warns when the served copy differs.
+
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->

--- a/packages/mcp/src/authoring-rules-drift.test.ts
+++ b/packages/mcp/src/authoring-rules-drift.test.ts
@@ -1,0 +1,173 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  authoringRulesDriftWarnings,
+  fetchServedAuthoringRulesStamp,
+  readProjectAuthoringRulesStamps,
+} from "./authoring-rules-drift.js";
+
+const env = { apiURL: "https://api.sapiom.ai" };
+const STAMP = "<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->";
+
+function servedResponse(headers: Record<string, string>, ok = true) {
+  return {
+    ok,
+    headers: new Headers(headers),
+    body: { cancel: () => Promise.resolve() },
+  } as unknown as Response;
+}
+
+function project(files: Record<string, string>): string {
+  const dir = mkdtempSync(path.join(tmpdir(), "sapiom-drift-"));
+  for (const [rel, content] of Object.entries(files)) {
+    mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true });
+    writeFileSync(path.join(dir, rel), content);
+  }
+  return dir;
+}
+
+describe("authoring-rules drift check", () => {
+  let originalFetch: typeof globalThis.fetch;
+  let dir: string | undefined;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+    dir = undefined;
+  });
+
+  describe("fetchServedAuthoringRulesStamp", () => {
+    it("reads the release and digest from the stamp headers on the resolved apiURL", async () => {
+      const fetchMock = vi.fn().mockResolvedValue(
+        servedResponse({
+          "x-sapiom-content-release": "1.1",
+          "x-sapiom-content-digest": "abcdefabcdef",
+        }),
+      );
+      globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+      await expect(fetchServedAuthoringRulesStamp(env)).resolves.toEqual({
+        release: "1.1",
+        digest: "abcdefabcdef",
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://api.sapiom.ai/v1/agents/authoring-rules",
+        expect.objectContaining({ signal: expect.anything() }),
+      );
+    });
+
+    it("is null on a non-200, on missing headers, and on a network error", async () => {
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          servedResponse({}, false),
+        ) as unknown as typeof globalThis.fetch;
+      await expect(fetchServedAuthoringRulesStamp(env)).resolves.toBeNull();
+
+      globalThis.fetch = vi
+        .fn()
+        .mockResolvedValue(
+          servedResponse({ "x-sapiom-content-release": "1.1" }),
+        ) as unknown as typeof globalThis.fetch;
+      await expect(fetchServedAuthoringRulesStamp(env)).resolves.toBeNull();
+
+      globalThis.fetch = vi
+        .fn()
+        .mockRejectedValue(
+          new Error("network down"),
+        ) as unknown as typeof globalThis.fetch;
+      await expect(fetchServedAuthoringRulesStamp(env)).resolves.toBeNull();
+    });
+  });
+
+  describe("readProjectAuthoringRulesStamps", () => {
+    it("finds the stamp in AGENTS.md and the scaffolded skill, and skips unstamped or absent files", async () => {
+      dir = project({
+        "AGENTS.md": `# Working in this agent\n\n${STAMP}\n`,
+        ".claude/skills/sapiom-agent-authoring/SKILL.md":
+          "---\nname: x\n---\nno stamp here",
+      });
+      await expect(readProjectAuthoringRulesStamps(dir)).resolves.toEqual([
+        {
+          file: "AGENTS.md",
+          stamp: { release: "1.0", digest: "1f3e5cd9648f" },
+        },
+      ]);
+    });
+  });
+
+  describe("authoringRulesDriftWarnings", () => {
+    it("makes no request and warns nothing when the project carries no stamp", async () => {
+      dir = project({ "AGENTS.md": "# hand-written, pre-stamp project\n" });
+      const fetchMock = vi.fn();
+      globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+
+      await expect(authoringRulesDriftWarnings(dir, env)).resolves.toEqual([]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("is silent when every stamp matches the served digest", async () => {
+      dir = project({ "AGENTS.md": `${STAMP}\n` });
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        servedResponse({
+          "x-sapiom-content-release": "1.0",
+          "x-sapiom-content-digest": "1f3e5cd9648f",
+        }),
+      ) as unknown as typeof globalThis.fetch;
+
+      await expect(authoringRulesDriftWarnings(dir, env)).resolves.toEqual([]);
+    });
+
+    it("warns once per stamped file that differs, naming both stamps and the URL, and never says 'older'", async () => {
+      dir = project({
+        "AGENTS.md": `${STAMP}\n`,
+        ".claude/skills/sapiom-agent-authoring/SKILL.md": `---\nname: sapiom-agent-authoring\n---\n${STAMP}\n`,
+      });
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        servedResponse({
+          "x-sapiom-content-release": "1.1",
+          "x-sapiom-content-digest": "abcdefabcdef",
+        }),
+      ) as unknown as typeof globalThis.fetch;
+
+      const warnings = await authoringRulesDriftWarnings(dir, env);
+
+      expect(warnings).toHaveLength(2);
+      expect(warnings[0]).toContain("AGENTS.md");
+      expect(warnings[1]).toContain(
+        path.join(".claude", "skills", "sapiom-agent-authoring", "SKILL.md"),
+      );
+      for (const warning of warnings) {
+        expect(warning).toContain("release 1.0 (digest 1f3e5cd9648f)");
+        expect(warning).toContain("differs");
+        expect(warning).toContain("release 1.1, digest abcdefabcdef");
+        expect(warning).toContain(
+          "https://api.sapiom.ai/v1/agents/authoring-rules",
+        );
+        // Digests do not order and release ids have collided (SAP-3190): the
+        // wording is "differs", never a ranking.
+        expect(warning).not.toMatch(/older|newer|outdated|behind/i);
+      }
+    });
+
+    it("stays silent when the server cannot be reached", async () => {
+      dir = project({ "AGENTS.md": `${STAMP}\n` });
+      globalThis.fetch = vi
+        .fn()
+        .mockRejectedValue(
+          new Error("offline"),
+        ) as unknown as typeof globalThis.fetch;
+
+      await expect(authoringRulesDriftWarnings(dir, env)).resolves.toEqual([]);
+    });
+  });
+});

--- a/packages/mcp/src/authoring-rules-drift.ts
+++ b/packages/mcp/src/authoring-rules-drift.ts
@@ -1,0 +1,109 @@
+/**
+ * Does this project's frozen copy of the platform rules still match what the
+ * server serves? (SAP-3181, the `check` half of SAP-2908 §3(d).)
+ *
+ * A scaffolded project carries two npm-shipped files that summarize and point
+ * at the served platform rules — `AGENTS.md` and the `sapiom-agent-authoring`
+ * skill — each stamped with the content release and body digest it was written
+ * against. Neither file can update itself: they are the user's, written once at
+ * scaffold time. What `check` can do is read the stamps, ask the server which
+ * release it serves (the `X-Sapiom-Content-*` headers of
+ * `GET /v1/agents/authoring-rules`, SAP-3190), and warn when they differ, so a
+ * stale copy is at least visible rather than silently authoritative.
+ *
+ * Wording is "differs from the served copy", never "older than": digests do not
+ * order, and release ids have collided. Best-effort by construction: no stamp
+ * in the project means no request at all, and a non-200, missing header,
+ * network error or 5 s timeout means no warning — `check` is a local pre-flight
+ * and must not fail, slow down materially, or nag because the network did.
+ */
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  AUTHORING_RULES_PATH,
+  authoringRulesDriftWarning,
+  parseAuthoringRulesStamp,
+  type AuthoringRulesStamp,
+} from "@sapiom/agent-core";
+
+import type { ResolvedEnvironment } from "./credentials.js";
+
+/** The project files that carry a stamp, relative to the project directory. */
+export const STAMPED_PROJECT_FILES = [
+  "AGENTS.md",
+  path.join(".claude", "skills", "sapiom-agent-authoring", "SKILL.md"),
+] as const;
+
+/** How long to wait for the rules endpoint before giving up on the comparison. */
+const FETCH_TIMEOUT_MS = 5000;
+
+/**
+ * Read the served release and digest from the endpoint's stamp headers. `null`
+ * on any failure — the comparison is then skipped, never reported. Only the
+ * headers are read; the body is discarded without buffering.
+ */
+export async function fetchServedAuthoringRulesStamp(
+  env: Pick<ResolvedEnvironment, "apiURL">,
+): Promise<AuthoringRulesStamp | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${env.apiURL}${AUTHORING_RULES_PATH}`, {
+      headers: { Accept: "text/markdown, text/plain" },
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const release = response.headers.get("x-sapiom-content-release");
+    const digest = response.headers.get("x-sapiom-content-digest");
+    // The body is not needed; release the connection without reading it.
+    await response.body?.cancel().catch(() => undefined);
+    return release && digest ? { release, digest } : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Read every stamped file in the project. A file that is absent or unstamped
+ * (a project scaffolded before stamps, or a hand-written AGENTS.md) is simply
+ * not in the result.
+ */
+export async function readProjectAuthoringRulesStamps(
+  sourceDir: string,
+): Promise<Array<{ file: string; stamp: AuthoringRulesStamp }>> {
+  const found: Array<{ file: string; stamp: AuthoringRulesStamp }> = [];
+  for (const file of STAMPED_PROJECT_FILES) {
+    let markdown: string;
+    try {
+      markdown = await readFile(path.join(sourceDir, file), "utf8");
+    } catch {
+      continue;
+    }
+    const stamp = parseAuthoringRulesStamp(markdown);
+    if (stamp) found.push({ file, stamp });
+  }
+  return found;
+}
+
+/**
+ * The warnings `sapiom_dev_agents_check` appends: one per stamped file whose
+ * digest differs from the served copy's. Empty when nothing is stamped, when the
+ * server cannot be reached, or when every stamp matches.
+ */
+export async function authoringRulesDriftWarnings(
+  sourceDir: string,
+  env: Pick<ResolvedEnvironment, "apiURL">,
+): Promise<string[]> {
+  const stamped = await readProjectAuthoringRulesStamps(sourceDir);
+  if (stamped.length === 0) return [];
+  const served = await fetchServedAuthoringRulesStamp(env);
+  if (!served) return [];
+  const url = `${env.apiURL}${AUTHORING_RULES_PATH}`;
+  return stamped.flatMap(({ file, stamp }) => {
+    const warning = authoringRulesDriftWarning(file, stamp, served, url);
+    return warning ? [warning] : [];
+  });
+}

--- a/packages/mcp/src/tools/agents.local-contract.test.ts
+++ b/packages/mcp/src/tools/agents.local-contract.test.ts
@@ -32,7 +32,11 @@ describe("local agent tool contracts", () => {
     register(server, env);
 
     const check = descriptions.get("sapiom_dev_agents_check") ?? "";
-    expect(check).toContain("no Sapiom account or service call");
+    expect(check).toContain("no Sapiom account or service call to validate");
+    // The one request it does make is named honestly — what it reads, that it is
+    // anonymous and best-effort, and that it never fails the check (SAP-3181).
+    expect(check).toContain("platform-rules stamp differs");
+    expect(check).toContain("best-effort anonymous read");
     expect(check).not.toMatch(/offline|instant/i);
 
     const runLocal = descriptions.get("sapiom_dev_agents_run_local") ?? "";

--- a/packages/mcp/src/tools/agents.ts
+++ b/packages/mcp/src/tools/agents.ts
@@ -45,6 +45,7 @@ import {
   type SchedulePolicy,
   type StubFile,
 } from "@sapiom/agent-core";
+import { authoringRulesDriftWarnings } from "../authoring-rules-drift.js";
 import { type ResolvedEnvironment } from "../credentials.js";
 import { registerTool } from "../register-tool.js";
 import {
@@ -204,7 +205,7 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
   registerTool(
     server,
     "sapiom_dev_agents_check",
-    "Validate an agent locally: typecheck, bundle and import index.ts, derive the manifest, and check the step graph. Needs no Sapiom account or service call; author-written top-level side effects still run when the definition is imported. Returns the agent name, step count, the manifest (which contains the full step graph for visualization), and any graph warnings.",
+    "Validate an agent locally: typecheck, bundle and import index.ts, derive the manifest, and check the step graph. Needs no Sapiom account or service call to validate; author-written top-level side effects still run when the definition is imported. Returns the agent name, step count, the manifest (which contains the full step graph for visualization), and any warnings — graph warnings, plus one per project file (AGENTS.md, the sapiom-agent-authoring skill) whose platform-rules stamp differs from the copy the Sapiom API currently serves, from a best-effort anonymous read of that endpoint's headers (skipped when the project carries no stamp, silent when unreachable).",
     {
       dir: z
         .string()
@@ -215,7 +216,13 @@ export function register(server: McpServer, env: ResolvedEnvironment): void {
     },
     async ({ dir }) => {
       try {
-        return ok(await check({ sourceDir: dir ?? process.cwd() }));
+        const sourceDir = dir ?? process.cwd();
+        const result = await check({ sourceDir });
+        // A scaffolded project's AGENTS.md and skill summarize the served platform
+        // rules and carry the release they were written against; they cannot update
+        // themselves, so this is where a stale copy gets named (SAP-3181).
+        const drift = await authoringRulesDriftWarnings(sourceDir, env);
+        return ok({ ...result, warnings: [...result.warnings, ...drift] });
       } catch (err) {
         return fail(err);
       }

--- a/packages/tools/src/llm/index.ts
+++ b/packages/tools/src/llm/index.ts
@@ -103,11 +103,12 @@ export interface LlmRunSpec {
    */
   request: Record<string, unknown>;
   /**
-   * Routing label (e.g. `"smart"`, `"small"`, `"medium"`, `"large"`). The
-   * gateway resolves it against its configured label set — a raw provider
-   * model id is never honored. Omit to let the gateway choose (the
-   * recommended default). `"smart"` IS that default, so pinning it is a no-op;
-   * pass `"small"`/`"medium"`/`"large"` only to pick a billing class deliberately.
+   * Routing label, resolved by the gateway against its configured label set —
+   * a raw provider model id is never honored. Omit it (recommended) to let the
+   * gateway choose; pass `"small"`/`"medium"`/`"large"` only to pick a billing
+   * class deliberately. The full rule, with the worked example, is the served
+   * platform text: https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface
+   * (written against release 1.0).
    */
   model?: RoutingLabel;
   /**
@@ -149,11 +150,12 @@ export interface LlmSubmitSpec {
    */
   request: Record<string, unknown>;
   /**
-   * Routing label (e.g. `"smart"`, `"small"`, `"medium"`, `"large"`). The
-   * gateway resolves it against its configured label set — a raw provider
-   * model id is never honored. Omit to let the gateway choose (the
-   * recommended default). `"smart"` IS that default, so pinning it is a no-op;
-   * pass `"small"`/`"medium"`/`"large"` only to pick a billing class deliberately.
+   * Routing label, resolved by the gateway against its configured label set —
+   * a raw provider model id is never honored. Omit it (recommended) to let the
+   * gateway choose; pass `"small"`/`"medium"`/`"large"` only to pick a billing
+   * class deliberately. The full rule, with the worked example, is the served
+   * platform text: https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface
+   * (written against release 1.0).
    */
   model?: RoutingLabel;
   /**

--- a/packages/tools/src/models/index.ts
+++ b/packages/tools/src/models/index.ts
@@ -76,11 +76,12 @@ export interface CodingRunSpec {
   /** Keep the sandbox alive after the run finishes. SDK default: true (the mesh needs it). */
   keepSandbox?: boolean;
   /**
-   * Routing label for the coding agent's LLM calls (e.g. `"smart"`). The
-   * platform resolves it against its configured label set — a raw provider
-   * model id is never honored. Omit to let the platform choose (the
-   * recommended default). `"smart"` IS that default, so pinning it is a no-op;
-   * pass `"small"`/`"medium"`/`"large"` only to pick a billing class deliberately.
+   * Routing label for the coding agent's LLM calls, resolved by the platform
+   * against its configured label set — a raw provider model id is never
+   * honored. Omit it (recommended) to let the platform choose; pass
+   * `"small"`/`"medium"`/`"large"` only to pick a billing class deliberately.
+   * The full rule is the served platform text: https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface
+   * (written against release 1.0).
    */
   model?: ModelLabel;
   /**
@@ -602,13 +603,14 @@ export interface ModelRunSpec {
   /** System prompt steering the agent. */
   system?: string;
   /**
-   * Routing label for the run's LLM calls (e.g. `"smart"`). The platform
-   * resolves it against its configured label set — a raw provider model id
-   * is never honored. An unrecognized value is never silently dropped: the
-   * run routes via the platform default and the platform reports it in the
-   * result's `warnings` (SAP-2765). Omit to let the platform choose (the
-   * recommended default). `"smart"` IS that default, so pinning it is a no-op;
-   * pass `"small"`/`"medium"`/`"large"` only to pick a billing class deliberately.
+   * Routing label for the run's LLM calls, resolved by the platform against
+   * its configured label set — a raw provider model id is never honored. An
+   * unrecognized value is never silently dropped: the run routes via the
+   * platform default and the platform reports it in the result's `warnings`
+   * (SAP-2765). Omit it (recommended) to let the platform choose; pass
+   * `"small"`/`"medium"`/`"large"` only to pick a billing class deliberately.
+   * The full rule is the served platform text: https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface
+   * (written against release 1.0).
    */
   model?: ModelLabel;
   /**

--- a/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
@@ -31,7 +31,9 @@ Sapiom regardless of your SDK version: one-off call vs agent, the capability cat
 lifetime, trigger kinds, App Links, which capability calls an LLM, composing deployed agents,
 vocabulary — are **served live** from <https://api.sapiom.ai/v1/agents/authoring-rules> and
 only summarized here; each such chapter is bracketed by `section:` markers naming the served
-section it points at. When a summary below and the served text disagree, the served text wins.
+section it points at. A pointer's `#name` fragment names that section's marker (an HTML
+comment, `section: name`) in the served text — the endpoint serves raw Markdown, so search for
+the marker rather than expecting a browser to jump to it. When a summary below and the served text disagree, the served text wins.
 This copy was written against release 1.0 of it; `sapiom_dev_agents_check` warns when the
 served copy differs.
 

--- a/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
+++ b/plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md
@@ -24,10 +24,26 @@ dashboard required.
 **Load this skill before scaffolding — it drives the whole lifecycle from zero.** Inside a
 scaffolded project, `AGENTS.md` is the quick reference; this skill is the deep guide.
 
-## If the Sapiom dev MCP isn't connected yet
+**Two kinds of content live here, and they update differently.** The authoring _mechanics_ —
+the step model, directives, `ctx.shared`, pause/resume, local stubs — describe the
+`@sapiom/agent` in your `node_modules` and ship with it. The _platform rules_ — what is true of
+Sapiom regardless of your SDK version: one-off call vs agent, the capability catalog, database
+lifetime, trigger kinds, App Links, which capability calls an LLM, composing deployed agents,
+vocabulary — are **served live** from <https://api.sapiom.ai/v1/agents/authoring-rules> and
+only summarized here; each such chapter is bracketed by `section:` markers naming the served
+section it points at. When a summary below and the served text disagree, the served text wins.
+This copy was written against release 1.0 of it; `sapiom_dev_agents_check` warns when the
+served copy differs.
 
-The lifecycle below runs through the **sapiom-dev** MCP server (`@sapiom/mcp`). If its tools
-(`sapiom_authenticate`, `sapiom_dev_agents_*`) aren't available, add the server first:
+<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->
+
+<!-- section: one-off-vs-agent -->
+
+## If the local authoring server isn't connected yet
+
+The lifecycle below runs through **the local authoring server** — the `@sapiom/mcp` package,
+stdio. If its tools (`sapiom_authenticate`, `sapiom_dev_agents_*`) aren't available, add it
+first:
 
 ```bash
 claude mcp add sapiom -- npx -y @sapiom/mcp
@@ -35,6 +51,12 @@ claude mcp add sapiom -- npx -y @sapiom/mcp
 
 Other clients: run `npx -y @sapiom/mcp` as a local (stdio) MCP server — see
 [docs.sapiom.ai](https://docs.sapiom.ai/integration/mcp-servers/setup) for per-client config.
+Sapiom's other server, **the hosted capability server** (`https://api.sapiom.ai/v1/mcp`), is
+for a one-off call with no automation to keep; which server a task belongs to, and what local
+work does and does not spend, is the served section
+[One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent).
+
+<!-- /section: one-off-vs-agent -->
 
 ## Lifecycle from Zero
 
@@ -71,7 +93,9 @@ filesystem, process, environment, network, and third-party services.
 
 Run `sapiom_authenticate` — it opens a browser login and caches an API key in
 `~/.sapiom/credentials.json`. Confirm with `sapiom_status`. This makes your coding agent an
-API-key principal; link, deploy, and cloud run require it.
+API-key principal; link, deploy, and cloud run require it. Which server's `sapiom_authenticate` that is (the one
+alongside the `sapiom_dev_agents_*` tools) and why local work needs no account: served section
+[One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent).
 
 ### 4. Link → deploy → run → inspect
 
@@ -276,25 +300,34 @@ reference instead.
 | `ctx.organizationId` | `string \| null`                 | Tenant org                                                                                                                                                |
 | `ctx.tenantId`       | `string \| null`                 | Tenant id                                                                                                                                                 |
 
+<!-- section: capability-catalog -->
+
 ## Capabilities from Steps
 
-Steps call Sapiom's paid capabilities through `ctx.sapiom.*` — sandboxes, repositories,
-coding models (`ctx.sapiom.models.coding`), file storage, content generation, search,
-databases, email, domains, memory, and more as they land. **Do not memorize the catalog:
-types are the source of truth.** The full surface is the `Sapiom` interface in `@sapiom/tools`
-— installed in your project's `node_modules`, so its types match the exact version you're on.
-`ctx.sapiom.` autocompletes what exists, `npm run typecheck` rejects what doesn't, and the full
-catalog with pricing lives at [docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities).
+Steps call Sapiom's paid capabilities through the typed `ctx.sapiom.*` client. **Do not
+memorize the catalog: types are the source of truth.** The full surface is the `Sapiom`
+interface in `@sapiom/tools` — installed in your project's `node_modules`, so its types match
+the exact version you're on. `ctx.sapiom.` autocompletes what exists, `npm run typecheck`
+rejects what doesn't, and the catalog with pricing lives at
+[docs.sapiom.ai/capabilities](https://docs.sapiom.ai/capabilities). What the catalog spans, how
+per-agent secrets and the read-only Vault reach a step, and why triggers are cloud objects
+rather than `ctx.sapiom` calls: served section
+[Capabilities from steps](https://api.sapiom.ai/v1/agents/authoring-rules#capability-catalog).
+Database lifetime and metering: served section
+[Database lifecycle](https://api.sapiom.ai/v1/agents/authoring-rules#database-lifecycle).
+
+<!-- /section: capability-catalog -->
 
 ### Secrets, `agents.launch`, receipts, App Link webhooks
 
-Taught once, in the served `sapiom-dev` primer (in your context from the moment the MCP
-connects) and on docs.sapiom.ai — not restated here. Per-agent secrets and the read-only
-Vault: [Credentials and
-configuration](https://docs.sapiom.ai/reference/credentials-and-configuration). Fire-and-forget
-dispatch with `ctx.sapiom.agents.launch`: "Composing Deployed Agents" below and
-[Authoring](https://docs.sapiom.ai/agents/authoring). Receipts and manual replay of inbound
-events: the primer's REST pointers. App Link `/hook/*` webhooks:
+Taught once, in the served text — not restated here. Per-agent secrets and the read-only Vault:
+[Capabilities from steps](https://api.sapiom.ai/v1/agents/authoring-rules#capability-catalog) and
+[Credentials and configuration](https://docs.sapiom.ai/reference/credentials-and-configuration).
+Fire-and-forget dispatch with `ctx.sapiom.agents.launch`: "Composing Deployed Agents" below and
+[Composing deployed agents](https://api.sapiom.ai/v1/agents/authoring-rules#agent-composition).
+Receipts and manual replay of inbound events: the local authoring server's served primer (in
+your context from the moment it connects) and its REST pointers. App Link `/hook/*` webhooks:
+[App Links and third-party webhooks](https://api.sapiom.ai/v1/agents/authoring-rules#app-links) and
 [App Links](https://docs.sapiom.ai/capabilities/app-links#webhooks).
 
 ### Coding Repository Errors
@@ -327,157 +360,56 @@ try {
 }
 ```
 
+<!-- section: llm-call-surface -->
+
 ## Calling LLMs from Steps
 
-Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the
-job is the most common mistake in authored agents:
+Three DIFFERENT capabilities call an LLM from step code — picking the wrong one for the job is
+the most common mistake in authored agents. In one line each: `ctx.sapiom.llm.run` is ONE call
+(summarize, extract, classify, one-shot generate); `ctx.sapiom.models.run` is a platform-driven
+multi-turn reasoning + tool-calling loop (never for a one-shot — it loops and overthinks);
+`ctx.sapiom.agents.run` dispatches a DEPLOYED agent by slug. You never pick a model: omit
+`model` and let the platform route it — a raw provider model id is never honored on any surface.
 
-| Capability              | Use for                                                                                                                            | Never for                                                        |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `ctx.sapiom.llm.run`    | ONE LLM call — summarize, extract, classify, one-shot generate                                                                     | A multi-turn task, or anything needing its own tool-calling loop |
-| `ctx.sapiom.models.run` | A platform-driven multi-turn reasoning + tool-calling loop (minutes, not seconds). `models.coding.run` for sandboxed coding tasks. | A one-shot completion — it will loop and overthink               |
-| `ctx.sapiom.agents.run` | Dispatching a DEPLOYED agent by slug — composing systems from small deployed agents                                                | Anything that isn't itself a deployed agent                      |
+The full rule — the worked example (`llm.run` with `output`, read back with `structuredOf`;
+`textOf` for plain text; never `content[0]`), why `max_tokens` must budget for thinking as well
+as output, the label rule and the result's `servedClass`/`lane` disclosure, and how to debug a
+run in the Run Inspector — is the served section
+[Calling LLMs from steps](https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface).
+Read it before the first `llm.*` / `models.run` / `agents.run` call. Customer guide:
+[Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
 
-**⚠️ The mistake to never repeat:** sending single-shot, fixed-shape intent through
-`models.run`'s multi-turn loop instead of one `llm.run` call. The symptom: the run takes
-far longer than the task needs, "overthinks" a trivial extraction, and — if the caller just
-grabs the first content block hoping it's the answer — returns a `thinking` block instead.
+<!-- /section: llm-call-surface -->
 
-### Worked example: a trivial fixed-shape-JSON task
-
-**Wrong** — one-shot intent sent through the multi-turn loop, then the answer string-parsed
-out of free text:
-
-```typescript
-// DON'T: models.run for a one-shot extraction — it loops and overthinks, and
-// "reply with only JSON" is brittle (prose, invalid JSON, or a leading
-// `thinking` block all break a naive `JSON.parse(content[0])`).
-const run = await ctx.sapiom.models.run({
-  prompt: `Reply with ONLY JSON: {"priority": "...", "category": "..."} for: ${input.text}`,
-});
-const parsed = JSON.parse(run.output ?? "{}"); // brittle, and pays for a reasoning loop
-```
-
-**Right** — `llm.run` with `output` for the fixed shape, read back with `structuredOf`
-(forced tool-use output has no `text` block — the result lives in `tool_use`, never
-`content[0]`):
-
-```typescript
-const response = await ctx.sapiom.llm.run({
-  request: {
-    messages: [
-      { role: "user", content: `Classify this support ticket: ${input.text}` },
-    ],
-    max_tokens: 256,
-  },
-  // No `model` — omit it and let the platform choose (recommended; passing
-  // "smart" would be a no-op — it already is the default — and a raw provider
-  // model id is never honored).
-  output: {
-    name: "classify_ticket",
-    schema: {
-      type: "object",
-      properties: {
-        priority: { type: "string", enum: ["low", "medium", "high"] },
-        category: { type: "string" },
-      },
-      required: ["priority", "category"],
-    },
-  },
-});
-
-const { priority, category } = ctx.sapiom.llm.structuredOf<{
-  priority: string;
-  category: string;
-}>(response)!;
-```
-
-`output` automates the forced tool call and its `tool_choice` wiring; `structuredOf` reads
-the result back out. For a **plain-text** reply instead, use
-`ctx.sapiom.llm.textOf(response)` — it reads only the `type === 'text'` block, skipping a
-`thinking` block that may precede it.
-
-### The label rule
-
-**You never pick a model.** Every `model`/`label` field across `llm.*`, `models.run`, and
-`models.coding.run` takes a **routing label** (e.g. `"smart"`) that the platform resolves
-against its configured label set — never a raw provider model id (never honored, on any
-surface). Omit it entirely to let the platform choose (the recommended default) — passing
-`"smart"` is a no-op: it already is the default. The result discloses what actually served, in the platform's own
-vocabulary — `servedClass` (the billing size the label resolved to) and `lane` (the billing
-lane it executed in) — never a model or provider id.
-
-### Debugging a run
-
-Find the run in the dashboard's run detail view, find the suspicious step's row id, then
-open the **Run Inspector** for that step's full-fidelity input/output/error/logs.
-
-Full guide: [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface).
+<!-- section: agent-composition -->
 
 ## Composing Deployed Agents (System Design)
 
 **One agent per project — but a system is several projects.** The "keep exactly one
-`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system. A
-multi-stage system ("research → write script → voiceover → assemble → post") is not one
-big agent with five steps: it is several small agents, each its own project, deployed
-separately, composed by a thin coordinator that dispatches them by slug. A small deployed
-agent is independently testable, versioned, and reusable from more than one caller; a
-monolith couples every stage into a single deploy unit and step graph, so any stage change
-redeploys — and risks — all of them.
+`defineAgent(...)` export" rule is a statement about a PROJECT, not about your system: a
+multi-stage system is several small agents, each its own project, deployed separately, composed
+by a thin coordinator that dispatches them by slug with `ctx.sapiom.agents.run`. `agents.run`
+resolves on ANY terminal status and does NOT throw — branch on
+`research.status !== "completed"` or a failed stage silently feeds `null` downstream. For a
+long-running child use `ctx.sapiom.agents.launch` and pause the calling step on the handle
+(`pauseUntilSignal`, below) so the coordinator's step doesn't time out. Deploy bottom-up —
+children first, the coordinator last, since it dispatches them by their slugs. The worked
+example is the served section
+[Composing deployed agents](https://api.sapiom.ai/v1/agents/authoring-rules#agent-composition).
 
-**Wrong** — one project inlining every stage as a step:
+<!-- /section: agent-composition -->
 
-```typescript
-// DON'T: video-pipeline/index.ts with research, script, voiceover, assemble,
-// post as five steps of ONE defineAgent. No stage is reusable or
-// independently testable, and every stage change redeploys all five.
-```
-
-**Right** — each stage its own deployed project; a coordinator composes them:
-
-```typescript
-// research-topic/, write-script/, generate-voiceover/, assemble-video/,
-// post-video/: five small projects, each deployed on its own slug.
-// video-pipeline/ is then just the coordinator:
-const research = await ctx.sapiom.agents.run({
-  definition: "research-topic", // the deployed child's slug
-  input: { topic: input.topic },
-});
-// agents.run resolves on ANY terminal status (completed | failed | cancelled)
-// and does NOT throw — a non-completed child is data the coordinator must
-// branch on, or a failed stage silently feeds `null` downstream.
-if (research.status !== "completed") {
-  // (fail() requires this step to declare canFail: true)
-  return fail(`research-topic ${research.status}: ${String(research.error)}`);
-}
-const script = await ctx.sapiom.agents.run({
-  definition: "write-script",
-  input: { research: research.output },
-});
-// …and so on. Use agents.launch + pauseUntilSignal for a long-running child
-// so the coordinator's step doesn't time out.
-```
-
-Building a system in one session? Scaffold the stages as separate projects and deploy
-bottom-up — children first, the coordinator last (it dispatches them by their slugs).
+<!-- section: platform-vocabulary -->
 
 ## Naming Conventions
 
-Several words are overloaded across this platform. Know which meaning a given context
-uses — conflating two costs you a wrong capability choice, not just a wrong word:
+"agent", "run", "task", "session", "dispatch" and "label" each carry several meanings on this
+platform, and conflating two costs you a wrong capability choice, not just a wrong word. The
+glossary — and the rule for new capabilities: don't re-overload "agent" or "run", give a new
+verb its own name — is the served section
+[Platform vocabulary](https://api.sapiom.ai/v1/agents/authoring-rules#platform-vocabulary).
 
-| Term         | Meaning(s) on this platform                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **agent**    | (1) `@sapiom/agent` — this authoring framework (`defineAgent`, this skill). (2) A **deployed agent** — one project's compiled definition, dispatched by `ctx.sapiom.agents.run`/`launch` (addressed by its slug via `AgentRunSpec.definition`) — the customer-facing name is always "agent." (3) `ctx.sapiom.models.run`'s managed multi-turn loop — a managed loop the platform runs for you; you call it, you never author it. (4) A **Claude Code subagent** — an unrelated feature of the coding tool itself, not part of the Sapiom SDK. |
-| **run**      | (1) `ctx.sapiom.llm.run` — one synchronous LLM call. (2) `ctx.sapiom.models.run` / `agents.run` — `launch()` + `wait()`, blocking until terminal (vs. `launch()` alone, which returns a pausable handle). (3) An execution instance/row of any of the above — the thing you inspect/debug. (4) The dashboard's Run button / Local Run / Prod Run (Studio UI actions, not an API call).                                                                                                                                                        |
-| **task**     | `CodingRunSpec.task` — the coding agent's prompt-equivalent field. Deliberately not called `prompt`: it's handed to a sandboxed coding agent, not a bare LLM call.                                                                                                                                                                                                                                                                                                                                                                            |
-| **session**  | (1) `ctx.sapiom.llm.createSession`/`callSession` — reserved LLM capacity accepting repeated drop-in calls until its TTL/budget ends it (replacing the deferred `submit`/`redeem` lane). (2) A Studio harness terminal session — unrelated, no LLM-capacity semantics.                                                                                                                                                                                                                                                                         |
-| **dispatch** | The structural contract (`DispatchHandle`) a long-running capability's `launch()` handle satisfies so a step can `pauseUntilSignal(handle, …)` and resume on completion. Every dispatched capability (coding, `models.run`, `agents.run`, more later) shares this ONE contract — "dispatch" always means this pattern, never anything else.                                                                                                                                                                                                   |
-| **label**    | The author-facing term for a `model:`/`label:` _input_ value (e.g. `"smart"`) — never a raw provider model id (never honored, on any surface). Not a contradiction that a result's `servedClass` field says "class": that field _reports_ the billing class the platform resolved your label to — it's a disclosure field, not author-facing input vocabulary. You still write `label`; the platform still reports back `servedClass`.                                                                                                        |
-
-**The rule new capabilities must follow:** don't re-overload "agent" or "run" further. If a
-new capability needs its own verb, name it something else (`dispatch`, `launch`, `submit`,
-`create*`) rather than adding a sixth meaning to a word that already has five.
+<!-- /section: platform-vocabulary -->
 
 ## Failure Handling & Retries
 
@@ -604,38 +536,22 @@ Under `run_local`, a dispatch pause auto-resumes with the stub result; a manual 
 auto-resumes with `{}`. There is no manual-signal payload override in the local runner, so
 type the resumed step's input with optional fields accordingly.
 
+<!-- section: trigger-kinds -->
+
 ## Triggers — Run a Deployed Agent Without a Human
 
-A trigger is a persisted cloud object attached to a **deployed** agent by slug; each fire starts an
-independent production run. Create one with `sapiom_dev_agents_schedule` — `kind` picks the shape:
+A trigger is a persisted cloud object attached to a **deployed** agent by slug; each fire starts
+an independent production run. Create one with `sapiom_dev_agents_schedule` — `kind` is one of
+`schedule_cron`, `schedule_once`, `event`, `webhook` (the `event`/`webhook` kinds and
+`sapiom_dev_agents_schedule_secret` need `@sapiom/mcp` >= 0.15). "Run this agent when an
+external system POSTs to us" is a `webhook` trigger, not a hand-built HTTP server. The required
+field per kind, the signing scheme a webhook sender must follow, secret rotation, and why a
+Slack / Stripe / GitHub / Meta sender needs an App Link `/hook/*` receiver instead of our HMAC:
+served sections [Trigger kinds](https://api.sapiom.ai/v1/agents/authoring-rules#trigger-kinds)
+and [App Links and third-party webhooks](https://api.sapiom.ai/v1/agents/authoring-rules#app-links).
+Full guide: [Triggers](https://docs.sapiom.ai/guides/triggers).
 
-| `kind`          | Fires when                                                                                                                    | Required field                                          |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `schedule_cron` | on a recurring cron (validate it first with `sapiom_dev_agents_cron_preview`)                                                 | `cron` (optional `timezone`)                            |
-| `schedule_once` | once, at a future time                                                                                                        | `at` (ISO 8601)                                         |
-| `event`         | every time this tenant emits that event type through the tenant events API (`{ type, payload }`; route in the Triggers guide) | `eventType` (`lead.created`; `sapiom.*` is reserved)    |
-| `webhook`       | every time an external system POSTs to a public hook URL minted for the trigger                                               | none — the result returns the URL + a shown-once secret |
-
-"Run this agent when an external system POSTs to us" is a **`webhook` trigger**, not a hand-built
-HTTP server. The create result carries the hook URL, the secret (shown once — it is derived,
-never stored, and cannot be read back), and the signing scheme every request must follow:
-
-- `X-Sapiom-Signature` = HMAC-SHA256(secret, `<X-Sapiom-Timestamp>.<X-Sapiom-Event-Id>.<raw body>`), lowercase hex
-- `X-Sapiom-Timestamp` = Unix epoch **milliseconds**, accepted within ±5 minutes
-- `X-Sapiom-Event-Id` = sender-chosen delivery id (`[A-Za-z0-9_-]{1,128}`); a repeat is deduplicated, so retries are safe
-- body = a JSON object (≤ 1 MiB) — it becomes the run input, folded over the trigger's stored `input`
-
-Only a sender you control can sign like that. **Slack, Meta (WhatsApp), Stripe, GitHub and other
-third parties sign with their own schemes and cannot produce our HMAC** — give them an
-[App Link](https://docs.sapiom.ai/capabilities/app-links) `/hook/*` receiver (`webhooksEnabled`)
-that verifies _their_ signature and then emits a tenant event or starts the run through the API,
-or a small translator that re-signs into a webhook trigger.
-
-`sapiom_dev_agents_schedule_inspect` and `_schedule_cancel` cover every kind (inspect never shows
-a webhook secret). `sapiom_dev_agents_schedule_secret` rotates a webhook secret (`rotate` → new
-secret, the old one verifies for a 24h grace → `complete_rotation` ends the grace early) or
-`revoke`s it (compromise: the hook dies now). The `event` / `webhook` kinds and the secret tool need
-`@sapiom/mcp` >= 0.15. Full guide: [Triggers](https://docs.sapiom.ai/guides/triggers).
+<!-- /section: trigger-kinds -->
 
 ## Determinism
 
@@ -730,10 +646,9 @@ Write each step the way it should run in production — never weaken logic to sh
 - **One `defineAgent` export per file.** The scaffold wraps a single `index.ts`.
 - **`ctx.shared` for fanout.** When three steps all need the entry input, write it into
   `ctx.shared` in the entry step — don't thread it through every `goto` payload.
-- **One-off capability call, no automation to keep?** That's not an agent — use Sapiom's
-  [remote MCP](https://docs.sapiom.ai/integration/mcp-servers/remote) (`https://api.sapiom.ai/v1/mcp`,
-  direct `sapiom_*` tools, `tool_discover` to find the right one) or the typed SDK client
-  ([`@sapiom/tools`](https://www.npmjs.com/package/@sapiom/tools)) instead of scaffolding.
+- **One-off capability call, no automation to keep?** That's not an agent — the served section
+  [One-off call, or an agent?](https://api.sapiom.ai/v1/agents/authoring-rules#one-off-vs-agent)
+  says which server or SDK client to use instead of scaffolding.
 
 ## Troubleshooting
 
@@ -751,11 +666,12 @@ Write each step the way it should run in production — never weaken logic to sh
 
 ## References
 
-| Resource                                                                     | What it covers                                                                |
-| ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| [Authoring guide](https://docs.sapiom.ai/agents/authoring)                   | Full step model, failure patterns, pause/resume, determinism                  |
-| [Quickstart](https://docs.sapiom.ai/agents/quick-start)                      | Scaffold → write → test → deploy walkthrough                                  |
-| [Capabilities](https://docs.sapiom.ai/capabilities)                          | The full `ctx.sapiom.*` catalog with pricing                                  |
-| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why             |
-| [Triggers](https://docs.sapiom.ai/guides/triggers)                           | Cron, one-off, event, and webhook triggers; webhook signing + secret rotation |
-| `AGENTS.md` in your scaffold                                                 | The quick in-project reference                                                |
+| Resource                                                                     | What it covers                                                                                                 |
+| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| [Platform rules (served)](https://api.sapiom.ai/v1/agents/authoring-rules)   | The live text every platform chapter above summarizes and points at; this copy was written against release 1.0 |
+| [Authoring guide](https://docs.sapiom.ai/agents/authoring)                   | Full step model, failure patterns, pause/resume, determinism                                                   |
+| [Quickstart](https://docs.sapiom.ai/agents/quick-start)                      | Scaffold → write → test → deploy walkthrough                                                                   |
+| [Capabilities](https://docs.sapiom.ai/capabilities)                          | The full `ctx.sapiom.*` catalog with pricing                                                                   |
+| [Choose a call surface](https://docs.sapiom.ai/guides/choose-a-call-surface) | `llm.run` vs `models.run` vs `agents.run` — which to call and why                                              |
+| [Triggers](https://docs.sapiom.ai/guides/triggers)                           | Cron, one-off, event, and webhook triggers; webhook signing + secret rotation                                  |
+| `AGENTS.md` in your scaffold                                                 | The quick in-project reference                                                                                 |

--- a/scripts/authoring-rules-stamp.mjs
+++ b/scripts/authoring-rules-stamp.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Move every platform-rules stamp this repo ships to a new content release
+ * (SAP-3181).
+ *
+ *   node scripts/authoring-rules-stamp.mjs --from-served [URL]
+ *   node scripts/authoring-rules-stamp.mjs --release 1.1 --digest 0123456789ab
+ *
+ * The backend serves the platform rules at GET /v1/agents/authoring-rules and
+ * stamps each response with `X-Sapiom-Content-Release` / `X-Sapiom-Content-Digest`.
+ * The skill's platform chapters, every AGENTS.md, examples/AUTHORING.md, the
+ * `@sapiom/tools` JSDoc pointers and the constants in
+ * packages/agent-core/src/authoring-rules.ts all record which release they were
+ * written against, and `packages/agent-core/src/__tests__/authoring-rules-stamp.test.ts`
+ * fails when any of them disagree. When a release is cut, re-read the summaries
+ * against the new text, then run this once so the stamps move together.
+ */
+import { readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { isDigest, restamp } from "./lib/authoring-rules-stamp.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const DEFAULT_URL = "https://api.sapiom.ai/v1/agents/authoring-rules";
+
+/** Every file that carries a stamp in any of its forms. Mirrors the test's list. */
+export function stampedFiles(root = ROOT) {
+  const files = [
+    "packages/agent-core/src/authoring-rules.ts",
+    "packages/agent-core/skills/sapiom-agent-authoring/SKILL.md",
+    "packages/agent-core/templates/default/.claude/skills/sapiom-agent-authoring/SKILL.md",
+    "packages/agent-core/templates/coding-pause/.claude/skills/sapiom-agent-authoring/SKILL.md",
+    "plugins/sapiom/skills/sapiom-agent-authoring/SKILL.md",
+    "packages/agent-core/templates/default/AGENTS.md",
+    "packages/agent-core/templates/coding-pause/AGENTS.md",
+    "packages/cli/templates/default/AGENTS.md",
+    "packages/tools/src/llm/index.ts",
+    "packages/tools/src/models/index.ts",
+    "examples/AUTHORING.md",
+  ];
+  const examples = path.join(root, "examples");
+  for (const entry of readdirSync(examples)) {
+    const agentsMd = path.join(examples, entry, "AGENTS.md");
+    if (statSync(path.join(examples, entry)).isDirectory()) {
+      try {
+        statSync(agentsMd);
+        files.push(path.relative(root, agentsMd));
+      } catch {
+        // an example without an AGENTS.md carries nothing to stamp
+      }
+    }
+  }
+  return files.map((f) => path.join(root, f));
+}
+
+function parseArgs(argv) {
+  const args = { fromServed: false, url: DEFAULT_URL };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--from-served") {
+      args.fromServed = true;
+      if (argv[i + 1] && !argv[i + 1].startsWith("--")) args.url = argv[++i];
+    } else if (arg === "--release") args.release = argv[++i];
+    else if (arg === "--digest") args.digest = argv[++i];
+    else throw new Error(`unknown argument ${arg}`);
+  }
+  return args;
+}
+
+async function resolveStamp(args) {
+  if (args.fromServed) {
+    const response = await fetch(args.url, {
+      headers: { Accept: "text/markdown" },
+    });
+    if (!response.ok)
+      throw new Error(`${args.url} answered ${response.status}`);
+    const release = response.headers.get("x-sapiom-content-release");
+    const digest = response.headers.get("x-sapiom-content-digest");
+    if (!release || !digest)
+      throw new Error(`${args.url} sent no X-Sapiom-Content-* stamp headers`);
+    return { release, digest };
+  }
+  if (!args.release || !args.digest) {
+    throw new Error("pass --from-served [URL], or both --release and --digest");
+  }
+  return { release: args.release, digest: args.digest };
+}
+
+async function main() {
+  const stamp = await resolveStamp(parseArgs(process.argv.slice(2)));
+  if (!isDigest(stamp.digest))
+    throw new Error(`digest must be 12 hex characters, got ${stamp.digest}`);
+  let changed = 0;
+  for (const file of stampedFiles()) {
+    const before = readFileSync(file, "utf8");
+    const after = restamp(before, stamp);
+    if (after !== before) {
+      writeFileSync(file, after);
+      changed++;
+    }
+  }
+  console.log(
+    `stamped release ${stamp.release} (digest ${stamp.digest}) into ${changed} file(s); ` +
+      "now re-read each summary against the served text before committing.",
+  );
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });
+}

--- a/scripts/authoring-rules-stamp.test.mjs
+++ b/scripts/authoring-rules-stamp.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { restamp } from "./lib/authoring-rules-stamp.mjs";
+
+const next = { release: "1.1", digest: "abcdefabcdef" };
+
+test("moves the Markdown stamp and the prose release together", () => {
+  const before =
+    "This copy was written against release 1.0 of it.\n\n<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->\n";
+  assert.equal(
+    restamp(before, next),
+    "This copy was written against release 1.1 of it.\n\n<!-- sapiom-authoring-rules release=1.1 digest=abcdefabcdef -->\n",
+  );
+});
+
+test("moves the JSDoc pointer's release without touching the URL", () => {
+  const before =
+    " * https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface (written against release 1.0).\n";
+  assert.equal(
+    restamp(before, next),
+    " * https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface (written against release 1.1).\n",
+  );
+});
+
+test("moves both agent-core constants", () => {
+  const before =
+    'export const AUTHORING_RULES_RELEASE = "1.0";\nexport const AUTHORING_RULES_DIGEST = "1f3e5cd9648f";\n';
+  assert.equal(
+    restamp(before, next),
+    'export const AUTHORING_RULES_RELEASE = "1.1";\nexport const AUTHORING_RULES_DIGEST = "abcdefabcdef";\n',
+  );
+});
+
+test("leaves a file with nothing to stamp unchanged", () => {
+  const before = "# Working in this agent\n\nNo stamp here.\n";
+  assert.equal(restamp(before, next), before);
+});
+
+test("moves a JSDoc pointer whose release wrapped onto the next comment line", () => {
+  const before =
+    " * https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface\n * (written against release 1.0).\n";
+  assert.equal(
+    restamp(before, next),
+    " * https://api.sapiom.ai/v1/agents/authoring-rules#llm-call-surface\n * (written against release 1.1).\n",
+  );
+});

--- a/scripts/lib/authoring-rules-stamp.mjs
+++ b/scripts/lib/authoring-rules-stamp.mjs
@@ -1,0 +1,46 @@
+/**
+ * Pure rewriting for `scripts/authoring-rules-stamp.mjs`: move every stamp the
+ * repo ships to a new release/digest pair (SAP-3181). Kept free of I/O so the
+ * regexes can be unit-tested; the CLI wrapper walks the files.
+ */
+
+/** `<!-- sapiom-authoring-rules release=X digest=Y -->` in Markdown. */
+export const MARKDOWN_STAMP =
+  /<!--\s*sapiom-authoring-rules\s+release=\S+\s+digest=[0-9a-f]{12}\s*-->/g;
+
+/**
+ * `.../authoring-rules#section (written against release X)` — the JSDoc form,
+ * used where a comment cannot hold an HTML comment (`@sapiom/tools`).
+ */
+export const JSDOC_STAMP =
+  /(authoring-rules(?:#[a-z-]+)?\s*(?:\*\s*)?\(written against release )([^)\s]+)(\))/g;
+
+/** `AUTHORING_RULES_RELEASE = "…"` / `AUTHORING_RULES_DIGEST = "…"` in agent-core. */
+export const CONSTANT_STAMP =
+  /(export const AUTHORING_RULES_(RELEASE|DIGEST) =\s*)"[^"]*"/g;
+
+/** The prose form the skill, AGENTS.md and AUTHORING.md carry: "written against release X". */
+export const PROSE_STAMP = /(written against release )\d+\.\d+/g;
+
+export function renderMarkdownStamp({ release, digest }) {
+  return `<!-- sapiom-authoring-rules release=${release} digest=${digest} -->`;
+}
+
+/**
+ * Rewrite one file's contents for the new stamp. Returns the new text, or the
+ * input unchanged when the file carries nothing to move.
+ */
+export function restamp(source, { release, digest }) {
+  return source
+    .replace(MARKDOWN_STAMP, renderMarkdownStamp({ release, digest }))
+    .replace(JSDOC_STAMP, `$1${release}$3`)
+    .replace(PROSE_STAMP, `$1${release}`)
+    .replace(
+      CONSTANT_STAMP,
+      (_m, head, which) => `${head}"${which === "RELEASE" ? release : digest}"`,
+    );
+}
+
+export function isDigest(value) {
+  return /^[0-9a-f]{12}$/.test(value);
+}


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [x] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The platform rules an agent author must follow (one-off call vs agent, the capability catalog, database lifetime, trigger kinds, App Links, which capability calls an LLM, composing deployed agents, vocabulary) are served by the Sapiom API at `GET /v1/agents/authoring-rules` (SAP-3223), stamped with a content release and body digest (SAP-3190). This repo still shipped full restatements of them: the skill's platform chapters, 32 scaffolded `AGENTS.md` files, `examples/AUTHORING.md`, and `@sapiom/tools` JSDoc. A copy inside a scaffolded project is frozen at scaffold time and can never be corrected; JSDoc is hover text in every consumer's editor and updates only on npm upgrade. Both channels carried the 7-day database claim. SAP-2908 §3(b)/(d) asked for pointers plus a version stamp so drift is visible instead of silent.

## Summary and scope

- The `sapiom-agent-authoring` skill's platform chapters become a 3–6 line summary plus a pointer to the served section, bracketed by `<!-- section: … -->` / `<!-- /section: … -->` markers (the anchor names are the backend's contract) so SAP-3225's Studio splice has a target. Mechanics chapters are untouched. All four copies stay byte-identical (`skill-sync.test.ts`).
- Every `AGENTS.md` (29 examples + 3 templates) and `AUTHORING.md` gain a pointer paragraph and `<!-- sapiom-authoring-rules release=1.0 digest=1f3e5cd9648f -->`. The three restatements in them (two LLM-rule sentences, the `resources.duration` 7-day row) are repointed; `template.schema.json`'s `duration` is marked legacy (the backend stopped reading it in SAP-3100; declarations still parse).
- `@sapiom/tools` JSDoc on the `model` field of `llm.run`, `llm.submit`, `models.run`, `models.coding.run` keeps "omit; raw ids never honored; size labels pick a class" and points at the served rule with the release it was written against.
- `sapiom_dev_agents_check` reads the stamps in the project's `AGENTS.md` and skill, makes one best-effort anonymous read of the endpoint's `X-Sapiom-Content-*` headers, and appends a warning per file whose digest differs. No stamp → no request; unreachable → no warning. Wording is "differs from the served copy", never "older" (digests do not order; release ids have collided).
- `@sapiom/agent-core` exports the stamp vocabulary; `packages/agent-core/src/__tests__/authoring-rules-stamp.test.ts` holds every stamped file to the constants and every pointer anchor to the known section set; `node scripts/authoring-rules-stamp.mjs --from-served` moves them all on a release.

Out of scope: the `@sapiom/tools` database SDK still requires `duration` and documents the lifetime tiers (the SDK half of SAP-3100 has no PR yet, and its JSDoc is a type contract, not a restatement to pointer-ize); the scaffold-time fetch and Studio splice (SAP-3225); the monorepo pointer file (SAP-3224).

## Related work

Related issue or discussion: SAP-3181 (https://linear.app/sapiom/issue/SAP-3181). Decision memo for the pointer targets: SAP-3189. Backend half: sapiom/Sapiom#5051. Monorepo docs half of this ticket: sapiom/Sapiom PR (linked in the ticket).

## Validation

```text
# pnpm build — all packages, exit 0
# pnpm typecheck — clean
# pnpm lint — clean for tools, agent-core, mcp (pre-existing warnings only in core/axios/fetch/langchain)
# packages/agent-core: npx jest --maxWorkers=1 src/__tests__/authoring-rules-stamp.test.ts src/__tests__/skill-sync.test.ts — 59 passed
# pnpm --filter @sapiom/mcp test — 17 files, 186 passed, 3 skipped
# pnpm examples:check — OK (12 templates, 54 assets terminology-checked)
# node --test scripts/authoring-rules-stamp.test.mjs scripts/examples-llm-surface.test.mjs — 19 pass (stamp: 5 pass)
# pnpm terminology:check — passed (992 files)
# curl -sI https://api.sapiom.ai/v1/agents/authoring-rules — release 1.0, digest 1f3e5cd9648f (the stamp shipped here)
```

### Tests and documentation

New: `authoring-rules-stamp.test.ts` (stamp agreement across the repo, anchor validity, section-marker pairing, no leftover restatements, warning wording), `authoring-rules-drift.test.ts` (header read, silence with no stamp / unreachable / matching, one warning per differing file), `authoring-rules-stamp.test.mjs` (the rewrite regexes). Updated: `agents.local-contract.test.ts` for the check tool's new description. Documentation is the change.

## Compatibility and release impact

- Breaking or externally visible changes: `sapiom_dev_agents_check` may now include drift warnings in `warnings[]` and makes one anonymous GET when the project is stamped. No API or type changes.
- Changeset: Added (`@sapiom/agent-core` minor, `@sapiom/mcp` minor, `@sapiom/tools` patch, `@sapiom/cli` patch).

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Written with Claude Code (Claude Fable 5.1) in an Agent Orchestrator session; verified with the commands above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tX3Nipuko9j2ZHgjuJvjK
