### PR TITLE
fix(harness): preserve Assistant bridge errors [SAP-3289]

### DIFF
--- a/.changeset/honest-assistant-errors.md
+++ b/.changeset/honest-assistant-errors.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Preserve actionable Assistant service status codes and validated retry delays while replacing upstream error content with sanitized structured responses. Return oversized local requests as JSON 413 errors through the assembled Studio server.

--- a/packages/harness/src/server/error-handler.test.ts
+++ b/packages/harness/src/server/error-handler.test.ts
@@ -39,4 +39,23 @@ describe("unhandledRequestErrorHandler", () => {
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: "internal error" });
   });
+
+  it("sanitizes body-parser size errors as structured JSON 413", async () => {
+    const res = await throwFrom(
+      Object.assign(new Error("request entity too large"), {
+        status: 413,
+        statusCode: 413,
+        type: "entity.too.large",
+        body: "private request content",
+      }),
+    );
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({
+      error: {
+        message: "Request body is too large.",
+        type: "invalid_request_error",
+        code: "request_body_too_large",
+      },
+    });
+  });
 });

--- a/packages/harness/src/server/error-handler.ts
+++ b/packages/harness/src/server/error-handler.ts
@@ -16,6 +16,27 @@ export function unhandledRequestErrorHandler(
   res: express.Response,
   _next: express.NextFunction,
 ): void {
+  const httpError = err as {
+    status?: unknown;
+    statusCode?: unknown;
+    type?: unknown;
+  } | null;
+  if (
+    httpError?.type === "entity.too.large" &&
+    (httpError.status === 413 || httpError.statusCode === 413)
+  ) {
+    // Body-parser errors can retain request details. Keep the only expected
+    // parser failure content-free in logs as well as in the response.
+    console.error("[harness] request body too large");
+    res.status(413).json({
+      error: {
+        message: "Request body is too large.",
+        type: "invalid_request_error",
+        code: "request_body_too_large",
+      },
+    });
+    return;
+  }
   console.error("[harness] unhandled request error:", err);
   const message = err instanceof Error && err.message ? err.message : "internal error";
   const code = (err as { code?: unknown } | null)?.code;

--- a/packages/harness/src/server/opencode-bridge.test.ts
+++ b/packages/harness/src/server/opencode-bridge.test.ts
@@ -1,10 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import express from "express";
 import { createServer, type Server } from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { AssistantGrant } from "../core/assistant-access.js";
 import { openCodeCompletionPrompt } from "../shared/opencode-completion.js";
+import { startServer } from "./index.js";
 import { openCodeModelCompletionToken } from "./opencode-model-response.js";
 import {
   OpenCodeBridge,
@@ -591,6 +595,188 @@ describe("Studio OpenCode credential bridge", () => {
     expect(
       (await request("mcp", { method: "GET", body: undefined })).status,
     ).toBe(502);
+  });
+
+  it.each([
+    [
+      400,
+      "invalid_request_error",
+      "assistant_invalid_request",
+      "The Assistant request was rejected as invalid.",
+    ],
+    [
+      401,
+      "authentication_error",
+      "assistant_authentication_failed",
+      "Studio credentials were rejected. Sign in again.",
+    ],
+    [
+      403,
+      "permission_error",
+      "assistant_permission_denied",
+      "The Assistant service denied this request.",
+    ],
+    [
+      413,
+      "invalid_request_error",
+      "assistant_request_too_large",
+      "The Assistant request is too large.",
+    ],
+    [
+      429,
+      "rate_limit_error",
+      "assistant_rate_limited",
+      "The Assistant service is rate limited.",
+    ],
+    [
+      408,
+      "upstream_error",
+      "assistant_upstream_error",
+      "The Assistant service request failed.",
+    ],
+    [
+      409,
+      "upstream_error",
+      "assistant_upstream_error",
+      "The Assistant service request failed.",
+    ],
+    [
+      500,
+      "server_error",
+      "assistant_service_unavailable",
+      "The Assistant service is temporarily unavailable.",
+    ],
+    [
+      502,
+      "server_error",
+      "assistant_service_unavailable",
+      "The Assistant service is temporarily unavailable.",
+    ],
+    [
+      503,
+      "server_error",
+      "assistant_service_unavailable",
+      "The Assistant service is temporarily unavailable.",
+    ],
+    [
+      504,
+      "server_error",
+      "assistant_service_unavailable",
+      "The Assistant service is temporarily unavailable.",
+    ],
+  ] as const)(
+    "preserves and sanitizes upstream HTTP %i without model-response replay",
+    async (status, type, code, message) => {
+      let calls = 0;
+      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+        calls++;
+        res
+          .status(status)
+          .set("x-private-upstream", "sk_private_studio")
+          .send("credential=sk_private_studio");
+      });
+      const response = await request();
+      expect(response.status).toBe(status);
+      expect(response.headers.get("x-private-upstream")).toBeNull();
+      expect(await response.json()).toEqual({
+        error: { message, type, code },
+      });
+      expect(calls).toBe(1);
+    },
+  );
+
+  it.each([
+    [413, "13", "13"],
+    [429, "17", "17"],
+    [503, "Wed, 21 Oct 2099 07:28:00 GMT", "Wed, 21 Oct 2099 07:28:00 GMT"],
+    [400, "19", null],
+    [502, "23", null],
+    [429, "1e3", null],
+    [429, "-1", null],
+    [413, "9007199254740992", null],
+    [503, "Wednesday, 21-Oct-99 07:28:00 GMT", null],
+    [503, "Wed, 21 Oct 2015 07:28:00 GMT", null],
+  ] as const)(
+    "for HTTP %i validates Retry-After %s before forwarding it",
+    async (status, retryAfter, expected) => {
+      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+        res.status(status).set("Retry-After", retryAfter).end();
+      });
+      const response = await request();
+      expect(response.status).toBe(status);
+      expect(response.headers.get("retry-after")).toBe(expected);
+    },
+  );
+
+  it("returns a sanitized retryable service error when the upstream is unreachable", async () => {
+    const unavailable = createServer();
+    await new Promise<void>((resolve) =>
+      unavailable.listen(0, "127.0.0.1", resolve),
+    );
+    const address = unavailable.address() as { port: number };
+    await new Promise<void>((resolve, reject) =>
+      unavailable.close((error) => (error ? reject(error) : resolve())),
+    );
+    grant!.environment.services.llm = `http://127.0.0.1:${address.port}`;
+
+    const response = await request();
+    expect(response.status).toBe(502);
+    expect(await response.json()).toEqual({
+      error: {
+        message: "Assistant connection failed.",
+        type: "server_error",
+        code: "assistant_connection_failed",
+      },
+    });
+  });
+
+  it("returns structured JSON 413 through the assembled Studio middleware", async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), "studio-bridge-limit-"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const studio = await startServer({
+      port: 0,
+      bootToken: "synthetic-boot-token",
+      telemetryOptIn: false,
+      authMode: "disabled",
+      adapters: {},
+      stateRoot,
+      launchDir: stateRoot,
+      autoCreateSession: false,
+      loadSystemPrompt: async () => "",
+    });
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${studio.port}/opencode-runtime/unknown/llm/v2/openai/v1/chat/completions`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: "Bearer synthetic-runtime-token",
+            "Content-Type": "application/json",
+          },
+          body: "x".repeat(4 * 1024 * 1024 + 1),
+        },
+      );
+      expect(response.status).toBe(413);
+      expect(response.headers.get("content-type")).toContain(
+        "application/json",
+      );
+      expect(await response.json()).toEqual({
+        error: {
+          message: "Request body is too large.",
+          type: "invalid_request_error",
+          code: "request_body_too_large",
+        },
+      });
+      expect(consoleError).toHaveBeenCalledWith(
+        "[harness] request body too large",
+      );
+    } finally {
+      await studio.close();
+      await rm(stateRoot, { recursive: true, force: true });
+      consoleError.mockRestore();
+    }
   });
 
   it("revokes credentials and active streams on access loss, and permits a fresh login", async () => {

--- a/packages/harness/src/server/opencode-bridge.ts
+++ b/packages/harness/src/server/opencode-bridge.ts
@@ -35,6 +35,99 @@ const sameAuthority = (a: AssistantGrant, b: AssistantGrant) =>
   a.environment.apiURL === b.environment.apiURL &&
   a.environment.credentials?.apiKey === b.environment.credentials?.apiKey;
 
+type BridgeErrorType =
+  | "authentication_error"
+  | "invalid_request_error"
+  | "permission_error"
+  | "rate_limit_error"
+  | "server_error"
+  | "upstream_error";
+
+function sendBridgeError(
+  res: Response,
+  status: number,
+  error: { message: string; type: BridgeErrorType; code: string },
+  retryAfter?: string,
+): void {
+  res.setHeader("Cache-Control", "no-store");
+  if (retryAfter) res.setHeader("Retry-After", retryAfter);
+  res.status(status).json({ error });
+}
+
+function upstreamError(status: number): {
+  message: string;
+  type: BridgeErrorType;
+  code: string;
+} {
+  switch (status) {
+    case 400:
+      return {
+        message: "The Assistant request was rejected as invalid.",
+        type: "invalid_request_error",
+        code: "assistant_invalid_request",
+      };
+    case 401:
+      return {
+        message: "Studio credentials were rejected. Sign in again.",
+        type: "authentication_error",
+        code: "assistant_authentication_failed",
+      };
+    case 403:
+      return {
+        message: "The Assistant service denied this request.",
+        type: "permission_error",
+        code: "assistant_permission_denied",
+      };
+    case 413:
+      return {
+        message: "The Assistant request is too large.",
+        type: "invalid_request_error",
+        code: "assistant_request_too_large",
+      };
+    case 429:
+      return {
+        message: "The Assistant service is rate limited.",
+        type: "rate_limit_error",
+        code: "assistant_rate_limited",
+      };
+    default:
+      return status >= 500
+        ? {
+            message: "The Assistant service is temporarily unavailable.",
+            type: "server_error",
+            code: "assistant_service_unavailable",
+          }
+        : {
+            message: "The Assistant service request failed.",
+            type: "upstream_error",
+            code: "assistant_upstream_error",
+          };
+  }
+}
+
+/** Only forward the standardized header on statuses that define its use. */
+function validatedRetryAfter(
+  response: globalThis.Response,
+): string | undefined {
+  if (![413, 429, 503].includes(response.status)) return;
+  const value = response.headers.get("retry-after");
+  if (!value) return;
+  if (/^\d+$/.test(value)) {
+    const seconds = Number(value);
+    if (Number.isSafeInteger(seconds)) return value;
+    return;
+  }
+  // HTTP senders generate IMF-fixdate. A canonical round trip rejects the
+  // obsolete/lenient date forms accepted by Date.parse and mismatched days.
+  const timestamp = Date.parse(value);
+  if (
+    Number.isFinite(timestamp) &&
+    timestamp > Date.now() &&
+    new Date(timestamp).toUTCString() === value
+  )
+    return value;
+}
+
 /** Destinations come exclusively from Studio's signed-in environment. */
 export function assistantUpstreams(env: ResolvedEnvironment): {
   llm: URL;
@@ -143,12 +236,20 @@ export class OpenCodeBridge {
       token.length > 256 ||
       !timingSafeEqual(entry.digest, digest(token))
     ) {
-      res.status(401).json({ error: "Invalid Assistant runtime credential" });
+      sendBridgeError(res, 401, {
+        message: "Invalid Assistant runtime credential.",
+        type: "authentication_error",
+        code: "assistant_runtime_credential_invalid",
+      });
       return;
     }
     if (!grant || !sameAuthority(entry.grant, grant)) {
       this.revoke(req.params.id!);
-      res.status(403).json({ error: "Assistant access is unavailable" });
+      sendBridgeError(res, 403, {
+        message: "Assistant access is unavailable.",
+        type: "permission_error",
+        code: "assistant_access_unavailable",
+      });
       return;
     }
     if (
@@ -157,7 +258,11 @@ export class OpenCodeBridge {
         req.method,
       )
     ) {
-      res.status(400).json({ error: "Unsupported Assistant service request" });
+      sendBridgeError(res, 400, {
+        message: "Unsupported Assistant service request.",
+        type: "invalid_request_error",
+        code: "assistant_request_unsupported",
+      });
       return;
     }
     const abort = new AbortController();
@@ -193,11 +298,19 @@ export class OpenCodeBridge {
         try {
           request = JSON.parse(body?.toString("utf8") ?? "");
         } catch {
-          res.status(400).json({ error: "Invalid model request" });
+          sendBridgeError(res, 400, {
+            message: "Invalid model request.",
+            type: "invalid_request_error",
+            code: "assistant_model_request_invalid",
+          });
           return;
         }
         if (!request || typeof request !== "object" || Array.isArray(request)) {
-          res.status(400).json({ error: "Invalid model request" });
+          sendBridgeError(res, 400, {
+            message: "Invalid model request.",
+            type: "invalid_request_error",
+            code: "assistant_model_request_invalid",
+          });
           return;
         }
         body = Buffer.from(JSON.stringify({ ...request, model: this.model }));
@@ -221,19 +334,14 @@ export class OpenCodeBridge {
         : await request();
       if (!response.ok) {
         await response.body?.cancel();
-        // MCP uses 405 to decline optional notification streams or session
-        // cleanup; clients handle that without treating it as a service outage.
-        const status =
-          response.status === 401 ||
-          (service === "mcp" && response.status === 405)
-            ? response.status
-            : 502;
-        res.status(status).json({
-          error:
-            response.status === 401
-              ? "Studio credentials were rejected. Sign in again, then retry."
-              : "The Assistant service request failed. Please retry.",
-        });
+        // Preserve status-based client policy, including MCP's optional 405,
+        // while replacing all credential-bearing upstream content.
+        sendBridgeError(
+          res,
+          response.status,
+          upstreamError(response.status),
+          validatedRetryAfter(response),
+        );
         return;
       }
       res.status(response.status);
@@ -255,9 +363,11 @@ export class OpenCodeBridge {
       } else res.end();
     } catch {
       if (!res.headersSent && !res.destroyed) {
-        res
-          .status(502)
-          .json({ error: "Assistant connection failed. Please retry." });
+        sendBridgeError(res, 502, {
+          message: "Assistant connection failed.",
+          type: "server_error",
+          code: "assistant_connection_failed",
+        });
       } else res.destroy();
     } finally {
       res.off("close", disconnected);


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Assistant bridge failures lost actionable status and retry information, and oversized local requests did not consistently use the sanitized structured error path.

## Summary and scope

Preserve validated 400, 413, and 429 bridge semantics, including bounded retry delays, while suppressing upstream diagnostics and preventing accepted prompts or tool calls from being replayed. Access lifecycle, UI actions, and runtime ownership are intentionally out of scope.

## Related work

Related issue or discussion: SAP-3289

## Validation

```text
pnpm --filter @sapiom/harness exec vitest run src/server/opencode-bridge.test.ts — 62/62 passed on the curated stack
Owner focused bridge/error suite — 63 tests passed; typecheck, lint, server build, and real 400/413/429 probes passed
git diff --check — passed
Final root pnpm build / pnpm typecheck / pnpm lint — passed on b04b296fd05d2e708d466d8869ab5dd4c65a1a4d
Final root pnpm test — exited 1 only at unchanged @sapiom/agent-core permission fixture
pnpm --filter @sapiom/agent-core exec jest --runInBand src/bundle-error.spec.ts — final and exact baseline 709573af39499dcefa10e8a682f043d51d57620e both reproduced 1 failed / 5 passed: "names an unreadable project directory instead of blaming dependencies"
mcp, harness, agent-studio, cli, and harness-desktop suites skipped after recursive first-failure — explicitly run and passed
```

### Tests and documentation

Added focused bridge and error-handler regressions for structured failures, Retry-After handling, bounded retries, and no replay. Added `.changeset/honest-assistant-errors.md`.

## Compatibility and release impact

- Breaking or externally visible changes: Assistant failures retain sanitized actionable status and retry metadata; no wire-compatible success behavior changes.
- Changeset: Added `.changeset/honest-assistant-errors.md`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and reviewed the focused correction. Codex curated the approved commit and verified exact tests, sizes, and source provenance.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/928" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Assistant service errors now preserve actionable HTTP status codes while returning sanitized, structured JSON responses.
  * Valid `Retry-After` guidance is preserved for applicable rate-limit and service-availability errors.
  * Unreachable upstream services now return a consistent sanitized 502 error.
  * Oversized request bodies now receive a clear structured 413 response without exposing request contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->