### PR TITLE
fix(studio): propagate Assistant recovery failures [SAP-3290]

### DIFF
--- a/.changeset/route-assistant-recovery-errors.md
+++ b/.changeset/route-assistant-recovery-errors.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Route strictly scoped Assistant runtime, authentication, and missing-history failures as actionable sanitized errors while preserving saved session associations and preventing replay.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -56,6 +56,15 @@ responses carry the current retirement barrier, and repeated disabled polls do
 not rotate it. Browser draft stores use this opaque boundary to prevent text
 from crossing authorities without persisting it.
 
+After a successful check, timeout, network, or HTTP 5xx failures from credential
+or capability refresh may retain that exact grant only while its original lease
+and observed user credential remain unexpired. A transient failure never moves
+either expiry. Sign-out, credential expiry, API key/environment/tenant/user
+change, an authentication rejection, an explicit `assistant: false`, or a
+malformed/ambiguous response revokes the grant. Thus an offline first launch
+cannot invent eligibility, while a short outage does not interrupt an unchanged
+verified principal before the server-issued lease ends.
+
 Eligible internal users see a **Terminal | Assistant** switch, with Terminal
 selected initially. Assistant sends prompts and streams Sapiom responses in the
 selected project. Returning to a session reopens its OpenCode conversation;
@@ -82,6 +91,30 @@ directory. Browser detachment leaves it running; sign-out, access revocation,
 and Studio shutdown stop it. Runtime state is isolated by user, organization,
 session, and directory under `~/.sapiom/harness/opencode`. A process lock prevents
 two Studio hosts from opening the same runtime state concurrently.
+
+Transport failures use fixed, credential-free codes and copy. HTTP responses
+carry a nested typed error; an already-open event stream receives the same error
+as a host-generated `studio.error` before closing when possible. Native events
+cannot claim that host-only type. Ordinary native events require matching
+session IDs, including every nested ID. The only session-less native failure
+converted to a terminal Studio error is a Sapiom provider-auth error received
+from the currently bound runtime and authority with an exact authorized-directory
+envelope; unknown, conflicting, stale-runtime, and differently scoped events are
+dropped. Reconnect reattaches and reloads history; it never replays an accepted
+prompt or tool call.
+
+The Studio session record remains authoritative for session identity, project,
+and working directory. Its authority-scoped runtime directory owns a versioned
+`association.json` sidecar that maps that Studio session to one native
+conversation. The host serializes creation and atomic commit under the same
+lifecycle that owns the native runtime; browser mounts do not own the mapping.
+Retirement, sign-out, missing native history, and transient lookup failures do
+not delete or replace it. A native 404 is reported as confirmed unavailable,
+while network and other transport failures remain retryable; neither path
+creates a second conversation. There is no implicit legacy scan or cleanup in
+this correction: a future migration adapter must validate both identities,
+commit a versioned mapping atomically, preserve the old history until verified,
+and make cleanup an explicit post-migration operation.
 
 The rail's cloud icon marks an agent as deployed once Studio confirms a ready
 hosted build. Failed checks silently retain the last confirmed indicator, and changing

--- a/packages/harness/src/core/opencode-association.test.ts
+++ b/packages/harness/src/core/opencode-association.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, expect, it, vi } from "vitest";
-import { mkdtemp, readFile, rename, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { OpenCodeAssociations } from "./opencode-association.js";
@@ -39,11 +39,14 @@ it("serializes association commits across runtime retirement, including an alrea
     cwd: root,
     stateRoot: root,
     signal: abort.signal,
+    isCurrent: () => !abort.signal.aborted,
     server: {
       pid: 123,
       exited: new Promise<void>(() => {}),
       close: vi.fn(),
-      fetch: vi.fn(),
+      fetch: vi.fn(async (path: string) =>
+        Response.json({ id: path.split("/").at(-1) }),
+      ),
       async fetchJson<T>(path: string): Promise<T> {
         return {
           id: path === "/session" ? `ses_${++created}` : path.split("/").at(-1),
@@ -55,7 +58,12 @@ it("serializes association commits across runtime retirement, including an alrea
   const old = associations.ensure(hosted);
   await writing;
   abort.abort();
-  const replacement = { ...hosted, signal: new AbortController().signal };
+  const replacementAbort = new AbortController();
+  const replacement = {
+    ...hosted,
+    signal: replacementAbort.signal,
+    isCurrent: () => !replacementAbort.signal.aborted,
+  };
   const next = associations.ensure(replacement);
   try {
     expect(created).toBe(1);
@@ -72,4 +80,47 @@ it("serializes association commits across runtime retirement, including an alrea
     commit();
     await Promise.allSettled([old, next]);
   }
+});
+
+it("distinguishes confirmed missing history from transient lookup failure without creating a replacement", async () => {
+  root = await mkdtemp(join(tmpdir(), "studio-association-"));
+  const conversationId = "ses_saved";
+  await writeFile(
+    join(root, "association.json"),
+    JSON.stringify({ version: 1, conversationId }),
+  );
+  const abort = new AbortController();
+  const fetch = vi
+    .fn()
+    .mockResolvedValueOnce(new Response("private missing", { status: 404 }))
+    .mockRejectedValueOnce(new TypeError("private network diagnostic"))
+    .mockResolvedValueOnce(Response.json({ id: conversationId }));
+  const create = vi.fn();
+  const hosted: HostedOpenCode = {
+    harnessSessionId: "studio-one",
+    cwd: root,
+    stateRoot: root,
+    signal: abort.signal,
+    isCurrent: () => !abort.signal.aborted,
+    server: {
+      pid: 123,
+      exited: new Promise<void>(() => {}),
+      close: vi.fn(),
+      fetch,
+      fetchJson: create,
+    },
+  };
+  const associations = new OpenCodeAssociations();
+  await expect(associations.ensure(hosted)).rejects.toMatchObject({
+    failure: { code: "native_history_missing", retryable: false },
+  });
+  await expect(associations.ensure(hosted)).rejects.toMatchObject({
+    failure: { code: "transport_unavailable", retryable: true },
+  });
+  await expect(associations.ensure(hosted)).resolves.toBe(conversationId);
+  expect(fetch).toHaveBeenCalledTimes(3);
+  expect(create).not.toHaveBeenCalled();
+  expect(
+    JSON.parse(await readFile(join(root, "association.json"), "utf8")),
+  ).toEqual({ version: 1, conversationId });
 });

--- a/packages/harness/src/core/opencode-association.ts
+++ b/packages/harness/src/core/opencode-association.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from "node:crypto";
 import { readFile, rename, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import type { HostedOpenCode } from "./opencode-host.js";
+import {
+  OpenCodeTransportError,
+  type HostedOpenCode,
+} from "./opencode-host.js";
+import { openCodeTransportFailure } from "../shared/opencode-errors.js";
 import { DurableFileLock } from "./durable-file-lock.js";
 
 export const isConversationId = (id: unknown): id is string =>
@@ -52,14 +56,45 @@ export class OpenCodeAssociations {
         !isConversationId(saved.conversationId) ||
         saved.conversationId === hosted.harnessSessionId
       )
-        throw new Error("Assistant conversation association is invalid");
+        throw new OpenCodeTransportError(
+          openCodeTransportFailure("native_history_missing"),
+        );
       // Missing history is an error, never permission to silently replace it.
-      const session = await hosted.server.fetchJson<{ id: string }>(
-        `/session/${saved.conversationId}`,
-        { signal },
-      );
+      let response: Response;
+      try {
+        response = await hosted.server.fetch(
+          `/session/${saved.conversationId}`,
+          { signal },
+        );
+      } catch {
+        if (signal.reason instanceof OpenCodeTransportError)
+          throw signal.reason;
+        throw new OpenCodeTransportError(
+          openCodeTransportFailure("transport_unavailable"),
+        );
+      }
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new OpenCodeTransportError(
+          openCodeTransportFailure(
+            response.status === 404
+              ? "native_history_missing"
+              : "transport_unavailable",
+          ),
+        );
+      }
+      let session: { id?: unknown };
+      try {
+        session = (await response.json()) as { id?: unknown };
+      } catch {
+        throw new OpenCodeTransportError(
+          openCodeTransportFailure("transport_unavailable"),
+        );
+      }
       if (session.id !== saved.conversationId)
-        throw new Error("Assistant conversation is unavailable");
+        throw new OpenCodeTransportError(
+          openCodeTransportFailure("transport_unavailable"),
+        );
       return saved.conversationId;
     }
     const session = await hosted.server.fetchJson<{ id: string }>("/session", {

--- a/packages/harness/src/core/opencode-host.test.ts
+++ b/packages/harness/src/core/opencode-host.test.ts
@@ -3,7 +3,7 @@ import { access, mkdtemp, mkdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AssistantGrant } from "./assistant-access.js";
-import { OpenCodeHost } from "./opencode-host.js";
+import { OpenCodeHost, OpenCodeTransportError } from "./opencode-host.js";
 
 let root: string;
 let cwd: string;
@@ -46,18 +46,18 @@ beforeEach(async () => {
   close.mockReset().mockResolvedValue(undefined);
   revoke.mockReset();
   issue.mockReset().mockReturnValue({ id: "runtime", token: "scoped", revoke });
-  start
-    .mockReset()
-    .mockResolvedValue({
-      pid: 123,
-      exited: neverExited,
-      fetch: vi.fn(),
-      fetchJson: vi.fn(),
-      close,
-    });
+  start.mockReset().mockResolvedValue({
+    pid: 123,
+    exited: neverExited,
+    fetch: vi.fn(),
+    fetchJson: vi.fn(),
+    close,
+  });
   host = new OpenCodeHost({
     access: {
       get: () => grant,
+      getFailureCode: () =>
+        grant ? "transport_unavailable" : "authentication_required",
       subscribe: (listener) => {
         changed = listener;
         return () => {};
@@ -119,7 +119,9 @@ describe("Studio-owned OpenCode lifecycle", () => {
 
   it("releases failed startup so retry can acquire the same state", async () => {
     start.mockRejectedValueOnce(new Error("startup failed"));
-    await expect(host.ensure("studio-one")).rejects.toThrow("startup failed");
+    await expect(host.ensure("studio-one")).rejects.toMatchObject({
+      failure: { code: "runtime_start_failed" },
+    });
     expect(revoke).toHaveBeenCalledOnce();
     await host.ensure("studio-one");
     expect(start).toHaveBeenCalledTimes(2);
@@ -159,12 +161,15 @@ describe("Studio-owned OpenCode lifecycle", () => {
     expect(revoke).toHaveBeenCalled();
   });
 
-  it("keeps attachment alive without a browser, revokes on identity changes, and closes idempotently", async () => {
+  it("keeps attachment alive without a browser, revokes on verified-user changes, and closes idempotently", async () => {
     const attachment = await host.ensure("studio-one");
     expect(close).not.toHaveBeenCalled();
-    grant = { ...grant!, identityRevision: "new-user" };
+    grant = { ...grant!, userId: "new-user" };
     changed();
     expect(attachment.signal.aborted).toBe(true);
+    expect(attachment.signal.reason).toMatchObject({
+      failure: { code: "access_denied" },
+    });
     await Promise.all([host.close(), host.close()]);
     expect(close).toHaveBeenCalledOnce();
     await expect(host.ensure("studio-one")).rejects.toThrow("unavailable");
@@ -193,9 +198,9 @@ describe("Studio-owned OpenCode lifecycle", () => {
     ).resolves.toBeUndefined();
     grant = saved;
     changed();
-    await expect(host.ensure("studio-one")).rejects.toThrow(
-      "another Studio window",
-    );
+    await expect(host.ensure("studio-one")).rejects.toMatchObject({
+      failure: { code: "transport_unavailable" },
+    });
     expect(start).toHaveBeenCalledOnce();
   });
 
@@ -262,5 +267,29 @@ describe("Studio-owned OpenCode lifecycle", () => {
     expect(restored.stateRoot).toBe(first.stateRoot);
     expect(start).toHaveBeenCalledTimes(2);
     expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("maps only the bounded native startup reason and suppresses expected cancellation", async () => {
+    start.mockRejectedValueOnce({
+      code: "permission-denied",
+      message: "/private/runtime/path",
+    });
+    await expect(host.ensure("studio-one")).rejects.toMatchObject({
+      failure: {
+        code: "runtime_start_failed",
+        reason: "permission-denied",
+        retryable: false,
+        action: "open_settings",
+      },
+    });
+    start.mockImplementationOnce(async ({ signal }) => {
+      grant = null;
+      changed();
+      signal.throwIfAborted();
+      throw new OpenCodeTransportError({} as never);
+    });
+    await expect(host.ensure("studio-one")).rejects.toMatchObject({
+      failure: { code: "authentication_required" },
+    });
   });
 });

--- a/packages/harness/src/core/opencode-host.ts
+++ b/packages/harness/src/core/opencode-host.ts
@@ -7,7 +7,17 @@ import {
   startOpenCodeServer,
   type OpenCodeServer,
 } from "@sapiom/opencode";
-import type { AssistantAccess, AssistantGrant } from "./assistant-access.js";
+import type {
+  AssistantAccess,
+  AssistantAccessFailureCode,
+  AssistantGrant,
+} from "./assistant-access.js";
+import {
+  openCodeStartupReasons,
+  openCodeTransportFailure,
+  type OpenCodeStartupReason,
+  type OpenCodeTransportFailure,
+} from "../shared/opencode-errors.js";
 import { DurableFileLock } from "./durable-file-lock.js";
 import type {
   OpenCodeBridge,
@@ -22,6 +32,7 @@ export interface HostedOpenCode extends OpenCodeWorkspace {
   stateRoot: string;
   server: OpenCodeServer;
   signal: AbortSignal;
+  isCurrent: () => boolean;
 }
 interface Managed {
   workspace: OpenCodeWorkspace;
@@ -33,18 +44,34 @@ interface Managed {
   cleanupFailed?: boolean;
 }
 interface Options {
-  access: Pick<AssistantAccess, "get" | "subscribe">;
+  access: Pick<AssistantAccess, "get" | "getFailureCode" | "subscribe">;
   bridge: Pick<OpenCodeBridge, "issue" | "model">;
   origin: () => string;
   stateRoot: string;
   authorize: (id: string) => Promise<OpenCodeWorkspace | null>;
   start?: typeof startOpenCodeServer;
 }
-export class OpenCodeAccessError extends Error {}
+export class OpenCodeTransportError extends Error {
+  constructor(readonly failure: OpenCodeTransportFailure) {
+    super(failure.message);
+  }
+}
+export class OpenCodeAccessError extends OpenCodeTransportError {
+  constructor(
+    message: string,
+    code: AssistantAccessFailureCode = "access_denied",
+  ) {
+    const failure = openCodeTransportFailure(code);
+    super(failure);
+    this.message = message;
+  }
+}
 const authority = (grant: AssistantGrant) =>
   createHash("sha256")
     .update(
       JSON.stringify([
+        grant.userId,
+        grant.tenantId,
         grant.identityRevision,
         grant.environment.name,
         grant.environment.apiURL,
@@ -67,10 +94,12 @@ export class OpenCodeHost {
         void this.workspace(id)
           .then(async (workspace) => {
             if (this.entries.get(id) !== entry) return;
-            if (workspace.cwd !== entry.workspace.cwd) await this.retire(id);
+            if (workspace.cwd !== entry.workspace.cwd)
+              await this.retire(id, openCodeTransportFailure("access_denied"));
           })
           .catch(() => {
-            if (this.entries.get(id) === entry) void this.retire(id);
+            if (this.entries.get(id) === entry)
+              void this.retire(id, openCodeTransportFailure("access_denied"));
           });
       }
     }, 30000);
@@ -79,7 +108,12 @@ export class OpenCodeHost {
       const grant = options.access.get();
       for (const [id, entry] of this.entries) {
         if (!grant || authority(grant) !== entry.authority)
-          void this.retire(id);
+          void this.retire(
+            id,
+            grant
+              ? openCodeTransportFailure("access_denied")
+              : this.accessFailure(),
+          );
       }
     });
   }
@@ -87,15 +121,23 @@ export class OpenCodeHost {
   async ensure(id: string): Promise<HostedOpenCode> {
     const grant = this.options.access.get();
     if (this.closed || !grant)
-      throw new OpenCodeAccessError("Assistant access is unavailable");
+      throw this.accessError("Assistant access is unavailable");
     const workspace = await this.workspace(id).catch(async (error) => {
-      await this.retire(id);
+      await this.retire(
+        id,
+        error instanceof OpenCodeTransportError
+          ? error.failure
+          : openCodeTransportFailure("access_denied"),
+      );
       throw error;
     });
     const { cwd } = workspace;
     const current = this.options.access.get();
     if (this.closed || !current || authority(current) !== authority(grant))
-      throw new OpenCodeAccessError("Assistant access changed. Please retry.");
+      throw new OpenCodeAccessError(
+        "Assistant access changed. Please retry.",
+        current ? "access_denied" : this.options.access.getFailureCode(),
+      );
     const existing = this.entries.get(id);
     if (
       existing &&
@@ -103,7 +145,8 @@ export class OpenCodeHost {
       existing.authority === authority(grant)
     )
       return existing.ready!;
-    if (existing) await this.retire(id);
+    if (existing)
+      await this.retire(id, openCodeTransportFailure("access_denied"));
     // A prior retirement must finish before another process uses its database.
     await Promise.all(this.closing);
     const verified = await this.workspace(id);
@@ -125,11 +168,14 @@ export class OpenCodeHost {
     return entry.ready;
   }
 
-  retire(id: string): Promise<void> {
+  retire(
+    id: string,
+    failure = openCodeTransportFailure("transport_unavailable"),
+  ): Promise<void> {
     const entry = this.entries.get(id);
     if (!entry) return Promise.resolve();
     this.entries.delete(id);
-    entry.abort.abort();
+    entry.abort.abort(new OpenCodeTransportError(failure));
     entry.credential?.revoke();
     const closing = (async () => {
       const hosted = await entry.ready?.catch(() => null);
@@ -180,7 +226,10 @@ export class OpenCodeHost {
       !grant ||
       authority(grant) !== entry.authority
     )
-      throw new OpenCodeAccessError("Assistant access changed. Please retry.");
+      throw new OpenCodeAccessError(
+        "Assistant access changed. Please retry.",
+        grant ? "access_denied" : this.options.access.getFailureCode(),
+      );
   }
 
   private async unlock(entry: Managed): Promise<void> {
@@ -208,6 +257,7 @@ export class OpenCodeHost {
       .digest("hex");
     const stateRoot = join(this.options.stateRoot, "opencode", scope);
     let server: OpenCodeServer | undefined;
+    let startupAttempted = false;
     try {
       entry.unlock = await new DurableFileLock(join(stateRoot, "runtime"), {
         timeoutMs: 1000,
@@ -223,6 +273,7 @@ export class OpenCodeHost {
         runtimeToken: entry.credential.token,
         model: this.options.bridge.model,
       });
+      startupAttempted = true;
       server = await (this.options.start ?? startOpenCodeServer)({
         cwd: entry.workspace.cwd,
         stateRoot: join(stateRoot, "engine"),
@@ -232,7 +283,10 @@ export class OpenCodeHost {
       void server.exited
         .then(() => {
           if (this.entries.get(entry.workspace.harnessSessionId) === entry)
-            return this.retire(entry.workspace.harnessSessionId);
+            return this.retire(
+              entry.workspace.harnessSessionId,
+              openCodeTransportFailure("runtime_exited"),
+            );
         })
         .catch(() => {});
       await this.validate(entry);
@@ -241,6 +295,16 @@ export class OpenCodeHost {
         stateRoot,
         server,
         signal: entry.abort.signal,
+        isCurrent: () => {
+          const current = this.options.access.get();
+          return (
+            !this.closed &&
+            !entry.abort.signal.aborted &&
+            this.entries.get(entry.workspace.harnessSessionId) === entry &&
+            !!current &&
+            authority(current) === entry.authority
+          );
+        },
       };
     } catch (error) {
       if (this.entries.get(entry.workspace.harnessSessionId) === entry)
@@ -255,7 +319,41 @@ export class OpenCodeHost {
         }
       }
       await this.unlock(entry);
-      throw error;
+      if (error instanceof OpenCodeTransportError) throw error;
+      if (
+        entry.abort.signal.aborted &&
+        entry.abort.signal.reason instanceof OpenCodeTransportError
+      )
+        throw entry.abort.signal.reason;
+      throw new OpenCodeTransportError(
+        startupAttempted
+          ? openCodeTransportFailure(
+              "runtime_start_failed",
+              startupReason(error),
+            )
+          : openCodeTransportFailure("transport_unavailable"),
+      );
     }
   }
+
+  private accessFailure(): OpenCodeTransportFailure {
+    return openCodeTransportFailure(this.options.access.getFailureCode());
+  }
+
+  private accessError(message: string): OpenCodeAccessError {
+    return new OpenCodeAccessError(
+      message,
+      this.options.access.getFailureCode(),
+    );
+  }
+}
+
+function startupReason(error: unknown): OpenCodeStartupReason | undefined {
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+  return openCodeStartupReasons.includes(code as OpenCodeStartupReason)
+    ? (code as OpenCodeStartupReason)
+    : undefined;
 }

--- a/packages/harness/src/server/opencode-events.ts
+++ b/packages/harness/src/server/opencode-events.ts
@@ -1,6 +1,10 @@
 import { once } from "node:events";
 import type { Response } from "express";
-import type { OpenCodeServer } from "@sapiom/opencode";
+import {
+  OpenCodeTransportError,
+  type HostedOpenCode,
+} from "../core/opencode-host.js";
+import { openCodeTransportFailure } from "../shared/opencode-errors.js";
 
 const record = (value: unknown): Record<string, unknown> =>
   value && typeof value === "object" && !Array.isArray(value)
@@ -11,10 +15,20 @@ const record = (value: unknown): Record<string, unknown> =>
 export function scopedOpenCodeEvent(
   value: unknown,
   id: string,
+  scope?: { cwd: string; isCurrent: () => boolean },
 ): Record<string, unknown> | null {
   const envelope = record(value);
   const event = record(envelope.payload ?? value);
   const properties = record(event.properties);
+  if (scope && !scope.isCurrent()) return null;
+  if (
+    scope &&
+    envelope.payload !== undefined &&
+    envelope.directory !== undefined &&
+    envelope.directory !== scope.cwd
+  )
+    return null;
+  if (event.type === "studio.error") return null;
   if (event.type === "server.connected" || event.type === "server.heartbeat")
     return { type: event.type, properties: {} };
   const info = record(properties.info);
@@ -30,6 +44,20 @@ export function scopedOpenCodeEvent(
   )
     ids.push(info.id);
   const present = ids.filter((value) => value !== undefined);
+  if (
+    event.type === "session.error" &&
+    record(properties.error).name === "ProviderAuthError" &&
+    record(record(properties.error).data).providerID === "sapiom" &&
+    ((present.length > 0 && present.every((value) => value === id)) ||
+      (present.length === 0 &&
+        scope &&
+        envelope.payload !== undefined &&
+        envelope.directory === scope.cwd))
+  )
+    return {
+      type: "studio.error",
+      properties: openCodeTransportFailure("authentication_required"),
+    };
   return present.length > 0 && present.every((value) => value === id)
     ? event
     : null;
@@ -37,12 +65,12 @@ export function scopedOpenCodeEvent(
 
 /** Buffer at most one incomplete frame; never collect the complete response. */
 export async function streamOpenCodeEvents(
-  server: OpenCodeServer,
+  hosted: HostedOpenCode,
   id: string,
   res: Response,
   signal: AbortSignal,
 ): Promise<void> {
-  const upstream = await server.fetch("/event", {
+  const upstream = await hosted.server.fetch("/event", {
     signal,
     headers: { Accept: "text/event-stream" },
   });
@@ -64,7 +92,7 @@ export async function streamOpenCodeEvents(
   };
   let statusSeen = false;
   // Start after subscribing; never overwrite a newer native status with this snapshot.
-  void server
+  void hosted.server
     .fetchJson<Record<string, unknown>>("/session/status", {
       signal: AbortSignal.any([signal, AbortSignal.timeout(3000)]),
     })
@@ -103,16 +131,48 @@ export async function streamOpenCodeEvents(
           .map((line) => line.slice(5).trimStart())
           .join("\n");
         if (!data) continue;
-        const event = scopedOpenCodeEvent(JSON.parse(data), id);
+        const event = scopedOpenCodeEvent(JSON.parse(data), id, hosted);
         if (!event) continue;
         if (event.type === "session.status" || event.type === "session.idle")
           statusSeen = true;
         await write(event);
+        if (event.type === "studio.error") {
+          res.end();
+          return;
+        }
       }
       if (pending.length > maxFrame)
         throw new Error("Assistant event is too large");
     }
+    if (
+      signal.reason instanceof OpenCodeTransportError &&
+      !res.destroyed &&
+      !res.writableEnded
+    ) {
+      res.write(
+        `data: ${JSON.stringify({
+          type: "studio.error",
+          properties: signal.reason.failure,
+        })}\n\n`,
+      );
+    }
     res.end();
+  } catch (error) {
+    if (
+      signal.reason instanceof OpenCodeTransportError &&
+      !res.destroyed &&
+      !res.writableEnded
+    ) {
+      res.write(
+        `data: ${JSON.stringify({
+          type: "studio.error",
+          properties: signal.reason.failure,
+        })}\n\n`,
+      );
+      res.end();
+      return;
+    }
+    throw error;
   } finally {
     await reader.cancel().catch(() => {});
   }

--- a/packages/harness/src/server/opencode.test.ts
+++ b/packages/harness/src/server/opencode.test.ts
@@ -6,9 +6,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   OpenCodeAccessError,
+  OpenCodeTransportError,
   type HostedOpenCode,
 } from "../core/opencode-host.js";
 import { createOpenCodeRouter } from "./opencode.js";
+import { openCodeTransportFailure } from "../shared/opencode-errors.js";
+import { scopedOpenCodeEvent } from "./opencode-events.js";
 
 let root: string;
 let origin: string;
@@ -104,6 +107,7 @@ beforeEach(async () => {
       cwd: root,
       stateRoot,
       signal: abort.signal,
+      isCurrent: () => !abort.signal.aborted,
       server: {
         pid: 123,
         exited: new Promise<void>(() => {}),
@@ -200,13 +204,13 @@ describe("Studio-scoped OpenCode transport", () => {
       ).status,
     ).toBe(403);
     expect(
-      (
+      await (
         await request(path, {
           method: "POST",
           body: JSON.stringify({ messageId: "msg_empty" }),
         })
-      ).status,
-    ).toBe(502);
+      ).json(),
+    ).toEqual({ error: openCodeTransportFailure("transport_unavailable") });
     expect(
       requests.filter(
         (request) =>
@@ -374,15 +378,163 @@ describe("Studio-scoped OpenCode transport", () => {
     sessions.delete(id);
     router = createOpenCodeRouter({ ensure }, "boot-token");
     const missing = await request("studio-a/attach", { method: "POST" });
-    expect(missing.status).toBe(502);
-    expect(await missing.text()).not.toContain("private native diagnostics");
+    expect(missing.status).toBe(410);
+    expect(await missing.json()).toEqual({
+      error: openCodeTransportFailure("native_history_missing"),
+    });
     await writeFile(
       join(hosts.get("studio-a")!.stateRoot, "association.json"),
       '{"version":1,"conversationId":"studio-a"}',
     );
-    expect((await request("studio-a/attach", { method: "POST" })).status).toBe(
-      502,
-    );
+    const corrupt = await request("studio-a/attach", { method: "POST" });
+    expect(corrupt.status).toBe(410);
+    expect(await corrupt.json()).toEqual({
+      error: openCodeTransportFailure("native_history_missing"),
+    });
     expect(created).toBe(1);
+  });
+
+  it("returns exact typed access and startup failures without exposing diagnostics", async () => {
+    ensure.mockRejectedValueOnce(
+      new OpenCodeAccessError(
+        "private credential detail",
+        "authentication_required",
+      ),
+    );
+    const authentication = await request("studio-a/attach", {
+      method: "POST",
+    });
+    expect(authentication.status).toBe(401);
+    expect(await authentication.json()).toEqual({
+      error: openCodeTransportFailure("authentication_required"),
+    });
+    ensure.mockRejectedValueOnce(
+      new OpenCodeAccessError("private authority detail", "access_expired"),
+    );
+    const expired = await request("studio-a/attach", { method: "POST" });
+    expect(expired.status).toBe(403);
+    expect(await expired.json()).toEqual({
+      error: openCodeTransportFailure("access_expired"),
+    });
+    ensure.mockRejectedValueOnce(
+      new OpenCodeTransportError(
+        openCodeTransportFailure(
+          "runtime_start_failed",
+          "executable-not-found",
+        ),
+      ),
+    );
+    const startup = await request("studio-a/attach", { method: "POST" });
+    expect(startup.status).toBe(503);
+    expect(await startup.json()).toEqual({
+      error: openCodeTransportFailure(
+        "runtime_start_failed",
+        "executable-not-found",
+      ),
+    });
+    expect(created).toBe(0);
+  });
+
+  it.each(["access_expired", "runtime_exited"] as const)(
+    "emits a typed terminal event on %s and never submits work",
+    async (code) => {
+      await attach();
+      const response = await request("studio-a/event");
+      const reader = response.body!.getReader();
+      await readUntil(reader, '"busy"');
+      aborts
+        .get("studio-a")!
+        .abort(
+          new OpenCodeTransportError(
+            code === "access_expired"
+              ? openCodeTransportFailure("access_expired")
+              : openCodeTransportFailure("runtime_exited"),
+          ),
+        );
+      const terminal = await readUntil(reader, '"studio.error"');
+      expect(terminal).toContain(`"code":"${code}"`);
+      expect(await reader.read()).toEqual({ done: true, value: undefined });
+      expect(
+        requests.filter((item) =>
+          /prompt_async|final-response/.test(item.path),
+        ),
+      ).toHaveLength(0);
+    },
+  );
+
+  it("drops native-spoofed, conflicting, unscoped, and stale terminal events", async () => {
+    const id = await attach();
+    const response = await request("studio-a/event");
+    const reader = response.body!.getReader();
+    await readUntil(reader, '"busy"');
+    const auth = {
+      type: "session.error",
+      properties: {
+        error: {
+          name: "ProviderAuthError",
+          data: { providerID: "sapiom", message: "private" },
+        },
+      },
+    };
+    const scope = { cwd: root, isCurrent: () => true };
+    for (const event of [
+      {
+        type: "studio.error",
+        properties: openCodeTransportFailure("access_denied"),
+      },
+      auth,
+      { directory: "/different", payload: auth },
+      {
+        ...auth,
+        properties: {
+          ...auth.properties,
+          sessionID: id,
+          part: { sessionID: "ses_secret" },
+        },
+      },
+      {
+        directory: root,
+        payload: {
+          ...auth,
+          properties: {
+            ...auth.properties,
+            sessionID: "ses_foreign",
+          },
+        },
+      },
+      {
+        directory: root,
+        payload: {
+          ...auth,
+          properties: {
+            ...auth.properties,
+            sessionID: id,
+            info: { sessionID: "ses_foreign" },
+          },
+        },
+      },
+    ])
+      expect(scopedOpenCodeEvent(event, id, scope)).toBeNull();
+    expect(
+      scopedOpenCodeEvent({ directory: root, payload: auth }, id, {
+        cwd: root,
+        isCurrent: () => false,
+      }),
+    ).toBeNull();
+    streams[0].write(
+      `data: ${JSON.stringify({
+        type: "message.part.delta",
+        properties: { sessionID: id, delta: "still-scoped" },
+      })}\n\n`,
+    );
+    const visible = await readUntil(reader, "still-scoped");
+    expect(visible).not.toContain("studio.error");
+    streams[0].write(
+      `data: ${JSON.stringify({ directory: root, payload: auth })}\n\n`,
+    );
+    const terminal = await readUntil(reader, "studio.error");
+    expect(terminal).toContain('"code":"authentication_required"');
+    expect(terminal).not.toContain("private");
+    expect(await reader.read()).toEqual({ done: true, value: undefined });
   });
 });

--- a/packages/harness/src/server/opencode.ts
+++ b/packages/harness/src/server/opencode.ts
@@ -4,13 +4,17 @@ import {
   isConversationId,
 } from "../core/opencode-association.js";
 import {
-  OpenCodeAccessError,
+  OpenCodeTransportError,
   type OpenCodeHost,
 } from "../core/opencode-host.js";
 import { createBootTokenMiddleware } from "./auth.js";
 import { streamOpenCodeEvents } from "./opencode-events.js";
 import { OpenCodeFinalResponse } from "../core/opencode-final-response.js";
 import { openCodeCompletionPrompt } from "../shared/opencode-completion.js";
+import {
+  openCodeTransportFailure,
+  type OpenCodeTransportFailure,
+} from "../shared/opencode-errors.js";
 
 export function createOpenCodeRouter(
   host: Pick<OpenCodeHost, "ensure">,
@@ -104,7 +108,7 @@ export function createOpenCodeRouter(
         return;
       }
       if (path === "event") {
-        await streamOpenCodeEvents(hosted.server, nativeId, res, signal);
+        await streamOpenCodeEvents(hosted, nativeId, res, signal);
         return;
       }
       if (recover) {
@@ -141,10 +145,14 @@ export function createOpenCodeRouter(
         : await hosted.server.fetch(`/${nativePath}`, init);
       if (!upstream.ok) {
         await upstream.body?.cancel();
-        res.status(upstream.status === 404 ? 404 : 502).json({
-          error:
-            "Assistant request failed. Refresh the conversation and retry.",
-        });
+        sendFailure(
+          res,
+          openCodeTransportFailure(
+            upstream.status === 404 && conversation
+              ? "native_history_missing"
+              : "transport_unavailable",
+          ),
+        );
         return;
       }
       if (upstream.status === 204) {
@@ -165,10 +173,12 @@ export function createOpenCodeRouter(
       else res.json(data);
     } catch (error) {
       if (!res.headersSent && !res.destroyed)
-        res.status(error instanceof OpenCodeAccessError ? 403 : 502).json({
-          error:
-            "Assistant is unavailable. Check Studio sign-in and workspace access, then retry.",
-        });
+        sendFailure(
+          res,
+          error instanceof OpenCodeTransportError
+            ? error.failure
+            : openCodeTransportFailure("transport_unavailable"),
+        );
       else res.destroy();
     } finally {
       disconnected.abort();
@@ -176,6 +186,18 @@ export function createOpenCodeRouter(
     }
   }
   return router;
+}
+
+function sendFailure(res: Response, failure: OpenCodeTransportFailure): void {
+  const status =
+    failure.code === "authentication_required"
+      ? 401
+      : failure.code === "access_denied" || failure.code === "access_expired"
+        ? 403
+        : failure.code === "native_history_missing"
+          ? 410
+          : 503;
+  res.status(status).json({ error: failure });
 }
 
 function validPrompt(value: unknown): boolean {


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Assistant host and native event failures need strict runtime, authority, directory, and session scoping so users receive actionable errors without accepting spoofed or conflicting events or losing saved history ownership.

## Summary and scope

Emit only validated typed host failures, reject stale, foreign, conflicting, and unscoped native events, preserve associations for missing native history, and close terminal streams without replaying work. Full Resume/Continue behavior and crash fencing remain separate.

## Related work

Related issue or discussion: SAP-3290

## Validation

```text
pnpm --filter @sapiom/harness exec vitest run src/core/opencode-association.test.ts src/core/opencode-host.test.ts src/server/opencode.test.ts — 26/26 passed
Combined relevant harness suite — 159/159 passed on the accepted integration tree
pnpm --filter @sapiom/harness typecheck — passed
pnpm --filter @sapiom/harness build — passed with existing Vite warnings only
git diff --check — passed
Final root pnpm build / pnpm typecheck / pnpm lint — passed on b04b296fd05d2e708d466d8869ab5dd4c65a1a4d
Final root pnpm test — exited 1 only at unchanged @sapiom/agent-core permission fixture
pnpm --filter @sapiom/agent-core exec jest --runInBand src/bundle-error.spec.ts — final and exact baseline 709573af39499dcefa10e8a682f043d51d57620e both reproduced 1 failed / 5 passed: "names an unreadable project directory instead of blaming dependencies"
mcp, harness, agent-studio, cli, and harness-desktop suites skipped after recursive first-failure — explicitly run and passed
```

### Tests and documentation

Added association, host, event scoping, conflicting-session, missing-history, terminal-stream, and retry/no-replay regressions. Documented recovery ownership and added `.changeset/route-assistant-recovery-errors.md`.

## Compatibility and release impact

- Breaking or externally visible changes: Assistant failures are sanitized and actionable; stale or conflicting native events are ignored and saved associations remain authoritative.
- Changeset: Added `.changeset/route-assistant-recovery-errors.md`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the host and event corrections. Codex curated the accepted sequence and verified exact scoping tests.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->