### PR TITLE
fix(studio): bound retries for incomplete model responses [SAP-3290]

### DIFF
--- a/.changeset/patient-model-answers.md
+++ b/.changeset/patient-model-answers.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Retry fully received incomplete Assistant model responses up to twice before exposing output or tool calls. Pass through tool fragments, refusals, errors, uncertain endings, and oversized prefixes without retrying. A completion declaration is the model's report and does not independently verify task success.

--- a/packages/harness/src/server/opencode-bridge.test.ts
+++ b/packages/harness/src/server/opencode-bridge.test.ts
@@ -8,6 +8,8 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { AssistantGrant } from "../core/assistant-access.js";
 import { startServer } from "./index.js";
+import { openCodeCompletionPrompt } from "../shared/opencode-completion.js";
+import { openCodeModelCompletionToken } from "./opencode-model-response.js";
 import {
   OpenCodeBridge,
   assistantUpstreams,
@@ -83,12 +85,334 @@ function request(
       Authorization: `Bearer ${credential.token}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ model: "browser-override", messages: [] }),
+    body: JSON.stringify({
+      model: "browser-override",
+      messages: [],
+      stream: true,
+    }),
     ...init,
   });
 }
 
 describe("Studio OpenCode credential bridge", () => {
+  const chunk = (delta: object, finish_reason: string | null = null) =>
+    `data: ${JSON.stringify({ choices: [{ index: 0, delta, finish_reason }] })}\n\n`;
+  const emptyStop =
+    chunk({ reasoning_content: "unfinished reasoning" }) +
+    chunk({}, "stop") +
+    "data: [DONE]\n\n";
+
+  const contractedRequest = () => {
+    const { system } = openCodeCompletionPrompt();
+    return { stream: true, messages: [{ role: "system", content: system }] };
+  };
+
+  it("retries an unmarked preamble with unchanged context and streams the marked answer before EOF", async () => {
+    const body = contractedRequest();
+    const token = openCodeModelCompletionToken(body)!;
+    const received: unknown[] = [];
+    let finish!: () => void;
+    upstream.post("/v2/openai/v1/chat/completions", (req, res) => {
+      received.push(req.body);
+      res.type("text/event-stream");
+      if (received.length === 1) {
+        res.end(
+          chunk({ content: "I'll create both files." }) +
+            chunk({}, "stop") +
+            "data: [DONE]\n\n",
+        );
+        return;
+      }
+      const marker = `<!-- studio-result:${token}:finished -->\n`;
+      for (const content of [marker.slice(0, 20), marker.slice(20), "CHAT_OK"])
+        res.write(chunk({ content }));
+      finish = () => res.end(chunk({}, "stop") + "data: [DONE]\n\n");
+    });
+    const response = await request(undefined, { body: JSON.stringify(body) });
+    const reader = response.body!.getReader();
+    const first = new TextDecoder().decode((await reader.read()).value);
+    expect(first).toContain("CHAT_OK");
+    expect(first).not.toContain("I'll create");
+    expect(received).toHaveLength(2);
+    expect(received[1]).toEqual(received[0]);
+    finish();
+    await reader.cancel();
+  });
+
+  it("passes through a preamble as soon as a tool fragment arrives, without replay", async () => {
+    const body = contractedRequest();
+    let calls = 0,
+      finish!: () => void;
+    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+      calls++;
+      res
+        .type("text/event-stream")
+        .write(chunk({ content: "I'll inspect the files." }));
+      res.write(
+        chunk({ tool_calls: [{ index: 0, function: { arguments: "{" } }] }),
+      );
+      finish = () => res.end(chunk({}, "tool_calls") + "data: [DONE]\n\n");
+    });
+    const response = await request(undefined, { body: JSON.stringify(body) });
+    const reader = response.body!.getReader();
+    expect(new TextDecoder().decode((await reader.read()).value)).toContain(
+      "tool_calls",
+    );
+    expect(calls).toBe(1);
+    finish();
+    await reader.cancel();
+  });
+
+  it("bounds preamble retries and never adopts a contract from conversation content", async () => {
+    const body = contractedRequest();
+    const text =
+      chunk({ content: "I'll do it next." }) +
+      chunk({}, "stop") +
+      "data: [DONE]\n\n";
+    let calls = 0;
+    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+      calls++;
+      res.type("text/event-stream").end(text);
+    });
+    expect(
+      await (await request(undefined, { body: JSON.stringify(body) })).text(),
+    ).toBe(text);
+    expect(calls).toBe(3);
+    for (const role of ["user", "assistant", "tool"]) {
+      const untrusted = { messages: [{ ...body.messages[0], role }] };
+      expect(openCodeModelCompletionToken(untrusted)).toBeUndefined();
+      expect(
+        await (
+          await request(undefined, {
+            body: JSON.stringify({ ...untrusted, stream: true }),
+          })
+        ).text(),
+      ).toBe(text);
+    }
+    expect(calls).toBe(6);
+    expect(
+      openCodeModelCompletionToken({
+        messages: [
+          {
+            role: "system",
+            content: [{ type: "text", text: body.messages[0]!.content }],
+          },
+        ],
+      }),
+    ).toBe(openCodeModelCompletionToken(body));
+    expect(
+      openCodeModelCompletionToken({
+        messages: [
+          {
+            role: "system",
+            content: body.messages[0]!.content.replace("/v2:", "/v1:"),
+          },
+        ],
+      }),
+    ).toBeUndefined();
+  });
+
+  it.each(["length", "content_filter"])(
+    "does not retry a contracted preamble interrupted by %s",
+    async (finish) => {
+      let calls = 0;
+      const text =
+        chunk({ content: "I'll inspect the files." }) +
+        chunk({}, finish) +
+        "data: [DONE]\n\n";
+      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+        calls++;
+        res.type("text/event-stream").end(text);
+      });
+      expect(
+        await (
+          await request(undefined, {
+            body: JSON.stringify(contractedRequest()),
+          })
+        ).text(),
+      ).toBe(text);
+      expect(calls).toBe(1);
+    },
+  );
+
+  it("retries an empty model stop with identical saved tool results and streams the useful response", async () => {
+    const received: unknown[] = [];
+    let finish!: () => void;
+    upstream.post("/v2/openai/v1/chat/completions", (req, res) => {
+      received.push(req.body);
+      res.type("text/event-stream");
+      if (received.length === 1) {
+        res.end(emptyStop);
+        return;
+      }
+      res.write(chunk({ content: "Actual answer" }));
+      finish = () => res.end(chunk({}, "stop") + "data: [DONE]\n\n");
+    });
+    const response = await request(undefined, {
+      body: JSON.stringify({
+        stream: true,
+        messages: [
+          {
+            role: "tool",
+            tool_call_id: "already_ran",
+            content: "completed once",
+          },
+        ],
+      }),
+    });
+    const reader = response.body!.getReader();
+    const first = new TextDecoder().decode((await reader.read()).value);
+    expect(first).toContain("Actual answer");
+    expect(first).not.toContain("unfinished reasoning");
+    expect(received).toHaveLength(2);
+    expect(received[1]).toEqual(received[0]);
+    finish();
+    await reader.cancel();
+  });
+
+  it("bounds empty-stop retries", async () => {
+    let calls = 0;
+    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+      calls++;
+      res.type("text/event-stream").end(emptyStop);
+    });
+    expect(await (await request()).text()).toBe(emptyStop);
+    expect(calls).toBe(3);
+  });
+
+  it("recognizes empty stops across split UTF-8 and CRLF frames", async () => {
+    let calls = 0;
+    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+      calls++;
+      res.type("text/event-stream");
+      if (calls === 1) {
+        const bytes = Buffer.from(
+          (
+            chunk({ reasoning_content: "café" }) +
+            chunk({}, "stop") +
+            "data: [DONE]\n\n"
+          ).replace(/\n/g, "\r\n"),
+        );
+        let i = 0;
+        const send = () => {
+          if (i === bytes.length) res.end();
+          else {
+            res.write(bytes.subarray(i, ++i));
+            setImmediate(send);
+          }
+        };
+        send();
+      } else
+        res.end(
+          chunk({ content: "Done" }) + chunk({}, "stop") + "data: [DONE]\n\n",
+        );
+    });
+    expect(await (await request()).text()).toContain("Done");
+    expect(calls).toBe(2);
+  });
+
+  it("caps buffering and passes through oversized prefixes", async () => {
+    const body =
+      chunk({ reasoning_content: "x".repeat(1024 * 1024) }) +
+      chunk({}, "stop") +
+      "data: [DONE]\n\n";
+    let calls = 0;
+    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+      calls++;
+      res.type("text/event-stream").end(body);
+    });
+    expect(await (await request()).text()).toBe(body);
+    expect(calls).toBe(1);
+  });
+
+  it("passes through a truncated UTF-8 ending without retrying", async () => {
+    const body = Buffer.concat([Buffer.from(emptyStop), Buffer.from([0xc3])]);
+    let calls = 0;
+    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+      calls++;
+      res.type("text/event-stream").end(body);
+    });
+    expect(Buffer.from(await (await request()).arrayBuffer())).toEqual(body);
+    expect(calls).toBe(1);
+  });
+
+  it.each(["disconnect", "revocation"])(
+    "aborts a buffered reasoning-only stream on %s without retrying",
+    async (kind) => {
+      let calls = 0,
+        began!: () => void,
+        closed!: () => void;
+      const started = new Promise<void>((resolve) => {
+        began = resolve;
+      });
+      const ended = new Promise<void>((resolve) => {
+        closed = resolve;
+      });
+      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+        calls++;
+        res
+          .type("text/event-stream")
+          .write(chunk({ reasoning_content: "Still working" }));
+        res.once("close", closed);
+        began();
+      });
+      const abort = new AbortController();
+      const response = request(undefined, { signal: abort.signal }).then(
+        (r) => r.status,
+        () => "aborted",
+      );
+      await started;
+      if (kind === "disconnect") abort.abort();
+      else {
+        grant = null;
+        changed();
+      }
+      await response;
+      await ended;
+      expect(calls).toBe(1);
+    },
+  );
+
+  it.each([
+    chunk({ tool_calls: [{ index: 0, function: { arguments: "{" } }] }) +
+      chunk({}, "stop") +
+      "data: [DONE]\n\n",
+    chunk({ function_call: { arguments: "{" } }) +
+      chunk({}, "stop") +
+      "data: [DONE]\n\n",
+    chunk({ content: "Partial answer" }) +
+      chunk({}, "stop") +
+      "data: [DONE]\n\n",
+    chunk({ refusal: "Cannot do that" }) +
+      chunk({}, "stop") +
+      "data: [DONE]\n\n",
+    chunk({}, "length") + "data: [DONE]\n\n",
+    chunk({}, "stop"),
+    "data: malformed\n\n" + emptyStop,
+    'data: {"error":{"message":"upstream failed"}}\n\n' + emptyStop,
+    'data: {"choices":[null]}\n\n' + emptyStop,
+    chunk([]) + emptyStop,
+    chunk({ role: "tool" }) + emptyStop,
+    chunk({ reasoning_content: { text: "unknown" } }) + emptyStop,
+    chunk({ reasoning: 1 }) + emptyStop,
+    chunk({ reasoning_details: {} }) + emptyStop,
+    'data: {"choices":[{"index":0,"delta":{},"finish_reason":0}]}\n\n' +
+      emptyStop,
+    'data: {"choices":[{"index":1,"delta":{}}]}\n\n' + emptyStop,
+    emptyStop + 'data: {"choices":[]}\n\n',
+  ])(
+    "never retries a stream with output, an error, or an uncertain ending (%#)",
+    async (body) => {
+      let calls = 0;
+      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+        calls++;
+        res.type("text/event-stream").end(body);
+      });
+      expect(await (await request()).text()).toBe(body);
+      expect(calls).toBe(1);
+    },
+  );
+
   it("injects the current Studio key and configured model without forwarding caller credentials", async () => {
     upstream.post("/v2/openai/v1/chat/completions", (req, res) => {
       expect(req.headers["x-sapiom-api-key"]).toBe("sk_private_studio");

--- a/packages/harness/src/server/opencode-bridge.ts
+++ b/packages/harness/src/server/opencode-bridge.ts
@@ -12,6 +12,10 @@ import type {
   AssistantAccess,
   AssistantGrant,
 } from "../core/assistant-access.js";
+import {
+  fetchOpenCodeModelResponse,
+  openCodeModelCompletionToken,
+} from "./opencode-model-response.js";
 
 type Access = Pick<AssistantAccess, "get" | "subscribe">;
 interface Registration {
@@ -289,6 +293,8 @@ export class OpenCodeBridge {
           headers.set(name, req.header(name)!);
       }
       let body = req.method === "POST" ? (req.body as Buffer) : undefined;
+      let streamingModel = false;
+      let completionToken: string | undefined;
       if (service === "llm") {
         let request: Record<string, unknown>;
         try {
@@ -310,14 +316,24 @@ export class OpenCodeBridge {
           return;
         }
         body = Buffer.from(JSON.stringify({ ...request, model: this.model }));
+        streamingModel = request.stream === true;
+        completionToken = openCodeModelCompletionToken(request);
       }
-      const response = await fetch(upstream, {
-        method: req.method,
-        headers,
-        body: body as Uint8Array<ArrayBuffer> | undefined,
-        redirect: "error",
-        signal: abort.signal,
-      });
+      const request = () =>
+        fetch(upstream, {
+          method: req.method,
+          headers,
+          body: body as Uint8Array<ArrayBuffer> | undefined,
+          redirect: "error",
+          signal: abort.signal,
+        });
+      const response = streamingModel
+        ? await fetchOpenCodeModelResponse(
+            request,
+            abort.signal,
+            completionToken,
+          )
+        : await request();
       if (!response.ok) {
         await response.body?.cancel();
         // Preserve status-based client policy, including MCP's optional 405,

--- a/packages/harness/src/server/opencode-model-response.ts
+++ b/packages/harness/src/server/opencode-model-response.ts
@@ -1,0 +1,190 @@
+import { parseOpenCodeCompletion } from "../shared/opencode-completion.js";
+
+/** Retry a clean incomplete generation before OpenCode can execute any call. */
+export async function fetchOpenCodeModelResponse(
+  request: () => Promise<Response>,
+  signal: AbortSignal,
+  completionToken?: string,
+): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    signal.throwIfAborted();
+    const upstream = await request();
+    const { response, empty } = await inspect(upstream, completionToken);
+    if (!empty || attempt === 2) return response;
+    await response.body?.cancel();
+    console.warn("[harness] Retrying an incomplete Assistant model response", {
+      attempt: attempt + 1,
+      requestId: upstream.headers.get("x-sapiom-request-id"),
+    });
+  }
+}
+
+/** Native sends the current contract in system text, never user/tool history. */
+export function openCodeModelCompletionToken(request: Record<string, unknown>) {
+  if (!Array.isArray(request.messages)) return;
+  let token: string | undefined;
+  for (const message of request.messages) {
+    if (!message || message.role !== "system") continue;
+    const content =
+      typeof message.content === "string"
+        ? message.content
+        : Array.isArray(message.content)
+          ? message.content
+              .filter(
+                (part: { type?: string; text?: unknown }) =>
+                  part?.type === "text" && typeof part.text === "string",
+              )
+              .map((part: { text: string }) => part.text)
+              .join("\n")
+          : "";
+    for (const match of content.matchAll(
+      /(?:^|\n)StudioAssistantResult\/v2:([a-f0-9-]{36})\n/g,
+    ))
+      token = match[1];
+  }
+  return token;
+}
+
+async function inspect(response: Response, completionToken?: string) {
+  if (
+    !response.ok ||
+    !response.body ||
+    !response.headers.get("content-type")?.includes("text/event-stream")
+  )
+    return { response, empty: false };
+  const reader = response.body.getReader();
+  const prefix: Uint8Array[] = [];
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let pending = "",
+    content = "",
+    size = 0,
+    stopped = false,
+    ended = false;
+  const replay = (empty = false) => ({
+    empty,
+    response: new Response(
+      new ReadableStream({
+        start(controller) {
+          for (const bytes of prefix) controller.enqueue(bytes);
+        },
+        async pull(controller) {
+          try {
+            const next = await reader.read();
+            if (next.done) {
+              reader.releaseLock();
+              controller.close();
+            } else controller.enqueue(next.value);
+          } catch (error) {
+            reader.releaseLock();
+            controller.error(error);
+          }
+        },
+        async cancel(reason) {
+          await reader.cancel(reason);
+          reader.releaseLock();
+        },
+      }),
+      {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      },
+    ),
+  });
+  try {
+    for (;;) {
+      const next = await reader.read();
+      if (next.done) {
+        try {
+          pending += decoder.decode();
+        } catch {
+          return replay();
+        }
+        return replay(stopped && ended && !pending.trim());
+      }
+      prefix.push(next.value);
+      size += next.value.byteLength;
+      // Bound pre-output buffering; ambiguous/oversized responses pass through.
+      if (size > 1024 * 1024) return replay();
+      try {
+        pending += decoder.decode(next.value, { stream: true });
+      } catch {
+        return replay();
+      }
+      let boundary: RegExpExecArray | null;
+      while ((boundary = /\r?\n\r?\n/.exec(pending))) {
+        const frame = pending.slice(0, boundary.index);
+        pending = pending.slice(boundary.index + boundary[0].length);
+        const lines = frame
+          .split(/\r?\n/)
+          .filter((line) => line.startsWith("data:"));
+        if (!lines.length) continue;
+        const data = lines.map((line) => line.slice(5).trimStart()).join("\n");
+        if (ended) return replay();
+        if (data === "[DONE]") {
+          ended = true;
+          continue;
+        }
+        let value;
+        try {
+          value = JSON.parse(data);
+        } catch {
+          return replay();
+        }
+        if (
+          !value ||
+          value.error ||
+          !Array.isArray(value.choices) ||
+          value.choices.length > 1
+        )
+          return replay();
+        for (const choice of value.choices) {
+          if (!choice || typeof choice !== "object" || choice.index !== 0)
+            return replay();
+          const delta = choice.delta;
+          if (!delta || typeof delta !== "object" || Array.isArray(delta))
+            return replay();
+          if (
+            (delta.role != null && delta.role !== "assistant") ||
+            [delta.reasoning_content, delta.reasoning].some(
+              (value) => value != null && typeof value !== "string",
+            ) ||
+            (delta.reasoning_details != null &&
+              !Array.isArray(delta.reasoning_details)) ||
+            (delta.content != null && typeof delta.content !== "string") ||
+            delta.tool_calls != null ||
+            delta.function_call != null ||
+            delta.refusal != null ||
+            Object.keys(delta).some(
+              (key) =>
+                ![
+                  "role",
+                  "content",
+                  "reasoning_content",
+                  "reasoning",
+                  "reasoning_details",
+                ].includes(key),
+            ) ||
+            (choice.finish_reason != null && choice.finish_reason !== "stop")
+          )
+            return replay();
+          content += delta.content ?? "";
+          // A marker commits streaming, not completion: native terminal state
+          // still rejects errors, absent answers, or simultaneous tools.
+          // Any tool fragment above also commits the stream before execution.
+          if (
+            content.trim() &&
+            (!completionToken ||
+              parseOpenCodeCompletion(content, completionToken))
+          )
+            return replay();
+          if (choice.finish_reason === "stop") stopped = true;
+        }
+      }
+    }
+  } catch (error) {
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+    throw error;
+  }
+}


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Incomplete model responses need a bounded retry policy that neither replays accepted tools nor treats uncertain endings as successful.

## Summary and scope

Retry only eligible incomplete model responses with bounded request count and unchanged context, while excluding tool fragments, refusals, oversized prefixes, malformed streams, and revoked access.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `studio-assistant-results`. Actual-parent size: **543 additions + 8 deletions = 551 changed lines**.

Absorbed reviewed provenance: original bounded incomplete-model retry behavior; ancestry propagation only.

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3290](https://linear.app/sapiom/issue/SAP-3290). This PR keeps its existing number and review history within the main-rooted native GitHub stack.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check 77c3ae87577312f801ccc2ee93ed5b54a1a84a76...462c43d5524b3fe9f6d80f91f4c4bd0eec72181d` — passed.
- Focused bridge retry/no-replay tests — passed.

### Tests and documentation

Real HTTP/SSE bridge tests cover retry bounds, incremental output, partial tool arguments, refusals, malformed/split frames, oversize buffering, disconnects, and revocation. A Changeset documents the bounded behavior.

## Compatibility and release impact

- Breaking or externally visible changes: May add at most the documented bounded model requests and latency for eligible incomplete answers; accepted prompt/tool effects are never replayed.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/919" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
