### PR TITLE
fix(opencode): supervise crash-safe runtime cleanup [SAP-3290] [SAP-3297]

### DIFF
--- a/.changeset/supervise-opencode-runtime.md
+++ b/.changeset/supervise-opencode-runtime.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/opencode": patch
+---
+
+Supervise native OpenCode process groups and publish cleanup proof only after owned runtime work is positively quiescent.

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -35,10 +35,17 @@ credential. This protects normal child-process and browser boundaries; it is not
 an operating-system sandbox. An unrestricted process running as the same user
 can inspect runtime memory or files and is outside this trust boundary.
 
-Startup and shutdown have deadlines. POSIX shutdown signals the owned process
-group; Windows process-tree hardening and packaged-platform validation remain
-tracked by SAP-3297. Binary paths inside `app.asar` resolve to their unpacked
-counterparts; the desktop packager must include the native binary there.
+Startup and shutdown have deadlines. Studio can durably protect the generated
+supervisor through `beforeLaunch`; native work starts only after that callback
+resolves. POSIX cleanup first stops the native launcher, then stops and removes
+its birth-validated native-managed descendants before publishing a run-scoped
+cleanup proof. A missing proof fails closed so another runtime cannot write the
+same state. The proof remains outside the ephemeral launch directory until the
+runtime lock consumes it. Windows uses its native process-tree termination for
+normal close; installed-platform validation remains tracked by SAP-3297.
+Binary paths inside `app.asar` resolve to their unpacked counterparts; the
+generated supervisor needs no source loader and runs under Electron with
+`ELECTRON_RUN_AS_NODE` without forwarding that variable to native or tools.
 
 `pnpm` must allow the `opencode-ai` install script so the platform binary exists
 before Studio starts. The workspace allowlist includes it. No UI is bundled in

--- a/packages/opencode/src/__fixtures__/server.mjs
+++ b/packages/opencode/src/__fixtures__/server.mjs
@@ -1,5 +1,10 @@
 import { createServer } from "node:http";
-import { readFileSync, writeFileSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
@@ -16,59 +21,103 @@ for (const specifier of config.plugin ?? []) {
   writeFileSync(readyPath, "ready\n", { flag: "wx", mode: 0o600 });
 }
 writeFileSync("runtime.pid", String(process.pid));
+if (config.resistant) {
+  const resistantSource =
+    'process.on("SIGTERM",()=>{' +
+    (config.resistantMarker
+      ? `require("node:fs").writeFileSync(${JSON.stringify(config.resistantMarker)},"ran")`
+      : "") +
+    "});setInterval(()=>{},60000)";
+  const resistant = spawn(process.execPath, ["-e", resistantSource], {
+    detached: true,
+    stdio: "ignore",
+  });
+  writeFileSync("runtime.tool.pid", String(resistant.pid));
+}
+if (config.spawnOnTermMarker) {
+  process.on("SIGTERM", () => {
+    spawn(
+      process.execPath,
+      [
+        "-e",
+        `require("node:fs").writeFileSync(${JSON.stringify(config.spawnOnTermMarker)},"ran")`,
+      ],
+      { detached: true, stdio: "ignore" },
+    ).unref();
+  });
+}
+if (config.startupExitWriter) {
+  const writerSource = `const fs=require("node:fs");fs.appendFileSync(${JSON.stringify(
+    config.startupExitWriter,
+  )},"write\\n");setInterval(()=>fs.appendFileSync(${JSON.stringify(
+    config.startupExitWriter,
+  )},"write\\n"),25)`;
+  const writer = spawn(process.execPath, ["-e", writerSource], {
+    detached: true,
+    stdio: "ignore",
+  });
+  writer.unref();
+  writeFileSync("runtime.tool.pid", String(writer.pid));
+  const deadline = Date.now() + 2_000;
+  const observeWriter = setInterval(() => {
+    if (existsSync(config.startupExitWriter)) process.exit(3);
+    if (Date.now() >= deadline) process.exit(4);
+  }, 10);
+}
 if (config.crash) {
   console.error("private provider diagnostic");
   process.exit(1);
 }
-createServer((req, res) => {
-  if (req.headers.authorization !== authorization) {
-    res.writeHead(401).end();
-    return;
-  }
-  if (req.url === "/global/health") {
-    if (!config.stall)
-      res.end(JSON.stringify({ healthy: true, version: "fixture" }));
-  } else if (req.url === "/config") {
-    res.end("{}");
-  } else if (req.url === "/inspect") {
-    const tool = spawn(process.execPath, [
-      "-e",
-      "console.log(JSON.stringify(Object.entries(process.env)))",
-    ]);
-    let output = "";
-    tool.stdout.on("data", (chunk) => {
-      output += chunk;
-    });
-    tool.on("exit", () => {
-      const entries = JSON.parse(output);
-      const credentials = [
-        password,
-        config.provider?.sapiom?.options?.apiKey,
-        config.mcp?.sapiom?.headers?.Authorization,
-      ].filter(Boolean);
-      res.end(
-        JSON.stringify({
-          cwd: process.cwd(),
-          keys: entries.map(([key]) => key),
-          runtimeKeys: Object.keys(process.env),
-          credentialValueInherited: entries.some(([, value]) =>
-            credentials.includes(value),
-          ),
-          configChecks: {
-            model: config.model,
-            modelBridge:
-              config.provider?.sapiom?.options?.baseURL?.endsWith(
-                "/llm/v2/openai/v1",
-              ),
-            mcpBridge: config.mcp?.sapiom?.url?.endsWith("/mcp"),
-          },
-        }),
-      );
-    });
-  } else {
-    res.writeHead(404).end("private diagnostic");
-  }
-}).listen(
-  Number(process.argv[process.argv.indexOf("--port") + 1]),
-  "127.0.0.1",
-);
+if (!config.startupExitWriter)
+  createServer((req, res) => {
+    if (req.headers.authorization !== authorization) {
+      res.writeHead(401).end();
+      return;
+    }
+    if (req.url === "/global/health") {
+      if (!config.stall)
+        res.end(JSON.stringify({ healthy: true, version: "fixture" }));
+    } else if (req.url === "/config") {
+      res.end("{}");
+    } else if (req.url === "/inspect") {
+      const tool = spawn(process.execPath, [
+        "-e",
+        "console.log(JSON.stringify(Object.entries(process.env)))",
+      ]);
+      let output = "";
+      tool.stdout.on("data", (chunk) => {
+        output += chunk;
+      });
+      tool.on("exit", () => {
+        const entries = JSON.parse(output);
+        const credentials = [
+          password,
+          config.provider?.sapiom?.options?.apiKey,
+          config.mcp?.sapiom?.headers?.Authorization,
+        ].filter(Boolean);
+        res.end(
+          JSON.stringify({
+            cwd: process.cwd(),
+            keys: entries.map(([key]) => key),
+            runtimeKeys: Object.keys(process.env),
+            credentialValueInherited: entries.some(([, value]) =>
+              credentials.includes(value),
+            ),
+            configChecks: {
+              model: config.model,
+              modelBridge:
+                config.provider?.sapiom?.options?.baseURL?.endsWith(
+                  "/llm/v2/openai/v1",
+                ),
+              mcpBridge: config.mcp?.sapiom?.url?.endsWith("/mcp"),
+            },
+          }),
+        );
+      });
+    } else {
+      res.writeHead(404).end("private diagnostic");
+    }
+  }).listen(
+    Number(process.argv[process.argv.indexOf("--port") + 1]),
+    "127.0.0.1",
+  );

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -7,6 +7,8 @@ export {
   OpenCodeShutdownError,
   OpenCodeStartupError,
   type OpenCodeServer,
+  type OpenCodeCleanupProof,
+  type OpenCodeProcessIdentity,
   type OpenCodeStartupFailureCode,
   type StartOpenCodeServerOptions,
 } from "./server.js";

--- a/packages/opencode/src/server.test.ts
+++ b/packages/opencode/src/server.test.ts
@@ -36,6 +36,23 @@ const options = (config: Record<string, unknown> = {}) => ({
   stateRoot: join(directory, "state"),
 });
 
+async function waitForRuntimePid(timeoutMs: number): Promise<number> {
+  const pidPath = join(directory, "runtime.pid");
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const pid = Number(await readFile(pidPath, "utf8"));
+      if (Number.isSafeInteger(pid) && pid > 0) return pid;
+      throw new Error("runtime fixture published an invalid PID");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    if (Date.now() >= deadline)
+      throw new Error("runtime fixture did not publish readiness");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
 describe("packaged OpenCode runtime", () => {
   it("distinguishes Windows no-child spawn failure from post-spawn exit", () => {
     expect(evaluateWindowsCleanup(undefined, undefined)).toBe("no-child");
@@ -144,22 +161,32 @@ describe("packaged OpenCode runtime", () => {
   });
 
   it("bounds hung startup, cleans up the child, and allows another startup", async () => {
-    await expect(
-      startOpenCodeServer({
-        ...options({ stall: true }),
-        startupTimeoutMs: 400,
-      }),
-    ).rejects.toMatchObject({
+    const starting = startOpenCodeServer({
+      ...options({ stall: true }),
+      startupTimeoutMs: 5_000,
+    });
+    const outcomePromise = starting.then(
+      () => ({ started: true as const, error: undefined }),
+      (error: unknown) => ({ started: false as const, error }),
+    );
+    let outcome!: Awaited<typeof outcomePromise>;
+    let pid!: number;
+    try {
+      pid = await waitForRuntimePid(4_000);
+    } finally {
+      outcome = await outcomePromise;
+    }
+    expect(outcome.started).toBe(false);
+    expect(outcome.error).toMatchObject({
       name: "OpenCodeStartupError",
       code: "timed-out",
       retryable: true,
       message: "OpenCode took too long to start. Retry the connection.",
     });
-    const pid = Number(await readFile(join(directory, "runtime.pid"), "utf8"));
     expect(() => process.kill(pid, 0)).toThrow();
     server = await startOpenCodeServer(options());
     expect(server.pid).not.toBe(pid);
-  });
+  }, 30_000);
 
   it("honors revocation during startup and sanitizes child diagnostics", async () => {
     const abort = new AbortController();

--- a/packages/opencode/src/server.test.ts
+++ b/packages/opencode/src/server.test.ts
@@ -4,6 +4,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+  evaluateTrackedClosure,
+  evaluateWindowsCleanup,
+  OpenCodeShutdownError,
   OpenCodeStartupError,
   startOpenCodeServer,
   type OpenCodeServer,
@@ -34,6 +37,48 @@ const options = (config: Record<string, unknown> = {}) => ({
 });
 
 describe("packaged OpenCode runtime", () => {
+  it("distinguishes Windows no-child spawn failure from post-spawn exit", () => {
+    expect(evaluateWindowsCleanup(undefined, undefined)).toBe("no-child");
+    expect(evaluateWindowsCleanup(42, null)).toBe("running");
+    expect(evaluateWindowsCleanup(42, 1)).toBe("uncertain");
+  });
+
+  it("rejects a zombie before positive descendant fencing", () => {
+    const tracked = new Map([
+      ["20:birth-20", { pid: 20, birthId: "birth-20" }],
+      ["22:birth-22", { pid: 22, birthId: "birth-22" }],
+    ]);
+    expect(
+      evaluateTrackedClosure(
+        tracked,
+        new Map([
+          [20, { pid: 20, birthId: "birth-20", state: "T" }],
+          [22, { pid: 22, birthId: "birth-22", state: "S" }],
+        ]),
+      ),
+    ).toBe("waiting");
+    expect(
+      evaluateTrackedClosure(
+        tracked,
+        new Map([
+          [20, { pid: 20, birthId: "birth-20", state: "Z" }],
+          [21, { pid: 21, birthId: "birth-21", state: "S" }],
+          [22, { pid: 22, birthId: "birth-22", state: "T" }],
+        ]),
+      ),
+    ).toBe("uncertain");
+
+    expect(
+      evaluateTrackedClosure(
+        tracked,
+        new Map([
+          [20, { pid: 20, birthId: "birth-20", state: "T" }],
+          [22, { pid: 22, birthId: "birth-22", state: "T" }],
+        ]),
+      ),
+    ).toBe("stopped");
+  });
+
   it("uses the bridge for model and MCP authentication and strips host secrets from tool environments", async () => {
     const config = createSapiomOpenCodeConfig({
       bridgeUrl: "http://127.0.0.1:1234/opencode-runtime/runtime",
@@ -131,14 +176,118 @@ describe("packaged OpenCode runtime", () => {
     } finally {
       clearTimeout(timer);
     }
+    await expect(startOpenCodeServer(options({ crash: true }))).rejects.toEqual(
+      new OpenCodeShutdownError(),
+    );
+  });
+
+  it.skipIf(process.platform !== "linux")(
+    "withholds cleanup proof when a startup exit leaves detached work",
+    async () => {
+      const writerLog = join(directory, "startup-writer.log");
+      let cleanupProof: { path: string; token: string } | undefined;
+      let writerPid: number | undefined;
+      let writerBirthId: string | undefined;
+      try {
+        await expect(
+          startOpenCodeServer({
+            ...options({ startupExitWriter: writerLog }),
+            beforeLaunch: (identity) => {
+              cleanupProof = identity.cleanupProof;
+            },
+          }),
+        ).rejects.toEqual(new OpenCodeShutdownError());
+
+        expect(cleanupProof).toBeDefined();
+        await expect(
+          readFile(cleanupProof!.path, "utf8"),
+        ).rejects.toMatchObject({ code: "ENOENT" });
+        writerPid = Number(
+          await readFile(join(directory, "runtime.tool.pid"), "utf8"),
+        );
+        writerBirthId = await linuxBirthId(writerPid);
+        expect(writerBirthId).toBeDefined();
+        const firstWrites = (await readFile(writerLog, "utf8")).split(
+          "\n",
+        ).length;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        const laterWrites = (await readFile(writerLog, "utf8")).split(
+          "\n",
+        ).length;
+        expect(laterWrites).toBeGreaterThan(firstWrites);
+      } finally {
+        if (
+          writerPid !== undefined &&
+          (await linuxBirthId(writerPid)) === writerBirthId
+        )
+          process.kill(writerPid, "SIGKILL");
+        if (writerPid !== undefined) await waitUntilStopped(writerPid);
+      }
+    },
+  );
+
+  it("never launches native after an awaited protection barrier is aborted", async () => {
+    const abort = new AbortController();
+    let releaseBarrier!: () => void;
+    let enteredBarrier!: () => void;
+    const barrierEntered = new Promise<void>((resolve) => {
+      enteredBarrier = resolve;
+    });
+    const barrier = new Promise<void>((resolve) => {
+      releaseBarrier = resolve;
+    });
+    const starting = startOpenCodeServer({
+      ...options(),
+      signal: abort.signal,
+      beforeLaunch: async (identity) => {
+        expect(identity.pid).toBeGreaterThan(0);
+        expect(identity.cleanupProof.token.length).toBeGreaterThanOrEqual(16);
+        enteredBarrier();
+        await barrier;
+      },
+    });
+    await barrierEntered;
+    abort.abort();
+    releaseBarrier();
+    await expect(starting).rejects.toMatchObject({ code: "cancelled" });
     await expect(
-      startOpenCodeServer(options({ crash: true })),
-    ).rejects.toMatchObject({
-      code: "exited",
-      exitCode: 1,
-      retryable: true,
-      message:
-        "OpenCode exited before it became ready. Retry, then update or reinstall Studio if the problem continues.",
+      readFile(join(directory, "runtime.pid"), "utf8"),
+    ).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("sanitizes protection failure and confirms resistant group cleanup", async () => {
+    await expect(
+      startOpenCodeServer({
+        ...options(),
+        beforeLaunch: async () => {
+          throw new Error("private lock diagnostic");
+        },
+      }),
+    ).rejects.toEqual(new OpenCodeStartupError("launch-failed"));
+
+    const nativeLaunchMarker = join(directory, "native-term-launch");
+    const descendantLaunchMarker = join(directory, "descendant-term-launch");
+    server = await startOpenCodeServer(
+      options({
+        resistant: true,
+        resistantMarker: descendantLaunchMarker,
+        spawnOnTermMarker: nativeLaunchMarker,
+      }),
+    );
+    const nativePid = Number(
+      await readFile(join(directory, "runtime.pid"), "utf8"),
+    );
+    const resistantPid = Number(
+      await readFile(join(directory, "runtime.tool.pid"), "utf8"),
+    );
+    await server.close();
+    expect(await processIsRunning(nativePid)).toBe(false);
+    expect(await processIsRunning(resistantPid)).toBe(false);
+    await expect(readFile(nativeLaunchMarker)).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+    await expect(readFile(descendantLaunchMarker)).rejects.toMatchObject({
+      code: "ENOENT",
     });
   });
 
@@ -178,3 +327,48 @@ describe("packaged OpenCode runtime", () => {
     ).toThrow("private loopback");
   });
 });
+
+async function processIsRunning(pid: number): Promise<boolean> {
+  if (process.platform === "linux") {
+    try {
+      const stat = await readFile(`/proc/${pid}/stat`, "utf8");
+      return stat.slice(stat.lastIndexOf(")") + 2).split(" ")[0] !== "Z";
+    } catch (error) {
+      if (
+        ["ENOENT", "ESRCH"].includes(
+          (error as NodeJS.ErrnoException).code ?? "",
+        )
+      )
+        return false;
+      throw error;
+    }
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") return false;
+    throw error;
+  }
+}
+
+async function linuxBirthId(pid: number): Promise<string | undefined> {
+  try {
+    const stat = await readFile(`/proc/${pid}/stat`, "utf8");
+    return stat.slice(stat.lastIndexOf(")") + 2).split(" ")[19];
+  } catch (error) {
+    if (
+      ["ENOENT", "ESRCH"].includes((error as NodeJS.ErrnoException).code ?? "")
+    )
+      return undefined;
+    throw error;
+  }
+}
+
+async function waitUntilStopped(pid: number): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (await processIsRunning(pid)) {
+    if (Date.now() >= deadline) throw new Error("fixture process did not stop");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/packages/opencode/src/server.ts
+++ b/packages/opencode/src/server.ts
@@ -1,6 +1,13 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomBytes } from "node:crypto";
-import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { createRequire } from "node:module";
 import { createServer } from "node:net";
 import { userInfo } from "node:os";
@@ -17,6 +24,16 @@ export interface StartOpenCodeServerOptions {
   command?: { executable: string; prefixArgs?: string[] };
   startupTimeoutMs?: number;
   shutdownTimeoutMs?: number;
+  beforeLaunch?: (identity: OpenCodeProcessIdentity) => void | Promise<void>;
+}
+export interface OpenCodeCleanupProof {
+  path: string;
+  token: string;
+}
+export interface OpenCodeProcessIdentity {
+  pid: number;
+  birthId?: string;
+  cleanupProof: OpenCodeCleanupProof;
 }
 export interface OpenCodeServer {
   pid: number;
@@ -24,6 +41,39 @@ export interface OpenCodeServer {
   fetch(path: string, init?: RequestInit): Promise<Response>;
   fetchJson<T>(path: string, init?: RequestInit): Promise<T>;
   close(): Promise<void>;
+}
+
+interface SupervisorProcessIdentity {
+  pid: number;
+  birthId: string;
+  state: string;
+}
+
+/** @internal Shared verbatim with the generated supervisor for deterministic tests. */
+export function evaluateTrackedClosure(
+  tracked: ReadonlyMap<
+    string,
+    Pick<SupervisorProcessIdentity, "pid" | "birthId">
+  >,
+  processes: ReadonlyMap<number, SupervisorProcessIdentity>,
+): "stopped" | "waiting" | "uncertain" {
+  let allStopped = true;
+  for (const identity of tracked.values()) {
+    const current = processes.get(identity.pid);
+    if (!current || current.birthId !== identity.birthId) return "uncertain";
+    if (current.state.startsWith("Z")) return "uncertain";
+    if (!current.state.startsWith("T")) allStopped = false;
+  }
+  return allStopped ? "stopped" : "waiting";
+}
+
+/** @internal Shared verbatim with the generated supervisor for deterministic tests. */
+export function evaluateWindowsCleanup(
+  nativePid: number | undefined,
+  exitCode: number | null | undefined,
+): "no-child" | "running" | "uncertain" {
+  if (nativePid === undefined) return "no-child";
+  return exitCode === null ? "running" : "uncertain";
 }
 
 export type OpenCodeStartupFailureCode =
@@ -112,6 +162,8 @@ const runtimeCredentialKeys = [
   "OPENCODE_SERVER_PASSWORD",
 ] as const;
 const toolHomeKeys = ["HOME", "USERPROFILE", "HOMEDRIVE", "HOMEPATH"] as const;
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
 
 async function createCredentialIsolationPlugin(
   launchRoot: string,
@@ -161,6 +213,269 @@ export const SapiomCredentialIsolation = async (input) => {
 `;
   await writeFile(pluginPath, source, { mode: 0o600 });
   return { pluginUrl: pathToFileURL(pluginPath).href, readyPath };
+}
+
+async function createRuntimeSupervisor(
+  launchRoot: string,
+  cleanupProof: OpenCodeCleanupProof,
+  shutdownTimeoutMs: number,
+): Promise<string> {
+  const supervisorPath = join(launchRoot, "runtime-supervisor.mjs");
+  const source = `import { spawn, spawnSync } from "node:child_process";
+import { link, open, readdir, readFile, rm } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { dirname } from "node:path";
+const cleanupPath = ${JSON.stringify(cleanupProof.path)};
+const cleanupToken = ${JSON.stringify(cleanupProof.token)};
+const shutdownTimeoutMs = ${JSON.stringify(shutdownTimeoutMs)};
+const evaluateTrackedClosure = ${evaluateTrackedClosure.toString()};
+const evaluateWindowsCleanup = ${evaluateWindowsCleanup.toString()};
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+let native;
+let nativePid;
+let launched = false;
+let stopping;
+const tracked = new Map();
+async function syncDirectory(directory) {
+  try {
+    const handle = await open(directory, "r");
+    try { await handle.sync(); } finally { await handle.close(); }
+  } catch (error) {
+    if (!["EINVAL", "ENOTSUP", "EPERM"].includes(error?.code ?? "")) throw error;
+  }
+}
+async function publishCleanupProof() {
+  const pending = cleanupPath + ".pending-" + randomUUID();
+  try {
+    const file = await open(pending, "wx", 0o600);
+    try {
+      await file.writeFile(JSON.stringify({ status: "complete", token: cleanupToken }) + "\\n", "utf8");
+      await file.sync();
+    } finally { await file.close(); }
+    await link(pending, cleanupPath);
+    await syncDirectory(dirname(cleanupPath));
+  } finally { await rm(pending, { force: true }).catch(() => {}); }
+}
+async function linuxProcesses() {
+  const processes = new Map();
+  for (const entry of await readdir("/proc")) {
+    if (!/^\\d+$/.test(entry)) continue;
+    try {
+      const stat = await readFile("/proc/" + entry + "/stat", "utf8");
+      const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+      processes.set(Number(entry), {
+        pid: Number(entry),
+        ppid: Number(fields[1]),
+        pgid: Number(fields[2]),
+        state: fields[0],
+        birthId: fields[19],
+      });
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+  }
+  return processes;
+}
+function darwinProcesses() {
+  const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid=,stat=,lstart="], { encoding: "utf8" });
+  if (result.status !== 0) return null;
+  const processes = new Map();
+  for (const line of result.stdout.split("\\n")) {
+    const match = line.trim().match(/^(\\d+)\\s+(\\d+)\\s+(\\d+)\\s+(\\S+)\\s+(.+)$/);
+    if (!match) continue;
+    processes.set(Number(match[1]), {
+      pid: Number(match[1]),
+      ppid: Number(match[2]),
+      pgid: Number(match[3]),
+      state: match[4],
+      birthId: match[5],
+    });
+  }
+  return processes;
+}
+async function processTable() {
+  if (process.platform === "linux") return linuxProcesses();
+  if (process.platform === "darwin") return darwinProcesses();
+  return null;
+}
+async function captureDescendants() {
+  const processes = await processTable();
+  if (processes === null || !nativePid) return false;
+  const roots = new Set([nativePid]);
+  for (const identity of tracked.values()) {
+    const current = processes.get(identity.pid);
+    if (current?.birthId === identity.birthId && !current.state.startsWith("Z"))
+      roots.add(identity.pid);
+  }
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const current of processes.values()) {
+      if (current.pid === nativePid || roots.has(current.pid) || !roots.has(current.ppid)) continue;
+      roots.add(current.pid);
+      tracked.set(current.pid + ":" + current.birthId, current);
+      changed = true;
+    }
+  }
+  return true;
+}
+async function runningTracked() {
+  const processes = await processTable();
+  if (processes === null) return null;
+  return [...tracked.values()].filter((identity) => {
+    const current = processes.get(identity.pid);
+    return current?.birthId === identity.birthId && !current.state.startsWith("Z");
+  });
+}
+async function groupMembers(pgid) {
+  const processes = await processTable();
+  if (processes === null) return null;
+  return [...processes.values()].filter(
+    (identity) => identity.pgid === pgid && !identity.state.startsWith("Z"),
+  );
+}
+function signalOwnedGroup(signal) {
+  if (!nativePid) return;
+  try { process.kill(-nativePid, signal); }
+  catch (error) { if (error?.code !== "ESRCH") throw error; }
+}
+async function signalTrackedGroups(signal) {
+  const running = await runningTracked();
+  if (running === null) return false;
+  for (const pgid of new Set(running.map((identity) => identity.pgid))) {
+    if (pgid === nativePid) continue;
+    try { process.kill(-pgid, signal); }
+    catch (error) { if (error?.code !== "ESRCH") throw error; }
+  }
+  return true;
+}
+async function waitForEmptyGroup(pgid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  do {
+    const members = await groupMembers(pgid);
+    if (members === null) return false;
+    if (members.length === 0) return true;
+    await wait(25);
+  } while (Date.now() < deadline);
+  return false;
+}
+async function freezeOwnedGroup() {
+  signalOwnedGroup("SIGSTOP");
+  const deadline = Date.now() + 1000;
+  do {
+    const members = await groupMembers(nativePid);
+    if (members === null || members.length === 0) return false;
+    if (members.every((identity) => identity.state.startsWith("T"))) return true;
+    await wait(10);
+  } while (Date.now() < deadline);
+  return false;
+}
+async function freezeDescendants() {
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    const before = tracked.size;
+    if (!(await captureDescendants())) return false;
+    if (!(await signalTrackedGroups("SIGSTOP"))) return false;
+    await wait(10);
+    const processes = await processTable();
+    if (processes === null) return false;
+    const closure = evaluateTrackedClosure(tracked, processes);
+    if (closure === "uncertain") return false;
+    if (closure === "stopped" && tracked.size === before) return true;
+  }
+  return false;
+}
+async function cleanupWindows() {
+  const disposition = evaluateWindowsCleanup(nativePid, native?.exitCode);
+  if (disposition === "no-child") return true;
+  if (disposition !== "running") return false;
+  const result = spawnSync("taskkill", ["/pid", String(nativePid), "/T", "/F"], {
+    windowsHide: true,
+    stdio: "ignore",
+  });
+  if (result.status !== 0) return false;
+  const deadline = Date.now() + shutdownTimeoutMs;
+  do {
+    try { process.kill(nativePid, 0); } catch (error) {
+      if (error?.code === "ESRCH") return true;
+      return false;
+    }
+    await wait(25);
+  } while (Date.now() < deadline);
+  return false;
+}
+async function cleanupPosix(cause) {
+  if (!nativePid) return true;
+  if (cause === "native-exit") return false;
+  if (!(await freezeOwnedGroup())) return false;
+  if (!(await freezeDescendants())) return false;
+  if (!(await signalTrackedGroups("SIGKILL"))) return false;
+  signalOwnedGroup("SIGKILL");
+  const forcedDeadline = Date.now() + 2000;
+  do {
+    await captureDescendants();
+    const running = await runningTracked();
+    if (running !== null && running.length === 0 && (await waitForEmptyGroup(nativePid, 25)))
+      return true;
+    await wait(25);
+  } while (Date.now() < forcedDeadline);
+  return false;
+}
+function stop(cause = "stop") {
+  if (stopping) return stopping;
+  stopping = (async () => {
+    const confirmed = !launched
+      ? true
+      : process.platform === "win32"
+        ? await cleanupWindows()
+        : await cleanupPosix(cause);
+    if (confirmed) await publishCleanupProof();
+    process.exitCode = confirmed ? 0 : 1;
+    if (process.connected) process.disconnect();
+    setTimeout(() => process.exit(process.exitCode ?? 1), 0);
+  })().catch(() => {
+    process.exitCode = 1;
+    if (process.connected) process.disconnect();
+    setTimeout(() => process.exit(1), 0);
+  });
+  return stopping;
+}
+process.once("disconnect", () => void stop("disconnect"));
+process.once("SIGTERM", () => void stop("signal"));
+process.once("SIGINT", () => void stop("signal"));
+process.on("message", (message) => {
+  if (message?.type === "stop") {
+    void stop();
+    return;
+  }
+  if (launched || stopping || !message || message.type !== "launch") return;
+  launched = true;
+  try {
+    native = spawn(message.executable, message.args, {
+      cwd: message.cwd,
+      env: message.env,
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+      detached: process.platform !== "win32",
+    });
+    nativePid = native.pid;
+    native.stdout?.resume();
+    native.stderr?.resume();
+    native.once("error", (error) => {
+      process.send?.({ type: "spawn-error", code: error?.code });
+      void stop();
+    });
+    native.once("exit", (exitCode, signal) => {
+      process.send?.({ type: "native-exit", exitCode, signal });
+      void stop("native-exit");
+    });
+  } catch (error) {
+    process.send?.({ type: "spawn-error", code: error?.code });
+    void stop();
+  }
+});
+`;
+  await writeFile(supervisorPath, source, { mode: 0o600 });
+  return supervisorPath;
 }
 
 export async function startOpenCodeServer(
@@ -222,48 +537,57 @@ export async function startOpenCodeServer(
     await rm(launchRoot, { recursive: true, force: true }).catch(() => {});
     throw new OpenCodeStartupError("cancelled");
   }
+  const shutdownTimeoutMs = options.shutdownTimeoutMs ?? 2000;
+  const cleanupProof: OpenCodeCleanupProof = {
+    path: join(
+      options.stateRoot,
+      `cleanup-${randomBytes(16).toString("hex")}.json`,
+    ),
+    token: randomBytes(32).toString("hex"),
+  };
+  const supervisorPath = await createRuntimeSupervisor(
+    launchRoot,
+    cleanupProof,
+    shutdownTimeoutMs,
+  );
+  const nativeArgs = [
+    ...(command.prefixArgs ?? []),
+    "serve",
+    "--hostname",
+    "127.0.0.1",
+    "--port",
+    String(port),
+  ];
+  const nativeEnvironment = {
+    ...platform,
+    HOME: isolatedHome,
+    ...(process.platform === "win32" ? { USERPROFILE: isolatedHome } : {}),
+    ...directories,
+    OPENCODE_CONFIG_CONTENT: JSON.stringify({
+      ...options.config,
+      plugin: [pluginUrl],
+    }),
+    OPENCODE_SERVER_USERNAME: "opencode",
+    OPENCODE_SERVER_PASSWORD: password,
+    OPENCODE_DISABLE_CLAUDE_CODE: "1",
+    OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: "1",
+    OPENCODE_DISABLE_DEFAULT_PLUGINS: "1",
+    OPENCODE_DISABLE_EXTERNAL_SKILLS: "1",
+    OPENCODE_DISABLE_PROJECT_CONFIG: "1",
+    OPENCODE_DISABLE_AUTOUPDATE: "1",
+    // Native discovery retains the complete MCP catalog without placing every
+    // remote tool schema in every model request.
+    OPENCODE_EXPERIMENTAL_CODE_MODE: "1",
+  };
   let child: ChildProcess;
   try {
-    child = spawn(
-      command.executable,
-      [
-        ...(command.prefixArgs ?? []),
-        "serve",
-        "--hostname",
-        "127.0.0.1",
-        "--port",
-        String(port),
-      ],
-      {
-        cwd: options.cwd,
-        env: {
-          ...platform,
-          HOME: isolatedHome,
-          ...(process.platform === "win32"
-            ? { USERPROFILE: isolatedHome }
-            : {}),
-          ...directories,
-          OPENCODE_CONFIG_CONTENT: JSON.stringify({
-            ...options.config,
-            plugin: [pluginUrl],
-          }),
-          OPENCODE_SERVER_USERNAME: "opencode",
-          OPENCODE_SERVER_PASSWORD: password,
-          OPENCODE_DISABLE_CLAUDE_CODE: "1",
-          OPENCODE_DISABLE_CLAUDE_CODE_SKILLS: "1",
-          OPENCODE_DISABLE_DEFAULT_PLUGINS: "1",
-          OPENCODE_DISABLE_EXTERNAL_SKILLS: "1",
-          OPENCODE_DISABLE_PROJECT_CONFIG: "1",
-          OPENCODE_DISABLE_AUTOUPDATE: "1",
-          // Native discovery retains the complete MCP catalog without placing
-          // every remote tool schema in every model request.
-          OPENCODE_EXPERIMENTAL_CODE_MODE: "1",
-        },
-        stdio: ["ignore", "pipe", "pipe"],
-        windowsHide: true,
-        detached: process.platform !== "win32",
-      },
-    );
+    child = spawn(process.execPath, [supervisorPath], {
+      cwd: launchRoot,
+      env: { ...platform, ELECTRON_RUN_AS_NODE: "1" },
+      stdio: ["ignore", "pipe", "pipe", "ipc"],
+      windowsHide: true,
+      detached: process.platform !== "win32",
+    });
   } catch (error) {
     await rm(launchRoot, { recursive: true, force: true }).catch(() => {});
     throw startupLaunchError(error);
@@ -272,6 +596,8 @@ export async function startOpenCodeServer(
   child.stdout?.resume();
   child.stderr?.resume();
   let exited = false;
+  let disconnected = false;
+  let protectionAcknowledged = false;
   let termination:
     | {
         exitCode: number | null;
@@ -279,6 +605,30 @@ export async function startOpenCodeServer(
         spawnErrorCode?: string;
       }
     | undefined;
+  child.once("disconnect", () => {
+    disconnected = true;
+  });
+  child.on("message", (message: unknown) => {
+    if (!isRecord(message) || typeof message.type !== "string") return;
+    if (message.type === "spawn-error") {
+      termination = {
+        exitCode: null,
+        signal: null,
+        ...(typeof message.code === "string"
+          ? { spawnErrorCode: message.code }
+          : {}),
+      };
+    } else if (
+      message.type === "native-exit" &&
+      (message.exitCode === null || typeof message.exitCode === "number") &&
+      (message.signal === null || typeof message.signal === "string")
+    ) {
+      termination = {
+        exitCode: message.exitCode,
+        signal: message.signal as NodeJS.Signals | null,
+      };
+    }
+  });
   const exit = new Promise<void>((resolve) => {
     const done = (next: typeof termination) => {
       if (exited) return;
@@ -286,7 +636,9 @@ export async function startOpenCodeServer(
       termination = next;
       resolve();
     };
-    child.once("exit", (exitCode, signal) => done({ exitCode, signal }));
+    child.once("exit", (exitCode, signal) =>
+      done(termination ?? { exitCode, signal }),
+    );
     child.once("error", (error) =>
       done({
         exitCode: null,
@@ -295,19 +647,36 @@ export async function startOpenCodeServer(
       }),
     );
   });
+  const cleanupConfirmed = async (): Promise<boolean> => {
+    try {
+      const decoded = JSON.parse(
+        await readFile(cleanupProof.path, "utf8"),
+      ) as unknown;
+      return (
+        isRecord(decoded) &&
+        Object.keys(decoded).sort().join(",") === "status,token" &&
+        decoded.status === "complete" &&
+        decoded.token === cleanupProof.token
+      );
+    } catch {
+      return false;
+    }
+  };
   let closing: Promise<void> | undefined;
   const close = () =>
     (closing ??= (async () => {
-      if (!exited) {
-        signalChild(child, "SIGTERM");
-        await Promise.race([exit, delay(options.shutdownTimeoutMs ?? 2000)]);
-      }
+      if (!exited && child.connected)
+        await sendToChild(child, { type: "stop" }).catch(() => {});
+      if (!exited) await Promise.race([exit, delay(shutdownTimeoutMs + 2500)]);
       if (!exited) {
         signalChild(child, "SIGKILL");
         await Promise.race([exit, delay(2000)]);
       }
-      if (!exited) throw new OpenCodeShutdownError();
+      if (!exited || !(await cleanupConfirmed()))
+        throw new OpenCodeShutdownError();
       await rm(launchRoot, { recursive: true, force: true }).catch(() => {});
+      if (!protectionAcknowledged)
+        await rm(cleanupProof.path, { force: true }).catch(() => {});
     })().catch(() => {
       throw new OpenCodeShutdownError();
     }));
@@ -328,6 +697,27 @@ export async function startOpenCodeServer(
     ? AbortSignal.any([options.signal, timeout])
     : timeout;
   try {
+    if (!child.pid) throw new OpenCodeStartupError("launch-failed");
+    const birthId = await processBirthId(child.pid);
+    if (options.beforeLaunch) {
+      await options.beforeLaunch({
+        pid: child.pid,
+        ...(birthId === undefined ? {} : { birthId }),
+        cleanupProof,
+      });
+      protectionAcknowledged = true;
+    }
+    if (options.signal?.aborted) throw new OpenCodeStartupError("cancelled");
+    if (exited || disconnected || !child.connected)
+      throw new OpenCodeStartupError("launch-failed");
+    await sendToChild(child, {
+      type: "launch",
+      executable: command.executable,
+      args: nativeArgs,
+      cwd: options.cwd,
+      env: nativeEnvironment,
+    });
+    if (options.signal?.aborted) throw new OpenCodeStartupError("cancelled");
     for (;;) {
       signal.throwIfAborted();
       if (exited) throw new Error("OpenCode exited during startup");
@@ -399,7 +789,10 @@ export async function startOpenCodeServer(
       throw new Error(
         "OpenCode credential isolation invalidated authentication",
       );
-    if (!child.pid || exited) throw new Error("OpenCode exited during startup");
+    if (!child.pid || exited || disconnected || !child.connected)
+      throw new Error("OpenCode exited during startup");
+    await sendToChild(child, { type: "ready" });
+    if (exited) throw new Error("OpenCode exited during startup");
     return {
       pid: child.pid,
       exited: exit,
@@ -446,12 +839,29 @@ function startupLaunchError(error: unknown): OpenCodeStartupError {
 }
 
 function signalChild(child: ChildProcess, signal: NodeJS.Signals): void {
-  if (!child.pid) return;
   try {
-    if (process.platform === "win32") child.kill(signal);
-    else process.kill(-child.pid, signal);
+    child.kill(signal);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+  }
+}
+
+async function sendToChild(
+  child: ChildProcess,
+  message: Record<string, unknown>,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    child.send(message, (error) => (error ? reject(error) : resolve()));
+  });
+}
+
+async function processBirthId(pid: number): Promise<string | undefined> {
+  if (process.platform !== "linux") return undefined;
+  try {
+    const stat = await readFile(`/proc/${pid}/stat`, "utf8");
+    return stat.slice(stat.lastIndexOf(")") + 2).split(" ")[19];
+  } catch {
+    return undefined;
   }
 }
 


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Host death, supervisor death, or unexpected native exit must never certify cleanup while a detached native-managed writer may survive.

## Summary and scope

Run native OpenCode beneath an inert generated supervisor, require durable process protection before launch, discover and freeze the complete owned POSIX process set, publish cleanup proof only after verified quiescence, and fail closed on uncertain startup/exit. This layer includes the reviewed pre-ready, zombie-closure, Windows no-child, and readiness corrections; the tombstone competitor correction is already delivered by the earlier `assistant-runtime-lock-ownership` layer prepared as the replacement for historical #939.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `studio-recovery-paths`. Actual-parent size: **817 additions + 123 deletions = 940 changed lines**. This is above the 600-line target and below the 1,000-line hard maximum; the source and tests stay together to preserve a compiling, independently reviewable boundary.

Absorbed reviewed provenance: retained #940 generated runtime supervisor and cleanup proof lifecycle; reviewed crash-race/closure/Windows no-child corrections; c3daa613 lifecycle readiness stabilization.

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3290](https://linear.app/sapiom/issue/SAP-3290), [SAP-3297](https://linear.app/sapiom/issue/SAP-3297). This PR keeps its existing number and review history within the main-rooted native GitHub stack.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check 1121534e6afe7598dd4411732ece5893a729ac28...42d29749341d5026a3bc1ad000ac6b549f26011b` — passed.
- Final OpenCode serial package gate — 3 files / 32 tests passed, including 5/5 actual pinned OpenCode 1.18.29 native tests.
- Earlier exact a9bb243 darwin/arm64 source smoke passed; the optional final-tip Mac RPC timed out waiting for the client, so no final-tip or installed-platform pass is claimed.

### Tests and documentation

Server/runtime tests cover late protection abort, resistant descendants, startup orphan proof withholding, whole-set closure uncertainty, Windows no-child evaluation, and actual pinned Linux native startup/cleanup. README and a Changeset state the bounded process boundary.

## Compatibility and release impact

- Breaking or externally visible changes: Unexpected unproven cleanup intentionally retains required runtime ownership and may report already-open/state-unavailable. Windows source covers confirmed no-child spawn failure and normal-close tree cleanup; installed platform certification remains SAP-3297.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
