### PR TITLE
fix(studio): fence native continuation of incomplete turns [SAP-3290]

### DIFF
--- a/.changeset/bounded-turn-continuation.md
+++ b/.changeset/bounded-turn-continuation.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/harness": patch
+"@sapiom/opencode": patch
+---
+
+Attach a per-request completion instruction and support one durable native continuation from saved conversation results after an eligible incomplete turn. Fence prompt admission and uncertain dispatch, retain normal permissions, bound recovery time, and prevent the same continuation from dispatching again after reload. This mitigates missing final answers; premature stops and unnecessary recaps can still occur.

--- a/.changeset/bounded-turn-continuation.md
+++ b/.changeset/bounded-turn-continuation.md
@@ -3,4 +3,4 @@
 "@sapiom/opencode": patch
 ---
 
-Attach a per-request completion instruction and support one durable native continuation from saved conversation results after an eligible incomplete turn. Fence prompt admission and uncertain dispatch, retain normal permissions, bound recovery time, and prevent the same continuation from dispatching again after reload. This mitigates missing final answers; premature stops and unnecessary recaps can still occur.
+Attach a per-request completion instruction and support one durable native continuation from saved conversation results after an eligible incomplete turn. Fence prompt admission and uncertain dispatch, retain normal permissions, bound recovery time, and prevent the same continuation from dispatching again after reload. Preserve the exact Studio completion protocol on native compaction continuations so completed answers remain classifiable without replaying prompts or tool calls.

--- a/packages/harness/src/core/opencode-final-response.test.ts
+++ b/packages/harness/src/core/opencode-final-response.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { HostedOpenCode } from "./opencode-host.js";
+import { OpenCodeFinalResponse } from "./opencode-final-response.js";
+
+let hosted: HostedOpenCode;
+let permission: unknown[];
+let state: string;
+let agent: string;
+let text: string;
+let abort: AbortController;
+const dispatch = vi.fn();
+beforeEach(async () => {
+  permission = [];
+  state = "idle";
+  agent = "build";
+  text = "";
+  abort = new AbortController();
+  dispatch.mockReset().mockResolvedValue(new Response("{}"));
+  hosted = {
+    stateRoot: await mkdtemp(join(tmpdir(), "opencode-final-")),
+    signal: abort.signal,
+    server: {
+      fetch: dispatch,
+      fetchJson: vi.fn(async (path: string) => {
+        if (path === "/session/status") return { ses_test: { type: state } };
+        if (path.endsWith("/message"))
+          return [
+            {
+              info: { id: "msg_user", role: "user", agent: "build", time: {} },
+              parts: [],
+            },
+            {
+              info: {
+                id: "msg_empty",
+                role: "assistant",
+                parentID: "msg_user",
+                agent,
+                finish: "stop",
+                time: { completed: 1 },
+              },
+              parts: [{ type: "text", text }],
+            },
+          ];
+        return { permission };
+      }),
+    },
+  } as unknown as HostedOpenCode;
+});
+afterEach(async () => {
+  await rm(hosted.stateRoot, { recursive: true, force: true });
+});
+
+it("coalesces recovery and never resends it after a host restart", async () => {
+  const recovery = new OpenCodeFinalResponse();
+  await Promise.all([
+    recovery.recover(hosted, "ses_test", "msg_empty"),
+    recovery.recover(hosted, "ses_test", "msg_empty"),
+  ]);
+  expect(dispatch).toHaveBeenCalledOnce();
+  const [path, init] = dispatch.mock.calls[0]!;
+  expect(path).toBe("/session/ses_test/message");
+  expect(JSON.parse(init.body)).toMatchObject({
+    agent: "sapiom-turn-recovery",
+    system: expect.stringContaining("StudioAssistantResult/v2:"),
+  });
+  expect(JSON.parse(init.body)).not.toHaveProperty("tools");
+  await expect(
+    new OpenCodeFinalResponse().recover(hosted, "ses_test", "msg_empty"),
+  ).rejects.toThrow();
+  expect(dispatch).toHaveBeenCalledOnce();
+});
+
+it("never dispatches for busy, answered, stale, or already recovered turns", async () => {
+  for (const scenario of [
+    "busy",
+    "answered",
+    "stale",
+    "recovered",
+    "continued",
+    "plan",
+  ]) {
+    state = scenario === "busy" ? "busy" : "idle";
+    text = scenario === "answered" ? "Final answer" : "";
+    agent =
+      scenario === "recovered"
+        ? "sapiom-final-response"
+        : scenario === "continued"
+          ? "sapiom-turn-recovery"
+          : scenario === "plan"
+            ? "plan"
+            : "build";
+    await expect(
+      new OpenCodeFinalResponse().recover(
+        hosted,
+        "ses_test",
+        scenario === "stale" ? "msg_old" : "msg_empty",
+      ),
+    ).rejects.toThrow();
+  }
+  expect(dispatch).not.toHaveBeenCalled();
+});
+
+it("fails closed for session overrides or failed status reads", async () => {
+  permission = [{ permission: "*", pattern: "*", action: "allow" }];
+  await expect(
+    new OpenCodeFinalResponse().recover(hosted, "ses_test", "msg_empty"),
+  ).rejects.toThrow();
+  permission = [];
+  vi.mocked(hosted.server.fetchJson).mockRejectedValue(new Error("offline"));
+  await expect(
+    new OpenCodeFinalResponse().recover(hosted, "ses_test", "msg_empty"),
+  ).rejects.toThrow();
+  expect(dispatch).not.toHaveBeenCalled();
+});
+
+it("does not replay an uncertain failed dispatch and rejects new prompts during recovery", async () => {
+  let reject!: (error: Error) => void;
+  dispatch.mockImplementation(
+    () =>
+      new Promise((_resolve, fail) => {
+        reject = fail;
+      }),
+  );
+  const recovery = new OpenCodeFinalResponse();
+  const pending = recovery.recover(hosted, "ses_test", "msg_empty");
+  await vi.waitFor(() => expect(dispatch).toHaveBeenCalledOnce());
+  expect(recovery.isRunning(hosted)).toBe(true);
+  reject(new Error("connection lost"));
+  await expect(pending).rejects.toThrow();
+  expect(hosted.server.fetchJson).toHaveBeenCalledWith(
+    "/session/ses_test/abort",
+    expect.objectContaining({ method: "POST" }),
+  );
+  expect(recovery.isRunning(hosted)).toBe(false);
+  await expect(
+    recovery.recover(hosted, "ses_test", "msg_empty"),
+  ).rejects.toThrow();
+  expect(dispatch).toHaveBeenCalledOnce();
+});
+
+it("fences recovery until an already submitted user message is persisted", async () => {
+  let acknowledge!: (response: Response) => void;
+  dispatch.mockImplementation(
+    () =>
+      new Promise((resolve) => {
+        acknowledge = resolve;
+      }),
+  );
+  const recovery = new OpenCodeFinalResponse();
+  const sending = recovery.send(hosted, "ses_test", {
+    method: "POST",
+    body: "{}",
+  });
+  await vi.waitFor(() => expect(dispatch).toHaveBeenCalledOnce());
+  await expect(
+    recovery.recover(hosted, "ses_test", "msg_empty"),
+  ).rejects.toThrow();
+  acknowledge(new Response(null, { status: 204 }));
+  await expect(
+    recovery.recover(hosted, "ses_test", "msg_empty"),
+  ).rejects.toThrow();
+  vi.mocked(hosted.server.fetchJson).mockResolvedValue([
+    { info: { id: "msg_new", role: "user", time: {} }, parts: [] },
+  ]);
+  expect((await sending).status).toBe(204);
+  expect(recovery.isRunning(hosted)).toBe(false);
+  expect(dispatch).toHaveBeenCalledOnce();
+});

--- a/packages/harness/src/core/opencode-final-response.ts
+++ b/packages/harness/src/core/opencode-final-response.ts
@@ -1,0 +1,183 @@
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import type { HostedOpenCode } from "./opencode-host.js";
+import { DurableFileLock } from "./durable-file-lock.js";
+import { openCodeCompletionPrompt } from "../shared/opencode-completion.js";
+import {
+  turnRecoveryAgent,
+  openCodeTurn,
+  type OpenCodeTurnMessage,
+} from "../shared/opencode-turn.js";
+
+/** One continuation from saved results; never resubmit the original prompt. */
+export class OpenCodeFinalResponse {
+  private pending = new Map<string, Promise<void>>();
+  private admitting = new Set<string>();
+  private uncertain = new Set<string>();
+
+  isRunning(hosted: HostedOpenCode): boolean {
+    return (
+      this.pending.has(hosted.stateRoot) || this.admitting.has(hosted.stateRoot)
+    );
+  }
+
+  async send(
+    hosted: HostedOpenCode,
+    sessionId: string,
+    init: RequestInit,
+  ): Promise<Response> {
+    if (this.isRunning(hosted))
+      throw new Error("Another request is being admitted");
+    this.admitting.add(hosted.stateRoot);
+    const signal = AbortSignal.any([
+      hosted.signal,
+      AbortSignal.timeout(30_000),
+    ]);
+    const history = () =>
+      hosted.server.fetchJson<OpenCodeTurnMessage[]>(
+        `/session/${sessionId}/message`,
+        { signal },
+      );
+    try {
+      if (this.uncertain.has(hosted.stateRoot)) {
+        const statuses = await hosted.server.fetchJson<
+          Record<string, { type: string }>
+        >("/session/status", { signal });
+        if (statuses[sessionId] && statuses[sessionId].type !== "idle")
+          throw new Error("Previous request is still running");
+      }
+      const before = new Set(
+        (await history()).map((message) => message.info?.id),
+      );
+      this.uncertain.add(hosted.stateRoot);
+      const response = await hosted.server.fetch(
+        `/session/${sessionId}/prompt_async`,
+        init,
+      );
+      if (!response.ok) return response;
+      // A native 204 means scheduled. Keep admission closed until the user
+      // message is persisted, so recovery cannot overtake a queued prompt.
+      while (
+        !(await history()).some(
+          ({ info }) => info?.role === "user" && !before.has(info.id),
+        )
+      )
+        await delay(25, undefined, { signal });
+      this.uncertain.delete(hosted.stateRoot);
+      return response;
+    } finally {
+      this.admitting.delete(hosted.stateRoot);
+    }
+  }
+
+  recover(
+    hosted: HostedOpenCode,
+    sessionId: string,
+    messageId: string,
+  ): Promise<void> {
+    if (
+      this.admitting.has(hosted.stateRoot) ||
+      this.uncertain.has(hosted.stateRoot)
+    )
+      return Promise.reject(
+        new Error("A user request has not been reconciled"),
+      );
+    const previous = this.pending.get(hosted.stateRoot);
+    if (previous) return previous;
+    const request = this.finish(hosted, sessionId, messageId).finally(() => {
+      this.pending.delete(hosted.stateRoot);
+    });
+    this.pending.set(hosted.stateRoot, request);
+    return request;
+  }
+
+  private async finish(
+    hosted: HostedOpenCode,
+    sessionId: string,
+    messageId: string,
+  ): Promise<void> {
+    const file = join(
+      hosted.stateRoot,
+      `final-response-${sessionId}-${messageId}.json`,
+    );
+    const unlock = await new DurableFileLock(file).acquire();
+    let dispatched = false;
+    try {
+      // Survives browser disconnects. Host revocation still cancels the request.
+      const signal = AbortSignal.any([
+        hosted.signal,
+        AbortSignal.timeout(120_000),
+      ]);
+      const messages = await hosted.server.fetchJson<OpenCodeTurnMessage[]>(
+        `/session/${sessionId}/message`,
+        { signal },
+      );
+      const statuses = await hosted.server.fetchJson<
+        Record<string, { type: string }>
+      >("/session/status", { signal });
+      if (
+        openCodeTurn(messages, statuses[sessionId]?.type ?? "idle").missing !==
+        messageId
+      )
+        throw new Error("Turn changed or no final response is missing");
+      const session = await hosted.server.fetchJson<{ permission?: unknown[] }>(
+        `/session/${sessionId}`,
+        { signal },
+      );
+      // Native session permissions override agent permissions. Studio sessions
+      // have none; fail closed if another client has changed that contract.
+      if (session.permission?.length)
+        throw new Error("Session permissions changed");
+      // Record BEFORE dispatch. An uncertain request is never retried on reload.
+      await writeFile(file, "{}\n", { flag: "wx", mode: 0o600 });
+      dispatched = true;
+      const response = await hosted.server.fetch(
+        `/session/${sessionId}/message`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            ...openCodeCompletionPrompt(),
+            agent: turnRecoveryAgent,
+            parts: [
+              {
+                type: "text",
+                text: "The previous execution stopped unexpectedly. Continue the original user request from the saved conversation and tool results. Complete any remaining requested work, then explain the actual results. Do not repeat completed actions or expand the task. If all requested work is already done, provide the missing explanation. If you cannot complete the task, clearly explain what remains and why.",
+              },
+            ],
+          }),
+          signal,
+        },
+      );
+      if (!response.ok) throw new Error("Final response failed");
+      await response.arrayBuffer();
+    } catch (error) {
+      if (dispatched && !hosted.signal.aborted) {
+        // Cancelling the HTTP waiter does not cancel OpenCode's native fiber.
+        // Fence new prompts until abort is confirmed, even on transport failure.
+        this.uncertain.add(hosted.stateRoot);
+        try {
+          const signal = AbortSignal.any([
+            hosted.signal,
+            AbortSignal.timeout(5000),
+          ]);
+          await hosted.server.fetchJson(`/session/${sessionId}/abort`, {
+            method: "POST",
+            signal,
+          });
+          const statuses = await hosted.server.fetchJson<
+            Record<string, { type: string }>
+          >("/session/status", { signal });
+          if (!statuses[sessionId] || statuses[sessionId].type === "idle")
+            this.uncertain.delete(hosted.stateRoot);
+        } catch {
+          /* Keep the fence until native state can be reconciled. */
+        }
+      }
+      throw error;
+    } finally {
+      await unlock();
+    }
+  }
+}

--- a/packages/harness/src/server/opencode.test.ts
+++ b/packages/harness/src/server/opencode.test.ts
@@ -68,8 +68,14 @@ beforeEach(async () => {
     if (session) res.json(session);
     else res.status(404).json({ error: "private native diagnostics" });
   });
-  engine.get("/session/:id/message", (_req, res) => {
-    res.json([]);
+  engine.get("/session/:id/message", (req, res) => {
+    res.json(
+      requests.some(
+        (request) => request.path === `/session/${req.params.id}/prompt_async`,
+      )
+        ? [{ info: { id: "msg_admitted", role: "user", time: {} }, parts: [] }]
+        : [],
+    );
   });
   engine.post("/session/:id/prompt_async", (_req, res) => {
     res.status(204).end();
@@ -166,6 +172,54 @@ async function readUntil(
 }
 
 describe("Studio-scoped OpenCode transport", () => {
+  it("authenticates and scopes final-answer recovery without exposing native overrides", async () => {
+    const id = await attach("studio-b");
+    const path = `studio-b/session/${id}/final-response`;
+    expect(
+      (
+        await request(path, {
+          method: "POST",
+          headers: {},
+          body: JSON.stringify({ messageId: "msg_empty" }),
+        })
+      ).status,
+    ).toBe(401);
+    for (const body of [
+      {},
+      { messageId: "../escape" },
+      { messageId: "msg_empty", agent: "build" },
+      { messageId: "msg_empty", tools: { bash: true } },
+    ])
+      expect(
+        (await request(path, { method: "POST", body: JSON.stringify(body) }))
+          .status,
+      ).toBe(400);
+    expect((await request(path)).status).toBe(400);
+    expect(
+      (
+        await request("studio-a/session/ses_secret/final-response", {
+          method: "POST",
+          body: JSON.stringify({ messageId: "msg_empty" }),
+        })
+      ).status,
+    ).toBe(403);
+    expect(
+      (
+        await request(path, {
+          method: "POST",
+          body: JSON.stringify({ messageId: "msg_empty" }),
+        })
+      ).status,
+    ).toBe(502);
+    expect(
+      requests.filter(
+        (request) =>
+          request.path.endsWith("/message") &&
+          Object.prototype.hasOwnProperty.call(request.body ?? {}, "agent"),
+      ),
+    ).toHaveLength(0);
+  });
+
   it("authenticates before startup and rejects flag-off or unauthorized workspaces", async () => {
     expect(
       (await request("studio-a/attach", { method: "POST", headers: {} }))
@@ -241,8 +295,14 @@ describe("Studio-scoped OpenCode transport", () => {
       },
     });
     expect(response.status).toBe(204);
-    const native = requests.at(-1)!;
-    expect(native.body).toEqual(body);
+    const native = requests.find((request) =>
+      request.path.endsWith("/prompt_async"),
+    )!;
+    expect(native.body).toEqual({
+      ...body,
+      system: expect.stringContaining("StudioAssistantResult/v2:"),
+    });
+    expect(native.body).not.toHaveProperty("format");
     expect(native.headers.authorization).toBe("Basic native-only");
     for (const name of ["x-harness-token", "cookie", "x-opencode-directory"])
       expect(native.headers[name]).toBeUndefined();

--- a/packages/harness/src/server/opencode.test.ts
+++ b/packages/harness/src/server/opencode.test.ts
@@ -204,13 +204,13 @@ describe("Studio-scoped OpenCode transport", () => {
       ).status,
     ).toBe(403);
     expect(
-      (
+      await (
         await request(path, {
           method: "POST",
           body: JSON.stringify({ messageId: "msg_empty" }),
         })
-      ).status,
-    ).toBe(502);
+      ).json(),
+    ).toEqual({ error: openCodeTransportFailure("transport_unavailable") });
     expect(
       requests.filter(
         (request) =>

--- a/packages/harness/src/server/opencode.ts
+++ b/packages/harness/src/server/opencode.ts
@@ -13,6 +13,8 @@ import {
   openCodeTransportFailure,
   type OpenCodeTransportFailure,
 } from "../shared/opencode-errors.js";
+import { OpenCodeFinalResponse } from "../core/opencode-final-response.js";
+import { openCodeCompletionPrompt } from "../shared/opencode-completion.js";
 
 export function createOpenCodeRouter(
   host: Pick<OpenCodeHost, "ensure">,
@@ -20,6 +22,7 @@ export function createOpenCodeRouter(
 ): Router {
   const router = express.Router();
   const associations = new OpenCodeAssociations();
+  const finalResponse = new OpenCodeFinalResponse();
   router.use(
     createBootTokenMiddleware(bootToken),
     express.json({ limit: "1mb" }),
@@ -36,7 +39,9 @@ export function createOpenCodeRouter(
     const id = req.params.harnessSessionId!;
     const read = req.method === "GET";
     const conversation =
-      /^session\/(ses_[A-Za-z0-9_-]+)(\/message|\/prompt_async)?$/.exec(path);
+      /^session\/(ses_[A-Za-z0-9_-]+)(\/message|\/prompt_async|\/final-response)?$/.exec(
+        path,
+      );
     const collection = [
       "experimental/session",
       "session/status",
@@ -46,13 +51,19 @@ export function createOpenCodeRouter(
     const prompt =
       !read && req.method === "POST" && conversation?.[2] === "/prompt_async";
     const attach = req.method === "POST" && path === "attach";
+    const recover =
+      req.method === "POST" && conversation?.[2] === "/final-response";
     const allowed =
       attach ||
       prompt ||
+      recover ||
       (read &&
         (path === "event" ||
           collection ||
-          (conversation && conversation[2] !== "/prompt_async")));
+          (conversation &&
+            !["/prompt_async", "/final-response"].includes(
+              conversation[2] ?? "",
+            ))));
     const queryAllowed = Object.entries(req.query).every(
       ([key, value]) =>
         path === "experimental/session" &&
@@ -63,17 +74,18 @@ export function createOpenCodeRouter(
       !allowed ||
       !/^[A-Za-z0-9_-]{1,128}$/.test(id) ||
       !queryAllowed ||
-      (conversation && !isConversationId(conversation[1]))
+      (conversation && !isConversationId(conversation[1])) ||
+      (recover &&
+        (Object.keys(req.body ?? {}).length !== 1 ||
+          !/^msg_[A-Za-z0-9_-]{1,128}$/.test(req.body?.messageId ?? "")))
     ) {
       res.status(400).json({ error: "Unsupported Assistant request" });
       return;
     }
     if (prompt && !validPrompt(req.body)) {
-      res
-        .status(400)
-        .json({
-          error: "Send a text message without model or workspace overrides",
-        });
+      res.status(400).json({
+        error: "Send a text message without model or workspace overrides",
+      });
       return;
     }
     const disconnected = new AbortController();
@@ -86,11 +98,9 @@ export function createOpenCodeRouter(
       const signal = AbortSignal.any([hosted.signal, disconnected.signal]);
       signal.throwIfAborted();
       if (conversation && conversation[1] !== nativeId) {
-        res
-          .status(403)
-          .json({
-            error: "Conversation does not belong to this Studio session",
-          });
+        res.status(403).json({
+          error: "Conversation does not belong to this Studio session",
+        });
         return;
       }
       if (attach) {
@@ -101,17 +111,38 @@ export function createOpenCodeRouter(
         await streamOpenCodeEvents(hosted, nativeId, res, signal);
         return;
       }
+      if (recover) {
+        await finalResponse.recover(hosted, nativeId, req.body.messageId);
+        if (!res.destroyed) res.status(204).end();
+        return;
+      }
+      if (prompt && finalResponse.isRunning(hosted)) {
+        res
+          .status(409)
+          .json({ error: "Assistant is finishing the previous response" });
+        return;
+      }
       const nativePath =
         path === "experimental/session" ? `session/${nativeId}` : path;
-      const upstream = await hosted.server.fetch(`/${nativePath}`, {
+      const init = {
         method: req.method,
         headers: {
           "Content-Type": "application/json",
           Accept: "application/json",
         },
-        ...(prompt ? { body: JSON.stringify(req.body) } : {}),
+        ...(prompt
+          ? {
+              body: JSON.stringify({
+                ...req.body,
+                ...openCodeCompletionPrompt(),
+              }),
+            }
+          : {}),
         signal: AbortSignal.any([signal, AbortSignal.timeout(30000)]),
-      });
+      };
+      const upstream = prompt
+        ? await finalResponse.send(hosted, nativeId, init)
+        : await hosted.server.fetch(`/${nativePath}`, init);
       if (!upstream.ok) {
         await upstream.body?.cancel();
         sendFailure(
@@ -119,7 +150,7 @@ export function createOpenCodeRouter(
           openCodeTransportFailure(
             upstream.status === 404 && conversation
               ? "native_history_missing"
-              : "transport_unavailable",
+            : "transport_unavailable",
           ),
         );
         return;

--- a/packages/opencode/src/__fixtures__/server.mjs
+++ b/packages/opencode/src/__fixtures__/server.mjs
@@ -1,16 +1,19 @@
 import { createServer } from "node:http";
-import { writeFileSync } from "node:fs";
+import { readFileSync, writeFileSync } from "node:fs";
 import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 
 const config = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT);
 const password = process.env.OPENCODE_SERVER_PASSWORD;
 const authorization = `Basic ${Buffer.from(`opencode:${password}`).toString("base64")}`;
 for (const specifier of config.plugin ?? []) {
-  const plugin = await import(specifier);
-  const initialize = Object.values(plugin).find(
-    (value) => typeof value === "function",
+  const source = readFileSync(fileURLToPath(specifier), "utf8");
+  const keys = JSON.parse(source.match(/^const keys = (.+);$/m)?.[1] ?? "[]");
+  const readyPath = JSON.parse(
+    source.match(/await writeFile\(("(?:[^"\\]|\\.)*"), "ready/)?.[1] ?? '""',
   );
-  await initialize?.();
+  for (const key of keys) delete process.env[key];
+  writeFileSync(readyPath, "ready\n", { flag: "wx", mode: 0o600 });
 }
 writeFileSync("runtime.pid", String(process.pid));
 if (config.crash) {

--- a/packages/opencode/src/completion-hook.test.ts
+++ b/packages/opencode/src/completion-hook.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import { createStudioCompletionHooks } from "./completion-hook.js";
+
+const tokenA = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const tokenB = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const contract = (token: string) =>
+  `StudioAssistantResult/v2:${token}\nCompletion instructions for ${token}`;
+const user = (
+  id: string,
+  options: {
+    sessionID?: string;
+    agent?: string;
+    system?: unknown;
+    continuation?: boolean;
+    text?: string;
+  } = {},
+) => ({
+  info: {
+    id,
+    role: "user",
+    sessionID: options.sessionID ?? "ses_current",
+    agent: options.agent ?? "build",
+    ...(options.system !== undefined ? { system: options.system } : {}),
+  },
+  parts: [
+    {
+      type: "text",
+      text: options.text ?? "request",
+      ...(options.continuation
+        ? {
+            synthetic: true,
+            metadata: { compaction_continue: true },
+          }
+        : {}),
+    },
+  ],
+});
+
+const compaction = (id: string) => ({
+  info: {
+    id,
+    role: "user",
+    sessionID: "ses_current",
+    agent: "build",
+  },
+  parts: [{ type: "compaction" }],
+});
+
+type FixtureMessage = ReturnType<typeof user> | ReturnType<typeof compaction>;
+
+async function transform(
+  messages: FixtureMessage[],
+  history: FixtureMessage[] = messages,
+) {
+  const hooks = createStudioCompletionHooks(async () => history);
+  await hooks["experimental.chat.messages.transform"]({}, { messages });
+}
+
+describe("Studio completion transform", () => {
+  it("restores the entire nearest same-session completion contract", async () => {
+    const continuation = user("continue", { continuation: true });
+    const messages = [
+      user("old", { system: contract(tokenA) }),
+      user("current", { system: contract(tokenB) }),
+      compaction("compaction"),
+      continuation,
+    ];
+
+    await transform(messages);
+
+    expect(continuation.info.system).toBe(contract(tokenB));
+  });
+
+  it("loads authoritative history when native filtered messages omit the boundary", async () => {
+    const continuation = user("continue", { continuation: true });
+    const control = compaction("compaction");
+    const source = user("source", { system: contract(tokenA) });
+
+    await transform([control, continuation], [source, control, continuation]);
+
+    expect(continuation.info.system).toBe(contract(tokenA));
+  });
+
+  it("preserves an existing system and ordinary or replayed users", async () => {
+    const existing = user("continue", {
+      continuation: true,
+      system: "another-authoritative-system",
+    });
+    const ordinary = user("ordinary");
+    const replay = user("replay", { system: contract(tokenB) });
+
+    await transform([user("source", { system: contract(tokenA) }), existing]);
+    await transform([user("source", { system: contract(tokenA) }), ordinary]);
+    await transform([user("source", { system: contract(tokenA) }), replay]);
+
+    expect(existing.info.system).toBe("another-authoritative-system");
+    expect(ordinary.info.system).toBeUndefined();
+    expect(replay.info.system).toBe(contract(tokenB));
+  });
+
+  it("does not borrow a contract across sessions or agents", async () => {
+    const otherSession = user("continue-session", {
+      sessionID: "ses_other",
+      continuation: true,
+    });
+    const otherAgent = user("continue-agent", {
+      agent: "sapiom-turn-recovery",
+      continuation: true,
+    });
+
+    await transform([
+      user("source", { system: contract(tokenA) }),
+      otherSession,
+    ]);
+    await transform([user("source", { system: contract(tokenA) }), otherAgent]);
+
+    expect(otherSession.info.system).toBeUndefined();
+    expect(otherAgent.info.system).toBeUndefined();
+  });
+
+  it("restores the recovery agent's own contract during compaction", async () => {
+    const recovery = user("recovery", {
+      agent: "sapiom-turn-recovery",
+      system: contract(tokenB),
+    });
+    const continuation = user("continue", {
+      agent: "sapiom-turn-recovery",
+      continuation: true,
+    });
+
+    await transform([
+      user("ordinary", { system: contract(tokenA) }),
+      recovery,
+      continuation,
+    ]);
+
+    expect(continuation.info.system).toBe(contract(tokenB));
+  });
+
+  it.each([
+    user("newer-missing"),
+    user("newer-unknown", { system: "unknown contract" }),
+    user("newer-agent", {
+      agent: "sapiom-turn-recovery",
+      system: contract(tokenB),
+    }),
+  ])("does not cross a newer ordinary user boundary", async (boundary) => {
+    const continuation = user("continue", { continuation: true });
+
+    await transform([
+      user("older", { system: contract(tokenA) }),
+      boundary,
+      compaction("compaction"),
+      continuation,
+    ]);
+
+    expect(continuation.info.system).toBeUndefined();
+  });
+
+  it("skips only recognized native compaction-control users", async () => {
+    const earlierContinuation = user("earlier-continuation", {
+      continuation: true,
+      system: contract(tokenA),
+    });
+    const target = user("target", { continuation: true });
+
+    await transform([
+      user("source", { system: contract(tokenA) }),
+      compaction("first-compaction"),
+      earlierContinuation,
+      compaction("second-compaction"),
+      target,
+    ]);
+
+    expect(target.info.system).toBe(contract(tokenA));
+  });
+
+  it.each([
+    `StudioAssistantResult/v1:${tokenA}\nold contract`,
+    `StudioAssistantResult/v2:not-a-uuid\ninvalid contract`,
+    "unrelated system",
+  ])("rejects an unsupported system source: %s", async (system) => {
+    const continuation = user("continue", {
+      continuation: true,
+      text: `arbitrary text StudioAssistantResult/v2:${tokenA}`,
+    });
+
+    await transform([user("source", { system }), continuation]);
+
+    expect(continuation.info.system).toBeUndefined();
+  });
+
+  it("requires the exact native synthetic continuation marker", async () => {
+    const falseMetadata = user("false-metadata", { continuation: true });
+    falseMetadata.parts[0]!.metadata!.compaction_continue = false;
+    const nonSynthetic = user("non-synthetic", { continuation: true });
+    nonSynthetic.parts[0]!.synthetic = false;
+    const nonText = user("non-text", { continuation: true });
+    nonText.parts[0]!.type = "compaction";
+
+    for (const target of [falseMetadata, nonSynthetic, nonText]) {
+      await transform([user("source", { system: contract(tokenA) }), target]);
+      expect(target.info.system).toBeUndefined();
+    }
+  });
+
+  it("fails closed when authoritative history cannot resolve the target", async () => {
+    const absent = user("absent", { continuation: true });
+    await transform([absent], [user("source", { system: contract(tokenA) })]);
+    expect(absent.info.system).toBeUndefined();
+
+    const failed = user("failed", { continuation: true });
+    const hooks = createStudioCompletionHooks(async () => {
+      throw new Error("synthetic loader failure");
+    });
+    await expect(
+      hooks["experimental.chat.messages.transform"](
+        {},
+        {
+          messages: [failed],
+        },
+      ),
+    ).resolves.toBeUndefined();
+    expect(failed.info.system).toBeUndefined();
+  });
+});

--- a/packages/opencode/src/completion-hook.ts
+++ b/packages/opencode/src/completion-hook.ts
@@ -1,0 +1,105 @@
+interface CompletionMessage {
+  info?: {
+    id?: unknown;
+    role?: unknown;
+    sessionID?: unknown;
+    agent?: unknown;
+    system?: unknown;
+  };
+  parts?: readonly {
+    type?: unknown;
+    synthetic?: unknown;
+    metadata?: { compaction_continue?: unknown };
+  }[];
+}
+
+interface CompletionTransformOutput {
+  messages: CompletionMessage[];
+}
+
+type LoadSessionMessages = (
+  sessionID: string,
+) => Promise<readonly CompletionMessage[]>;
+
+const completionSystem =
+  /^StudioAssistantResult\/v2:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\n/;
+
+function isSyntheticContinuation(message: CompletionMessage): boolean {
+  return (
+    message.info?.role === "user" &&
+    !!message.parts?.some(
+      (part) =>
+        part.type === "text" &&
+        part.synthetic === true &&
+        part.metadata?.compaction_continue === true,
+    )
+  );
+}
+
+function isCompactionControl(message: CompletionMessage): boolean {
+  return (
+    isSyntheticContinuation(message) ||
+    (message.info?.role === "user" &&
+      !!message.parts?.some((part) => part.type === "compaction"))
+  );
+}
+
+/** Restore Studio's turn contract on OpenCode's system-less auto-continue. */
+export function createStudioCompletionHooks(
+  loadSessionMessages: LoadSessionMessages,
+): {
+  "experimental.chat.messages.transform": (
+    input: Record<string, never>,
+    output: CompletionTransformOutput,
+  ) => Promise<void>;
+} {
+  return {
+    async "experimental.chat.messages.transform"(_input, output) {
+      const target = output.messages.at(-1);
+      if (
+        target?.info?.role !== "user" ||
+        target.info.system !== undefined ||
+        typeof target.info.id !== "string" ||
+        typeof target.info.sessionID !== "string" ||
+        typeof target.info.agent !== "string" ||
+        !isSyntheticContinuation(target)
+      )
+        return;
+      const targetID = target.info.id;
+      const sessionID = target.info.sessionID;
+      const agent = target.info.agent;
+
+      let messages: readonly CompletionMessage[];
+      try {
+        messages = await loadSessionMessages(sessionID);
+      } catch {
+        return;
+      }
+      let targetIndex = -1;
+      for (let index = messages.length - 1; index >= 0; index--)
+        if (
+          messages[index]?.info?.id === targetID &&
+          messages[index]?.info?.sessionID === sessionID
+        ) {
+          targetIndex = index;
+          break;
+        }
+      if (targetIndex === -1) return;
+
+      for (let index = targetIndex - 1; index >= 0; index--) {
+        const message = messages[index];
+        if (message?.info?.role !== "user") continue;
+        if (isCompactionControl(message)) continue;
+        const candidate = message.info;
+        if (
+          candidate.sessionID === sessionID &&
+          candidate.agent === agent &&
+          typeof candidate.system === "string" &&
+          completionSystem.test(candidate.system)
+        )
+          target.info.system = candidate.system;
+        return;
+      }
+    },
+  };
+}

--- a/packages/opencode/src/config.ts
+++ b/packages/opencode/src/config.ts
@@ -27,6 +27,18 @@ export function createSapiomOpenCodeConfig(
     model: `sapiom/${model}`,
     enabled_providers: ["sapiom"],
     plugin: [],
+    agent: {
+      "sapiom-final-response": {
+        mode: "primary",
+        hidden: true,
+        permission: { "*": "deny" },
+        prompt:
+          "Write the final answer using the existing conversation and completed tool results. Do not perform additional work. Explain any limitations plainly.",
+      },
+      // Inherits native coding instructions and default permissions. Unlike the
+      // old summary-only agent, this can finish the user's remaining work.
+      "sapiom-turn-recovery": { mode: "primary", hidden: true },
+    },
     provider: {
       sapiom: {
         npm: "@ai-sdk/openai-compatible",

--- a/packages/opencode/src/server.ts
+++ b/packages/opencode/src/server.ts
@@ -6,7 +6,7 @@ import { createServer } from "node:net";
 import { userInfo } from "node:os";
 import { dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 export interface StartOpenCodeServerOptions {
   cwd: string;
@@ -119,14 +119,35 @@ async function createCredentialIsolationPlugin(
 ): Promise<{ pluginUrl: string; readyPath: string }> {
   const pluginPath = join(launchRoot, "credential-isolation.mjs");
   const readyPath = join(launchRoot, "credential-isolation.ready");
+  const compiledHook = fileURLToPath(
+    new URL("./completion-hook.js", import.meta.url),
+  );
+  let hookPath = compiledHook;
+  try {
+    await access(hookPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    hookPath = fileURLToPath(new URL("./completion-hook.ts", import.meta.url));
+    await access(hookPath);
+  }
+  hookPath = hookPath.replace(
+    /([/\\])app\.asar([/\\])/,
+    "$1app.asar.unpacked$2",
+  );
   const source = `import { writeFile } from "node:fs/promises";
+import { createStudioCompletionHooks } from ${JSON.stringify(pathToFileURL(hookPath).href)};
 const keys = ${JSON.stringify(runtimeCredentialKeys)};
 const toolHomeKeys = ${JSON.stringify(toolHomeKeys)};
 const toolHomeEnvironment = ${JSON.stringify(toolHomeEnvironment)};
-export const SapiomCredentialIsolation = async () => {
+export const SapiomCredentialIsolation = async (input) => {
   for (const key of keys) delete process.env[key];
+  const completionHooks = createStudioCompletionHooks(async (sessionID) => {
+    const response = await input.client.session.messages({ path: { id: sessionID } });
+    return response.data ?? [];
+  });
   await writeFile(${JSON.stringify(readyPath)}, "ready\\n", { flag: "wx", mode: 0o600 });
   return {
+    ...completionHooks,
     "shell.env": async (_input, output) => {
       for (const key of keys) {
         delete process.env[key];


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Native compaction and recovery must preserve Studio's completion protocol without replaying an accepted prompt or tool, and final-response transport failure must remain typed.

## Summary and scope

Fence native continuation with durable final-response state, add the scoped authoritative-history completion hook, and compose it into the sole controlled plugin before readiness. The exact typed final-response transport assertion belongs here because `/final-response` first exists in this layer; browser rendering remains in the prepared `assistant-transport-ui` replacement for historical #937.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `studio-model-responses`. Actual-parent size: **846 additions + 28 deletions = 874 changed lines**. This is above the 600-line target and below the 1,000-line hard maximum; the source and tests stay together to preserve a compiling, independently reviewable boundary.

Absorbed reviewed provenance: #933 completion protocol hook and sole-wrapper composition; b8af3632 typed final-response transport assertion (endpoint first exists here).

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3290](https://linear.app/sapiom/issue/SAP-3290). This PR keeps its existing number and review history within the main-rooted native GitHub stack.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check 462c43d5524b3fe9f6d80f91f4c4bd0eec72181d...4bb1ed3a1514d471a2fd37ca5ae14b0ccfe69fd8` — passed.
- OpenCode build/typecheck/test at this boundary — passed; 27 tests passed.
- Focused turn/final-response/bridge/server gate — 87/87 passed.
- Exact f34ddaaf real pinned-native five-scenario compaction matrix and strict close — passed.

### Tests and documentation

Final-response, turn, bridge, server, completion-hook, and native compaction tests cover concurrency fences, persistent 413 bounds, ordinary/overflow/recovery/tool paths, session isolation, and typed transport_unavailable handling.

## Compatibility and release impact

- Breaking or externally visible changes: No replay or compaction disable. One authenticated history read occurs only for a positively recognized final synthetic continuation; missing lineage fails honestly closed.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
