### PR TITLE
fix(harness): fence Assistant drafts by authority [SAP-3290]

### DIFF
--- a/.changeset/fence-assistant-drafts.md
+++ b/.changeset/fence-assistant-drafts.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Fence in-memory Assistant drafts by the server-issued authority revision so drafts cannot cross account, tenant, denial, or readmission boundaries.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -76,14 +76,15 @@ rejected send shows its error and keeps the selected view. Unsent chat text is
 keyed by authenticated principal and Studio session above the centre pane, so it
 survives Terminal/Assistant and session switches, reconnects, exited-session
 views, and temporary New Session or past-session review navigation. It is never
-persisted: sign-out/account change, session deletion, and page/app reload clear
-the applicable in-memory draft. Conversation view is a separate, unpersisted
-mount-local preference: Terminal is the initial/reset view, while a foreground
-CLI prompt accepted by Studio explicitly reveals it. Background actions keep
-the selected view. A failed UI
-access poll retains the open draft for at most 60 seconds after the last success;
-explicit revocation/sign-out takes effect immediately when observed. The host
-continues enforcing its own capability expiry independently.
+persisted: actual Assistant-access retirement, authority crossover, sign-out,
+session deletion, and page/app reload clear the applicable in-memory draft.
+Same-authority renewals, polls, and reconnects retain it. Conversation view is
+a separate, unpersisted mount-local preference: Terminal is the initial/reset
+view, while a foreground CLI prompt accepted by Studio explicitly reveals it.
+Background actions keep the selected view. A failed UI access poll retains the
+open draft for at most 60 seconds after the last success; explicit
+revocation/sign-out takes effect immediately when observed. The host continues
+enforcing its own capability expiry independently.
 
 The current `@assistant-ui/react-opencode` integration stays behind
 `OpenCodeChat`, the host-to-UI adapter. The host exposes only the shared,

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -20,6 +20,7 @@ type Conversation = {
 let server: Server;
 let origin: string;
 let enabled: boolean;
+let accessAuthorityRevision: string;
 let failAttach: boolean;
 let attachError: unknown | null;
 let failMetadata: boolean;
@@ -59,6 +60,7 @@ function finish(id: string, suffix: string) {
 test.beforeEach(async ({ page }) => {
   conversations.clear();
   enabled = true;
+  accessAuthorityRevision = "authority-a";
   failAttach = false;
   attachError = null;
   failMetadata = false;
@@ -285,7 +287,10 @@ test.beforeEach(async ({ page }) => {
   });
   await page.route("**/api/assistant/access", (route) => {
     accessCalls++;
-    return route.fulfill({ status: failAccess ? 503 : 200, json: { enabled } });
+    return route.fulfill({
+      status: failAccess ? 503 : 200,
+      json: { enabled, authorityRevision: accessAuthorityRevision },
+    });
   });
   await page.route("**/opencode/**", (route) =>
     route.continue({
@@ -1090,13 +1095,19 @@ test("surfaces a rejected prompt POST and reconnects without replaying it", asyn
   expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
 });
 
-test("retains the draft during a failed access poll but applies explicit revocation", async ({
+test("retains the draft across stable and failed access polls but clears it at a disabled authority barrier", async ({
   page,
 }) => {
   await page.clock.install();
   await openAssistant(page);
   const input = page.getByRole("textbox", { name: "Message Assistant" });
   await input.fill("An unsent draft");
+
+  const beforeStablePoll = accessCalls;
+  await page.clock.fastForward(16000);
+  await expect.poll(() => accessCalls).toBeGreaterThan(beforeStablePoll);
+  await expect(input).toHaveValue("An unsent draft");
+
   const before = accessCalls;
   failAccess = true;
   await page.clock.fastForward(16000);
@@ -1105,11 +1116,42 @@ test("retains the draft during a failed access poll but applies explicit revocat
   expect(conversations.get("ses_sess_boot")!.streams.size).toBe(1);
   failAccess = false;
   enabled = false;
+  accessAuthorityRevision = "authority-retired";
   await page.clock.fastForward(16000);
   await expect(
     page.getByRole("group", { name: "Conversation view" }),
   ).toHaveCount(0);
   await expect(page.locator(".harness-terminal")).toBeVisible();
+
+  // Repeated disabled observations retain the same barrier. Readmission uses
+  // a new authority epoch, and neither can recover the retired draft.
+  const beforeDisabledPoll = accessCalls;
+  await page.clock.fastForward(16000);
+  await expect.poll(() => accessCalls).toBeGreaterThan(beforeDisabledPoll);
+  enabled = true;
+  accessAuthorityRevision = "authority-readmitted";
+  await page.clock.fastForward(16000);
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(input).toHaveValue("");
+});
+
+test("clears a draft on a direct enabled authority crossover without an auth event", async ({
+  page,
+}) => {
+  await page.clock.install();
+  await openAssistant(page);
+  const input = page.getByRole("textbox", { name: "Message Assistant" });
+  await input.fill("Principal A private draft");
+
+  const before = accessCalls;
+  accessAuthorityRevision = "authority-b";
+  await page.clock.fastForward(16000);
+  await expect.poll(() => accessCalls).toBeGreaterThan(before);
+
+  // authRevision is deliberately unchanged: the access epoch alone must swap
+  // the App-owned store before the enabled Principal B chat can mount.
+  await expect(input).toHaveValue("");
+  expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
 });
 
 test("expires the cached UI capability after sixty seconds without a successful poll", async ({

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -286,13 +286,16 @@ const shellApi = createApi();
 
 export const App = (): JSX.Element => {
   const harness = useHarnessState();
+  const [assistantAuthorityRevision, setAssistantAuthorityRevision] = useState<
+    string | null
+  >(null);
   // Draft text belongs to a principal + Studio session, not to whichever
   // centre-pane branch happens to be mounted. An auth barrier replaces this
   // whole store; an app reload intentionally drops it rather than persisting
   // sensitive, unsent text.
   const assistantDrafts = useMemo<ChatDraftStore>(
     () => new Map(),
-    [harness.authRevision, harness.bootToken],
+    [assistantAuthorityRevision, harness.authRevision, harness.bootToken],
   );
   // Successful session deletion removes its keyed draft. Exited sessions stay
   // in state (and keep their draft) until the user actually closes them.
@@ -3300,6 +3303,8 @@ export const App = (): JSX.Element => {
                   drafts={assistantDrafts}
                   onSignIn={signInForAssistant}
                   onOpenSettings={() => setSettingsOpen(true)}
+                  authorityRevision={assistantAuthorityRevision}
+                  onAuthorityRevision={setAssistantAuthorityRevision}
                   terminalRevision={
                     harness.terminalRevealBySession.get(
                       conversationSession.id,
@@ -3395,6 +3400,8 @@ export const App = (): JSX.Element => {
                       drafts={assistantDrafts}
                       onSignIn={signInForAssistant}
                       onOpenSettings={() => setSettingsOpen(true)}
+                      authorityRevision={assistantAuthorityRevision}
+                      onAuthorityRevision={setAssistantAuthorityRevision}
                       terminalRevision={
                         harness.terminalRevealBySession.get(
                           conversationSession.id,

--- a/packages/harness/web/src/components/AssistantPane.tsx
+++ b/packages/harness/web/src/components/AssistantPane.tsx
@@ -14,6 +14,8 @@ export function AssistantPane({
   drafts,
   onSignIn,
   onOpenSettings,
+  authorityRevision,
+  onAuthorityRevision,
   children,
 }: {
   sessionId: string;
@@ -23,9 +25,18 @@ export function AssistantPane({
   drafts: ChatDraftStore;
   onSignIn: () => void;
   onOpenSettings: () => void;
+  authorityRevision: string | null;
+  onAuthorityRevision: (revision: string) => void;
   children: ReactNode;
 }) {
-  const [enabled, setEnabled] = useState(false);
+  const [access, setAccess] = useState<{
+    enabled: boolean;
+    authorityRevision: string;
+  } | null>(null);
+  // An enabled response cannot mount chat until App has adopted the same
+  // opaque authority barrier and replaced the principal-scoped draft map.
+  const enabled =
+    access?.enabled === true && access.authorityRevision === authorityRevision;
   const [mode, setMode] = useState<"Terminal" | "Assistant">("Terminal");
   const draft = useMemo(() => {
     const entry = drafts.get(sessionId) ?? { text: "" };
@@ -45,10 +56,12 @@ export function AssistantPane({
     let expiry: ReturnType<typeof setTimeout>;
     const disable = () => {
       clearTimeout(expiry);
-      setEnabled(false);
+      setAccess((current) =>
+        current ? { ...current, enabled: false } : current,
+      );
       setMode("Terminal");
     };
-    setEnabled(false);
+    setAccess(null);
     setMode("Terminal");
     const refresh = async () => {
       try {
@@ -61,12 +74,21 @@ export function AssistantPane({
         if (abort.signal.aborted) return;
         if (response.status === 401 || response.status === 403) disable();
         if (!response.ok) throw new Error("Access check unavailable");
-        const { enabled: allowed } = await response.json();
+        const { enabled: allowed, authorityRevision: nextAuthorityRevision } =
+          await response.json();
         if (abort.signal.aborted) return;
-        if (typeof allowed !== "boolean")
+        if (
+          typeof allowed !== "boolean" ||
+          typeof nextAuthorityRevision !== "string" ||
+          nextAuthorityRevision.length === 0
+        )
           throw new Error("Invalid access check");
         clearTimeout(expiry);
-        setEnabled(allowed);
+        onAuthorityRevision(nextAuthorityRevision);
+        setAccess({
+          enabled: allowed,
+          authorityRevision: nextAuthorityRevision,
+        });
         if (allowed) expiry = setTimeout(disable, 60000);
         else setMode("Terminal");
       } catch {
@@ -84,7 +106,7 @@ export function AssistantPane({
       clearTimeout(timer);
       clearTimeout(expiry);
     };
-  }, [bootToken, authRevision]);
+  }, [bootToken, authRevision, onAuthorityRevision]);
 
   return (
     <div className="studio-conversation">
@@ -110,7 +132,7 @@ export function AssistantPane({
       <div className="studio-conversation-body">
         {enabled && mode === "Assistant" ? (
           <OpenCodeChat
-            key={sessionId}
+            key={`${authorityRevision}:${sessionId}`}
             harnessSessionId={sessionId}
             bootToken={bootToken}
             draft={draft}

--- a/packages/harness/web/src/components/OpenCodeChat.tsx
+++ b/packages/harness/web/src/components/OpenCodeChat.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   AssistantRuntimeProvider,
   ComposerPrimitive,
@@ -353,7 +360,7 @@ function ChatSurface({
   const ready = useOpenCodeThreadState(
     (s) => s.sessionId === conversationId && s.loadState.type === "ready",
   );
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!ready) return;
     composer.setText(draft.text);
     return composer.subscribe(() => {


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

An Assistant draft could cross a direct verified authority change when the existing authentication revision did not change.

## Summary and scope

Adopt the server-issued opaque authority revision in App, fail closed until pane and parent revisions agree, replace the in-memory draft store atomically on revision changes, and hydrate by authority plus Studio session before paint. No principal identifiers or persistence are added.

## Related work

Related issue or discussion: SAP-3290

## Validation

```text
pnpm --filter @sapiom/harness typecheck — passed
pnpm --filter @sapiom/harness build — passed with existing Vite warnings only
pnpm --filter @sapiom/harness lint — passed
pnpm exec playwright test --config web/e2e/playwright.config.ts web/e2e/opencode-chat.spec.ts --workers=1 — 31/31 passed
git diff --check — passed
Final root pnpm build / pnpm typecheck / pnpm lint — passed on b04b296fd05d2e708d466d8869ab5dd4c65a1a4d
Final root pnpm test — exited 1 only at unchanged @sapiom/agent-core permission fixture
pnpm --filter @sapiom/agent-core exec jest --runInBand src/bundle-error.spec.ts — final and exact baseline 709573af39499dcefa10e8a682f043d51d57620e both reproduced 1 failed / 5 passed: "names an unreadable project directory instead of blaming dependencies"
mcp, harness, agent-studio, cli, and harness-desktop suites skipped after recursive first-failure — explicitly run and passed
```

### Tests and documentation

Added browser regressions for stable and failed polls, disabled retirement/readmission, and direct enabled A-to-B crossover under an unchanged auth revision. Preserved the reviewed App blob, updated combined lifecycle documentation, and added `.changeset/fence-assistant-drafts.md`.

## Compatibility and release impact

- Breaking or externally visible changes: Assistant drafts clear on server authority retirement or crossover while stable-authority reconnects and polls retain them.
- Changeset: Added `.changeset/fence-assistant-drafts.md`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the authority barrier. Codex curated the exact accepted consumer after the literal endpoint dependency and verified the full browser file.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->