### PR TITLE
fix(studio): validate recovery identifiers before file access [SAP-3290]

### DIFF
--- a/.changeset/validated-recovery-files.md
+++ b/.changeset/validated-recovery-files.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Validate native session and message identifiers before creating Assistant continuation records or lock files. Reject malformed identifiers at the storage boundary while preserving the existing record names and protection against dispatching recovery twice.

--- a/packages/harness/src/core/opencode-final-response.test.ts
+++ b/packages/harness/src/core/opencode-final-response.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { HostedOpenCode } from "./opencode-host.js";
@@ -51,6 +51,27 @@ beforeEach(async () => {
 });
 afterEach(async () => {
   await rm(hosted.stateRoot, { recursive: true, force: true });
+});
+
+it.each([
+  ["ses_nested/path", "msg_empty"],
+  ["ses_test", "msg_nested/path"],
+  ["ses_test", "msg_nested\\path"],
+  ["ses_test", "msg_%2foutside"],
+  ["ses_test", "msg_"],
+  ["ses_test", `msg_${"a".repeat(129)}`],
+  ["ses_test", ["msg_empty"]],
+])("rejects invalid recovery IDs before storage or native requests: %j / %j", async (sessionId, messageId) => {
+  await expect(
+    new OpenCodeFinalResponse().recover(
+      hosted,
+      sessionId as string,
+      messageId as string,
+    ),
+  ).rejects.toThrow("Invalid Assistant recovery identifiers");
+  expect(await readdir(hosted.stateRoot)).toEqual([]);
+  expect(hosted.server.fetchJson).not.toHaveBeenCalled();
+  expect(dispatch).not.toHaveBeenCalled();
 });
 
 it("coalesces recovery and never resends it after a host restart", async () => {

--- a/packages/harness/src/core/opencode-final-response.ts
+++ b/packages/harness/src/core/opencode-final-response.ts
@@ -97,6 +97,15 @@ export class OpenCodeFinalResponse {
     sessionId: string,
     messageId: string,
   ): Promise<void> {
+    // Validate at the storage boundary, including callers outside the router.
+    // Keep the existing filenames so persisted dispatch fences still apply.
+    if (
+      typeof sessionId !== "string" ||
+      !/^ses_[A-Za-z0-9_-]{1,128}$/.test(sessionId) ||
+      typeof messageId !== "string" ||
+      !/^msg_[A-Za-z0-9_-]{1,128}$/.test(messageId)
+    )
+      throw new Error("Invalid Assistant recovery identifiers");
     const file = join(
       hosted.stateRoot,
       `final-response-${sessionId}-${messageId}.json`,


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Recovery identifiers must be validated before they participate in filesystem paths.

## Summary and scope

Validate recovery session/response identifiers before file access while retaining the existing durable final-response fence semantics.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `studio-conversation-status`. Actual-parent size: **36 additions + 1 deletions = 37 changed lines**.

Absorbed reviewed provenance: original recovery identifier path hardening; ancestry propagation only.

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3290](https://linear.app/sapiom/issue/SAP-3290). This PR keeps its existing number and review history within the main-rooted native GitHub stack.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check 3b9823456389467e30203cc7e5dce2687a072eeb...1121534e6afe7598dd4411732ece5893a729ac28` — passed.
- Focused final-response path validation tests — passed.

### Tests and documentation

Focused final-response path tests cover accepted identifiers and traversal/malformed inputs. A Changeset documents the hardening.

## Compatibility and release impact

- Breaking or externally visible changes: No valid identifier behavior changes; malformed identifiers are rejected before filesystem access.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/924" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
