### PR TITLE
fix(opencode): classify sanitized startup failures [SAP-3290]

### DIFF
--- a/.changeset/sanitize-opencode-startup-errors.md
+++ b/.changeset/sanitize-opencode-startup-errors.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/opencode": patch
+---
+
+Expose stable, retry-aware OpenCode startup failure codes without leaking native output, paths, configuration, or underlying causes.

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -5,6 +5,8 @@ export {
 export {
   startOpenCodeServer,
   OpenCodeShutdownError,
+  OpenCodeStartupError,
   type OpenCodeServer,
+  type OpenCodeStartupFailureCode,
   type StartOpenCodeServerOptions,
 } from "./server.js";

--- a/packages/opencode/src/server.test.ts
+++ b/packages/opencode/src/server.test.ts
@@ -1,9 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { startOpenCodeServer, type OpenCodeServer } from "./server.js";
+import {
+  OpenCodeStartupError,
+  startOpenCodeServer,
+  type OpenCodeServer,
+} from "./server.js";
 import { createSapiomOpenCodeConfig } from "./config.js";
 
 let directory: string;
@@ -100,7 +104,12 @@ describe("packaged OpenCode runtime", () => {
         ...options({ stall: true }),
         startupTimeoutMs: 400,
       }),
-    ).rejects.toThrow("could not start");
+    ).rejects.toMatchObject({
+      name: "OpenCodeStartupError",
+      code: "timed-out",
+      retryable: true,
+      message: "OpenCode took too long to start. Retry the connection.",
+    });
     const pid = Number(await readFile(join(directory, "runtime.pid"), "utf8"));
     expect(() => process.kill(pid, 0)).toThrow();
     server = await startOpenCodeServer(options());
@@ -115,13 +124,47 @@ describe("packaged OpenCode runtime", () => {
     });
     const timer = setTimeout(() => abort.abort(), 100);
     try {
-      await expect(starting).rejects.toThrow();
+      await expect(starting).rejects.toMatchObject({
+        code: "cancelled",
+        retryable: true,
+      });
     } finally {
       clearTimeout(timer);
     }
-    await expect(startOpenCodeServer(options({ crash: true }))).rejects.toThrow(
-      "OpenCode could not start. Please retry.",
-    );
+    await expect(
+      startOpenCodeServer(options({ crash: true })),
+    ).rejects.toMatchObject({
+      code: "exited",
+      exitCode: 1,
+      retryable: true,
+      message:
+        "OpenCode exited before it became ready. Retry, then update or reinstall Studio if the problem continues.",
+    });
+  });
+
+  it("classifies real executable path and permission failures without raw details", async () => {
+    const missing = join(directory, "private-provider-token-missing");
+    await expect(
+      startOpenCodeServer({
+        ...options(),
+        command: { executable: missing },
+      }),
+    ).rejects.toEqual(new OpenCodeStartupError("executable-not-found"));
+    if (process.platform !== "win32") {
+      const blocked = join(directory, "private-provider-token-blocked");
+      await writeFile(blocked, "#!/bin/sh\nexit 0\n", { mode: 0o600 });
+      await expect(
+        startOpenCodeServer({
+          ...options(),
+          command: { executable: blocked },
+        }),
+      ).rejects.toEqual(new OpenCodeStartupError("permission-denied"));
+    }
+    expect(
+      (await readdir(join(directory, "state"))).filter((entry) =>
+        entry.startsWith("launch-"),
+      ),
+    ).toEqual([]);
   });
 
   it.each([

--- a/packages/opencode/src/server.ts
+++ b/packages/opencode/src/server.ts
@@ -26,6 +26,53 @@ export interface OpenCodeServer {
   close(): Promise<void>;
 }
 
+export type OpenCodeStartupFailureCode =
+  | "executable-not-found"
+  | "permission-denied"
+  | "launch-failed"
+  | "exited"
+  | "timed-out"
+  | "cancelled";
+
+const startupMessages: Record<OpenCodeStartupFailureCode, string> = {
+  "executable-not-found":
+    "Studio's OpenCode runtime is missing. Update or reinstall Studio, then retry.",
+  "permission-denied":
+    "Studio cannot launch its OpenCode runtime because the executable is not permitted. Check the installation permissions or reinstall Studio, then retry.",
+  "launch-failed":
+    "Studio could not launch its OpenCode runtime. Retry, then update or reinstall Studio if the problem continues.",
+  exited:
+    "OpenCode exited before it became ready. Retry, then update or reinstall Studio if the problem continues.",
+  "timed-out": "OpenCode took too long to start. Retry the connection.",
+  cancelled: "OpenCode startup was cancelled.",
+};
+
+const permanentlyBlocked = new Set<OpenCodeStartupFailureCode>([
+  "executable-not-found",
+  "permission-denied",
+]);
+
+/** A credential-free, stable reason for a native runtime startup failure. */
+export class OpenCodeStartupError extends Error {
+  readonly retryable: boolean;
+  readonly exitCode?: number;
+  readonly signal?: NodeJS.Signals;
+
+  constructor(
+    readonly code: OpenCodeStartupFailureCode,
+    termination?: { exitCode: number | null; signal: NodeJS.Signals | null },
+  ) {
+    super(startupMessages[code]);
+    this.name = "OpenCodeStartupError";
+    this.retryable = !permanentlyBlocked.has(code);
+    if (code === "exited") {
+      if (typeof termination?.exitCode === "number")
+        this.exitCode = termination.exitCode;
+      if (termination?.signal) this.signal = termination.signal;
+    }
+  }
+}
+
 /** The caller must retain its state-owner lock when process exit is unconfirmed. */
 export class OpenCodeShutdownError extends Error {
   constructor() {
@@ -98,7 +145,7 @@ export const SapiomCredentialIsolation = async () => {
 export async function startOpenCodeServer(
   options: StartOpenCodeServerOptions,
 ): Promise<OpenCodeServer> {
-  options.signal?.throwIfAborted();
+  if (options.signal?.aborted) throw new OpenCodeStartupError("cancelled");
   const command = options.command ?? {
     executable: join(
       dirname(
@@ -150,65 +197,94 @@ export async function startOpenCodeServer(
       mkdir(path, { recursive: true, mode: 0o700 }),
     ),
   );
-  options.signal?.throwIfAborted();
-  const child = spawn(
-    command.executable,
-    [
-      ...(command.prefixArgs ?? []),
-      "serve",
-      "--hostname",
-      "127.0.0.1",
-      "--port",
-      String(port),
-    ],
-    {
-      cwd: options.cwd,
-      env: {
-        ...platform,
-        HOME: isolatedHome,
-        ...(process.platform === "win32" ? { USERPROFILE: isolatedHome } : {}),
-        ...directories,
-        OPENCODE_CONFIG_CONTENT: JSON.stringify({
-          ...options.config,
-          plugin: [pluginUrl],
-        }),
-        OPENCODE_SERVER_USERNAME: "opencode",
-        OPENCODE_SERVER_PASSWORD: password,
-        OPENCODE_DISABLE_CLAUDE_CODE: "1",
-        OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: "1",
-        OPENCODE_DISABLE_DEFAULT_PLUGINS: "1",
-        OPENCODE_DISABLE_EXTERNAL_SKILLS: "1",
-        OPENCODE_DISABLE_PROJECT_CONFIG: "1",
-        OPENCODE_DISABLE_AUTOUPDATE: "1",
-        // Native discovery retains the complete MCP catalog without placing
-        // every remote tool schema in every model request.
-        OPENCODE_EXPERIMENTAL_CODE_MODE: "1",
+  if (options.signal?.aborted) {
+    await rm(launchRoot, { recursive: true, force: true }).catch(() => {});
+    throw new OpenCodeStartupError("cancelled");
+  }
+  let child: ChildProcess;
+  try {
+    child = spawn(
+      command.executable,
+      [
+        ...(command.prefixArgs ?? []),
+        "serve",
+        "--hostname",
+        "127.0.0.1",
+        "--port",
+        String(port),
+      ],
+      {
+        cwd: options.cwd,
+        env: {
+          ...platform,
+          HOME: isolatedHome,
+          ...(process.platform === "win32"
+            ? { USERPROFILE: isolatedHome }
+            : {}),
+          ...directories,
+          OPENCODE_CONFIG_CONTENT: JSON.stringify({
+            ...options.config,
+            plugin: [pluginUrl],
+          }),
+          OPENCODE_SERVER_USERNAME: "opencode",
+          OPENCODE_SERVER_PASSWORD: password,
+          OPENCODE_DISABLE_CLAUDE_CODE: "1",
+          OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: "1",
+          OPENCODE_DISABLE_DEFAULT_PLUGINS: "1",
+          OPENCODE_DISABLE_EXTERNAL_SKILLS: "1",
+          OPENCODE_DISABLE_PROJECT_CONFIG: "1",
+          OPENCODE_DISABLE_AUTOUPDATE: "1",
+          // Native discovery retains the complete MCP catalog without placing
+          // every remote tool schema in every model request.
+          OPENCODE_EXPERIMENTAL_CODE_MODE: "1",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        detached: process.platform !== "win32",
       },
-      stdio: ["ignore", "pipe", "pipe"],
-      windowsHide: true,
-      detached: process.platform !== "win32",
-    },
-  );
+    );
+  } catch (error) {
+    await rm(launchRoot, { recursive: true, force: true }).catch(() => {});
+    throw startupLaunchError(error);
+  }
   // Raw diagnostics can contain configuration or provider credentials.
   child.stdout?.resume();
   child.stderr?.resume();
   let exited = false;
+  let termination:
+    | {
+        exitCode: number | null;
+        signal: NodeJS.Signals | null;
+        spawnErrorCode?: string;
+      }
+    | undefined;
   const exit = new Promise<void>((resolve) => {
-    const done = () => {
+    const done = (next: typeof termination) => {
+      if (exited) return;
       exited = true;
+      termination = next;
       resolve();
     };
-    child.once("exit", done);
-    child.once("error", done);
+    child.once("exit", (exitCode, signal) => done({ exitCode, signal }));
+    child.once("error", (error) =>
+      done({
+        exitCode: null,
+        signal: null,
+        spawnErrorCode: (error as NodeJS.ErrnoException).code,
+      }),
+    );
   });
   let closing: Promise<void> | undefined;
   const close = () =>
     (closing ??= (async () => {
-      signalChild(child, "SIGTERM");
-      if (!exited)
+      if (!exited) {
+        signalChild(child, "SIGTERM");
         await Promise.race([exit, delay(options.shutdownTimeoutMs ?? 2000)]);
-      signalChild(child, "SIGKILL");
-      if (!exited) await Promise.race([exit, delay(2000)]);
+      }
+      if (!exited) {
+        signalChild(child, "SIGKILL");
+        await Promise.race([exit, delay(2000)]);
+      }
       if (!exited) throw new OpenCodeShutdownError();
       await rm(launchRoot, { recursive: true, force: true }).catch(() => {});
     })().catch(() => {
@@ -314,11 +390,38 @@ export async function startOpenCodeServer(
         return (await response.json()) as T;
       },
     };
-  } catch {
+  } catch (error) {
+    let startupError: OpenCodeStartupError;
+    if (options.signal?.aborted) {
+      startupError = new OpenCodeStartupError("cancelled");
+    } else if (timeout.aborted) {
+      startupError = new OpenCodeStartupError("timed-out");
+    } else if (exited) {
+      startupError = termination?.spawnErrorCode
+        ? startupLaunchError(termination.spawnErrorCode)
+        : new OpenCodeStartupError("exited", termination);
+    } else {
+      startupError =
+        error instanceof OpenCodeStartupError
+          ? error
+          : new OpenCodeStartupError("launch-failed");
+    }
     await close();
     await rm(launchRoot, { recursive: true, force: true }).catch(() => {});
-    throw new Error("OpenCode could not start. Please retry.");
+    throw startupError;
   }
+}
+
+function startupLaunchError(error: unknown): OpenCodeStartupError {
+  const code =
+    typeof error === "string"
+      ? error
+      : (error as NodeJS.ErrnoException | undefined)?.code;
+  if (code === "ENOENT" || code === "ENOTDIR")
+    return new OpenCodeStartupError("executable-not-found");
+  if (code === "EACCES" || code === "EPERM")
+    return new OpenCodeStartupError("permission-denied");
+  return new OpenCodeStartupError("launch-failed");
 }
 
 function signalChild(child: ChildProcess, signal: NodeJS.Signals): void {


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Runtime startup failures need stable actionable classification without exposing native output, executable paths, configuration, or underlying causes.

## Summary and scope

Export sanitized startup failure codes and a retryable error type covering missing executables, permission denial, launch failure, early exit, timeout, and cancellation. Request transport and host rendering are handled by dependent increments.

## Related work

Related issue or discussion: SAP-3290

## Validation

```text
pnpm --filter @sapiom/opencode typecheck — passed on the curated increment
pnpm --filter @sapiom/opencode build — passed on the curated increment
pnpm --filter @sapiom/opencode exec vitest run src/server.test.ts — 8/8 passed
git diff --check — passed
Final root pnpm build / pnpm typecheck / pnpm lint — passed on b04b296fd05d2e708d466d8869ab5dd4c65a1a4d
Final root pnpm test — exited 1 only at unchanged @sapiom/agent-core permission fixture
pnpm --filter @sapiom/agent-core exec jest --runInBand src/bundle-error.spec.ts — final and exact baseline 709573af39499dcefa10e8a682f043d51d57620e both reproduced 1 failed / 5 passed: "names an unreadable project directory instead of blaming dependencies"
mcp, harness, agent-studio, cli, and harness-desktop suites skipped after recursive first-failure — explicitly run and passed
```

### Tests and documentation

Added startup classification, retryability, sanitization, cleanup, and retry regressions. Added `.changeset/sanitize-opencode-startup-errors.md`.

## Compatibility and release impact

- Breaking or externally visible changes: Adds exported sanitized startup error types; existing successful startup behavior is unchanged.
- Changeset: Added `.changeset/sanitize-opencode-startup-errors.md`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and reviewed the startup API. Codex rebased the accepted source mechanically onto the final credential parent and reran focused checks.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/932" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->