### PR TITLE
fix(harness): isolate Assistant bridge authority [SAP-3289]

### DIFF
--- a/.changeset/isolate-assistant-authority.md
+++ b/.changeset/isolate-assistant-authority.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Revoke Assistant bridge credentials when the verified user or tenant changes, even if an identity revision is incorrectly reused.

--- a/packages/harness/src/server/opencode-bridge.test.ts
+++ b/packages/harness/src/server/opencode-bridge.test.ts
@@ -553,7 +553,9 @@ describe("Studio OpenCode credential bridge", () => {
       } else if (method === "tools/call") {
         calls++;
         callId = id;
-        res.type("text/event-stream").end("id: queued-start\nretry: 10\ndata:\n\n");
+        res
+          .type("text/event-stream")
+          .end("id: queued-start\nretry: 10\ndata:\n\n");
       } else res.status(202).end();
     });
     expect(
@@ -565,7 +567,11 @@ describe("Studio OpenCode credential bridge", () => {
     const client = new Client({ name: "replay-test", version: "1" });
     const transport = new StreamableHTTPClientTransport(
       new URL(`${origin}/opencode-runtime/${credential.id}/mcp`),
-      { requestInit: { headers: { Authorization: `Bearer ${credential.token}` } } },
+      {
+        requestInit: {
+          headers: { Authorization: `Bearer ${credential.token}` },
+        },
+      },
     );
     try {
       await client.connect(transport);
@@ -798,6 +804,40 @@ describe("Studio OpenCode credential bridge", () => {
     expect(next.token).not.toBe(credential.token);
     next.revoke();
   });
+
+  it.each([
+    ["userId", "other-user"],
+    ["tenantId", "other-tenant"],
+  ] as const)(
+    "rejects and revokes a credential after verified %s changes",
+    async (field, value) => {
+      let calls = 0;
+      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+        calls++;
+        res.json({ choices: [] });
+      });
+      const previous = grant!;
+      grant = { ...previous, [field]: value };
+
+      const rejected = await request();
+      expect(rejected.status).toBe(403);
+      expect(await rejected.json()).toEqual({
+        error: {
+          message: "Assistant access is unavailable.",
+          type: "permission_error",
+          code: "assistant_access_unavailable",
+        },
+      });
+      expect((await request()).status).toBe(401);
+
+      grant = previous;
+      credential = bridge.issue();
+      grant = { ...previous, [field]: `notified-${field}` };
+      changed();
+      expect((await request()).status).toBe(401);
+      expect(calls).toBe(0);
+    },
+  );
 
   it("requires explicit service configuration outside the production environment", () => {
     expect(() =>

--- a/packages/harness/src/server/opencode-bridge.ts
+++ b/packages/harness/src/server/opencode-bridge.ts
@@ -30,6 +30,8 @@ export interface OpenCodeBridgeCredential {
 }
 const digest = (value: string) => createHash("sha256").update(value).digest();
 const sameAuthority = (a: AssistantGrant, b: AssistantGrant) =>
+  a.userId === b.userId &&
+  a.tenantId === b.tenantId &&
   a.identityRevision === b.identityRevision &&
   a.environment.name === b.environment.name &&
   a.environment.apiURL === b.environment.apiURL &&


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

A bridge credential must stop authorizing requests immediately when the verified user or tenant changes, even if a backend reuses other authority revision fields.

## Summary and scope

Include verified user and tenant fields in bridge authority equality, and cover both request-time crossover rejection and subscriber-triggered revocation without additional upstream requests. This does not change the wire shape.

## Related work

Related issue or discussion: SAP-3289

## Validation

```text
pnpm --filter @sapiom/harness exec vitest run src/server/opencode-bridge.test.ts — 62/62 passed
pnpm --filter @sapiom/harness typecheck — passed
pnpm --filter @sapiom/harness build — passed with existing Vite warnings only
git diff --check — passed
Final root pnpm build / pnpm typecheck / pnpm lint — passed on b04b296fd05d2e708d466d8869ab5dd4c65a1a4d
Final root pnpm test — exited 1 only at unchanged @sapiom/agent-core permission fixture
pnpm --filter @sapiom/agent-core exec jest --runInBand src/bundle-error.spec.ts — final and exact baseline 709573af39499dcefa10e8a682f043d51d57620e both reproduced 1 failed / 5 passed: "names an unreadable project directory instead of blaming dependencies"
mcp, harness, agent-studio, cli, and harness-desktop suites skipped after recursive first-failure — explicitly run and passed
```

### Tests and documentation

Added one focused authority table covering request-time rejection, subscriber notification, revocation, and zero upstream traffic. Added `.changeset/isolate-assistant-authority.md`.

## Compatibility and release impact

- Breaking or externally visible changes: Stale bridge credentials are rejected after verified user or tenant crossovers.
- Changeset: Added `.changeset/isolate-assistant-authority.md`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and reviewed the official correction. Codex reconciled the approved notification coverage and Changeset into one local authority increment.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/930" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->