### PR TITLE
fix(studio): retain verified Assistant authority [SAP-3288] [SAP-3290]

### DIFF
--- a/.changeset/retain-assistant-access.md
+++ b/.changeset/retain-assistant-access.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Retain unchanged verified Assistant access through bounded transient outages while revoking principal crossovers and exposing an opaque browser authority barrier for draft isolation.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -46,7 +46,15 @@ The Studio host refreshes the internal Assistant capability at most every 30
 seconds and expires an enabled decision within 60 seconds. Missing identity,
 offline startup, unsupported backends, and unavailable flags leave it off.
 These access checks are independent of optional telemetry and never prevent
-ordinary Terminal startup. Only the resolved boolean is exposed to the browser.
+ordinary Terminal startup. The browser receives only the resolved boolean and a
+random, process-memory `authorityRevision`; it never receives principal fields,
+credentials, identity hashes, or grant diagnostics. The revision stays stable
+through polling, reconnects, transient retention, and renewed leases for the
+same authority. A verified principal crossover or actual revocation, denial,
+expiry, or sign-out rotates it before the new state is observable. Disabled
+responses carry the current retirement barrier, and repeated disabled polls do
+not rotate it. Browser draft stores use this opaque boundary to prevent text
+from crossing authorities without persisting it.
 
 Eligible internal users see a **Terminal | Assistant** switch, with Terminal
 selected initially. Assistant sends prompts and streams Sapiom responses in the

--- a/packages/harness/src/core/assistant-access.test.ts
+++ b/packages/harness/src/core/assistant-access.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedEnvironment } from "@sapiom/mcp/auth";
 import { AssistantAccess } from "./assistant-access.js";
+import { StudioCredentialRefreshError } from "./studio-credentials.js";
 
 let access: AssistantAccess;
 let env: ResolvedEnvironment;
@@ -78,6 +79,78 @@ describe("Assistant access", () => {
     expect(JSON.stringify(request.mock.calls)).not.toContain("sk_private");
   });
 
+  it("projects only an opaque authority revision and keeps it for same-principal renewals and outages", async () => {
+    const disabled = access.getBrowserState();
+    expect(disabled).toEqual({
+      enabled: false,
+      authorityRevision: expect.any(String),
+    });
+    expect(JSON.stringify(disabled)).not.toMatch(/user-one|tenant|sk_private/);
+
+    await access.refresh();
+    const verified = access.getBrowserState();
+    expect(verified.enabled).toBe(true);
+    expect(verified.authorityRevision).not.toBe(disabled.authorityRevision);
+
+    request.mockResolvedValueOnce(
+      Response.json({ ...enabled, maxAgeMs: 45_000 }),
+    );
+    await access.refresh();
+    expect(access.getBrowserState()).toEqual(verified);
+
+    request.mockRejectedValueOnce(new TypeError("offline"));
+    await access.refresh();
+    expect(access.getBrowserState()).toEqual(verified);
+  });
+
+  it("rotates the browser authority before notifying a principal crossover or retirement", async () => {
+    const observed: string[] = [];
+    access.subscribe(() => {
+      observed.push(access.getBrowserState().authorityRevision);
+    });
+    await access.refresh();
+    const first = access.getBrowserState().authorityRevision;
+    expect(observed).toEqual([first]);
+
+    request.mockResolvedValueOnce(
+      Response.json({ ...enabled, userId: "user-two" }),
+    );
+    await access.refresh();
+    const second = access.getBrowserState().authorityRevision;
+    expect(second).not.toBe(first);
+    expect(observed.at(-1)).toBe(second);
+
+    request.mockResolvedValue(Response.json({ assistant: false }));
+    await access.refresh();
+    const retired = access.getBrowserState();
+    expect(retired.enabled).toBe(false);
+    expect(retired.authorityRevision).not.toBe(second);
+    expect(observed.at(-1)).toBe(retired.authorityRevision);
+
+    await access.refresh();
+    expect(access.getBrowserState()).toEqual(retired);
+
+    request.mockResolvedValue(Response.json(enabled));
+    await access.refresh();
+    const readmitted = access.getBrowserState();
+    expect(readmitted.enabled).toBe(true);
+    expect(readmitted.authorityRevision).not.toBe(retired.authorityRevision);
+  });
+
+  it("rotates once when clear retires a grant and keeps that retired barrier", async () => {
+    await access.refresh();
+    const initial = access.getBrowserState().authorityRevision;
+    access.clear();
+    const retired = access.getBrowserState();
+    expect(retired).toEqual({
+      enabled: false,
+      authorityRevision: expect.any(String),
+    });
+    expect(retired.authorityRevision).not.toBe(initial);
+    access.clear();
+    expect(access.getBrowserState()).toEqual(retired);
+  });
+
   it.each([
     {},
     { ...enabled, assistant: false },
@@ -114,7 +187,74 @@ describe("Assistant access", () => {
     request.mockImplementation(async () => Response.json({ assistant: false }));
     await vi.advanceTimersByTimeAsync(30000);
     expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("access_denied");
     expect(changed).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains an unchanged verified grant through successive network and 5xx failures only until its original expiry", async () => {
+    const changed = vi.fn();
+    access.subscribe(changed);
+    await access.refresh();
+    const grant = access.get()!;
+    request.mockRejectedValueOnce(new TypeError("offline"));
+    await access.refresh();
+    expect(access.get()).toBe(grant);
+    request.mockResolvedValueOnce(new Response("", { status: 503 }));
+    await access.refresh();
+    expect(access.get()).toBe(grant);
+    expect(access.get()!.expiresAt).toBe(grant.expiresAt);
+    expect(changed).toHaveBeenCalledOnce();
+    vi.setSystemTime(grant.expiresAt + 1);
+    expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("access_expired");
+    expect(changed).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains a grant through a classified credential-refresh outage without extending it", async () => {
+    await access.refresh();
+    const grant = access.get()!;
+    env.credentials!.studioCredentials = {
+      ...pair,
+      expiresAt: new Date(Date.now() + 30_000).toISOString(),
+    };
+    access.close();
+    access = new AssistantAccess({
+      enabled: true,
+      harnessVersion: "0.16.0",
+      getApiKey: () => key,
+      loadEnvironment: load,
+      refreshCredentials: async () => {
+        throw new StudioCredentialRefreshError("transient", "offline");
+      },
+      fetch: request,
+    });
+    // A new host must never invent eligibility from an outage.
+    await access.refresh();
+    expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("transport_unavailable");
+
+    access.close();
+    env.credentials!.studioCredentials = pair;
+    let fail = false;
+    access = new AssistantAccess({
+      enabled: true,
+      harnessVersion: "0.16.0",
+      getApiKey: () => key,
+      loadEnvironment: load,
+      refreshCredentials: async (environment) => {
+        if (fail)
+          throw new StudioCredentialRefreshError("transient", "offline");
+        return environment.credentials!.studioCredentials!;
+      },
+      fetch: request,
+    });
+    await access.refresh();
+    const verified = access.get()!;
+    fail = true;
+    await access.refresh();
+    expect(access.get()).toBe(verified);
+    expect(access.get()!.expiresAt).toBe(verified.expiresAt);
+    expect(verified.expiresAt).toBe(grant.expiresAt);
   });
 
   it("expires within 60 seconds even when a refresh is stuck", async () => {
@@ -150,6 +290,18 @@ describe("Assistant access", () => {
     await access.refresh();
     expect(access.get()?.identityRevision).toBe("identity-one");
     expect(changed).toHaveBeenCalledOnce();
+  });
+
+  it("notifies hosts when the verified user changes even if an identity revision is reused", async () => {
+    const changed = vi.fn();
+    access.subscribe(changed);
+    await access.refresh();
+    request.mockResolvedValue(
+      Response.json({ ...enabled, userId: "user-two" }),
+    );
+    await access.refresh();
+    expect(access.get()?.userId).toBe("user-two");
+    expect(changed).toHaveBeenCalledTimes(2);
   });
 
   it("fences an older response when a newer credential observation is queued", async () => {
@@ -188,17 +340,42 @@ describe("Assistant access", () => {
     expect(access.get()).toBeNull();
   });
 
-  it("invalidates on a key change, offline evaluation, and unreadable credentials", async () => {
+  it("invalidates on a key change, unreadable credentials, and expired credentials", async () => {
     await access.refresh();
     key = null;
     expect(access.get()).toBeNull();
     key = "sk_private";
-    request.mockRejectedValue(new Error("offline"));
-    await access.refresh();
-    expect(access.get()).toBeNull();
     load.mockRejectedValue(new Error("unreadable"));
     await access.refresh();
     expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("access_denied");
+    load.mockImplementation(async () => structuredClone(env));
+    env.credentials!.studioCredentials = {
+      ...pair,
+      expiresAt: new Date(Date.now() - 1).toISOString(),
+    };
+    await access.refresh();
+    expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("authentication_required");
+  });
+
+  it("revokes the old authority before evaluating an identity or tenant crossover", async () => {
+    const changed = vi.fn();
+    access.subscribe(changed);
+    await access.refresh();
+    let finish!: (response: Response) => void;
+    env.credentials!.tenantId = "other-tenant";
+    request.mockImplementationOnce(
+      () => new Promise<Response>((resolve) => (finish = resolve)),
+    );
+    const pending = access.refresh();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(access.get()).toBeNull();
+    expect(access.getFailureCode()).toBe("access_denied");
+    expect(changed).toHaveBeenCalledTimes(2);
+    finish(Response.json({ ...enabled, tenantId: "other-tenant" }));
+    await pending;
+    expect(access.get()).toMatchObject({ tenantId: "other-tenant" });
   });
 
   it("does not extend the lease by slow response delivery", async () => {

--- a/packages/harness/src/core/assistant-access.ts
+++ b/packages/harness/src/core/assistant-access.ts
@@ -1,18 +1,36 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   resolveEnvironment,
   readCredentialsOrThrow,
   type ResolvedEnvironment,
 } from "@sapiom/mcp/auth";
-import { refreshStudioCredentials } from "./studio-credentials.js";
+import {
+  refreshStudioCredentials,
+  StudioCredentialRefreshError,
+} from "./studio-credentials.js";
+import type { OpenCodeTransportErrorCode } from "../shared/opencode-errors.js";
 
-/** Private host state. Only `enabled` is projected to the browser. */
+export type AssistantAccessFailureCode = Extract<
+  OpenCodeTransportErrorCode,
+  | "access_denied"
+  | "access_expired"
+  | "authentication_required"
+  | "transport_unavailable"
+>;
+
+/** Private host state. Principal fields are never projected to the browser. */
 export interface AssistantGrant {
   userId: string;
   tenantId: string;
   identityRevision: string;
   expiresAt: number;
   environment: ResolvedEnvironment;
+}
+
+/** Browser-safe access state. The revision is opaque and process-memory only. */
+export interface AssistantAccessProjection {
+  enabled: boolean;
+  authorityRevision: string;
 }
 
 interface CapabilityResponse {
@@ -51,7 +69,11 @@ const fingerprint = (env: ResolvedEnvironment): string =>
 /** Bounded, revocable eligibility; no analytics opt-in or persisted enabled cache. */
 export class AssistantAccess {
   private grant: AssistantGrant | null = null;
+  private failure: AssistantAccessFailureCode = this.options.enabled
+    ? "authentication_required"
+    : "access_denied";
   private credentialFingerprint: string | null = null;
+  private authorityRevision = randomUUID();
   private epoch = 0;
   private closed = false;
   private queue: Promise<void> = Promise.resolve();
@@ -62,13 +84,26 @@ export class AssistantAccess {
   constructor(private readonly options: AssistantAccessOptions) {}
 
   get(): AssistantGrant | null {
-    if (
+    if (this.grant?.expiresAt && this.grant.expiresAt <= Date.now())
+      this.adopt(null, "access_expired");
+    else if (
       this.grant &&
-      (this.grant.expiresAt <= Date.now() ||
-        this.options.getApiKey() !== this.grant.environment.credentials?.apiKey)
+      this.options.getApiKey() !== this.grant.environment.credentials?.apiKey
     )
-      this.adopt(null);
+      this.adopt(null, "authentication_required");
     return this.grant;
+  }
+
+  getFailureCode(): AssistantAccessFailureCode {
+    this.get();
+    return this.failure;
+  }
+
+  getBrowserState(): AssistantAccessProjection {
+    return {
+      enabled: this.get() !== null,
+      authorityRevision: this.authorityRevision,
+    };
   }
 
   subscribe(listener: () => void): () => void {
@@ -79,7 +114,7 @@ export class AssistantAccess {
   clear(): void {
     this.epoch++;
     this.credentialFingerprint = null;
-    this.adopt(null);
+    this.adopt(null, "authentication_required");
   }
 
   refresh(): Promise<void> {
@@ -89,7 +124,8 @@ export class AssistantAccess {
     const epoch = ++this.epoch;
     const run = this.queue.then(() => this.evaluate(epoch));
     this.queue = run.catch(() => {
-      this.adopt(null);
+      if (!this.closed && epoch === this.epoch)
+        this.adopt(null, "access_denied");
     });
     return this.queue;
   }
@@ -101,18 +137,25 @@ export class AssistantAccess {
     this.listeners.clear();
   }
 
-  private adopt(grant: AssistantGrant | null): void {
+  private adopt(
+    grant: AssistantGrant | null,
+    failure: AssistantAccessFailureCode = this.failure,
+  ): void {
     const changed =
+      this.grant?.userId !== grant?.userId ||
+      this.grant?.tenantId !== grant?.tenantId ||
       this.grant?.identityRevision !== grant?.identityRevision ||
       this.grant?.environment.name !== grant?.environment.name ||
       this.grant?.environment.apiURL !== grant?.environment.apiURL ||
       this.grant?.environment.credentials?.apiKey !==
         grant?.environment.credentials?.apiKey;
+    if (changed) this.authorityRevision = randomUUID();
     this.grant = grant;
+    this.failure = failure;
     clearTimeout(this.expiryTimer);
     if (grant) {
       this.expiryTimer = setTimeout(
-        () => this.adopt(null),
+        () => this.adopt(null, "access_expired"),
         Math.max(0, grant.expiresAt - Date.now()),
       );
       this.expiryTimer.unref?.();
@@ -126,53 +169,113 @@ export class AssistantAccess {
     let refreshAfterMs = 30_000;
     const current = () => !this.closed && epoch === this.epoch;
     try {
-      const env = this.options.loadEnvironment
-        ? await this.options.loadEnvironment()
-        : await resolveEnvironment(
-            this.options.environment ?? process.env.SAPIOM_ENVIRONMENT,
-          );
-      if (!this.options.loadEnvironment)
-        env.credentials = await readCredentialsOrThrow(env.name);
+      let env: ResolvedEnvironment;
+      try {
+        env = this.options.loadEnvironment
+          ? await this.options.loadEnvironment()
+          : await resolveEnvironment(
+              this.options.environment ?? process.env.SAPIOM_ENVIRONMENT,
+            );
+        if (!this.options.loadEnvironment)
+          env.credentials = await readCredentialsOrThrow(env.name);
+      } catch {
+        if (current()) this.adopt(null, "access_denied");
+        return;
+      }
       if (!current()) return;
       const before = fingerprint(env);
-      if (before !== this.credentialFingerprint) this.adopt(null);
+      if (
+        this.credentialFingerprint !== null &&
+        before !== this.credentialFingerprint
+      )
+        this.adopt(null, "access_denied");
       this.credentialFingerprint = before;
       if (
         !env.credentials?.studioCredentials ||
         !env.credentials.apiKey ||
         env.credentials.apiKey !== this.options.getApiKey()
       ) {
-        this.adopt(null);
+        this.adopt(null, "authentication_required");
         return;
       }
-      const credentials = await (
-        this.options.refreshCredentials ?? refreshStudioCredentials
-      )(env);
+      const observedCredentialExpiry = Date.parse(
+        env.credentials.studioCredentials.expiresAt,
+      );
+      if (
+        !Number.isFinite(observedCredentialExpiry) ||
+        observedCredentialExpiry <= Date.now()
+      ) {
+        this.adopt(null, "authentication_required");
+        return;
+      }
+      let credentials;
+      try {
+        credentials = await (
+          this.options.refreshCredentials ?? refreshStudioCredentials
+        )(env);
+      } catch (error) {
+        if (!current()) return;
+        if (
+          error instanceof StudioCredentialRefreshError &&
+          error.kind === "transient"
+        )
+          this.retainTransient(before, observedCredentialExpiry);
+        else this.adopt(null, "authentication_required");
+        return;
+      }
       if (!current()) return;
       if (!credentials) {
-        this.adopt(null);
+        this.adopt(null, "authentication_required");
+        return;
+      }
+      const credentialExpiry = Date.parse(credentials.expiresAt);
+      if (
+        !Number.isFinite(credentialExpiry) ||
+        credentialExpiry <= Date.now()
+      ) {
+        this.adopt(null, "authentication_required");
         return;
       }
       env.credentials = { ...env.credentials, studioCredentials: credentials };
       const startedAt = Date.now();
-      const response = await (this.options.fetch ?? fetch)(
-        `${env.apiURL}/v1/studio/capabilities`,
-        {
-          headers: {
-            Authorization: `Bearer ${credentials.accessToken}`,
-            "X-Studio-Capability-Version": "1",
-            "X-Studio-Harness-Version": this.options.harnessVersion,
+      let response: Response;
+      try {
+        response = await (this.options.fetch ?? fetch)(
+          `${env.apiURL}/v1/studio/capabilities`,
+          {
+            headers: {
+              Authorization: `Bearer ${credentials.accessToken}`,
+              "X-Studio-Capability-Version": "1",
+              "X-Studio-Harness-Version": this.options.harnessVersion,
+            },
+            signal: AbortSignal.timeout(5000),
+            redirect: "error",
           },
-          signal: AbortSignal.timeout(5000),
-          redirect: "error",
-        },
-      );
-      if (!current()) return;
-      if (!response.ok) {
-        this.adopt(null);
+        );
+      } catch {
+        if (current()) this.retainTransient(before, credentialExpiry);
         return;
       }
-      const result = (await response.json()) as CapabilityResponse;
+      if (!current()) return;
+      if (!response.ok) {
+        if (response.status >= 500)
+          this.retainTransient(before, credentialExpiry);
+        else
+          this.adopt(
+            null,
+            [401, 403].includes(response.status)
+              ? "authentication_required"
+              : "access_denied",
+          );
+        return;
+      }
+      let result: CapabilityResponse;
+      try {
+        result = (await response.json()) as CapabilityResponse;
+      } catch {
+        this.adopt(null, "access_denied");
+        return;
+      }
       if (!current()) return;
       if (
         result.protocol !== 1 ||
@@ -186,15 +289,15 @@ export class AssistantAccess {
         !Number.isFinite(result.maxAgeMs) ||
         result.maxAgeMs <= 0
       ) {
-        this.adopt(null);
+        this.adopt(null, "access_denied");
         return;
       }
       const expiresAt = Math.min(
         startedAt + Math.min(result.maxAgeMs, 60_000),
-        Date.parse(credentials.expiresAt),
+        credentialExpiry,
       );
       if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) {
-        this.adopt(null);
+        this.adopt(null, "authentication_required");
         return;
       }
       this.credentialFingerprint = fingerprint(env);
@@ -214,7 +317,7 @@ export class AssistantAccess {
           Math.min(result.refreshAfterMs, 30_000),
         );
     } catch {
-      if (current()) this.adopt(null);
+      if (current()) this.adopt(null, "access_denied");
     } finally {
       if (current()) {
         this.refreshTimer = setTimeout(() => {
@@ -223,5 +326,23 @@ export class AssistantAccess {
         this.refreshTimer.unref?.();
       }
     }
+  }
+
+  private retainTransient(
+    fingerprintAtFailure: string,
+    credentialExpiry: number,
+  ): void {
+    const grant = this.get();
+    if (!grant) {
+      if (this.failure !== "access_denied" && this.failure !== "access_expired")
+        this.adopt(null, "transport_unavailable");
+      return;
+    }
+    if (
+      this.credentialFingerprint !== fingerprintAtFailure ||
+      credentialExpiry <= Date.now() ||
+      grant.environment.credentials?.apiKey !== this.options.getApiKey()
+    )
+      this.adopt(null, "transport_unavailable");
   }
 }

--- a/packages/harness/src/core/studio-credentials.test.ts
+++ b/packages/harness/src/core/studio-credentials.test.ts
@@ -114,6 +114,22 @@ describe("Studio user credentials", () => {
     expect(await readFile(store.path, "utf8")).toContain("srt_old");
   });
 
+  it.each([
+    [new Response("private diagnostic", { status: 503 }), "transient"],
+    [new TypeError("private network diagnostic"), "transient"],
+    [new Response("private diagnostic", { status: 429 }), "rejected"],
+  ])(
+    "classifies only network and 5xx refresh failures as transient",
+    async (failure, kind) => {
+      if (failure instanceof Response) fetchMock.mockResolvedValue(failure);
+      else fetchMock.mockRejectedValue(failure);
+      await expect(refreshStudioCredentials(env)).rejects.toMatchObject({
+        kind,
+      });
+      expect(await readFile(store.path, "utf8")).toContain("srt_old");
+    },
+  );
+
   it("waits for an existing Studio credential mutation before reading", async () => {
     let release!: () => void;
     let locked!: () => void;

--- a/packages/harness/src/core/studio-credentials.ts
+++ b/packages/harness/src/core/studio-credentials.ts
@@ -8,6 +8,15 @@ import {
 } from "@sapiom/mcp/auth";
 import { DurableFileLock } from "./durable-file-lock.js";
 
+export class StudioCredentialRefreshError extends Error {
+  constructor(
+    readonly kind: "transient" | "rejected",
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
 /** Shared by Studio login, sign-out and refresh across CLI/desktop hosts. */
 export async function withStudioCredentialLock<T>(
   operation: () => Promise<T>,
@@ -41,20 +50,41 @@ export async function refreshStudioCredentials(
     if (!credentials) return null;
     if (Date.parse(credentials.expiresAt) > Date.now() + 90_000)
       return credentials;
-    const response = await fetch(`${env.apiURL}/v1/tokens/refresh`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ refreshToken: credentials.refreshToken }),
-      signal: AbortSignal.timeout(5000),
-      redirect: "error",
-    });
+    let response: Response;
+    try {
+      response = await fetch(`${env.apiURL}/v1/tokens/refresh`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ refreshToken: credentials.refreshToken }),
+        signal: AbortSignal.timeout(5000),
+        redirect: "error",
+      });
+    } catch {
+      throw new StudioCredentialRefreshError(
+        "transient",
+        "Studio credential refresh is temporarily unavailable",
+      );
+    }
     if (!response.ok)
-      throw new Error("Sign in again to restore Assistant access");
-    const pair = (await response.json()) as {
+      throw new StudioCredentialRefreshError(
+        response.status >= 500 ? "transient" : "rejected",
+        response.status >= 500
+          ? "Studio credential refresh is temporarily unavailable"
+          : "Sign in again to restore Assistant access",
+      );
+    let pair: {
       access_token?: string;
       refresh_token?: string;
       expires_in?: number;
     };
+    try {
+      pair = (await response.json()) as typeof pair;
+    } catch {
+      throw new StudioCredentialRefreshError(
+        "rejected",
+        "Invalid Studio credential refresh",
+      );
+    }
     if (
       !pair.access_token?.startsWith("sat_") ||
       !pair.refresh_token?.startsWith("srt_") ||
@@ -62,7 +92,10 @@ export async function refreshStudioCredentials(
       !Number.isFinite(pair.expires_in) ||
       pair.expires_in <= 0
     )
-      throw new Error("Invalid Studio credential refresh");
+      throw new StudioCredentialRefreshError(
+        "rejected",
+        "Invalid Studio credential refresh",
+      );
     const next = {
       accessToken: pair.access_token,
       refreshToken: pair.refresh_token,

--- a/packages/harness/src/server/auth-mcp-wiring.test.ts
+++ b/packages/harness/src/server/auth-mcp-wiring.test.ts
@@ -253,7 +253,15 @@ describe("Agent Studio MCP authentication wiring", () => {
       headers: { "X-Harness-Token": "test-token" },
     });
     expect(response.headers.get("cache-control")).toBe("no-store");
-    expect(await response.json()).toEqual({ enabled: false });
+    const first = (await response.json()) as Record<string, unknown>;
+    expect(first).toEqual({
+      enabled: false,
+      authorityRevision: expect.any(String),
+    });
+    const repeated = await fetch(url, {
+      headers: { "X-Harness-Token": "test-token" },
+    });
+    expect(await repeated.json()).toEqual(first);
   });
 
   async function waitForAuthenticated(): Promise<void> {

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -3955,7 +3955,7 @@ export const startServer = async (
   );
   app.get("/api/assistant/access", (_req, res) => {
     res.setHeader("Cache-Control", "no-store");
-    res.json({ enabled: assistantAccess.get() !== null });
+    res.json(assistantAccess.getBrowserState());
   });
   app.use(
     "/api",


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Assistant access should survive only bounded transient refresh outages and must retire immediately when verified authority changes. The browser also needs a safe stable barrier for principal-scoped drafts.

## Summary and scope

Retain only an unchanged previously verified grant through classified transient failures without extending its original expiry. Revoke denial, expiry, authentication loss, or verified authority crossover, and return an opaque memory-only authority revision from the shared CLI/Electron endpoint.

## Related work

Related issue or discussion: SAP-3288 and SAP-3290

## Validation

```text
pnpm --filter @sapiom/harness exec vitest run src/core/assistant-access.test.ts src/core/studio-credentials.test.ts src/server/auth-mcp-wiring.test.ts — 45/45 passed
pnpm --filter @sapiom/harness typecheck — passed
pnpm --filter @sapiom/harness build — passed with existing Vite warnings only
Owner real pinned-native original-expiry retention probe — passed
git diff --check — passed
Final root pnpm build / pnpm typecheck / pnpm lint — passed on b04b296fd05d2e708d466d8869ab5dd4c65a1a4d
Final root pnpm test — exited 1 only at unchanged @sapiom/agent-core permission fixture
pnpm --filter @sapiom/agent-core exec jest --runInBand src/bundle-error.spec.ts — final and exact baseline 709573af39499dcefa10e8a682f043d51d57620e both reproduced 1 failed / 5 passed: "names an unreadable project directory instead of blaming dependencies"
mcp, harness, agent-studio, cli, and harness-desktop suites skipped after recursive first-failure — explicitly run and passed
```

### Tests and documentation

Added lease retention, expiry, denial, user/tenant crossover, retirement/readmission, and literal endpoint tests. Updated the lifecycle README and added `.changeset/retain-assistant-access.md`.

## Compatibility and release impact

- Breaking or externally visible changes: Authenticated Assistant access responses now include the required opaque `authorityRevision` alongside `enabled`.
- Changeset: Added `.changeset/retain-assistant-access.md`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the access lifecycle and native probe. Codex curated only the approved commits and verified the endpoint dependency boundary.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/934" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->