### PR TITLE
fix(harness): route Assistant transport failures [SAP-3290]

### DIFF
--- a/.changeset/show-assistant-recovery-actions.md
+++ b/.changeset/show-assistant-recovery-actions.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Show trusted static recovery actions for typed Assistant transport and final-response failures while keeping incomplete turns blocked and preventing prompt or tool replay.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -86,6 +86,16 @@ open draft for at most 60 seconds after the last success; explicit
 revocation/sign-out takes effect immediately when observed. The host continues
 enforcing its own capability expiry independently.
 
+The current `@assistant-ui/react-opencode` integration stays behind
+`OpenCodeChat`, the host-to-UI adapter. The host exposes only the shared,
+strictly parsed transport-error contract; the adapter selects trusted static
+copy and maps its bounded actions to the existing sign-in, Settings, Terminal,
+or reconnect surfaces. Replacing the pinned UI library means replacing that
+adapter, not changing the host association/runtime protocol or adopting native
+events directly. Confirmed missing native history leaves the Studio session and
+record intact and opens Terminal; it never fabricates Continue/Resume or a new
+native conversation.
+
 The Assistant's model and remote MCP requests use a Studio-owned local bridge.
 Its short-lived runtime credential is separate from browser authentication;
 Studio adds the Sapiom key only when forwarding to the configured services.

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -14,6 +14,8 @@ type Conversation = {
   }>;
   streams: Set<Response>;
   prompts: string[];
+  busy: boolean;
+  recoveries: string[];
 };
 let server: Server;
 let origin: string;
@@ -34,6 +36,8 @@ const historyReplies: Array<() => void> = [];
 let routeCalls: number;
 const conversations = new Map<string, Conversation>();
 const emit = (c: Conversation, type: string, properties: object) => {
+  if (type === "session.status")
+    c.busy = (properties as any).status.type !== "idle";
   for (const stream of c.streams)
     stream.write(`data: ${JSON.stringify({ type, properties })}\n\n`);
 };
@@ -92,7 +96,14 @@ test.beforeEach(async ({ page }) => {
     const id = `ses_${req.params.studioId.replaceAll("-", "_")}`;
     let c = conversations.get(id);
     if (!c) {
-      c = { id, turns: [], streams: new Set(), prompts: [] };
+      c = {
+        id,
+        turns: [],
+        streams: new Set(),
+        prompts: [],
+        busy: false,
+        recoveries: [],
+      };
       conversations.set(id, c);
     }
     const path = req.params[0];
@@ -131,7 +142,7 @@ test.beforeEach(async ({ page }) => {
       return;
     }
     if (path === "session/status") {
-      res.json({ [id]: { type: "idle" } });
+      res.json({ [id]: { type: c.busy ? "busy" : "idle" } });
       return;
     }
     if (path === "event") {
@@ -142,6 +153,9 @@ test.beforeEach(async ({ page }) => {
       res.type("text/event-stream").flushHeaders();
       c.streams.add(res);
       res.write('data: {"type":"server.connected","properties":{}}\n\n');
+      res.write(
+        `data: ${JSON.stringify({ type: "session.status", properties: { sessionID: id, status: { type: c.busy ? "busy" : "idle" } } })}\n\n`,
+      );
       res.once("close", () => c!.streams.delete(res));
       return;
     }
@@ -294,6 +308,38 @@ async function openAssistant(page: Page) {
   await expect(
     page.getByRole("textbox", { name: "Message Assistant" }),
   ).toBeEnabled();
+}
+
+function endWithoutAnswer(c: Conversation) {
+  const preamble = c.turns.at(-1)!;
+  preamble.info.finish = "tool-calls";
+  preamble.info.time.completed = Date.now();
+  const tool = {
+    id: "prt_tool",
+    sessionID: c.id,
+    messageID: preamble.info.id,
+    type: "tool",
+    callID: "call_read",
+    tool: "read",
+    state: {
+      status: "completed",
+      input: { filePath: "README.md" },
+      output: "# OpenCode playground",
+      title: "README.md",
+      metadata: {},
+      time: { start: 1, end: 2 },
+    },
+  };
+  preamble.parts.push(tool);
+  emit(c, "message.updated", { info: preamble.info });
+  emit(c, "message.part.updated", { part: tool });
+  const final = {
+    info: { ...preamble.info, id: "msg_empty", agent: "build", finish: "stop" },
+    parts: [],
+  };
+  c.turns.push(final);
+  emit(c, "message.updated", { info: final.info });
+  emit(c, "session.status", { sessionID: c.id, status: { type: "idle" } });
 }
 
 test("defaults to Terminal and keeps Assistant unavailable when access is off", async ({

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -27,7 +27,9 @@ let holdHistory: boolean;
 let failEvents: boolean;
 let failPrompt: boolean;
 let failAccess: boolean;
+let finalResponseError: unknown | null;
 let accessCalls: number;
+let recoveryReply: ((text: string, agent?: string) => void) | undefined;
 const historyReplies: Array<() => void> = [];
 let routeCalls: number;
 const conversations = new Map<string, Conversation>();
@@ -63,7 +65,9 @@ test.beforeEach(async ({ page }) => {
   failEvents = false;
   failPrompt = false;
   failAccess = false;
+  finalResponseError = null;
   accessCalls = 0;
+  recoveryReply = undefined;
   historyReplies.length = 0;
   routeCalls = 0;
   const app = express();
@@ -139,6 +143,61 @@ test.beforeEach(async ({ page }) => {
       c.streams.add(res);
       res.write('data: {"type":"server.connected","properties":{}}\n\n');
       res.once("close", () => c!.streams.delete(res));
+      return;
+    }
+    if (path === `session/${id}/final-response`) {
+      c.recoveries.push(req.body.messageId);
+      if (finalResponseError) {
+        res.status(410).json(finalResponseError);
+        return;
+      }
+      emit(c, "session.status", { sessionID: id, status: { type: "busy" } });
+      recoveryReply = (text, agent = "sapiom-turn-recovery") => {
+        const previous = c!.turns.at(-1)!;
+        const messageId = `${previous.info.id}_recovered`;
+        const user = {
+          info: {
+            id: `${messageId}_user`,
+            sessionID: id,
+            role: "user",
+            agent,
+            time: { created: Date.now() },
+          },
+          parts: [
+            {
+              id: `prt_${messageId}_user`,
+              sessionID: id,
+              messageID: `${messageId}_user`,
+              type: "text",
+              text: "Internal recovery instruction",
+            },
+          ],
+        };
+        const answer = {
+          info: {
+            ...previous.info,
+            id: messageId,
+            agent,
+            parentID: user.info.id,
+          },
+          parts: [
+            {
+              id: `prt_${messageId}`,
+              sessionID: id,
+              messageID: messageId,
+              type: "text",
+              text,
+            },
+          ],
+        };
+        c!.turns.push(user, answer);
+        emit(c!, "message.updated", { info: user.info });
+        emit(c!, "message.part.updated", { part: user.parts[0] });
+        emit(c!, "message.updated", { info: answer.info });
+        emit(c!, "message.part.updated", { part: answer.parts[0] });
+        emit(c!, "session.status", { sessionID: id, status: { type: "idle" } });
+        res.status(204).end();
+      };
       return;
     }
     if (path === `session/${id}/prompt_async`) {
@@ -611,6 +670,40 @@ test("drops unscoped native errors and stops continuation on a scoped terminal e
   for (const stream of c.streams) stream.end();
   await expect.poll(() => c.recoveries).toEqual([]);
   expect(c.prompts).toEqual(["One accepted request"]);
+});
+
+test("keeps an incomplete turn blocked when final-response returns a typed terminal error", async ({
+  page,
+}) => {
+  await openAssistant(page);
+  const input = page.getByRole("textbox", { name: "Message Assistant" });
+  await input.fill("One request with incomplete native history");
+  await input.press("Enter");
+  const c = conversations.get("ses_sess_boot")!;
+  await expect
+    .poll(() => c.prompts)
+    .toEqual(["One request with incomplete native history"]);
+  await expect(page.getByText("First chunk", { exact: true })).toBeVisible();
+
+  finalResponseError = {
+    error: openCodeTransportFailure("native_history_missing"),
+  };
+  endWithoutAnswer(c);
+
+  await expect.poll(() => c.recoveries).toEqual(["msg_empty"]);
+  const alert = page.getByRole("alert");
+  await expect(alert).toContainText(
+    "saved Assistant conversation is unavailable",
+  );
+  await expect(
+    page.getByRole("button", { name: "Send message" }),
+  ).toBeDisabled();
+  await expect(input).toBeDisabled();
+  await expect(alert.getByRole("button", { name: "Reconnect" })).toHaveCount(0);
+  expect(c.prompts).toEqual(["One request with incomplete native history"]);
+
+  await alert.getByRole("button", { name: "Open Terminal" }).click();
+  await expect(page.locator(".harness-terminal")).toBeVisible();
 });
 
 test("shows stream loss and reconnects without replaying an accepted prompt", async ({

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test, type Page } from "@playwright/test";
 import express, { type Response } from "express";
 import type { Server } from "node:http";
+import { openCodeCompletionPrompt } from "../../src/shared/opencode-completion";
+import { openCodeTransportFailure } from "../../src/shared/opencode-errors";
 
 // Exercise the pinned adapter over actual incremental HTTP SSE, without a model.
 test.describe.configure({ mode: "serial" });
@@ -18,7 +20,9 @@ let origin: string;
 let enabled: boolean;
 let accessAuthorityRevision: string;
 let failAttach: boolean;
+let attachError: unknown | null;
 let failMetadata: boolean;
+let metadataError: unknown | null;
 let holdHistory: boolean;
 let failEvents: boolean;
 let failPrompt: boolean;
@@ -52,7 +56,9 @@ test.beforeEach(async ({ page }) => {
   enabled = true;
   accessAuthorityRevision = "authority-a";
   failAttach = false;
+  attachError = null;
   failMetadata = false;
+  metadataError = null;
   holdHistory = false;
   failEvents = false;
   failPrompt = false;
@@ -92,6 +98,10 @@ test.beforeEach(async ({ page }) => {
       time: { created: 1, updated: 1 },
     };
     if (path === "attach") {
+      if (attachError) {
+        res.status(503).json(attachError);
+        return;
+      }
       res.status(failAttach ? 502 : 200).json({ conversationId: id });
       return;
     }
@@ -100,6 +110,10 @@ test.beforeEach(async ({ page }) => {
       return;
     }
     if (path === `session/${id}`) {
+      if (metadataError) {
+        res.status(403).json(metadataError);
+        return;
+      }
       res.status(failMetadata ? 503 : 200).json(session);
       return;
     }
@@ -332,6 +346,37 @@ test("keeps principal-scoped session drafts across centre-pane routes and exited
   await page.getByRole("button", { name: "Assistant", exact: true }).click();
   await expect(input).toHaveValue("First session draft");
 
+  // Closing an exited session is the deletion boundary for its draft. If a
+  // later server event reuses that Studio session id, no deleted text returns.
+  await page.getByRole("button", { name: "Terminal", exact: true }).click();
+  await page.getByTestId("dead-session-close").click();
+  await expect(page.getByTestId("session-context")).toHaveAttribute(
+    "data-session-id",
+    "sess-leasing-2",
+  );
+  await page.evaluate(() =>
+    (window as any).__HARNESS_TEST__.publish({
+      type: "session.status",
+      session: {
+        id: "sess-boot",
+        agentSessionId: null,
+        boundWorkflowPath: "/Users/demo/acme-app/leasing",
+        harness: "claude-code",
+        cwd: "/Users/demo/acme-app",
+        title: "acme-app",
+        status: "running",
+        ready: true,
+        createdAt: new Date().toISOString(),
+        lastActiveAt: new Date().toISOString(),
+      },
+    }),
+  );
+  await page.getByTestId("session-tab-sess-boot").click();
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(input).toHaveValue("");
+  await page.getByTestId("session-tab-sess-leasing-2").click();
+  await expect(input).toHaveValue("Second session draft");
+
   // An auth barrier replaces the whole store. A newly verified principal can
   // use Assistant, but never inherits either prior principal's unsent text.
   enabled = false;
@@ -438,6 +483,134 @@ test("shows startup failure and reconnects without sending a prompt", async ({
     page.getByRole("textbox", { name: "Message Assistant" }),
   ).toBeEnabled();
   expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
+});
+
+test("renders a permanent startup repair action from the strict shared contract", async ({
+  page,
+}) => {
+  attachError = {
+    error: openCodeTransportFailure(
+      "runtime_start_failed",
+      "executable-not-found",
+    ),
+  };
+  await page.goto("/?seed=0");
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  const alert = page.getByRole("alert");
+  await expect(alert).toContainText("OpenCode runtime is missing");
+  await expect(alert.getByRole("button", { name: "Reconnect" })).toHaveCount(0);
+  await alert.getByRole("button", { name: "Open Settings" }).click();
+  await expect(page.getByTestId("settings-popover")).toBeVisible();
+  expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
+});
+
+test("keeps confirmed missing native history honest and opens the existing session", async ({
+  page,
+}) => {
+  attachError = {
+    error: openCodeTransportFailure("native_history_missing"),
+  };
+  await page.goto("/?seed=0");
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  const alert = page.getByRole("alert");
+  await expect(alert).toContainText(
+    "saved Assistant conversation is unavailable",
+  );
+  await expect(alert.getByRole("button", { name: "Reconnect" })).toHaveCount(0);
+  await alert.getByRole("button", { name: "Open Terminal" }).click();
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+  expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
+});
+
+test("passes a typed adapter read denial to account settings without trusting wire copy", async ({
+  page,
+}) => {
+  metadataError = {
+    error: openCodeTransportFailure("access_denied"),
+  };
+  await page.goto("/?seed=0");
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  const alert = page.getByRole("alert");
+  await expect(alert).toContainText(
+    "Assistant access is not available for this account",
+  );
+  await expect(
+    page.getByRole("button", { name: "Send message" }),
+  ).toBeDisabled();
+  await alert.getByRole("button", { name: "Open Settings" }).click();
+  await expect(page.getByTestId("settings-popover")).toBeVisible();
+  expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
+
+  // A server-controlled string that does not match the shared table is not a
+  // typed error. The adapter falls back without rendering the diagnostic.
+  metadataError = {
+    error: {
+      ...openCodeTransportFailure("access_denied"),
+      message: "credential=must-not-render",
+    },
+  };
+  await page.keyboard.press("Escape");
+  await expect(page.getByTestId("settings-popover")).toBeHidden();
+  await page.getByRole("button", { name: "Terminal", exact: true }).click();
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(page.getByRole("alert")).toContainText("Could not load or send");
+  await expect(page.getByText("credential=must-not-render")).toHaveCount(0);
+});
+
+test("offers the existing sign-in flow only for authentication_required", async ({
+  page,
+}) => {
+  attachError = {
+    error: openCodeTransportFailure("authentication_required"),
+  };
+  await page.goto("/?seed=0");
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  const alert = page.getByRole("alert");
+  await expect(alert).toContainText("Sign in to Studio to use Assistant");
+  await alert.getByRole("button", { name: "Sign in" }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => (window as any).__HARNESS_TEST__?.lastAuthStart ?? null,
+      ),
+    )
+    .not.toBeNull();
+  expect(conversations.get("ses_sess_boot")!.prompts).toEqual([]);
+});
+
+test("drops unscoped native errors and stops continuation on a scoped terminal error", async ({
+  page,
+}) => {
+  await openAssistant(page);
+  const input = page.getByRole("textbox", { name: "Message Assistant" });
+  await input.fill("One accepted request");
+  await input.press("Enter");
+  const c = conversations.get("ses_sess_boot")!;
+  await expect.poll(() => c.prompts).toEqual(["One accepted request"]);
+
+  // Neither an unscoped native session error nor a native-spoofed Studio event
+  // may reach the pinned adapter as a terminal failure.
+  emit(c, "session.error", {
+    error: { name: "UnknownError", data: { message: "unscoped" } },
+  });
+  emit(c, "studio.error", {
+    ...openCodeTransportFailure("authentication_required"),
+    sessionID: "ses_spoofed",
+  });
+  await expect(page.getByRole("alert")).toHaveCount(0);
+
+  emit(c, "studio.error", openCodeTransportFailure("runtime_exited"));
+  await expect(page.getByRole("alert")).toContainText("Assistant stopped");
+  await expect(
+    page.getByRole("button", { name: "Send message" }),
+  ).toBeDisabled();
+
+  // Even if idle/missing-turn evidence follows, the terminal error suppresses
+  // the bounded final-response request and never repeats the accepted prompt.
+  endWithoutAnswer(c);
+  for (const stream of c.streams) stream.end();
+  await expect.poll(() => c.recoveries).toEqual([]);
+  expect(c.prompts).toEqual(["One accepted request"]);
 });
 
 test("shows stream loss and reconnects without replaying an accepted prompt", async ({

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -227,6 +227,7 @@ test.beforeEach(async ({ page }) => {
           id: userId,
           sessionID: id,
           role: "user",
+          agent: "build",
           time: { created: Date.now() },
         },
         parts: [

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -705,6 +705,11 @@ export const App = (): JSX.Element => {
   // Lifted so the telemetry chip in the session bar can open the settings
   // popover from outside SessionBar's own gear button.
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const signInForAssistant = useCallback(() => {
+    void harness.startAuth().catch((error) => {
+      harness.showToast(errorMessage(error, "Could not start sign-in."));
+    });
+  }, [harness.showToast, harness.startAuth]);
   // Right tab is part of the held arrangement: restored on reload.
   // Guard against a stored value for a tab that no longer exists ("skills",
   // and now "code" — its snippets moved to the deploy surface) — fall back to
@@ -3328,9 +3333,12 @@ export const App = (): JSX.Element => {
                   drafts={assistantDrafts}
                   authorityRevision={assistantAuthorityRevision}
                   onAuthorityRevision={setAssistantAuthorityRevision}
+                  onSignIn={signInForAssistant}
+                  onOpenSettings={() => setSettingsOpen(true)}
                   terminalRevision={
-                    harness.terminalRevealBySession.get(conversationSession.id) ??
-                    0
+                    harness.terminalRevealBySession.get(
+                      conversationSession.id,
+                    ) ?? 0
                   }
                 >
                   <DeadSessionPane
@@ -3422,6 +3430,8 @@ export const App = (): JSX.Element => {
                       drafts={assistantDrafts}
                       authorityRevision={assistantAuthorityRevision}
                       onAuthorityRevision={setAssistantAuthorityRevision}
+                      onSignIn={signInForAssistant}
+                      onOpenSettings={() => setSettingsOpen(true)}
                       terminalRevision={
                         harness.terminalRevealBySession.get(
                           conversationSession.id,

--- a/packages/harness/web/src/components/AssistantPane.tsx
+++ b/packages/harness/web/src/components/AssistantPane.tsx
@@ -14,6 +14,8 @@ export function AssistantPane({
   drafts,
   authorityRevision,
   onAuthorityRevision,
+  onSignIn,
+  onOpenSettings,
   children,
 }: {
   sessionId: string;
@@ -23,6 +25,8 @@ export function AssistantPane({
   drafts: ChatDraftStore;
   authorityRevision: string | null;
   onAuthorityRevision: (revision: string) => void;
+  onSignIn: () => void;
+  onOpenSettings: () => void;
   children: ReactNode;
 }) {
   const [access, setAccess] = useState<{
@@ -132,6 +136,9 @@ export function AssistantPane({
             harnessSessionId={sessionId}
             bootToken={bootToken}
             draft={draft}
+            onSignIn={onSignIn}
+            onOpenSettings={onOpenSettings}
+            onOpenTerminal={() => setMode("Terminal")}
           />
         ) : (
           children

--- a/packages/harness/web/src/components/OpenCodeChat.tsx
+++ b/packages/harness/web/src/components/OpenCodeChat.tsx
@@ -3,6 +3,7 @@ import {
   useEffect,
   useLayoutEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import {
@@ -12,7 +13,6 @@ import {
   MessagePrimitive,
   ThreadPrimitive,
   useAuiState,
-  type TextMessagePartProps,
   type ThreadComposerRuntime,
   type ToolCallMessagePartProps,
 } from "@assistant-ui/react";
@@ -24,6 +24,22 @@ import {
 import { Icon } from "./Icon";
 import { Markdown } from "./Markdown";
 import { EmptyState } from "./EmptyState";
+import {
+  finalResponseAgent,
+  turnRecoveryAgent,
+  openCodeTurn,
+  openCodeResult,
+} from "../../../src/shared/opencode-turn";
+import {
+  openCodeCompletionTokens,
+  openCodeVisibleParts,
+} from "../../../src/shared/opencode-completion";
+import {
+  parseOpenCodeStudioErrorEvent,
+  parseOpenCodeTransportErrorBody,
+  type OpenCodeTransportAction,
+  type OpenCodeTransportFailure,
+} from "../../../src/shared/opencode-errors";
 
 export interface ChatDraft {
   text: string;
@@ -34,15 +50,57 @@ interface Props {
   harnessSessionId: string;
   bootToken: string;
   draft: ChatDraft;
+  onSignIn: () => void;
+  onOpenSettings: () => void;
+  onOpenTerminal: () => void;
 }
-const connectionError =
-  "Connection lost. Reconnect to see the latest response.";
-const runError =
-  "Assistant could not finish. Reconnect and check the conversation before sending again.";
+interface RecoveryNotice {
+  message: string;
+  action: OpenCodeTransportAction;
+}
+const reconnectNotice = (message: string): RecoveryNotice => ({
+  message,
+  action: "reconnect",
+});
+const connectionError = reconnectNotice(
+  "Connection lost. Reconnect to see the latest response.",
+);
+const runError = reconnectNotice(
+  "Assistant could not finish. Reconnect and check the conversation before sending again.",
+);
+const openError = reconnectNotice(
+  "Assistant could not open. Check Studio sign-in and workspace access, then retry.",
+);
+const requestError = reconnectNotice(
+  "Could not load or send the message. Reconnect and check the conversation before sending again.",
+);
 
-export function OpenCodeChat({ harnessSessionId, bootToken, draft }: Props) {
+/** The parser returns the shared table entry, never the server's string. */
+const trustedNotice = (failure: OpenCodeTransportFailure): RecoveryNotice => ({
+  message: failure.message,
+  action: failure.action,
+});
+
+async function responseFailure(
+  response: Response,
+): Promise<OpenCodeTransportFailure | null> {
+  try {
+    return parseOpenCodeTransportErrorBody(await response.clone().json());
+  } catch {
+    return null;
+  }
+}
+
+export function OpenCodeChat({
+  harnessSessionId,
+  bootToken,
+  draft,
+  onSignIn,
+  onOpenSettings,
+  onOpenTerminal,
+}: Props) {
   const [conversationId, setConversationId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<RecoveryNotice | null>(null);
   const [attempt, setAttempt] = useState(0);
   const baseUrl = new URL(
     `/opencode/${encodeURIComponent(harnessSessionId)}`,
@@ -59,7 +117,12 @@ export function OpenCodeChat({ harnessSessionId, bootToken, draft }: Props) {
       signal: abort.signal,
     })
       .then(async (response) => {
-        if (!response.ok) throw new Error("attach failed");
+        if (!response.ok) {
+          const failure = await responseFailure(response);
+          if (!abort.signal.aborted)
+            setError(failure ? trustedNotice(failure) : openError);
+          return;
+        }
         const data = await response.json();
         if (
           typeof data.conversationId !== "string" ||
@@ -69,10 +132,7 @@ export function OpenCodeChat({ harnessSessionId, bootToken, draft }: Props) {
         if (!abort.signal.aborted) setConversationId(data.conversationId);
       })
       .catch(() => {
-        if (!abort.signal.aborted)
-          setError(
-            "Assistant could not open. Check Studio sign-in and workspace access, then retry.",
-          );
+        if (!abort.signal.aborted) setError(openError);
       });
     return () => abort.abort();
   }, [baseUrl, bootToken, attempt]);
@@ -89,11 +149,20 @@ export function OpenCodeChat({ harnessSessionId, bootToken, draft }: Props) {
       conversationId={conversationId}
       retry={retry}
       draft={draft}
+      onSignIn={onSignIn}
+      onOpenSettings={onOpenSettings}
+      onOpenTerminal={onOpenTerminal}
     />
   ) : (
     <div className="studio-chat-start">
       {error ? (
-        <Recovery message={error} retry={retry} />
+        <Recovery
+          notice={error}
+          retry={retry}
+          onSignIn={onSignIn}
+          onOpenSettings={onOpenSettings}
+          onOpenTerminal={onOpenTerminal}
+        />
       ) : (
         <span role="status">Opening Assistant…</span>
       )}
@@ -107,23 +176,29 @@ function RuntimeChat({
   conversationId,
   retry,
   draft,
+  onSignIn,
+  onOpenSettings,
+  onOpenTerminal,
 }: {
   baseUrl: string;
   bootToken: string;
   conversationId: string;
   retry: () => void;
   draft: ChatDraft;
+  onSignIn: () => void;
+  onOpenSettings: () => void;
+  onOpenTerminal: () => void;
 }) {
-  const [transportError, setTransportError] = useState<string | null>(null);
-  const [actionError, setActionError] = useState<string | null>(null);
-  const [connected, setConnected] = useState(false);
-  const onError = useCallback(
-    () =>
-      setActionError(
-        "Could not load or send the message. Reconnect and check the conversation before sending again.",
-      ),
-    [],
+  const [transportError, setTransportError] = useState<RecoveryNotice | null>(
+    null,
   );
+  const [actionError, setActionError] = useState<RecoveryNotice | null>(null);
+  const [connected, setConnected] = useState(false);
+  const onError = useCallback(() => setActionError(requestError), []);
+  const onTypedError = useCallback((failure: OpenCodeTransportFailure) => {
+    setConnected(false);
+    setActionError(trustedNotice(failure));
+  }, []);
   const client = useMemo(() => {
     const client = createOpencodeClient({
       baseUrl,
@@ -139,7 +214,11 @@ function RuntimeChat({
           path.endsWith("/experimental/session");
         try {
           const response = await globalThis.fetch(request);
-          if (!response.ok && required) onError();
+          if (!response.ok) {
+            const failure = await responseFailure(response);
+            if (failure) onTypedError(failure);
+            else if (required) onError();
+          }
           return response;
         } catch (error) {
           if (required && !request.signal.aborted) onError();
@@ -159,10 +238,27 @@ function RuntimeChat({
           }
         },
         onSseEvent(event) {
-          options?.onSseEvent?.(event);
           if (!options?.signal?.aborted) {
-            const data = event.data as { type?: string };
-            if (data.type === "session.error") setActionError(runError);
+            const failure = parseOpenCodeStudioErrorEvent(event.data);
+            if (failure) {
+              onTypedError(failure);
+              return;
+            }
+            const data = event.data as {
+              type?: string;
+              properties?: { sessionID?: string };
+            };
+            // A terminal Studio error is valid only through the exact shared
+            // host-generated shape above. Native/malformed lookalikes and
+            // unscoped session errors cannot poison this conversation.
+            if (data.type === "studio.error") return;
+            if (data.type === "session.error") {
+              if (data.properties?.sessionID !== conversationId) return;
+              options?.onSseEvent?.(event);
+              setActionError(runError);
+              return;
+            }
+            options?.onSseEvent?.(event);
             setConnected(true);
             setTransportError(null);
           }
@@ -186,7 +282,7 @@ function RuntimeChat({
     // generates titles; suppress that unrelated model action, as in the POC.
     client.session.summarize = async () => ({ data: true }) as never;
     return client;
-  }, [baseUrl, bootToken, conversationId, onError]);
+  }, [baseUrl, bootToken, conversationId, onError, onTypedError]);
   const runtime = useOpenCodeRuntime({
     client,
     initialSessionId: conversationId,
@@ -195,23 +291,22 @@ function RuntimeChat({
   return (
     <AssistantRuntimeProvider runtime={runtime}>
       <ChatSurface
+        baseUrl={baseUrl}
+        bootToken={bootToken}
         conversationId={conversationId}
         connected={connected}
-        error={transportError ?? actionError}
+        error={actionError ?? transportError}
         retry={retry}
         composer={runtime.thread.composer}
         draft={draft}
+        onSignIn={onSignIn}
+        onOpenSettings={onOpenSettings}
+        onOpenTerminal={onOpenTerminal}
       />
     </AssistantRuntimeProvider>
   );
 }
 
-const AssistantText = ({ text }: TextMessagePartProps) => (
-  <Markdown text={text} />
-);
-const UserText = ({ text }: TextMessagePartProps) => (
-  <p className="studio-chat-user-text">{text}</p>
-);
 const ToolProgress = ({
   toolName,
   status,
@@ -232,19 +327,29 @@ const ToolProgress = ({
 );
 
 function ChatSurface({
+  baseUrl,
+  bootToken,
   conversationId,
   connected,
   error,
   retry,
   composer,
   draft,
+  onSignIn,
+  onOpenSettings,
+  onOpenTerminal,
 }: {
+  baseUrl: string;
+  bootToken: string;
   conversationId: string;
   connected: boolean;
-  error: string | null;
+  error: RecoveryNotice | null;
   retry: () => void;
   composer: ThreadComposerRuntime;
   draft: ChatDraft;
+  onSignIn: () => void;
+  onOpenSettings: () => void;
+  onOpenTerminal: () => void;
 }) {
   const loading = useAuiState((s) => s.thread.isLoading);
   const running = useAuiState((s) => s.thread.isRunning);
@@ -259,23 +364,111 @@ function ChatSurface({
       draft.text = composer.getState().text;
     });
   }, [composer, draft, ready]);
-  const hasText = useAuiState((s) => {
-    for (let i = s.thread.messages.length - 1; i >= 0; i--) {
-      const message = s.thread.messages[i];
-      if (message.role === "user") return false;
-      if (
-        message.content.some(
-          (part) => part.type === "text" && part.text.length > 0,
-        )
-      )
-        return true;
-    }
-    return false;
-  });
+  const native = useOpenCodeThreadState((s) => s);
+  const completionTokens = useMemo(
+    () =>
+      openCodeCompletionTokens(
+        native.messageOrder
+          .map((id) => native.messagesById[id]!)
+          .filter(Boolean),
+      ),
+    [native.messageOrder, native.messagesById],
+  );
+  const turn = openCodeTurn(
+    native.messageOrder.map((id) => native.messagesById[id]!).filter(Boolean),
+    native.sessionStatus?.type,
+  );
+  const attempted = useRef(new Set<string>());
+  const recoveryAbort = useRef<AbortController | null>(null);
+  const [recovering, setRecovering] = useState(false);
+  const [recoveryFailed, setRecoveryFailed] = useState(false);
+  const missing = turn.missing;
+  const pending = Object.values(native.pendingUserMessages).some(
+    (message) => message.status === "pending",
+  );
+  useEffect(() => {
+    if (!error) return;
+    recoveryAbort.current?.abort();
+    recoveryAbort.current = null;
+    setRecovering(false);
+  }, [error]);
+  useEffect(() => {
+    if (
+      !ready ||
+      !connected ||
+      error ||
+      running ||
+      pending ||
+      !missing ||
+      attempted.current.has(missing)
+    )
+      return;
+    attempted.current.add(missing);
+    setRecovering(true);
+    setRecoveryFailed(false);
+    const abort = new AbortController();
+    recoveryAbort.current?.abort();
+    recoveryAbort.current = abort;
+    // The host verifies native history and allows one continuation.
+    // Never resend the original prompt on idle, disconnect, or remount.
+    void fetch(`${baseUrl}/session/${conversationId}/final-response`, {
+      method: "POST",
+      headers: {
+        "X-Harness-Token": bootToken,
+        "Content-Type": "application/json",
+      },
+      credentials: "omit",
+      body: JSON.stringify({ messageId: missing }),
+      signal: AbortSignal.any([abort.signal, AbortSignal.timeout(130_000)]),
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error("Final response failed");
+        retry(); // Reconcile history even if the last text event was missed.
+      })
+      .catch(() => {
+        if (!abort.signal.aborted) setRecoveryFailed(true);
+      })
+      .finally(() => {
+        if (recoveryAbort.current === abort) recoveryAbort.current = null;
+        setRecovering(false);
+      });
+  }, [
+    baseUrl,
+    bootToken,
+    connected,
+    conversationId,
+    error,
+    missing,
+    pending,
+    ready,
+    retry,
+    running,
+  ]);
   const failed = useOpenCodeThreadState(
     (s) => s.loadState.type === "error" || s.runState.type === "error",
   );
   const visibleError = error ?? (failed ? runError : null);
+  const checking = !connected || !ready || loading || turn.status === "unknown";
+  const working =
+    !visibleError &&
+    (running ||
+      recovering ||
+      turn.status === "working" ||
+      pending ||
+      (!!missing && !attempted.current.has(missing)));
+  const status = visibleError
+    ? "Failed"
+    : checking
+      ? "Checking status…"
+      : working
+        ? "Working"
+        : turn.status === "finished"
+          ? "Finished"
+          : turn.status === "failed" || recoveryFailed
+            ? "Failed"
+            : turn.status === "stopped"
+              ? "Stopped"
+              : "Ready";
   return (
     <ThreadPrimitive.Root
       className="studio-chat"
@@ -293,42 +486,89 @@ function ChatSurface({
             />
           </ThreadPrimitive.Empty>
           <ThreadPrimitive.Messages>
-            {({ message }) => (
-              <MessagePrimitive.Root
-                className={
-                  message.role === "user"
-                    ? "studio-chat-user"
-                    : "studio-chat-assistant"
-                }
-              >
-                <MessagePrimitive.Parts
-                  components={{
-                    Text: message.role === "user" ? UserText : AssistantText,
-                    tools: { Fallback: ToolProgress },
-                  }}
-                />
-                <MessagePrimitive.Error>
-                  <ErrorPrimitive.Root className="studio-chat-error">
-                    <ErrorPrimitive.Message />
-                  </ErrorPrimitive.Root>
-                </MessagePrimitive.Error>
-              </MessagePrimitive.Root>
-            )}
+            {({ message }) => {
+              const nativeMessage = native.messagesById[message.id];
+              const token =
+                nativeMessage?.info?.role === "assistant"
+                  ? completionTokens.get(nativeMessage.info.parentID)
+                  : undefined;
+              const result = openCodeResult(nativeMessage, token);
+              const visibleParts = openCodeVisibleParts(message.content, token);
+              return message.role === "user" &&
+                [finalResponseAgent, turnRecoveryAgent].includes(
+                  native.messagesById[message.id]?.info?.agent ?? "",
+                ) ? null : (
+                <MessagePrimitive.Root
+                  className={
+                    message.role === "user"
+                      ? "studio-chat-user"
+                      : "studio-chat-assistant"
+                  }
+                >
+                  {message.content.map((part, index) =>
+                    part.type === "text" ? (
+                      message.role === "user" ? (
+                        <p key={index} className="studio-chat-user-text">
+                          {part.text}
+                        </p>
+                      ) : result ? null : (
+                        <Markdown
+                          key={index}
+                          text={visibleParts[index] ?? ""}
+                        />
+                      )
+                    ) : (
+                      <MessagePrimitive.PartByIndex
+                        key={index}
+                        index={index}
+                        components={{ tools: { Fallback: ToolProgress } }}
+                      />
+                    ),
+                  )}
+                  {result && <Markdown text={result.answer} />}
+                  <MessagePrimitive.Error>
+                    <ErrorPrimitive.Root className="studio-chat-error">
+                      <ErrorPrimitive.Message />
+                    </ErrorPrimitive.Root>
+                  </MessagePrimitive.Error>
+                </MessagePrimitive.Root>
+              );
+            }}
           </ThreadPrimitive.Messages>
-          {(!connected || !ready || loading || (running && !hasText)) &&
-            !visibleError && (
-              <div role="status" className="studio-chat-meta">
-                {!connected
-                  ? "Connecting…"
-                  : loading || !ready
-                    ? "Loading conversation…"
-                    : "Assistant is working…"}
-              </div>
-            )}
-          {visibleError && <Recovery message={visibleError} retry={retry} />}
+          {status === "Failed" && !visibleError && (
+            <div className="studio-chat-error" role="alert">
+              Assistant could not complete this request. Review the response
+              above and send a follow-up to continue.
+            </div>
+          )}
+          {status === "Stopped" && (
+            <div className="studio-chat-meta" role="note">
+              Assistant has stopped. Completion was not confirmed; review the
+              response above before continuing.
+            </div>
+          )}
+          {visibleError && (
+            <Recovery
+              notice={visibleError}
+              retry={retry}
+              onSignIn={onSignIn}
+              onOpenSettings={onOpenSettings}
+              onOpenTerminal={onOpenTerminal}
+            />
+          )}
         </div>
       </ThreadPrimitive.Viewport>
       <div className="studio-chat-dock">
+        <div
+          role="status"
+          aria-label="Assistant status"
+          className="status-tag studio-chat-status"
+          data-status={status}
+        >
+          <span className="status-tag-dot" aria-hidden="true" />
+          {status}
+          {recovering ? " · Continuing unfinished work…" : ""}
+        </div>
         <ComposerPrimitive.Root className="studio-chat-composer">
           <ComposerPrimitive.Input
             className="studio-chat-input"
@@ -340,14 +580,26 @@ function ChatSurface({
             cancelOnEscape={false}
             addAttachmentOnPaste={false}
             disabled={
-              !connected || !ready || loading || disabled || !!visibleError
+              !connected ||
+              !ready ||
+              loading ||
+              disabled ||
+              !!visibleError ||
+              recovering ||
+              (!!missing && !recoveryFailed)
             }
           />
           <div className="studio-chat-actions">
             <ComposerPrimitive.Send
               className="composer-send"
               aria-label="Send message"
-              disabled={!connected || !ready || !!visibleError}
+              disabled={
+                !connected ||
+                !ready ||
+                !!visibleError ||
+                working ||
+                (!!missing && !recoveryFailed)
+              }
             >
               <Icon name="ArrowUp" size={14} />
             </ComposerPrimitive.Send>
@@ -358,12 +610,37 @@ function ChatSurface({
   );
 }
 
-function Recovery({ message, retry }: { message: string; retry: () => void }) {
+function Recovery({
+  notice,
+  retry,
+  onSignIn,
+  onOpenSettings,
+  onOpenTerminal,
+}: {
+  notice: RecoveryNotice;
+  retry: () => void;
+  onSignIn: () => void;
+  onOpenSettings: () => void;
+  onOpenTerminal: () => void;
+}) {
+  const action = {
+    sign_in: { label: "Sign in", run: onSignIn },
+    open_settings: { label: "Open Settings", run: onOpenSettings },
+    open_terminal: { label: "Open Terminal", run: onOpenTerminal },
+    reconnect: { label: "Reconnect", run: retry },
+  } satisfies Record<
+    OpenCodeTransportAction,
+    { label: string; run: () => void }
+  >;
   return (
     <div className="studio-chat-error" role="alert">
-      <p>{message}</p>
-      <button type="button" className="btn-ghost" onClick={retry}>
-        Reconnect
+      <p>{notice.message}</p>
+      <button
+        type="button"
+        className="btn-ghost"
+        onClick={action[notice.action].run}
+      >
+        {action[notice.action].label}
       </button>
     </div>
   );

--- a/packages/harness/web/src/components/OpenCodeChat.tsx
+++ b/packages/harness/web/src/components/OpenCodeChat.tsx
@@ -302,6 +302,7 @@ function RuntimeChat({
         onSignIn={onSignIn}
         onOpenSettings={onOpenSettings}
         onOpenTerminal={onOpenTerminal}
+        onTypedError={onTypedError}
       />
     </AssistantRuntimeProvider>
   );
@@ -338,6 +339,7 @@ function ChatSurface({
   onSignIn,
   onOpenSettings,
   onOpenTerminal,
+  onTypedError,
 }: {
   baseUrl: string;
   bootToken: string;
@@ -350,6 +352,7 @@ function ChatSurface({
   onSignIn: () => void;
   onOpenSettings: () => void;
   onOpenTerminal: () => void;
+  onTypedError: (failure: OpenCodeTransportFailure) => void;
 }) {
   const loading = useAuiState((s) => s.thread.isLoading);
   const running = useAuiState((s) => s.thread.isRunning);
@@ -421,8 +424,18 @@ function ChatSurface({
       body: JSON.stringify({ messageId: missing }),
       signal: AbortSignal.any([abort.signal, AbortSignal.timeout(130_000)]),
     })
-      .then((response) => {
-        if (!response.ok) throw new Error("Final response failed");
+      .then(async (response) => {
+        if (!response.ok) {
+          const failure = await responseFailure(response);
+          if (failure) {
+            // A typed terminal rejection is not a failed recovery attempt the
+            // composer may work around. Keep the incomplete turn blocked and
+            // expose its exact static action without submitting anything else.
+            onTypedError(failure);
+            return;
+          }
+          throw new Error("Final response failed");
+        }
         retry(); // Reconcile history even if the last text event was missed.
       })
       .catch(() => {
@@ -443,6 +456,7 @@ function ChatSurface({
     ready,
     retry,
     running,
+    onTypedError,
   ]);
   const failed = useOpenCodeThreadState(
     (s) => s.loadState.type === "error" || s.runState.type === "error",


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Typed Assistant transport failures must reach trusted static UI actions across SSE, prompt submission, history reads, and automatic final-response recovery.

## Summary and scope

Route only strict shared failures through the Assistant adapter, drop unscoped/spoofed native errors, suppress replay, and parse non-OK `/final-response` bodies through the same typed path. A terminal native_history_missing recovery keeps the incomplete turn blocked and shows the trusted action. Outcome/result presentation remains in #923.

This consolidated head remains a normal fast-forward of the published PR head and is based on the preceding retained stack branch `studio-turn-continuation`. Actual-parent size: **726 additions + 90 deletions = 816 changed lines**. This is above the 600-line target and below the 1,000-line hard maximum; the source and tests stay together to preserve a compiling, independently reviewable boundary.

Absorbed reviewed provenance: historical #937 typed Assistant UI adapter; typed /final-response parsing/onTypedError wiring and terminal regression moved from #923.

Fix-forward: stop this stack layer and correct forward on its branch if CI or production evidence reveals a regression; do not bypass checks or weaken the documented boundary.

## Related work

Related issues: [SAP-3290](https://linear.app/sapiom/issue/SAP-3290). This replacement preserves the exact reviewed semantic increment from historical PR #937, which GitHub marked merged during the consolidation reachability cascade; the historical record remains unchanged.

## Validation

- `pnpm build` — passed on the exact final reconstructed tree.
- `pnpm typecheck` — passed on the exact final reconstructed tree.
- `pnpm lint` — passed with existing warning-only findings and zero errors.
- `pnpm test` — exit 1: `@sapiom/agent-core` reported `Test Suites: 1 failed, 18 passed, 19 total; Tests: 1 failed, 239 passed, 240 total` for `describeBundleFailure › names an unreadable project directory instead of blaming dependencies`.
- The same focused Agent Core command on exact incoming main `4936ce992af2da95741fe22222e2bc8b75525efb` also exited 1 with `1 failed, 5 passed (6 total)`; the complete Agent Core package is byte-identical between that main tree and the final reconstruction.
- Packages skipped by recursive first-failure were run explicitly and passed: MCP `190 passed, 3 skipped (193 total)`; Harness `4009 passed, 2 skipped (4011 total)` plus performance `10 passed`; Agent Studio `12 passed`; CLI `73 passed`; Harness Desktop `205 passed`. No todo cases were reported.
- `git diff --check 4bb1ed3a1514d471a2fd37ca5ae14b0ccfe69fd8...5862cf24d5bf5e7f32dae2822b0dd7b4a4813def` — passed.
- Focused typed final-response browser regression at this exact layer — 1/1 passed.
- Exact final Assistant browser command with one Chromium worker — 31 passed (1.1m).

### Tests and documentation

The focused browser regression for typed final-response failure is delivered here exactly once, alongside startup, auth, access, native-history, spoof-scope, reconnect, and no-replay UI coverage.

## Compatibility and release impact

- Breaking or externally visible changes: No arbitrary wire diagnostics are rendered. Only contract-approved static actions appear; terminal failures keep sends disabled.
- Changeset: Added or updated in this PR for its first observable package behavior.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Conductor coding agents implemented and independently reviewed the owned corrections. Codex reconstructed the fast-forward-compatible stack, preserved exact reviewed blobs and incoming main, measured every actual-parent diff, and ran or recorded the validation above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/937" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
