### PR TITLE
fix(ci): review stacked pull requests with CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+# Preserve the organization's review settings unless overridden below.
+inheritance: true
+
+reviews:
+  auto_review:
+    enabled: true
+    # Stacked PRs target the preceding feature branch instead of main.
+    base_branches:
+      - ".*"


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

CodeRabbit skips automatic reviews when a PR targets a feature branch, which prevents later PRs in a native GitHub stack from receiving reviews. For example, #920 targets `studio-model-responses` and initially reported that automatic reviews were disabled for non-default base branches.

## Summary and scope

Add a root `.coderabbit.yaml` that enables automatic reviews for all base branches with `reviews.auto_review.base_branches: [".*"]`. Set `inheritance: true` to preserve organization review settings for values this file does not override.

The configuration follows CodeRabbit's [automatic review controls](https://docs.coderabbit.ai/configuration/auto-review) and [configuration inheritance](https://docs.coderabbit.ai/configuration/configuration-inheritance) documentation.

## Related work

Related issue or discussion:

- #886 introduced the CodeRabbit trial and removed the previous Claude review workflow.
- #920 demonstrates the branch-filter skip on a stacked PR.

## Validation

```text
CodeRabbit live JSON schema validation with Ajv 2020-12 and PyYAML — passed
Regex checks for main and representative stacked PR base branches — passed
pnpm exec prettier --check .coderabbit.yaml — passed
git diff --cached --check — passed
pnpm build — passed
pnpm lint — passed with existing warnings
pnpm typecheck — passed
pnpm test — stopped on one existing agent-core bundle-error.spec.ts failure
pnpm --filter @sapiom/agent-core test --runInBand src/bundle-error.spec.ts — same failure with .coderabbit.yaml temporarily absent
```

The failing test is `describeBundleFailure > names an unreadable project directory instead of blaming dependencies`. It fails on the unchanged main code in this environment, with and without the new CodeRabbit configuration. The recursive test command stops at that package, so downstream package tests did not run.

### Tests and documentation

Validated the YAML against CodeRabbit's current schema and checked the target pattern against `main`, `studio-model-responses`, `studio-assistant-results`, and `yashnadge/sap-3288-studio-user-access`. N/A for new package tests and user documentation: this changes only the external review service's repository configuration. Inline comments explain inheritance and the stacked-PR target pattern.

## Compatibility and release impact

- Breaking or externally visible changes: Automatic reviews become eligible for all base branches. CodeRabbit reads configuration from each PR's feature branch, so existing stacks must pick up this file after merge. Review quotas still apply.
- Changeset: N/A because no published package changes.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex wrote the configuration, checked the current CodeRabbit documentation and schema, verified representative stacked branch names, and ran the validation commands listed above. The final diff was reviewed for scope and configuration precedence.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
