### PR TITLE
fix(studio): interpret completion separately from tool progress [SAP-3290]

### DIFF
--- a/.changeset/clear-turn-results.md
+++ b/.changeset/clear-turn-results.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Add shared Assistant turn interpretation that distinguishes native activity, explicit completion reports, errors, and unconfirmed stops. Bind completion declarations to the current request and hide their bookkeeping across streamed parts and restored history. The host and chat integration follow in dependent changes.

--- a/packages/harness/src/shared/opencode-completion.ts
+++ b/packages/harness/src/shared/opencode-completion.ts
@@ -1,0 +1,121 @@
+import type { OpenCodeTurnMessage } from "./opencode-turn.js";
+
+// OpenCode 1.18.29 cannot read persisted json_schema format messages through
+// its history API. Keep normal text and bind a result marker to each request.
+export function openCodeCompletionPrompt() {
+  const token = globalThis.crypto.randomUUID();
+  return {
+    system: `StudioAssistantResult/v2:${token}\nComplete the user's requested work before ending the turn, including any requested explanation. Finish necessary tool calls and examine their results before writing the final answer. A promise or plan to do the work is not completion. For conversational requests, provide the requested reply without unnecessary tool calls.\nBegin your final answer with exactly one of these bookkeeping lines, then write the answer on the following line, outside code blocks:\n<!-- studio-result:${token}:finished -->\n<!-- studio-result:${token}:failed -->\nUse finished only when the request is fulfilled. If you cannot finish, use failed and explain what remains and why. Do not include a result line in progress messages or alongside tool calls. Studio removes this line from the displayed answer; keep the rest of your answer in the format the user requested.`,
+  };
+}
+
+export function openCodeCompletionTokens(
+  messages: readonly OpenCodeTurnMessage[],
+) {
+  const tokens = new Map<string, string | undefined>();
+  let current: string | undefined;
+  for (const message of messages) {
+    if (message.info?.role !== "user") continue;
+    // Native overflow compaction may insert a user without its system field.
+    if (
+      !message.parts.some(
+        (part) =>
+          part.type === "compaction" ||
+          (part.synthetic && part.metadata?.compaction_continue === true),
+      )
+    ) {
+      current = /^StudioAssistantResult\/v[12]:([a-f0-9-]{36})\n/.exec(
+        message.info.system ?? "",
+      )?.[1];
+    }
+    tokens.set(message.info.id, current);
+  }
+  return tokens;
+}
+
+export function parseOpenCodeCompletion(text: string, token: string) {
+  const suffix = "<!-- studio-result:" + token + ":";
+  for (const status of ["finished", "failed"] as const) {
+    const footer = suffix + status + " -->";
+    const value = text.trim();
+    if (value.startsWith(footer + "\n") || value.startsWith(footer + "\r\n")) {
+      const answer = value.slice(footer.length).trimStart();
+      if (answer && !answer.includes(suffix)) return { status, answer };
+      continue;
+    }
+    // Preserve saved responses from the earlier footer contract.
+    if (!value.endsWith("\n" + footer)) continue;
+    const answer = value.slice(0, -footer.length).trimEnd();
+    if (answer.trim() && !answer.includes(suffix) && !hasOpenFence(answer))
+      return { status, answer };
+  }
+}
+
+function hasOpenFence(text: string) {
+  let fence: string | undefined;
+  for (const line of text.split(/\r?\n/)) {
+    const match = /^ {0,3}(`{3,}|~{3,})(.*)$/.exec(line);
+    if (!match) continue;
+    const [, marker, rest] = match;
+    if (!fence) {
+      if (marker![0] !== "`" || !rest!.includes("`")) fence = marker;
+    } else if (
+      marker![0] === fence[0] &&
+      marker!.length >= fence.length &&
+      !rest!.trim()
+    ) {
+      fence = undefined;
+    }
+  }
+  return !!fence;
+}
+
+function visibleRange(
+  text: string,
+  token: string | undefined,
+): [number, number] {
+  if (!token) return [0, text.length];
+  const prefix = "<!-- studio-result:" + token + ":";
+  const leading = text.length - text.trimStart().length;
+  if (text.slice(leading).startsWith(prefix)) {
+    const end = text.indexOf("-->", leading + prefix.length);
+    if (end === -1) return [text.length, text.length];
+    const start = text.length - text.slice(end + 3).trimStart().length;
+    const duplicate = text.indexOf(prefix, start);
+    return [start, duplicate === -1 ? text.length : duplicate];
+  }
+  if (prefix.startsWith(text.slice(leading))) return [text.length, text.length];
+  const index = text.indexOf(prefix);
+  if (index !== -1) return [0, text.slice(0, index).trimEnd().length];
+  for (let length = prefix.length - 1; length > 0; length--) {
+    if (text.endsWith(prefix.slice(0, length)))
+      return [0, text.slice(0, -length).trimEnd().length];
+  }
+  return [0, text.length];
+}
+
+/** Hide complete and partially streamed bookkeeping without changing other text. */
+export function openCodeVisibleText(text: string, token: string | undefined) {
+  return text.slice(...visibleRange(text, token));
+}
+
+/** Filter across part boundaries, including interrupted or unfinished answers. */
+export function openCodeVisibleParts(
+  parts: readonly { type: string; text?: string }[],
+  token: string | undefined,
+) {
+  const text = parts
+    .map((part) => (part.type === "text" ? (part.text ?? "") : ""))
+    .join("");
+  const [visibleStart, visibleEnd] = visibleRange(text, token);
+  let offset = 0;
+  return parts.map((part) => {
+    if (part.type !== "text") return undefined;
+    const start = offset;
+    offset += part.text?.length ?? 0;
+    return text.slice(
+      Math.max(start, visibleStart),
+      Math.min(offset, visibleEnd),
+    );
+  });
+}

--- a/packages/harness/src/shared/opencode-turn.test.ts
+++ b/packages/harness/src/shared/opencode-turn.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+import {
+  finalResponseAgent,
+  turnRecoveryAgent,
+  openCodeTurn,
+  openCodeResult,
+  type OpenCodeTurnMessage,
+} from "./opencode-turn.js";
+
+import {
+  openCodeCompletionPrompt,
+  openCodeCompletionTokens,
+  openCodeVisibleText,
+  openCodeVisibleParts,
+} from "./opencode-completion.js";
+
+const user: OpenCodeTurnMessage = {
+  info: { id: "msg_user", role: "user", agent: "build", time: {} },
+  parts: [],
+};
+const answer = (text: string, overrides = {}): OpenCodeTurnMessage => ({
+  info: {
+    id: "msg_answer",
+    role: "assistant",
+    agent: "build",
+    parentID: "msg_user",
+    finish: "stop",
+    time: { completed: 1 },
+    ...overrides,
+  },
+  parts: [{ type: "text", text }],
+});
+
+describe("overall OpenCode turn status", () => {
+  it("requires a result tied to this request, not merely a preamble or another turn's footer", () => {
+    const currentUser = {
+      ...user,
+      info: { ...user.info!, ...openCodeCompletionPrompt() },
+    };
+    const token = openCodeCompletionTokens([currentUser]).get("msg_user")!;
+    const footer = (status = "finished") =>
+      `<!-- studio-result:${token}:${status} -->`;
+    const preamble = answer(
+      "I'll create both files and verify the directory structure in parallel.",
+    );
+    expect(openCodeTurn([currentUser, preamble], "idle")).toEqual({
+      status: "stopped",
+      missing: "msg_answer",
+    });
+    for (const status of ["finished", "failed"] as const) {
+      const message = answer(`CHAT_OK\n\n${footer(status)}`);
+      expect(openCodeTurn([currentUser, message], "idle")).toEqual({ status });
+      expect(openCodeResult(message, token)?.answer).toBe("CHAT_OK");
+      const prefixed = answer(`${footer(status)}\nCHAT_OK`);
+      expect(openCodeTurn([currentUser, prefixed], "idle")).toEqual({ status });
+      expect(openCodeResult(prefixed, token)?.answer).toBe("CHAT_OK");
+    }
+    for (const text of [
+      footer(),
+      `Done\n${footer("unknown")}`,
+      `Done\n${footer()}\n${footer()}`,
+      `Done ${footer()}`,
+      `\`\`\`html\n${footer()}`,
+      `~~~html\n${footer()}`,
+      `${footer()} CHAT_OK`,
+      `${footer()}\nCHAT_OK\n${footer()}`,
+      "Done\n<!-- studio-result:00000000-0000-0000-0000-000000000000:finished -->",
+    ]) {
+      const turn = openCodeTurn([currentUser, answer(text)], "idle");
+      expect(turn.status).not.toBe("finished");
+      expect(turn).toMatchObject({
+        missing: "msg_answer",
+      });
+    }
+    expect(
+      openCodeResult(answer(`\`\`\`js\nadd(2, 3)\n\`\`\`\n${footer()}`), token)
+        ?.status,
+    ).toBe("finished");
+    for (const finish of ["length", "content-filter", "error", "unknown"]) {
+      const interrupted = answer(`Done\n${footer()}`, { finish });
+      expect(openCodeResult(interrupted, token)).toBeUndefined();
+      expect(openCodeTurn([currentUser, interrupted], "idle")).toEqual({
+        status: "failed",
+      });
+      expect(
+        openCodeResult(answer(`${footer()}\nCHAT_OK`, { finish }), token),
+      ).toBeUndefined();
+    }
+    const premature = {
+      ...answer(`Tests passed\n${footer()}`),
+      parts: [
+        ...answer(`Tests passed\n${footer()}`).parts,
+        { type: "tool", tool: "bash", state: { status: "completed" } },
+      ],
+    };
+    expect(openCodeResult(premature, token)).toBeUndefined();
+    expect(openCodeTurn([currentUser, premature], "idle")).toEqual({
+      status: "failed",
+      missing: "msg_answer",
+    });
+    premature.parts[1] = {
+      type: "tool",
+      tool: "bash",
+      state: { status: "error" },
+    };
+    expect(openCodeTurn([currentUser, premature], "idle")).toEqual({
+      status: "failed",
+    });
+    expect(
+      openCodeTurn(
+        [
+          {
+            ...currentUser,
+            info: { ...currentUser.info, agent: turnRecoveryAgent },
+          },
+          answer("I'll do it next", { agent: turnRecoveryAgent }),
+        ],
+        "idle",
+      ),
+    ).toEqual({ status: "stopped" });
+  });
+
+  it("preserves completion checks across native compaction without inheriting them into unrelated legacy requests", () => {
+    const currentUser = {
+      ...user,
+      info: { ...user.info!, ...openCodeCompletionPrompt() },
+    };
+    const compacted = {
+      ...user,
+      info: { ...user.info!, id: "msg_compaction" },
+      parts: [
+        {
+          type: "text",
+          synthetic: true,
+          metadata: { compaction_continue: true },
+        },
+      ],
+    };
+    expect(
+      openCodeTurn(
+        [
+          currentUser,
+          {
+            ...user,
+            info: { ...user.info!, id: "msg_compaction_control" },
+            parts: [{ type: "compaction" }],
+          },
+          answer("Conversation summary", {
+            parentID: "msg_compaction_control",
+            summary: true,
+          }),
+          compacted,
+          answer("I'll create the files", { parentID: "msg_compaction" }),
+        ],
+        "idle",
+      ),
+    ).toEqual({ status: "stopped", missing: "msg_answer" });
+    expect(
+      openCodeTurn([currentUser, user, answer("CHAT_OK")], "idle"),
+    ).toEqual({ status: "finished" });
+  });
+
+  it("hides the result footer throughout streaming and preserves ordinary text", () => {
+    const currentUser = {
+      ...user,
+      info: { ...user.info!, ...openCodeCompletionPrompt() },
+    };
+    const token = openCodeCompletionTokens([currentUser]).get("msg_user")!;
+    const footer = `<!-- studio-result:${token}:finished -->`;
+    for (let size = 1; size <= footer.length; size++) {
+      expect(
+        openCodeVisibleText(`CHAT_OK\n\n${footer.slice(0, size)}`, token),
+      ).toBe("CHAT_OK");
+      const parts = [
+        { type: "text", text: `CHAT_OK\n\n${footer.slice(0, size)}` },
+        { type: "tool" },
+        { type: "text", text: footer.slice(size) },
+      ];
+      expect(openCodeVisibleParts(parts, token)).toEqual([
+        "CHAT_OK",
+        undefined,
+        "",
+      ]);
+      expect(openCodeVisibleText(footer.slice(0, size), token)).toBe("");
+      expect(
+        openCodeVisibleParts(
+          [
+            { type: "text", text: footer.slice(0, size) },
+            { type: "text", text: footer.slice(size) + "\nCHAT_OK" },
+          ],
+          token,
+        ),
+      ).toEqual(["", "CHAT_OK"]);
+    }
+    expect(openCodeVisibleText("Use x < y in the condition", token)).toBe(
+      "Use x < y in the condition",
+    );
+    expect(openCodeVisibleText("CHAT_OK", undefined)).toBe("CHAT_OK");
+  });
+
+  it("requires known idle state and a completed final answer", () => {
+    const messages = [user, answer("Here is the explanation")];
+    expect(openCodeTurn(messages, undefined).status).toBe("unknown");
+    expect(openCodeTurn(messages, "busy").status).toBe("working");
+    expect(openCodeTurn(messages, "retry").status).toBe("working");
+    expect(openCodeTurn(messages, "idle").status).toBe("finished");
+    expect(openCodeTurn([], "idle").status).toBe("ready");
+  });
+
+  it("does not mistake tool steps, preambles, or old answers for a final answer", () => {
+    const preamble = answer("I'll read the files", { finish: "tool-calls" });
+    expect(openCodeTurn([user, preamble], "idle").status).toBe("failed");
+    expect(openCodeTurn([user, preamble, answer("  ")], "idle")).toEqual({
+      status: "failed",
+      missing: "msg_answer",
+    });
+    expect(
+      openCodeTurn(
+        [user, answer("Old response", { parentID: "msg_old" })],
+        "idle",
+      ).status,
+    ).toBe("failed");
+    expect(
+      openCodeTurn(
+        [user, answer("Compacted history", { summary: true })],
+        "idle",
+      ).status,
+    ).toBe("failed");
+  });
+
+  it("does not recover errors, interrupted responses, or a failed recovery again", () => {
+    for (const overrides of [
+      { error: {} },
+      { finish: "length" },
+      { time: {} },
+      { agent: finalResponseAgent },
+      { agent: turnRecoveryAgent },
+      { agent: "plan" },
+    ])
+      expect(openCodeTurn([user, answer("", overrides)], "idle")).toEqual({
+        status: "failed",
+      });
+    expect(
+      openCodeTurn([user, answer("Partial text", { error: {} })], "idle")
+        .status,
+    ).toBe("failed");
+    // Permission/question rejection can stop a tool without assistant.error.
+    expect(
+      openCodeTurn(
+        [user, { ...answer(""), parts: [{ type: "tool" }] }],
+        "idle",
+      ),
+    ).toEqual({ status: "failed" });
+  });
+
+  it("does not mistake a recovery summary for completion of the original task", () => {
+    const recoveryUser = {
+      ...user,
+      info: { ...user.info!, id: "msg_recovery", agent: finalResponseAgent },
+    };
+    const messages = [
+      user,
+      answer(""),
+      recoveryUser,
+      answer(
+        "Only a todo list was created. No files were written or tests run.",
+        {
+          agent: finalResponseAgent,
+          parentID: "msg_recovery",
+        },
+      ),
+    ];
+    expect(openCodeTurn(messages, "idle")).toEqual({ status: "failed" });
+    expect(
+      openCodeTurn(
+        [...messages, user, answer("Files created; 3 tests passed.")],
+        "idle",
+      ),
+    ).toEqual({ status: "finished" });
+  });
+
+  it("allows a continuation to finish, but never automatically continues it again", () => {
+    const continued = {
+      ...user,
+      info: { ...user.info!, agent: turnRecoveryAgent },
+    };
+    expect(
+      openCodeTurn(
+        [
+          continued,
+          answer("Files created and tests passed.", {
+            agent: turnRecoveryAgent,
+          }),
+        ],
+        "idle",
+      ),
+    ).toEqual({ status: "finished" });
+    expect(
+      openCodeTurn(
+        [continued, answer("", { agent: turnRecoveryAgent })],
+        "idle",
+      ),
+    ).toEqual({ status: "failed" });
+  });
+});

--- a/packages/harness/src/shared/opencode-turn.ts
+++ b/packages/harness/src/shared/opencode-turn.ts
@@ -1,0 +1,128 @@
+import {
+  openCodeCompletionTokens,
+  openCodeVisibleText,
+  parseOpenCodeCompletion,
+} from "./opencode-completion.js";
+
+/** Use native messages: the UI adapter merges tool steps and final answers. */
+export interface OpenCodeTurnMessage {
+  info?: {
+    id: string;
+    role: string;
+    parentID?: string;
+    agent?: string;
+    summary?: unknown;
+    finish?: string;
+    error?: unknown;
+    system?: string;
+    time: { created?: number; completed?: number };
+  };
+  parts: readonly {
+    type: string;
+    text?: string;
+    ignored?: boolean;
+    synthetic?: boolean;
+    tool?: string;
+    state?: { status?: string; input?: unknown };
+    metadata?: { compaction_continue?: unknown };
+  }[];
+}
+
+export const finalResponseAgent = "sapiom-final-response";
+export const turnRecoveryAgent = "sapiom-turn-recovery";
+
+export function openCodeResult(
+  message: OpenCodeTurnMessage | undefined,
+  token: string | undefined,
+) {
+  if (
+    !message?.info?.time.completed ||
+    message.info.error ||
+    message.info.finish !== "stop" ||
+    !token ||
+    message.parts.some((part) => part.type === "tool")
+  )
+    return;
+  return parseOpenCodeCompletion(
+    message.parts
+      .filter(
+        (part) => part.type === "text" && !part.ignored && !part.synthetic,
+      )
+      .map((part) => part.text ?? "")
+      .join(""),
+    token,
+  );
+}
+
+export function openCodeTurn(
+  messages: readonly OpenCodeTurnMessage[],
+  status: string | undefined,
+): {
+  status: "ready" | "working" | "finished" | "stopped" | "failed" | "unknown";
+  missing?: string;
+} {
+  if (!status) return { status: "unknown" };
+  if (status !== "idle") return { status: "working" };
+  const newestFirst = [...messages].reverse();
+  const user = newestFirst.find((message) => message.info?.role === "user");
+  if (!user) return { status: "ready" };
+  // Older previews only summarized a stopped run; that did not finish its task.
+  if (user.info?.agent === finalResponseAgent) return { status: "failed" };
+  const answer = newestFirst.find(
+    ({ info }) =>
+      info?.role === "assistant" &&
+      !info.summary &&
+      info.parentID === user.info?.id,
+  );
+  if (!answer?.info || !answer.info.time.completed) return { status: "failed" };
+  if (answer.info.agent === finalResponseAgent) return { status: "failed" };
+  const token = openCodeCompletionTokens(messages).get(user.info!.id);
+  if (answer.info.error) return { status: "failed" };
+  if (token) {
+    const result = openCodeResult(answer, token);
+    if (result) return { status: result.status };
+    const tools = answer.parts.filter((part) => part.type === "tool");
+    const text = answer.parts
+      .filter(
+        (part) => part.type === "text" && !part.ignored && !part.synthetic,
+      )
+      .map((part) => part.text ?? "")
+      .join("");
+    // An omitted/malformed declaration can continue from completed results;
+    // permission failures, cancelled tools, and native errors cannot.
+    return {
+      status:
+        answer.info.finish === "stop" &&
+        tools.length === 0 &&
+        openCodeVisibleText(text, token).trim()
+          ? "stopped"
+          : "failed",
+      ...(user.info?.agent === "build" &&
+      answer.info.agent === "build" &&
+      ["stop", "tool-calls"].includes(answer.info.finish ?? "") &&
+      tools.every((part) => part.state?.status === "completed")
+        ? { missing: answer.info.id }
+        : {}),
+    };
+  }
+  // A preamble or a completed tool step is not the final response.
+  if (answer.info.finish !== "stop") return { status: "failed" };
+  if (
+    answer.parts.some(
+      (part) =>
+        part.type === "text" &&
+        !part.ignored &&
+        !part.synthetic &&
+        part.text?.trim(),
+    )
+  )
+    return { status: "finished" };
+  return {
+    status: "failed",
+    ...(user.info?.agent === "build" &&
+    answer.info.agent === "build" &&
+    !answer.parts.some((part) => part.type === "tool")
+      ? { missing: answer.info.id }
+      : {}),
+  };
+}


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Studio must classify explicit completion separately from intermediate tool progress or ambiguous stopped output.

## Summary and scope

Introduce the exact v2 completion declaration parser and turn classifier, separating final completion from tool progress while preserving honest Stopped/Failed states for malformed or missing declarations.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `studio-mcp-responses`. Actual-parent size: **559 additions + 0 deletions = 559 changed lines**.

Absorbed reviewed provenance: original completion/result classification; ancestry propagation only.

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3290](https://linear.app/sapiom/issue/SAP-3290). This PR keeps its existing number and review history within the main-rooted native GitHub stack.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check 1d23c37fff1b3d0e2da291d7d10805081e349d04...77c3ae87577312f801ccc2ee93ed5b54a1a84a76` — passed.
- Focused completion/turn classification tests — passed.

### Tests and documentation

Shared completion and turn tests cover exact v2 declarations, malformed/old contracts, tool-only output, interrupted turns, and final classification. A Changeset documents the status behavior.

## Compatibility and release impact

- Breaking or externally visible changes: No breaking public API. Assistant turn status becomes stricter and explicit.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/918" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer assistant turn status handling, including completed, failed, stopped, working, and unconfirmed states.
  - Completion results are now matched to the active request for more reliable turn interpretation.
  - Internal completion markers are hidden from streamed responses and restored conversation history.
  - Supports completion and recovery handling when tools finish without producing a final answer.

- **Bug Fixes**
  - Improved detection of final answers, errors, idle states, and incomplete responses.

- **Tests**
  - Added comprehensive coverage for streaming, continuation, compaction, recovery, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->