### PR TITLE
fix(harness): preserve first-run attachment drafts

### DIFF
--- a/.changeset/preserve-first-run-attachment-drafts.md
+++ b/.changeset/preserve-first-run-attachment-drafts.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Keep the initial creation form open when attachment preparation fails, preserving the request and files so you can retry.

--- a/packages/harness/web/e2e/first-run-attachments.spec.ts
+++ b/packages/harness/web/e2e/first-run-attachments.spec.ts
@@ -1,0 +1,229 @@
+import { expect, test, type Page } from "@playwright/test";
+import type { CreateSessionRequest } from "../../src/shared/types";
+
+interface CreationEvidence {
+  createSessionCalls?: { req: CreateSessionRequest }[];
+  createOrder?: string[];
+  lastInitialInput?: { id: string; text: string };
+  injectInputCalls?: unknown[];
+}
+
+const creationEvidence = (page: Page): Promise<CreationEvidence> =>
+  page.evaluate(
+    () =>
+      (window as unknown as { __HARNESS_TEST__?: CreationEvidence })
+        .__HARNESS_TEST__ ?? {},
+  );
+
+async function queueFiles(page: Page, desktop: boolean): Promise<void> {
+  if (desktop) {
+    await page.evaluate(() => {
+      window.sapiomDesktop = {
+        appVersion: "test",
+        checkForUpdates: async () => ({ kind: "disabled" }),
+        pathForFile: (file: File) =>
+          file.name === "notes.txt" ? "/Users/test/input/notes.txt" : "",
+      };
+    });
+  }
+  await page.getByTestId("composer-file-input").setInputFiles({
+    name: "notes.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("Source notes"),
+  });
+  await page.evaluate(() => {
+    const transfer = new DataTransfer();
+    transfer.items.add(
+      new File(["pixels"], "screenshot.png", { type: "image/png" }),
+    );
+    document.querySelector("[data-testid='composer-input']")!.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: transfer,
+      }),
+    );
+  });
+  await expect(page.locator(".composer-file-name")).toHaveText([
+    "notes.txt",
+    "screenshot.png",
+  ]);
+}
+
+for (const scenario of [
+  {
+    name: "browser uploads",
+    desktop: false,
+    idea: "Build from these files.",
+    harness: "claude-code",
+  },
+  {
+    name: "a desktop clipboard image",
+    desktop: true,
+    idea: "Build from these files.",
+    harness: "codex",
+  },
+  {
+    name: "an attachment-only request",
+    desktop: false,
+    idea: "",
+    harness: "claude-code",
+  },
+] as const) {
+  test(`the automatic home retains ${scenario.name} after failure and retries once`, async ({
+    page,
+  }) => {
+    // Do not click Create new: that explicitly activates the composer and
+    // would hide the automatic-home state bug this test must exercise.
+    await page.goto("/?mockState=fresh");
+    const composer = page.getByTestId("new-session-composer");
+    await expect(composer).toBeVisible();
+    await composer.evaluate((node) => {
+      node.setAttribute("data-original-draft", "true");
+    });
+    await page.getByTestId("composer-harness-select").click();
+    await page
+      .getByTestId(`composer-harness-option-${scenario.harness}`)
+      .click();
+    await page.getByTestId("composer-input").fill(scenario.idea);
+    await queueFiles(page, scenario.desktop);
+    await page.evaluate(() => {
+      (
+        window as unknown as { __MOCK_ATTACH_FILE_FAIL_ONCE__?: boolean }
+      ).__MOCK_ATTACH_FILE_FAIL_ONCE__ = true;
+      const send = document.querySelector<HTMLButtonElement>(
+        "[data-testid='composer-send']",
+      )!;
+      send.click();
+      send.click();
+    });
+
+    await expect(page.getByTestId("toast")).toContainText(
+      /materialization failed/i,
+    );
+    // Reopening an empty composer after the error is not recovery: its local
+    // text and queue must survive on the original mounted instance.
+    await expect(composer).toHaveAttribute("data-original-draft", "true");
+    await expect(page.getByTestId("composer-input")).toHaveValue(scenario.idea);
+    await expect(page.getByTestId("composer-input")).toBeFocused();
+    await expect(page.locator(".composer-file-name")).toHaveText([
+      "notes.txt",
+      "screenshot.png",
+    ]);
+    await expect(
+      page.getByRole("button", { name: "Remove screenshot.png" }),
+    ).toBeEnabled();
+    await expect(page.getByTestId("composer-send")).toBeEnabled();
+    await expect(page.getByTestId("composer-harness-select")).toContainText(
+      scenario.harness === "codex" ? "Codex" : "Claude Code",
+    );
+
+    const failed = await creationEvidence(page);
+    expect(failed.createSessionCalls).toHaveLength(1);
+    expect(failed.lastInitialInput).toBeUndefined();
+    expect(failed.injectInputCalls ?? []).toHaveLength(0);
+    const firstRequest = failed.createSessionCalls![0]!.req;
+    expect(failed.createOrder).toEqual([`scaffold:${firstRequest.cwd}`]);
+    // Discovery has reached the UI even though the unrooted section is
+    // collapsed by default on a fresh install.
+    await expect(page.getByTestId("unrooted-count")).toHaveText("1");
+
+    await page.getByTestId("composer-send").click();
+    await expect(composer).toHaveCount(0);
+    const completed = await creationEvidence(page);
+    expect(completed.createSessionCalls).toHaveLength(2);
+    const retry = completed.createSessionCalls![1]!.req;
+    // The first scaffold stays registered. Retry uses the existing next-name
+    // rule rather than overwriting the completed folder from the failed try.
+    expect(retry.cwd).toBe(`${firstRequest.cwd}-2`);
+    expect(retry.harness).toBe(scenario.harness);
+    expect(retry.initialPrompt ?? "").toBe(scenario.idea);
+    expect(retry.initialAttachments).toEqual(firstRequest.initialAttachments);
+    expect(completed.createOrder).toEqual([
+      `scaffold:${firstRequest.cwd}`,
+      `scaffold:${retry.cwd}`,
+      `session:${retry.cwd}`,
+    ]);
+    const paths = [
+      scenario.desktop
+        ? "/Users/test/input/notes.txt"
+        : `${retry.cwd}/.sapiom/uploads/mock-notes.txt`,
+      `${retry.cwd}/.sapiom/uploads/mock-screenshot.png`,
+    ];
+    expect(completed.lastInitialInput?.text).toBe(
+      [
+        scenario.idea,
+        `Attached files (read each as context):\n${paths.join("\n")}`,
+      ]
+        .filter(Boolean)
+        .join("\n\n"),
+    );
+    expect(completed.injectInputCalls ?? []).toHaveLength(0);
+    await expect(page.getByTestId("session-context")).toHaveAttribute(
+      "data-session-id",
+      completed.lastInitialInput!.id,
+    );
+  });
+}
+
+test("the automatic home stays mounted until a delayed first request is prepared", async ({
+  page,
+}) => {
+  await page.goto("/?mockState=fresh");
+  await expect(page.getByTestId("new-session-composer")).toBeVisible();
+  await page.getByTestId("composer-input").fill("Use both files.");
+  await queueFiles(page, false);
+  await page.evaluate(() => {
+    const testWindow = window as unknown as {
+      __MOCK_CREATE_SESSION_DELAY_MS__?: number;
+      __HARNESS_TEST__?: CreationEvidence;
+      __COMPOSER_PREPARATION__?: {
+        detachedEarly: boolean;
+        sawScaffold: boolean;
+      };
+    };
+    testWindow.__MOCK_CREATE_SESSION_DELAY_MS__ = 600;
+    const composer = document.querySelector(
+      "[data-testid='new-session-composer']",
+    )!;
+    const observation = { detachedEarly: false, sawScaffold: false };
+    testWindow.__COMPOSER_PREPARATION__ = observation;
+    const observer = new MutationObserver(() => {
+      if (testWindow.__HARNESS_TEST__?.lastInitialInput) {
+        observer.disconnect();
+        return;
+      }
+      observation.detachedEarly ||= !composer.isConnected;
+      observation.sawScaffold ||=
+        testWindow.__HARNESS_TEST__?.createOrder?.some((entry) =>
+          entry.startsWith("scaffold:"),
+        ) ?? false;
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  });
+  await page.getByTestId("composer-send").click();
+  await expect(page.getByTestId("composer-send")).toBeDisabled();
+  await expect(page.getByTestId("new-session-composer")).toHaveCount(0);
+  const completed = await creationEvidence(page);
+  expect(completed.createSessionCalls).toHaveLength(1);
+  expect(completed.lastInitialInput?.text).toContain("Use both files.");
+  expect(completed.lastInitialInput?.text).toContain("mock-notes.txt");
+  expect(completed.lastInitialInput?.text).toContain("mock-screenshot.png");
+  expect(
+    await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __COMPOSER_PREPARATION__?: {
+              detachedEarly: boolean;
+              sawScaffold: boolean;
+            };
+          }
+        ).__COMPOSER_PREPARATION__,
+    ),
+  ).toEqual({ detachedEarly: false, sawScaffold: true });
+  await expect(page.getByTestId("session-context")).toHaveAttribute(
+    "data-session-id",
+    completed.lastInitialInput!.id,
+  );
+});

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -351,8 +351,8 @@ export const App = (): JSX.Element => {
     },
     [harness.getWorkflowInputContract],
   );
-  // The composer-first "new session" home. `composing` is explicit rail
-  // Create-new intent; the workbench tab + starts a sibling directly instead.
+  // The composer-first "new session" home. `composing` holds it open for
+  // explicit Create-new intent or a submission from the automatic home.
   // The home also shows whenever nothing else claims the centre pane.
   const [composing, setComposing] = useState(false);
   // The tab + is a one-at-a-time create/bind transaction. State renders the
@@ -1860,7 +1860,9 @@ export const App = (): JSX.Element => {
     agentHarness: HarnessKind,
     options: CreateSessionAtOptions = {},
   ): Promise<HarnessSession> => {
-    if (!options.keepComposerOpen) setComposing(false);
+    // Activate the automatic home before a scaffold update can replace it;
+    // its local draft and files must survive a later preparation failure.
+    setComposing(options.keepComposerOpen === true);
     setReviewSummary(null);
     // Preserve a same-project selection while the create is in flight. The
     // caller owns the final destination: a project-row create can deliberately


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

On the automatically displayed empty home, a submitted request could disappear when scaffolding discovered its new agent before attachment preparation finished. If an upload then failed, Studio showed **No running session** and lost the unsent text and queued files. The explicit Create new button already protected the same form by setting `composing=true`.

## Summary and scope

Make `createSessionAt` actively set `composing` from `keepComposerOpen` before changing focus or starting preparation. The original composer stays mounted on failure, preserving its draft for retry; successful creation still dismisses it and selects the resulting ordinary session.

Global creation and templates keep their existing destinations, and a project's `+` keeps starting an ordinary session at that project root. The existing scaffold retention, collision-safe retry destination, and server first-request behavior are unchanged.

## Related work

Closes [SAP-3240](https://linear.app/sapiom/issue/SAP-3240/agent-studio-preserve-first-run-drafts-after-attachment-failures).

## Validation

From the repository root (Node 24.15.0):

```text
pnpm build — passed
pnpm typecheck — passed
pnpm lint — passed (existing warnings)
pnpm test — passed (all package test scripts, including harness performance tests)
pnpm --filter @sapiom/harness test:ui first-run-attachments.spec.ts --workers=2 --trace=off --reporter=list — 4 passed
```

The selected existing browser coverage also passed: all 18 tests in `new-session-composer.spec.ts`, both template creation paths (`templates.spec.ts:228`, `:270`), legacy creation ordering (`create-agent.spec.ts:83`), and project-root `+` (`project-axis.spec.ts:161`): 22 tests.

All four new regressions failed on the original code: the three failure/retry cases lost the original composer, and delayed success detached it before preparation completed. They pass with the state fix. Browser runs used isolated `E2E_PORT=5396` and a private temporary directory.

For the full test run, the cloud VM's extra permission-bypass capabilities had to be dropped so the existing unreadable-directory fixture could exercise normal permissions. The successful invocation used `TMPDIR=/tmp/sap-3240-implementation-ram npm_config_workspace_concurrency=1 setpriv --inh-caps=-dac_override,-dac_read_search --ambient-caps=-dac_override,-dac_read_search --bounding-set=-dac_override,-dac_read_search taskset -c 0,1,2,3 pnpm test`. An external `elkjs` dependency was copied into this isolated checkout to satisfy Vite's filesystem restriction. Neither adjustment changes tracked code or skips a check.

### Tests and documentation

Added four automatic-home regressions covering browser uploads, a simulated desktop native-path file plus pathless clipboard image, attachment-only retry, and delayed successful preparation. They assert the same mounted form, preserved text/provider/file order, duplicate-submit protection, no launched session or first task after failure, collision-safe retry, exact first-task contents, and the resulting active session.

Desktop coverage uses the preload bridge mock; an installed Electron app was not exercised locally. The patch Changeset documents the recovered behavior; a guide/API update is N/A for restoring existing draft recovery.

## Compatibility and release impact

- Breaking or externally visible changes: no breaking change; a failed first-run upload leaves the original request editable and retryable.
- Changeset: added a patch release note for `@sapiom/harness`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex implemented the state assignment, regression tests, and Changeset. Verification included a before/after regression run, source/callsite review, and the checks listed above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/925" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The new-session composer now remains open when attachment preparation fails.
  - Draft text, selected harness, and queued attachments are preserved so you can retry without starting over.
  - The composer stays available while session setup is in progress, reducing the chance of losing work.
- **Tests**
  - Added coverage for browser uploads, clipboard images, attachment-only requests, retries, and delayed session creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->