### PR TITLE
fix(harness): keep Assistant responses visible [SAP-3290]

### DIFF
--- a/.changeset/hide-mismatched-assistant-markers.md
+++ b/.changeset/hide-mismatched-assistant-markers.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Hide internal Assistant completion markers with an incorrect turn ID in streamed responses and saved history. Completion still requires the expected turn ID; an unconfirmed answer remains Stopped.

--- a/.changeset/hide-mismatched-assistant-markers.md
+++ b/.changeset/hide-mismatched-assistant-markers.md
@@ -2,4 +2,4 @@
 "@sapiom/harness": patch
 ---
 
-Hide internal Assistant completion markers with an incorrect turn ID in streamed responses and saved history. Completion still requires the expected turn ID; an unconfirmed answer remains Stopped.
+Hide internal Assistant completion markers with an incorrect turn ID in streamed responses and saved history. Preserve literal prose and invalid marker syntax, and restore incomplete marker candidates when streaming ends. Completion still requires the expected turn ID; an unconfirmed answer remains Stopped.

--- a/.changeset/hide-mismatched-assistant-markers.md
+++ b/.changeset/hide-mismatched-assistant-markers.md
@@ -2,6 +2,6 @@
 "@sapiom/harness": patch
 ---
 
-Hide internal Assistant completion markers with an incorrect turn ID in streamed responses and saved history. Preserve literal prose and invalid marker syntax, and restore incomplete marker candidates when streaming ends. Completion still requires the expected turn ID; an unconfirmed answer remains Stopped.
+Hide internal Assistant completion markers with an incorrect turn ID in streamed responses, confirmed answers, and saved history. Preserve literal prose and invalid marker syntax, and restore incomplete marker candidates when streaming ends. Completion still requires the expected turn ID; an unconfirmed answer remains Stopped.
 
 Keep the Assistant conversation and unsent draft visible while automatic answer recovery reconnects the event stream and reconciles saved history and execution status.

--- a/.changeset/hide-mismatched-assistant-markers.md
+++ b/.changeset/hide-mismatched-assistant-markers.md
@@ -3,3 +3,5 @@
 ---
 
 Hide internal Assistant completion markers with an incorrect turn ID in streamed responses and saved history. Preserve literal prose and invalid marker syntax, and restore incomplete marker candidates when streaming ends. Completion still requires the expected turn ID; an unconfirmed answer remains Stopped.
+
+Keep the Assistant conversation and unsent draft visible while automatic answer recovery reconnects the event stream and reconciles saved history and execution status.

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -63,10 +63,15 @@ jobs:
   # The live/real-pty tiers (e2e:live, sim) are opt-in local only; nothing here
   # invokes them — they require real agent binaries and credentials not in CI.
   playwright-mock:
+    name: playwright-mock (${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
-    # The expanded mock suite has over 680 cases, followed by canvas checks.
-    # Keep the existing per-test deadlines; allow both suites to finish.
+    # Split the growing suite across runners to leave time for canvas checks.
+    # Keep the existing per-test and job deadlines.
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     # Single Node version is enough — the mock tier tests browser behaviour,
     # not Node version compat; that's covered by the matrix job in test.yml.
     steps:
@@ -106,22 +111,21 @@ jobs:
         run: pnpm --filter @sapiom/harness exec playwright install-deps chromium
 
       - name: Run Playwright mock-mode suite
-        # The default two workers exceed this job's budget as the suite grows.
-        # Four workers retain the per-test deadlines and leave time for canvas.
-        run: pnpm --filter @sapiom/harness test:ui --workers=4
+        run: pnpm --filter @sapiom/harness test:ui --workers=2 --shard=${{ matrix.shard }}/2
 
       # The canvas suite renders the generated diagram documents in the same
       # chromium this job already installed. It was previously opt-in only, so
       # nothing verified in CI that a canvas the renderer produces actually
       # paints — a rendering regression could only be caught by hand.
       - name: Run Playwright canvas suite
+        if: matrix.shard == 1
         run: pnpm --filter @sapiom/harness test:canvas
 
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.shard }}
           path: packages/harness/web/e2e/playwright-report/
           retention-days: 7
 

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -64,7 +64,7 @@ jobs:
   # invokes them — they require real agent binaries and credentials not in CI.
   playwright-mock:
     runs-on: ubuntu-latest
-    # The expanded mock suite has over 560 cases, followed by canvas checks.
+    # The expanded mock suite has over 680 cases, followed by canvas checks.
     # Keep the existing per-test deadlines; allow both suites to finish.
     timeout-minutes: 20
     # Single Node version is enough — the mock tier tests browser behaviour,
@@ -106,7 +106,9 @@ jobs:
         run: pnpm --filter @sapiom/harness exec playwright install-deps chromium
 
       - name: Run Playwright mock-mode suite
-        run: pnpm --filter @sapiom/harness test:ui
+        # The default two workers exceed this job's budget as the suite grows.
+        # Four workers retain the per-test deadlines and leave time for canvas.
+        run: pnpm --filter @sapiom/harness test:ui --workers=4
 
       # The canvas suite renders the generated diagram documents in the same
       # chromium this job already installed. It was previously opt-in only, so

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -74,6 +74,8 @@ This first slice includes basic tool status; richer controls arrive separately.
 An unconfirmed response keeps the answer and tool results visible as **Stopped**.
 Studio hides its internal completion markers even if the model supplies an
 incorrect turn ID.
+Literal prose and invalid marker syntax remain visible. Incomplete marker
+candidates are hidden while streaming and restored when the response ends.
 Studio actions reveal Terminal after a foreground CLI prompt is accepted; a
 rejected send shows its error and keeps the selected view. Unsent chat text is
 keyed by authenticated principal and Studio session above the centre pane, so it

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -71,6 +71,9 @@ selected project. Returning to a session reopens its OpenCode conversation;
 switching views detaches the display while execution continues. Connection errors
 offer **Reconnect**, which reloads history without resending accepted prompts.
 This first slice includes basic tool status; richer controls arrive separately.
+An unconfirmed response keeps the answer and tool results visible as **Stopped**.
+Studio hides its internal completion markers even if the model supplies an
+incorrect turn ID.
 Studio actions reveal Terminal after a foreground CLI prompt is accepted; a
 rejected send shows its error and keeps the selected view. Unsent chat text is
 keyed by authenticated principal and Studio session above the centre pane, so it

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -76,6 +76,8 @@ Studio hides its internal completion markers even if the model supplies an
 incorrect turn ID.
 Literal prose and invalid marker syntax remain visible. Incomplete marker
 candidates are hidden while streaming and restored when the response ends.
+After automatic answer recovery, Studio reconnects the conversation's event
+stream to reconcile history and status while keeping the chat and draft visible.
 Studio actions reveal Terminal after a foreground CLI prompt is accepted; a
 rejected send shows its error and keeps the selected view. Unsent chat text is
 keyed by authenticated principal and Studio session above the centre pane, so it

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -73,7 +73,7 @@ offer **Reconnect**, which reloads history without resending accepted prompts.
 This first slice includes basic tool status; richer controls arrive separately.
 An unconfirmed response keeps the answer and tool results visible as **Stopped**.
 Studio hides its internal completion markers even if the model supplies an
-incorrect turn ID.
+incorrect turn ID, including extra markers inside a confirmed answer.
 Literal prose and invalid marker syntax remain visible. Incomplete marker
 candidates are hidden while streaming and restored when the response ends.
 After automatic answer recovery, Studio reconnects the conversation's event

--- a/packages/harness/src/shared/opencode-completion.ts
+++ b/packages/harness/src/shared/opencode-completion.ts
@@ -70,33 +70,65 @@ function hasOpenFence(text: string) {
   return !!fence;
 }
 
+const completionMarkerPrefix = "<!-- studio-result:";
+
+/** Match UUID-and-status syntax, including a possible prefix only while streaming. */
+function completionMarkerLength(
+  text: string,
+  index: number,
+  streaming: boolean,
+) {
+  let end = index + completionMarkerPrefix.length;
+  for (const character of "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx") {
+    if (end === text.length) return streaming ? end - index : 0;
+    if (character === "-" ? text[end] !== "-" : !/^[a-f0-9]$/i.test(text[end]!))
+      return 0;
+    end++;
+  }
+  for (const ending of [":finished -->", ":failed -->"]) {
+    if (text.startsWith(ending, end)) return end + ending.length - index;
+    if (streaming && ending.startsWith(text.slice(end)))
+      return text.length - index;
+  }
+  return 0;
+}
+
+/** Preserve prose around complete markers and unfinished streamed candidates. */
 function visibleRanges(
   text: string,
   token: string | undefined,
+  streaming: boolean,
 ): [number, number][] {
   if (!token) return [[0, text.length]];
   // A model can emit the wrong turn ID. Hide its bookkeeping too; only
   // parseOpenCodeCompletion may confirm a result against the expected token.
-  const prefix = "<!-- studio-result:";
+  const prefix = completionMarkerPrefix;
   const ranges: [number, number][] = [];
   let start = 0;
-  while (start <= text.length) {
-    const index = text.indexOf(prefix, start);
+  let searchFrom = 0;
+  while (searchFrom <= text.length) {
+    const index = text.indexOf(prefix, searchFrom);
     if (index === -1) {
       let end = text.length;
-      for (let length = prefix.length - 1; length > 0; length--) {
-        if (text.slice(start).endsWith(prefix.slice(0, length))) {
-          end -= length;
-          break;
+      if (streaming) {
+        for (let length = prefix.length - 1; length > 0; length--) {
+          if (text.slice(searchFrom).endsWith(prefix.slice(0, length))) {
+            end -= length;
+            break;
+          }
         }
       }
       ranges.push([start, end]);
       break;
     }
+    const length = completionMarkerLength(text, index, streaming);
+    if (!length) {
+      searchFrom = index + prefix.length;
+      continue;
+    }
     ranges.push([start, index]);
-    const end = text.indexOf("-->", index + prefix.length);
-    if (end === -1) break;
-    start = end + 3;
+    start = index + length;
+    searchFrom = start;
   }
   // Trim the space left by a leading/footer marker, but retain text on both
   // sides of markers in the middle of a merged tool-progress/final response.
@@ -115,22 +147,27 @@ function visibleRanges(
   return ranges;
 }
 
-/** Hide complete and partially streamed bookkeeping without changing other text. */
-export function openCodeVisibleText(text: string, token: string | undefined) {
-  return visibleRanges(text, token)
+/** Hide markers; with streaming enabled, also withhold still-valid partial candidates. */
+export function openCodeVisibleText(
+  text: string,
+  token: string | undefined,
+  streaming = false,
+) {
+  return visibleRanges(text, token, streaming)
     .map((range) => text.slice(...range))
     .join("");
 }
 
-/** Filter across part boundaries, including interrupted or unfinished answers. */
+/** Filter across part boundaries; settled responses retain incomplete marker syntax. */
 export function openCodeVisibleParts(
   parts: readonly { type: string; text?: string }[],
   token: string | undefined,
+  streaming = false,
 ) {
   const text = parts
     .map((part) => (part.type === "text" ? (part.text ?? "") : ""))
     .join("");
-  const ranges = visibleRanges(text, token);
+  const ranges = visibleRanges(text, token, streaming);
   let offset = 0;
   return parts.map((part) => {
     if (part.type !== "text") return undefined;

--- a/packages/harness/src/shared/opencode-completion.ts
+++ b/packages/harness/src/shared/opencode-completion.ts
@@ -70,33 +70,56 @@ function hasOpenFence(text: string) {
   return !!fence;
 }
 
-function visibleRange(
+function visibleRanges(
   text: string,
   token: string | undefined,
-): [number, number] {
-  if (!token) return [0, text.length];
-  const prefix = "<!-- studio-result:" + token + ":";
-  const leading = text.length - text.trimStart().length;
-  if (text.slice(leading).startsWith(prefix)) {
-    const end = text.indexOf("-->", leading + prefix.length);
-    if (end === -1) return [text.length, text.length];
-    const start = text.length - text.slice(end + 3).trimStart().length;
-    const duplicate = text.indexOf(prefix, start);
-    return [start, duplicate === -1 ? text.length : duplicate];
+): [number, number][] {
+  if (!token) return [[0, text.length]];
+  // A model can emit the wrong turn ID. Hide its bookkeeping too; only
+  // parseOpenCodeCompletion may confirm a result against the expected token.
+  const prefix = "<!-- studio-result:";
+  const ranges: [number, number][] = [];
+  let start = 0;
+  while (start <= text.length) {
+    const index = text.indexOf(prefix, start);
+    if (index === -1) {
+      let end = text.length;
+      for (let length = prefix.length - 1; length > 0; length--) {
+        if (text.slice(start).endsWith(prefix.slice(0, length))) {
+          end -= length;
+          break;
+        }
+      }
+      ranges.push([start, end]);
+      break;
+    }
+    ranges.push([start, index]);
+    const end = text.indexOf("-->", index + prefix.length);
+    if (end === -1) break;
+    start = end + 3;
   }
-  if (prefix.startsWith(text.slice(leading))) return [text.length, text.length];
-  const index = text.indexOf(prefix);
-  if (index !== -1) return [0, text.slice(0, index).trimEnd().length];
-  for (let length = prefix.length - 1; length > 0; length--) {
-    if (text.endsWith(prefix.slice(0, length)))
-      return [0, text.slice(0, -length).trimEnd().length];
+  // Trim the space left by a leading/footer marker, but retain text on both
+  // sides of markers in the middle of a merged tool-progress/final response.
+  while (ranges.length && !text.slice(...ranges[0]!).trim()) ranges.shift();
+  const first = ranges[0];
+  if (first && first[0] > 0) {
+    const value = text.slice(...first);
+    first[0] += value.length - value.trimStart().length;
   }
-  return [0, text.length];
+  while (ranges.length && !text.slice(...ranges.at(-1)!).trim()) ranges.pop();
+  const last = ranges.at(-1);
+  if (last && last[1] < text.length) {
+    const value = text.slice(...last);
+    last[1] -= value.length - value.trimEnd().length;
+  }
+  return ranges;
 }
 
 /** Hide complete and partially streamed bookkeeping without changing other text. */
 export function openCodeVisibleText(text: string, token: string | undefined) {
-  return text.slice(...visibleRange(text, token));
+  return visibleRanges(text, token)
+    .map((range) => text.slice(...range))
+    .join("");
 }
 
 /** Filter across part boundaries, including interrupted or unfinished answers. */
@@ -107,15 +130,16 @@ export function openCodeVisibleParts(
   const text = parts
     .map((part) => (part.type === "text" ? (part.text ?? "") : ""))
     .join("");
-  const [visibleStart, visibleEnd] = visibleRange(text, token);
+  const ranges = visibleRanges(text, token);
   let offset = 0;
   return parts.map((part) => {
     if (part.type !== "text") return undefined;
     const start = offset;
     offset += part.text?.length ?? 0;
-    return text.slice(
-      Math.max(start, visibleStart),
-      Math.min(offset, visibleEnd),
-    );
+    return ranges
+      .map(([visibleStart, visibleEnd]) =>
+        text.slice(Math.max(start, visibleStart), Math.min(offset, visibleEnd)),
+      )
+      .join("");
   });
 }

--- a/packages/harness/src/shared/opencode-turn.test.ts
+++ b/packages/harness/src/shared/opencode-turn.test.ts
@@ -160,42 +160,108 @@ describe("overall OpenCode turn status", () => {
     ).toEqual({ status: "finished" });
   });
 
-  it("hides the result footer throughout streaming and preserves ordinary text", () => {
-    const currentUser = {
-      ...user,
-      info: { ...user.info!, ...openCodeCompletionPrompt() },
-    };
-    const token = openCodeCompletionTokens([currentUser]).get("msg_user")!;
-    const footer = `<!-- studio-result:${token}:finished -->`;
-    for (let size = 1; size <= footer.length; size++) {
+  it.each(["current", "different"])(
+    "hides a %s turn's result marker throughout streaming and preserves ordinary text",
+    (turn) => {
+      const currentUser = {
+        ...user,
+        info: { ...user.info!, ...openCodeCompletionPrompt() },
+      };
+      const token = openCodeCompletionTokens([currentUser]).get("msg_user")!;
+      const markerToken =
+        turn === "current" ? token : "00000000-0000-0000-0000-000000000000";
+      const footer = `<!-- studio-result:${markerToken}:finished -->`;
+      for (let size = 1; size <= footer.length; size++) {
+        expect(
+          openCodeVisibleText(`CHAT_OK\n\n${footer.slice(0, size)}`, token),
+        ).toBe("CHAT_OK");
+        const parts = [
+          { type: "text", text: `CHAT_OK\n\n${footer.slice(0, size)}` },
+          { type: "tool" },
+          { type: "text", text: footer.slice(size) },
+        ];
+        expect(openCodeVisibleParts(parts, token)).toEqual([
+          "CHAT_OK",
+          undefined,
+          "",
+        ]);
+        expect(openCodeVisibleText(footer.slice(0, size), token)).toBe("");
+        expect(
+          openCodeVisibleParts(
+            [
+              { type: "text", text: footer.slice(0, size) },
+              { type: "text", text: footer.slice(size) + "\nCHAT_OK" },
+            ],
+            token,
+          ),
+        ).toEqual(["", "CHAT_OK"]);
+      }
+      expect(openCodeVisibleText("Use x < y in the condition", token)).toBe(
+        "Use x < y in the condition",
+      );
+      expect(openCodeVisibleText("CHAT_OK", undefined)).toBe("CHAT_OK");
       expect(
-        openCodeVisibleText(`CHAT_OK\n\n${footer.slice(0, size)}`, token),
-      ).toBe("CHAT_OK");
-      const parts = [
-        { type: "text", text: `CHAT_OK\n\n${footer.slice(0, size)}` },
-        { type: "tool" },
-        { type: "text", text: footer.slice(size) },
-      ];
-      expect(openCodeVisibleParts(parts, token)).toEqual([
-        "CHAT_OK",
-        undefined,
-        "",
-      ]);
-      expect(openCodeVisibleText(footer.slice(0, size), token)).toBe("");
-      expect(
-        openCodeVisibleParts(
-          [
-            { type: "text", text: footer.slice(0, size) },
-            { type: "text", text: footer.slice(size) + "\nCHAT_OK" },
-          ],
+        openCodeVisibleText(
+          "Keep <!-- ordinary comment --> in the example",
           token,
         ),
-      ).toEqual(["", "CHAT_OK"]);
-    }
-    expect(openCodeVisibleText("Use x < y in the condition", token)).toBe(
-      "Use x < y in the condition",
-    );
-    expect(openCodeVisibleText("CHAT_OK", undefined)).toBe("CHAT_OK");
+      ).toBe("Keep <!-- ordinary comment --> in the example");
+      expect(openCodeVisibleText(footer, undefined)).toBe(footer);
+    },
+  );
+
+  it.each(["finished", "failed"])(
+    "hides a mismatched %s marker without confirming the recovered turn",
+    (status) => {
+      const currentUser = {
+        ...user,
+        info: {
+          ...user.info!,
+          agent: turnRecoveryAgent,
+          ...openCodeCompletionPrompt(),
+        },
+      };
+      const token = openCodeCompletionTokens([currentUser]).get("msg_user")!;
+      const marker = `<!-- studio-result:00000000-0000-0000-0000-000000000000:${status} -->`;
+      for (const text of [
+        `${marker}\nThe tool call completed.`,
+        `The tool call completed.\n\n${marker}`,
+      ]) {
+        const message = answer(text, { agent: turnRecoveryAgent });
+        expect(openCodeVisibleText(text, token)).toBe(
+          "The tool call completed.",
+        );
+        expect(openCodeResult(message, token)).toBeUndefined();
+        expect(openCodeTurn([currentUser, message], "idle")).toEqual({
+          status: "stopped",
+        });
+      }
+    },
+  );
+
+  it("preserves progress and the answer around multiple markers across tool parts", () => {
+    const token = "11111111-1111-1111-1111-111111111111";
+    const marker =
+      "<!-- studio-result:00000000-0000-0000-0000-000000000000:finished -->";
+    const parts = [
+      { type: "text", text: "Checking the README.\n\n" + marker.slice(0, 30) },
+      { type: "tool" },
+      {
+        type: "text",
+        text:
+          marker.slice(30) +
+          "\nThe README describes this project.\n\n" +
+          marker,
+      },
+    ];
+    expect(openCodeVisibleParts(parts, token)).toEqual([
+      "Checking the README.\n\n",
+      undefined,
+      "\nThe README describes this project.",
+    ]);
+    expect(
+      openCodeVisibleText(parts.map((part) => part.text ?? "").join(""), token),
+    ).toBe("Checking the README.\n\n\nThe README describes this project.");
   });
 
   it("requires known idle state and a completed final answer", () => {

--- a/packages/harness/src/shared/opencode-turn.test.ts
+++ b/packages/harness/src/shared/opencode-turn.test.ts
@@ -173,19 +173,25 @@ describe("overall OpenCode turn status", () => {
       const footer = `<!-- studio-result:${markerToken}:finished -->`;
       for (let size = 1; size <= footer.length; size++) {
         expect(
-          openCodeVisibleText(`CHAT_OK\n\n${footer.slice(0, size)}`, token),
+          openCodeVisibleText(
+            `CHAT_OK\n\n${footer.slice(0, size)}`,
+            token,
+            true,
+          ),
         ).toBe("CHAT_OK");
         const parts = [
           { type: "text", text: `CHAT_OK\n\n${footer.slice(0, size)}` },
           { type: "tool" },
           { type: "text", text: footer.slice(size) },
         ];
-        expect(openCodeVisibleParts(parts, token)).toEqual([
+        expect(openCodeVisibleParts(parts, token, true)).toEqual([
           "CHAT_OK",
           undefined,
           "",
         ]);
-        expect(openCodeVisibleText(footer.slice(0, size), token)).toBe("");
+        expect(openCodeVisibleText(footer.slice(0, size), token, true)).toBe(
+          "",
+        );
         expect(
           openCodeVisibleParts(
             [
@@ -193,6 +199,7 @@ describe("overall OpenCode turn status", () => {
               { type: "text", text: footer.slice(size) + "\nCHAT_OK" },
             ],
             token,
+            true,
           ),
         ).toEqual(["", "CHAT_OK"]);
       }
@@ -262,6 +269,59 @@ describe("overall OpenCode turn status", () => {
     expect(
       openCodeVisibleText(parts.map((part) => part.text ?? "").join(""), token),
     ).toBe("Checking the README.\n\n\nThe README describes this project.");
+  });
+
+  it.each([
+    "Document the <!-- studio-result: placeholder used by Studio.",
+    "<!-- studio-result:not-a-uuid:finished --> is only an example.",
+    "<!-- studio-result:00000000-0000-0000-0000-00000000000g:finished --> is invalid.",
+    "<!-- studio-result:000000000000-0000-0000-0000-00000000:finished --> is invalid.",
+    "<!-- studio-result:00000000-0000-0000-0000-000000000000:unknown --> is invalid.",
+    "<!-- studio-result:00000000-0000-0000-0000-000000000000:finished without a delimiter.",
+  ])(
+    "preserves invalid marker prose while streaming and after completion: %s",
+    (text) => {
+      const token = "11111111-1111-1111-1111-111111111111";
+      for (const streaming of [true, false]) {
+        expect(openCodeVisibleText(text, token, streaming)).toBe(text);
+        for (let split = 0; split <= text.length; split++) {
+          const parts = [
+            { type: "text", text: text.slice(0, split) },
+            { type: "tool" },
+            { type: "text", text: text.slice(split) },
+          ];
+          expect(
+            openCodeVisibleParts(parts, token, streaming)
+              .filter((part) => part !== undefined)
+              .join(""),
+          ).toBe(text);
+        }
+      }
+    },
+  );
+
+  it("restores incomplete marker candidates when streaming ends", () => {
+    const token = "11111111-1111-1111-1111-111111111111";
+    const marker =
+      "<!-- studio-result:00000000-0000-0000-0000-000000000000:finished -->";
+    for (let size = 1; size < marker.length; size++) {
+      const text = `Example: ${marker.slice(0, size)}`;
+      expect(openCodeVisibleText(text, token, true)).toBe("Example:");
+      expect(openCodeVisibleText(text, token)).toBe(text);
+      expect(openCodeVisibleParts([{ type: "text", text }], token)).toEqual([
+        text,
+      ]);
+    }
+    expect(openCodeVisibleText("Use x <", token)).toBe("Use x <");
+  });
+
+  it("keeps scanning for real markers after invalid prose", () => {
+    const token = "11111111-1111-1111-1111-111111111111";
+    const prose =
+      "Document the <!-- studio-result: placeholder used by Studio.";
+    const marker = `<!-- studio-result:00000000-0000-0000-0000-000000000000:failed -->`;
+    expect(openCodeVisibleText(`${prose}\n\n${marker}`, token)).toBe(prose);
+    expect(openCodeVisibleText(`${marker}\n\n${prose}`, token)).toBe(prose);
   });
 
   it("requires known idle state and a completed final answer", () => {

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -425,6 +425,51 @@ test("hides a footer split across text parts when the native turn is interrupted
   expect(c.prompts).toHaveLength(1);
 });
 
+for (const position of ["prefix", "footer"]) {
+  test(`hides a mismatched recovery ${position} while preserving Stopped after history restoration`, async ({
+    page,
+  }) => {
+    await openAssistant(page);
+    const input = page.getByRole("textbox", { name: "Message Assistant" });
+    await input.fill("Read the README and explain what's here.");
+    await input.press("Enter");
+    await expect(page.getByText("First chunk", { exact: true })).toBeVisible();
+    const c = conversations.get("ses_sess_boot")!;
+    useCompletionContract(c);
+    endWithoutAnswer(c);
+    await expect.poll(() => c.recoveries.length).toBe(1);
+    const marker =
+      "<!-- studio-result:00000000-0000-0000-0000-000000000000:finished -->";
+    const answer =
+      "The README describes a project for testing Studio Assistant.";
+    recoveryReply!(
+      position === "prefix" ? `${marker}\n${answer}` : `${answer}\n\n${marker}`,
+    );
+    useCompletionContract(c);
+    const status = page.getByRole("status", { name: "Assistant status" });
+    await expect(status).toHaveText("Stopped");
+    await expect(page.getByText(answer, { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("studio-result:", { exact: false }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByText("read · Complete", { exact: true }),
+    ).toBeVisible();
+    await page.reload();
+    await page.getByRole("button", { name: "Assistant", exact: true }).click();
+    await expect(status).toHaveText("Stopped");
+    await expect(page.getByText(answer, { exact: true })).toBeVisible();
+    await expect(
+      page.getByText("studio-result:", { exact: false }),
+    ).toHaveCount(0);
+    await expect(page.getByRole("note")).toContainText(
+      "Completion was not confirmed",
+    );
+    expect(c.recoveries).toHaveLength(1);
+    expect(c.prompts).toHaveLength(1);
+  });
+}
+
 for (const recovered of [true, false]) {
   test(`continues a preamble-only native stop once and then shows ${recovered ? "Finished" : "Stopped"}`, async ({
     page,

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -586,6 +586,67 @@ for (const recovered of [true, false]) {
   });
 }
 
+for (const delivery of ["streamed", "history only"]) {
+  test(`keeps the conversation visible while reconciling a recovered answer (${delivery})`, async ({
+    page,
+  }, testInfo) => {
+    let attachments = 0;
+    page.on("request", (request) => {
+      if (new URL(request.url()).pathname.endsWith("/attach")) attachments++;
+    });
+    await openAssistant(page);
+    const input = page.getByRole("textbox", { name: "Message Assistant" });
+    const status = page.getByRole("status", { name: "Assistant status" });
+    await input.fill("Read the README and explain what's here.");
+    await input.press("Enter");
+    await expect(page.getByText("First chunk", { exact: true })).toBeVisible();
+    await input.fill("Keep this next question as a draft.");
+    const chat = await page.locator(".studio-chat").elementHandle();
+    const composer = await input.elementHandle();
+    const initialAttachments = attachments;
+    const c = conversations.get("ses_sess_boot")!;
+    endWithoutAnswer(c);
+    await expect.poll(() => c.recoveries.length).toBe(1);
+    await expect(page.locator(".studio-chat-meta")).toContainText(
+      "read · Complete",
+    );
+
+    holdHistory = true;
+    const streams = [...c.streams];
+    if (delivery === "history only") c.streams.clear();
+    recoveryReply!("The project contains a README and a .sapiom folder.");
+    for (const stream of streams) c.streams.add(stream);
+    await expect.poll(() => historyReplies.length).toBeGreaterThan(0);
+    await page.locator(".studio-conversation").screenshot({
+      path: testInfo.outputPath("reconciling-answer.png"),
+    });
+    expect(await chat!.evaluate((element) => element.isConnected)).toBe(true);
+    expect(await composer!.evaluate((element) => element.isConnected)).toBe(
+      true,
+    );
+    await expect(page.locator(".studio-chat-meta")).toContainText(
+      "read · Complete",
+    );
+    await expect(input).toHaveValue("Keep this next question as a draft.");
+    await expect(
+      page.getByText("Opening Assistant…", { exact: true }),
+    ).toHaveCount(0);
+
+    holdHistory = false;
+    for (const reply of historyReplies.splice(0)) reply();
+    await expect(status).toHaveText("Finished");
+    await expect(page.locator(".studio-chat-assistant")).toContainText(
+      "The project contains a README and a .sapiom folder.",
+    );
+    await expect(input).toBeEnabled();
+    await expect(input).toHaveValue("Keep this next question as a draft.");
+    expect(attachments).toBe(initialAttachments);
+    expect(c.prompts).toHaveLength(1);
+    expect(c.recoveries).toHaveLength(1);
+    await expect(page.getByRole("alert")).toHaveCount(0);
+  });
+}
+
 test("preserves an unconfirmed explanation as Stopped after history restoration", async ({
   page,
 }) => {

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -470,6 +470,80 @@ for (const position of ["prefix", "footer"]) {
   });
 }
 
+test("restores incomplete marker prose on completion and after reload", async ({
+  page,
+}) => {
+  await openAssistant(page);
+  await page
+    .getByRole("textbox", { name: "Message Assistant" })
+    .fill("Explain Studio's completion format.");
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(page.getByText("First chunk", { exact: true })).toBeVisible();
+  const c = conversations.get("ses_sess_boot")!;
+  useCompletionContract(c);
+  const turn = c.turns.at(-1)!;
+  const partial =
+    "<!-- studio-result:00000000-0000-0000-0000-000000000000:finished --";
+  const response = page.locator(`[data-message-id="${turn.info.id}"]`);
+  const delta = `\n\nIncomplete example:\n\n${partial}`;
+  turn.parts[0].text += delta;
+  emit(c, "message.part.delta", {
+    sessionID: c.id,
+    messageID: turn.info.id,
+    partID: turn.parts[0].id,
+    field: "text",
+    delta,
+  });
+  await expect(
+    page.getByText("Incomplete example:", { exact: true }),
+  ).toBeVisible();
+  await expect(response).not.toContainText(partial);
+  finish(c.id, "");
+  await expect(
+    page.getByRole("status", { name: "Assistant status" }),
+  ).toHaveText("Stopped");
+  await expect(response).toContainText(partial);
+  await page.reload();
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(response).toContainText(partial);
+  expect(c.prompts).toHaveLength(1);
+  expect(c.recoveries).toHaveLength(0);
+});
+
+test("preserves literal completion-prefix prose during streaming and restored history", async ({
+  page,
+}) => {
+  await openAssistant(page);
+  await page
+    .getByRole("textbox", { name: "Message Assistant" })
+    .fill("Document the completion placeholder.");
+  await page.getByRole("button", { name: "Send message" }).click();
+  await expect(page.getByText("First chunk", { exact: true })).toBeVisible();
+  const c = conversations.get("ses_sess_boot")!;
+  useCompletionContract(c);
+  const turn = c.turns.at(-1)!;
+  const text = "Document the <!-- studio-result: placeholder used by Studio.";
+  const response = page.locator(`[data-message-id="${turn.info.id}"]`);
+  turn.parts[0].text += `\n\n${text}`;
+  emit(c, "message.part.delta", {
+    sessionID: c.id,
+    messageID: turn.info.id,
+    partID: turn.parts[0].id,
+    field: "text",
+    delta: `\n\n${text}`,
+  });
+  await expect(response).toContainText(text);
+  finish(c.id, "");
+  await expect(
+    page.getByRole("status", { name: "Assistant status" }),
+  ).toHaveText("Stopped");
+  await page.reload();
+  await page.getByRole("button", { name: "Assistant", exact: true }).click();
+  await expect(response).toContainText(text);
+  expect(c.prompts).toHaveLength(1);
+  expect(c.recoveries).toHaveLength(0);
+});
+
 for (const recovered of [true, false]) {
   test(`continues a preamble-only native stop once and then shows ${recovered ? "Finished" : "Stopped"}`, async ({
     page,

--- a/packages/harness/web/e2e/opencode-chat.spec.ts
+++ b/packages/harness/web/e2e/opencode-chat.spec.ts
@@ -387,6 +387,77 @@ for (const reported of ["finished", "failed"] as const) {
   });
 }
 
+for (const [position, reported] of [
+  ["prefix", "finished"],
+  ["prefix", "failed"],
+  ["footer", "finished"],
+  ["footer", "failed"],
+] as const) {
+  test(`hides mismatched markers in a confirmed ${position} ${reported} answer and restored history`, async ({
+    page,
+  }, testInfo) => {
+    await openAssistant(page);
+    await page
+      .getByRole("textbox", { name: "Message Assistant" })
+      .fill("Explain the completion placeholder.");
+    await page.getByRole("button", { name: "Send message" }).click();
+    await expect(page.getByText("First chunk", { exact: true })).toBeVisible();
+    const c = conversations.get("ses_sess_boot")!;
+    const token = useCompletionContract(c);
+    const expected = `<!-- studio-result:${token}:${reported} -->`;
+    const mismatched = `<!-- studio-result:00000000-0000-0000-0000-000000000000:${reported === "finished" ? "failed" : "finished"} -->`;
+    const prose =
+      "Document the <!-- studio-result: placeholder used by Studio.";
+    const incomplete =
+      "Incomplete example: <!-- studio-result:00000000-0000-0000-0000-000000000000:finished --";
+    const answer = `Done.\n\n${prose}\n\n${incomplete}`;
+    const text =
+      position === "prefix"
+        ? `${expected}\n${answer}\n\n${mismatched}`
+        : `${mismatched}\n${answer}\n\n${expected}`;
+    const split = text.indexOf(mismatched) + 30;
+    const turn = c.turns.at(-1)!;
+    turn.parts[0].text = text.slice(0, split);
+    turn.parts.push({
+      ...turn.parts[0],
+      id: "prt_answer_tail",
+      text: text.slice(split),
+    });
+    turn.info.finish = "stop";
+    turn.info.time.completed = Date.now();
+    for (const part of turn.parts) emit(c, "message.part.updated", { part });
+    emit(c, "message.updated", { info: turn.info });
+    emit(c, "session.status", { sessionID: c.id, status: { type: "idle" } });
+    const status = page.getByRole("status", { name: "Assistant status" });
+    const response = page.locator(".studio-chat-assistant");
+    await expect(status).toHaveText(
+      reported === "finished" ? "Finished" : "Failed",
+    );
+    await response.screenshot({
+      path: testInfo.outputPath("confirmed-answer.png"),
+    });
+    await expect(response).not.toContainText(mismatched);
+    await expect(response).not.toContainText(expected);
+    for (const paragraph of ["Done.", prose, incomplete])
+      await expect(response.getByText(paragraph, { exact: true })).toHaveCount(
+        1,
+      );
+    await page.reload();
+    await page.getByRole("button", { name: "Assistant", exact: true }).click();
+    await expect(status).toHaveText(
+      reported === "finished" ? "Finished" : "Failed",
+    );
+    await expect(response).not.toContainText(mismatched);
+    await expect(response).not.toContainText(expected);
+    for (const paragraph of ["Done.", prose, incomplete])
+      await expect(response.getByText(paragraph, { exact: true })).toHaveCount(
+        1,
+      );
+    expect(c.prompts).toHaveLength(1);
+    expect(c.recoveries).toHaveLength(0);
+  });
+}
+
 test("hides a footer split across text parts when the native turn is interrupted", async ({
   page,
 }) => {

--- a/packages/harness/web/src/components/OpenCodeChat.tsx
+++ b/packages/harness/web/src/components/OpenCodeChat.tsx
@@ -194,6 +194,13 @@ function RuntimeChat({
   );
   const [actionError, setActionError] = useState<RecoveryNotice | null>(null);
   const [connected, setConnected] = useState(false);
+  const eventAbort = useRef<AbortController | null>(null);
+  const reconcile = useCallback(() => {
+    // The adapter reconnects this display stream and reloads history/status.
+    // Keep its controller mounted so answers, tool output, and drafts stay put.
+    setConnected(false);
+    eventAbort.current?.abort();
+  }, []);
   const onError = useCallback(() => setActionError(requestError), []);
   const onTypedError = useCallback((failure: OpenCodeTransportFailure) => {
     setConnected(false);
@@ -228,17 +235,22 @@ function RuntimeChat({
     });
     const subscribe = client.event.subscribe.bind(client.event);
     client.event.subscribe = async (parameters, options) => {
+      const abort = new AbortController();
+      eventAbort.current = abort;
       const result = await subscribe(parameters, {
         ...options,
+        signal: options?.signal
+          ? AbortSignal.any([options.signal, abort.signal])
+          : abort.signal,
         onSseError(error) {
           options?.onSseError?.(error);
-          if (!options?.signal?.aborted) {
+          if (!options?.signal?.aborted && !abort.signal.aborted) {
             setConnected(false);
             setTransportError(connectionError);
           }
         },
         onSseEvent(event) {
-          if (!options?.signal?.aborted) {
+          if (!options?.signal?.aborted && !abort.signal.aborted) {
             const failure = parseOpenCodeStudioErrorEvent(event.data);
             if (failure) {
               onTypedError(failure);
@@ -270,9 +282,10 @@ function RuntimeChat({
           try {
             yield* result.stream;
           } finally {
+            if (eventAbort.current === abort) eventAbort.current = null;
             if (!options?.signal?.aborted) {
               setConnected(false);
-              setTransportError(connectionError);
+              if (!abort.signal.aborted) setTransportError(connectionError);
             }
           }
         })(),
@@ -295,6 +308,7 @@ function RuntimeChat({
         bootToken={bootToken}
         conversationId={conversationId}
         connected={connected}
+        reconcile={reconcile}
         error={actionError ?? transportError}
         retry={retry}
         composer={runtime.thread.composer}
@@ -332,6 +346,7 @@ function ChatSurface({
   bootToken,
   conversationId,
   connected,
+  reconcile,
   error,
   retry,
   composer,
@@ -345,6 +360,7 @@ function ChatSurface({
   bootToken: string;
   conversationId: string;
   connected: boolean;
+  reconcile: () => void;
   error: RecoveryNotice | null;
   retry: () => void;
   composer: ThreadComposerRuntime;
@@ -436,7 +452,7 @@ function ChatSurface({
           }
           throw new Error("Final response failed");
         }
-        retry(); // Reconcile history even if the last text event was missed.
+        reconcile(); // Catch up on missed final events without resetting chat.
       })
       .catch(() => {
         if (!abort.signal.aborted) setRecoveryFailed(true);
@@ -454,7 +470,7 @@ function ChatSurface({
     missing,
     pending,
     ready,
-    retry,
+    reconcile,
     running,
     onTypedError,
   ]);

--- a/packages/harness/web/src/components/OpenCodeChat.tsx
+++ b/packages/harness/web/src/components/OpenCodeChat.tsx
@@ -507,7 +507,12 @@ function ChatSurface({
                   ? completionTokens.get(nativeMessage.info.parentID)
                   : undefined;
               const result = openCodeResult(nativeMessage, token);
-              const visibleParts = openCodeVisibleParts(message.content, token);
+              const visibleParts = openCodeVisibleParts(
+                message.content,
+                token,
+                nativeMessage?.info?.role === "assistant" &&
+                  !nativeMessage.info.time.completed,
+              );
               return message.role === "user" &&
                 [finalResponseAgent, turnRecoveryAgent].includes(
                   native.messagesById[message.id]?.info?.agent ?? "",

--- a/packages/harness/web/src/components/OpenCodeChat.tsx
+++ b/packages/harness/web/src/components/OpenCodeChat.tsx
@@ -33,6 +33,7 @@ import {
 import {
   openCodeCompletionTokens,
   openCodeVisibleParts,
+  openCodeVisibleText,
 } from "../../../src/shared/opencode-completion";
 import {
   parseOpenCodeStudioErrorEvent,
@@ -560,7 +561,11 @@ function ChatSurface({
                       />
                     ),
                   )}
-                  {result && <Markdown text={result.answer} />}
+                  {result && (
+                    <Markdown
+                      text={openCodeVisibleText(result.answer, token)}
+                    />
+                  )}
                   <MessagePrimitive.Error>
                     <ErrorPrimitive.Root className="studio-chat-error">
                       <ErrorPrimitive.Message />


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Assistant output could expose an internal completion marker with the wrong turn ID. A broad prefix filter could also hide legitimate answer text. Separately, automatic answer recovery reset the chat display to reload history, briefly removing the conversation and draft before they returned.

## Summary and scope

Recognize the complete UUID, status, and delimiter before hiding a marker, independently of its turn ID. Withhold partial candidates only while streaming and only while they can still form a marker. Preserve invalid syntax immediately and restore incomplete candidates when the native response completes. Apply the same display filter to confirmed answers after strict turn validation, so an extra marker with another turn ID cannot bypass filtering.

After answer recovery, reconnect the existing display event stream so the adapter reloads saved messages and execution status while keeping the chat controller mounted. Preserve the answer, tool output, and unsent draft throughout that catch-up. Ignore intentional stream cancellation as a connection error. Completion validation still requires the expected turn ID, and reconciliation never resubmits the original prompt.

Split browser CI across two standard runners, with two workers per runner and canvas checks on the first runner. The full suite takes about 19 minutes on one CI runner, exhausting the 20-minute job budget during finalization. Retain every test and the existing per-test deadlines, retries, and job cap; keep failure reports separate for each shard.

Review size: 624 changed lines across 7 files against `origin/main`. `pnpm pr:size` is not defined in this repository, so size was measured with Git additions plus deletions.

## Related work

Related issue or discussion:
[Assistant conversation integration](https://linear.app/sapiom/issue/SAP-3290/ui-run-a-real-opencode-assistant-conversation-inside-studio).

Broader unnecessary recaps and incomplete-turn recovery remain in [Assistant recovery](https://linear.app/sapiom/issue/SAP-3295/ui-stop-assistant-work-and-recover-failed-operations).

## Validation

Final GitHub validation at `9b40f11`: all checks pass, including Node 20/22, CodeQL, Devin review, desktop smoke, both browser shards (**341 + 340 passed; zero retries**), and all **15 canvas tests**. Browser jobs finish in 13 and 11 minutes within the 20-minute cap. One unchanged session-bootstrap timing test failed on the first Node 20 attempt and cancelled Node 22; all 15 rehydration tests passed locally, and both Node jobs passed on the failed-job rerun.

```text
pnpm --filter @sapiom/harness build — passed
pnpm --filter @sapiom/harness typecheck — passed
pnpm --filter @sapiom/harness lint — passed for the marker correction; server/unit source unchanged in the refresh follow-up
pnpm --filter @sapiom/harness exec eslint --no-ignore --parser-options '{"project":"./web/tsconfig.json"}' --env browser web/src/components/OpenCodeChat.tsx — passed
pnpm --filter @sapiom/harness test — 4,021 passed, 2 skipped; 10 performance checks passed before the display-only refresh follow-up
pnpm --filter @sapiom/harness exec vitest run src/shared/opencode-turn.test.ts — 20 passed
E2E_PORT=5312 pnpm --filter @sapiom/harness test:ui opencode-chat.spec.ts --workers=2 — 41 passed on the final correction
Earlier full Studio run at 85b58f7: 677 passed in 13.5 minutes; all 37 then-existing Assistant cases passed
pnpm terminology:check — passed
pnpm provider-copy:check — passed
Changed TypeScript/TSX and changeset formatting — passed
pnpm pr-ci-security:check — 3 security-contract checks and workflow formatting passed
git diff --check — passed
```

Playwright test discovery verifies that the two shards contain 341 and 340 cases: their union is exactly the full 681-case suite, with no omissions or duplicates. The one-runner CI attempt completed all browser cases (678 passed, 3 passed on existing retries) and all 15 canvas cases, but the job was cancelled at its deadline. The sharded workflow reduces the work each runner must finish.

Red/green regressions reproduced the literal-prefix truncation, the chat unmount during recovery, and the confirmed-answer rendering bypass. Four additional browser cases cover prefix/footer contracts and finished/failed statuses with a mismatched marker split across native text parts. They preserve the expected status, ordinary prefix prose, and incomplete settled syntax before and after page reload, with no extra prompts or recoveries. Both recovery display cases pass: normally streamed events and all final answer/status events missed. They hold the history response open and assert the original chat/composer nodes, visible tool output, preserved draft, restored completion, and no extra attach, prompt, or recovery requests.

The built frontend loaded the existing hosted-account conversation with six displayed messages, no visible completion markers, no page errors, and no prompt/recovery/abort requests. After installation and an idle restart of the owned local server, the same check passed again. The Mac localhost asset hash matches the built asset. Both saved native histories retained identical message/part digests. The final confirmed-answer correction was also built and checked against the existing saved conversation using browser-local asset substitution: six displayed messages, no visible complete markers, no page errors, and no prompt/recovery/abort requests. The running user server was not restarted for this follow-up. Both captured real-model responses still preserve their answer text and hide wrong-ID markers without confirming completion.

The marker correction passed the wider root build/typecheck/lint and all 19 package suites were exercised (6,395 passed, 7 skipped, 1 known local Agent Core permission-error failure). Current frontend changes were verified with the checks above. GitHub checks at 85b58f7 all passed, including Node 20/22, desktop smoke, and the full browser job. The final CI results are recorded above. Packaged macOS/Windows were not retested.

### Tests and documentation

Unit cases cover current and mismatched IDs, every streaming split, literal prefixes, malformed IDs, invalid statuses, missing delimiters, and surrounding answer/tool content. Browser regressions cover streaming, confirmed prefix/footer answers containing extra markers, literal and incomplete marker prose, completion, reload, preserved Stopped status, retained chat/draft during recovery, missed final events, and absence of extra prompt/recovery requests. The harness README, helper documentation, and patch changeset describe the behavior.

## Compatibility and release impact

- Breaking or externally visible changes: No API or history-format changes. Correctly shaped internal markers are hidden; prose and incomplete settled syntax stay visible. Automatic recovery keeps the existing conversation mounted. Complete wrong-ID markers remain insufficient to confirm the request.
- Changeset: Added `.changeset/hide-mismatched-assistant-markers.md` for `@sapiom/harness` (patch).

Fix-forward: correct any further answer-loss regression through a focused main PR while retaining strict turn-ID validation.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex implemented the display corrections, reproduced the reported failures, and verified behavior with unit, browser, build, and captured-response checks.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

