### PR TITLE
feat(harness): use Luna through the rebuilt router [SAP-3289]

### DIFF
--- a/.changeset/assistant-router-luna.md
+++ b/.changeset/assistant-router-luna.md
@@ -5,4 +5,5 @@
 
 Route the Assistant through router.sapiom.ai using Luna and the Responses API.
 Preserve streaming tool use, account-scoped credentials, and bounded retries for
-empty answers. Custom Assistant gateways must support /v1/responses.
+empty answers. Throttle repeated failed runtime authentication attempts.
+Custom Assistant gateways must support /v1/responses.

--- a/.changeset/assistant-router-luna.md
+++ b/.changeset/assistant-router-luna.md
@@ -1,0 +1,8 @@
+---
+"@sapiom/harness": patch
+"@sapiom/opencode": patch
+---
+
+Route the Assistant through router.sapiom.ai using Luna and the Responses API.
+Preserve streaming tool use, account-scoped credentials, and bounded retries for
+empty answers. Custom Assistant gateways must support /v1/responses.

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -63,10 +63,15 @@ jobs:
   # The live/real-pty tiers (e2e:live, sim) are opt-in local only; nothing here
   # invokes them — they require real agent binaries and credentials not in CI.
   playwright-mock:
+    name: playwright-mock (${{ matrix.shard }}/2)
     runs-on: ubuntu-latest
-    # The expanded mock suite has over 680 cases, followed by canvas checks.
-    # Keep the existing per-test deadlines; allow both suites to finish.
+    # Split the growing suite across runners to leave time for canvas checks.
+    # Keep the existing per-test and job deadlines.
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     # Single Node version is enough — the mock tier tests browser behaviour,
     # not Node version compat; that's covered by the matrix job in test.yml.
     steps:
@@ -106,22 +111,21 @@ jobs:
         run: pnpm --filter @sapiom/harness exec playwright install-deps chromium
 
       - name: Run Playwright mock-mode suite
-        # The default two workers exceed this job's budget as the suite grows.
-        # Four workers retain the per-test deadlines and leave time for canvas.
-        run: pnpm --filter @sapiom/harness test:ui --workers=4
+        run: pnpm --filter @sapiom/harness test:ui --workers=2 --shard=${{ matrix.shard }}/2
 
       # The canvas suite renders the generated diagram documents in the same
       # chromium this job already installed. It was previously opt-in only, so
       # nothing verified in CI that a canvas the renderer produces actually
       # paints — a rendering regression could only be caught by hand.
       - name: Run Playwright canvas suite
+        if: matrix.shard == 1
         run: pnpm --filter @sapiom/harness test:canvas
 
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.shard }}
           path: packages/harness/web/e2e/playwright-report/
           retention-days: 7
 

--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -64,7 +64,7 @@ jobs:
   # invokes them — they require real agent binaries and credentials not in CI.
   playwright-mock:
     runs-on: ubuntu-latest
-    # The expanded mock suite has over 560 cases, followed by canvas checks.
+    # The expanded mock suite has over 680 cases, followed by canvas checks.
     # Keep the existing per-test deadlines; allow both suites to finish.
     timeout-minutes: 20
     # Single Node version is enough — the mock tier tests browser behaviour,
@@ -106,7 +106,9 @@ jobs:
         run: pnpm --filter @sapiom/harness exec playwright install-deps chromium
 
       - name: Run Playwright mock-mode suite
-        run: pnpm --filter @sapiom/harness test:ui
+        # The default two workers exceed this job's budget as the suite grows.
+        # Four workers retain the per-test deadlines and leave time for canvas.
+        run: pnpm --filter @sapiom/harness test:ui --workers=4
 
       # The canvas suite renders the generated diagram documents in the same
       # chromium this job already installed. It was previously opt-in only, so

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -99,9 +99,13 @@ native conversation.
 The Assistant's model and remote MCP requests use a Studio-owned local bridge.
 Its short-lived runtime credential is separate from browser authentication;
 Studio adds the Sapiom key only when forwarding to the configured services.
-Production uses the Sapiom LLM gateway. Other environments must explicitly set
-`services.llm` to their gateway origin in the matching credentials-file environment
-entry; Studio never falls back from a custom environment to production.
+Production sends Responses API requests to `https://router.sapiom.ai/v1/responses`
+with the explicit `gpt-luna` model and the signed-in account's `x-api-key`. Luna uses
+low reasoning effort and streams both tool calls and answers. Responses are not
+stored by the provider; encrypted reasoning travels with native conversation
+history. Other environments must explicitly set `services.llm` to a router origin
+that supports `/v1/responses` in the matching credentials-file environment entry;
+Studio never falls back from a custom environment to production.
 
 Studio owns each Assistant runtime for the authorized session and working
 directory. Browser detachment leaves it running; sign-out, access revocation,

--- a/packages/harness/src/core/opencode-association.test.ts
+++ b/packages/harness/src/core/opencode-association.test.ts
@@ -35,6 +35,7 @@ it("serializes association commits across runtime retirement, including an alrea
   let created = 0;
   const abort = new AbortController();
   const hosted: HostedOpenCode = {
+    model: { providerID: "sapiom", modelID: "gpt-luna" },
     harnessSessionId: "studio-one",
     cwd: root,
     stateRoot: root,
@@ -97,6 +98,7 @@ it("distinguishes confirmed missing history from transient lookup failure withou
     .mockResolvedValueOnce(Response.json({ id: conversationId }));
   const create = vi.fn();
   const hosted: HostedOpenCode = {
+    model: { providerID: "sapiom", modelID: "gpt-luna" },
     harnessSessionId: "studio-one",
     cwd: root,
     stateRoot: root,

--- a/packages/harness/src/core/opencode-final-response.test.ts
+++ b/packages/harness/src/core/opencode-final-response.test.ts
@@ -20,6 +20,7 @@ beforeEach(async () => {
   abort = new AbortController();
   dispatch.mockReset().mockResolvedValue(new Response("{}"));
   hosted = {
+    model: { providerID: "sapiom", modelID: "gpt-luna" },
     stateRoot: await mkdtemp(join(tmpdir(), "opencode-final-")),
     signal: abort.signal,
     server: {
@@ -61,18 +62,21 @@ it.each([
   ["ses_test", "msg_"],
   ["ses_test", `msg_${"a".repeat(129)}`],
   ["ses_test", ["msg_empty"]],
-])("rejects invalid recovery IDs before storage or native requests: %j / %j", async (sessionId, messageId) => {
-  await expect(
-    new OpenCodeFinalResponse().recover(
-      hosted,
-      sessionId as string,
-      messageId as string,
-    ),
-  ).rejects.toThrow("Invalid Assistant recovery identifiers");
-  expect(await readdir(hosted.stateRoot)).toEqual([]);
-  expect(hosted.server.fetchJson).not.toHaveBeenCalled();
-  expect(dispatch).not.toHaveBeenCalled();
-});
+])(
+  "rejects invalid recovery IDs before storage or native requests: %j / %j",
+  async (sessionId, messageId) => {
+    await expect(
+      new OpenCodeFinalResponse().recover(
+        hosted,
+        sessionId as string,
+        messageId as string,
+      ),
+    ).rejects.toThrow("Invalid Assistant recovery identifiers");
+    expect(await readdir(hosted.stateRoot)).toEqual([]);
+    expect(hosted.server.fetchJson).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+  },
+);
 
 it("coalesces recovery and never resends it after a host restart", async () => {
   const recovery = new OpenCodeFinalResponse();
@@ -85,6 +89,7 @@ it("coalesces recovery and never resends it after a host restart", async () => {
   expect(path).toBe("/session/ses_test/message");
   expect(JSON.parse(init.body)).toMatchObject({
     agent: "sapiom-turn-recovery",
+    model: { providerID: "sapiom", modelID: "gpt-luna" },
     system: expect.stringContaining("StudioAssistantResult/v2:"),
   });
   expect(JSON.parse(init.body)).not.toHaveProperty("tools");

--- a/packages/harness/src/core/opencode-final-response.ts
+++ b/packages/harness/src/core/opencode-final-response.ts
@@ -148,6 +148,7 @@ export class OpenCodeFinalResponse {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             ...openCodeCompletionPrompt(),
+            model: hosted.model,
             agent: turnRecoveryAgent,
             parts: [
               {

--- a/packages/harness/src/core/opencode-host.test.ts
+++ b/packages/harness/src/core/opencode-host.test.ts
@@ -76,7 +76,7 @@ beforeEach(async () => {
         return () => {};
       },
     },
-    bridge: { issue, model: "smart" },
+    bridge: { issue, model: "gpt-luna" },
     origin: () => "http://127.0.0.1:1234",
     stateRoot: root,
     authorize,
@@ -102,7 +102,7 @@ describe("Studio-owned OpenCode lifecycle", () => {
     expect(first.harnessSessionId).toBe("studio-one");
     expect(first.stateRoot.startsWith(join(root, "opencode"))).toBe(true);
     expect(JSON.stringify(start.mock.calls)).not.toContain("sk_private");
-    expect(start.mock.calls[0][0].config.model).toBe("sapiom/smart");
+    expect(start.mock.calls[0][0].config.model).toBe("sapiom/gpt-luna");
     await host.ensure("studio-two");
     expect(start).toHaveBeenCalledTimes(2);
     expect(start.mock.calls[0][0].stateRoot).not.toBe(

--- a/packages/harness/src/core/opencode-host.ts
+++ b/packages/harness/src/core/opencode-host.ts
@@ -32,6 +32,7 @@ export interface OpenCodeWorkspace {
   cwd: string;
 }
 export interface HostedOpenCode extends OpenCodeWorkspace {
+  model: { providerID: "sapiom"; modelID: string };
   stateRoot: string;
   server: OpenCodeServer;
   signal: AbortSignal;
@@ -298,6 +299,7 @@ export class OpenCodeHost {
       await this.validate(entry);
       return {
         ...entry.workspace,
+        model: { providerID: "sapiom", modelID: this.options.bridge.model },
         stateRoot,
         server,
         signal: entry.abort.signal,

--- a/packages/harness/src/server/opencode-bridge.test.ts
+++ b/packages/harness/src/server/opencode-bridge.test.ts
@@ -75,10 +75,7 @@ afterEach(async () => {
     ),
   );
 });
-function request(
-  path = "llm/v2/openai/v1/chat/completions",
-  init: RequestInit = {},
-) {
+function request(path = "llm/v1/responses", init: RequestInit = {}) {
   return fetch(`${origin}/opencode-runtime/${credential.id}/${path}`, {
     method: "POST",
     headers: {
@@ -87,7 +84,7 @@ function request(
     },
     body: JSON.stringify({
       model: "browser-override",
-      messages: [],
+      input: [],
       stream: true,
     }),
     ...init,
@@ -95,245 +92,95 @@ function request(
 }
 
 describe("Studio OpenCode credential bridge", () => {
-  const chunk = (delta: object, finish_reason: string | null = null) =>
-    `data: ${JSON.stringify({ choices: [{ index: 0, delta, finish_reason }] })}\n\n`;
-  const emptyStop =
-    chunk({ reasoning_content: "unfinished reasoning" }) +
-    chunk({}, "stop") +
-    "data: [DONE]\n\n";
-
+  const event = (type: string, fields: object = {}) =>
+    `event: ${type}\ndata: ${JSON.stringify({ type, ...fields })}\n\n`;
+  const completed = () =>
+    event("response.completed", {
+      response: { status: "completed", output: [] },
+    });
   const contractedRequest = () => {
     const { system } = openCodeCompletionPrompt();
-    return { stream: true, messages: [{ role: "system", content: system }] };
+    return { stream: true, input: [{ role: "developer", content: system }] };
   };
 
-  it("retries an unmarked preamble with unchanged context and streams the marked answer before EOF", async () => {
-    const body = contractedRequest();
+  it("retries an unmarked preamble with identical history and streams the marked answer before EOF", async () => {
+    const contract = contractedRequest();
+    const body = {
+      ...contract,
+      store: true,
+      input: [
+        ...contract.input,
+        {
+          type: "function_call_output",
+          call_id: "already_ran",
+          output: "completed once",
+        },
+      ],
+    };
     const token = openCodeModelCompletionToken(body)!;
     const received: unknown[] = [];
     let finish!: () => void;
-    upstream.post("/v2/openai/v1/chat/completions", (req, res) => {
+    upstream.post("/v1/responses", (req, res) => {
       received.push(req.body);
       res.type("text/event-stream");
       if (received.length === 1) {
         res.end(
-          chunk({ content: "I'll create both files." }) +
-            chunk({}, "stop") +
-            "data: [DONE]\n\n",
+          event("response.output_text.delta", {
+            delta: "I'll create both files.",
+          }) + completed(),
         );
         return;
       }
       const marker = `<!-- studio-result:${token}:finished -->\n`;
-      for (const content of [marker.slice(0, 20), marker.slice(20), "CHAT_OK"])
-        res.write(chunk({ content }));
-      finish = () => res.end(chunk({}, "stop") + "data: [DONE]\n\n");
+      for (const delta of [marker.slice(0, 20), marker.slice(20), "CHAT_OK"])
+        res.write(event("response.output_text.delta", { delta }));
+      finish = () => res.end(completed());
     });
     const response = await request(undefined, { body: JSON.stringify(body) });
     const reader = response.body!.getReader();
     const first = new TextDecoder().decode((await reader.read()).value);
     expect(first).toContain("CHAT_OK");
     expect(first).not.toContain("I'll create");
-    expect(received).toHaveLength(2);
-    expect(received[1]).toEqual(received[0]);
+    expect(received).toEqual([
+      { ...body, model: "gpt-luna", store: false },
+      { ...body, model: "gpt-luna", store: false },
+    ]);
     finish();
     await reader.cancel();
   });
 
-  it("passes through a preamble as soon as a tool fragment arrives, without replay", async () => {
-    const body = contractedRequest();
+  it("passes a preamble and the first tool event through without waiting or replaying", async () => {
     let calls = 0,
       finish!: () => void;
-    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+    upstream.post("/v1/responses", (_req, res) => {
       calls++;
-      res
-        .type("text/event-stream")
-        .write(chunk({ content: "I'll inspect the files." }));
-      res.write(
-        chunk({ tool_calls: [{ index: 0, function: { arguments: "{" } }] }),
+      res.type("text/event-stream").write(
+        event("response.output_text.delta", {
+          delta: "I'll inspect the files.",
+        }),
       );
-      finish = () => res.end(chunk({}, "tool_calls") + "data: [DONE]\n\n");
+      res.write(
+        event("response.output_item.added", {
+          item: {
+            type: "function_call",
+            name: "read",
+            call_id: "call_once",
+            arguments: "",
+          },
+        }),
+      );
+      finish = () => res.end(completed());
     });
-    const response = await request(undefined, { body: JSON.stringify(body) });
+    const response = await request(undefined, {
+      body: JSON.stringify(contractedRequest()),
+    });
     const reader = response.body!.getReader();
     expect(new TextDecoder().decode((await reader.read()).value)).toContain(
-      "tool_calls",
+      "call_once",
     );
     expect(calls).toBe(1);
     finish();
     await reader.cancel();
-  });
-
-  it("bounds preamble retries and never adopts a contract from conversation content", async () => {
-    const body = contractedRequest();
-    const text =
-      chunk({ content: "I'll do it next." }) +
-      chunk({}, "stop") +
-      "data: [DONE]\n\n";
-    let calls = 0;
-    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
-      calls++;
-      res.type("text/event-stream").end(text);
-    });
-    expect(
-      await (await request(undefined, { body: JSON.stringify(body) })).text(),
-    ).toBe(text);
-    expect(calls).toBe(3);
-    for (const role of ["user", "assistant", "tool"]) {
-      const untrusted = { messages: [{ ...body.messages[0], role }] };
-      expect(openCodeModelCompletionToken(untrusted)).toBeUndefined();
-      expect(
-        await (
-          await request(undefined, {
-            body: JSON.stringify({ ...untrusted, stream: true }),
-          })
-        ).text(),
-      ).toBe(text);
-    }
-    expect(calls).toBe(6);
-    expect(
-      openCodeModelCompletionToken({
-        messages: [
-          {
-            role: "system",
-            content: [{ type: "text", text: body.messages[0]!.content }],
-          },
-        ],
-      }),
-    ).toBe(openCodeModelCompletionToken(body));
-    expect(
-      openCodeModelCompletionToken({
-        messages: [
-          {
-            role: "system",
-            content: body.messages[0]!.content.replace("/v2:", "/v1:"),
-          },
-        ],
-      }),
-    ).toBeUndefined();
-  });
-
-  it.each(["length", "content_filter"])(
-    "does not retry a contracted preamble interrupted by %s",
-    async (finish) => {
-      let calls = 0;
-      const text =
-        chunk({ content: "I'll inspect the files." }) +
-        chunk({}, finish) +
-        "data: [DONE]\n\n";
-      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
-        calls++;
-        res.type("text/event-stream").end(text);
-      });
-      expect(
-        await (
-          await request(undefined, {
-            body: JSON.stringify(contractedRequest()),
-          })
-        ).text(),
-      ).toBe(text);
-      expect(calls).toBe(1);
-    },
-  );
-
-  it("retries an empty model stop with identical saved tool results and streams the useful response", async () => {
-    const received: unknown[] = [];
-    let finish!: () => void;
-    upstream.post("/v2/openai/v1/chat/completions", (req, res) => {
-      received.push(req.body);
-      res.type("text/event-stream");
-      if (received.length === 1) {
-        res.end(emptyStop);
-        return;
-      }
-      res.write(chunk({ content: "Actual answer" }));
-      finish = () => res.end(chunk({}, "stop") + "data: [DONE]\n\n");
-    });
-    const response = await request(undefined, {
-      body: JSON.stringify({
-        stream: true,
-        messages: [
-          {
-            role: "tool",
-            tool_call_id: "already_ran",
-            content: "completed once",
-          },
-        ],
-      }),
-    });
-    const reader = response.body!.getReader();
-    const first = new TextDecoder().decode((await reader.read()).value);
-    expect(first).toContain("Actual answer");
-    expect(first).not.toContain("unfinished reasoning");
-    expect(received).toHaveLength(2);
-    expect(received[1]).toEqual(received[0]);
-    finish();
-    await reader.cancel();
-  });
-
-  it("bounds empty-stop retries", async () => {
-    let calls = 0;
-    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
-      calls++;
-      res.type("text/event-stream").end(emptyStop);
-    });
-    expect(await (await request()).text()).toBe(emptyStop);
-    expect(calls).toBe(3);
-  });
-
-  it("recognizes empty stops across split UTF-8 and CRLF frames", async () => {
-    let calls = 0;
-    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
-      calls++;
-      res.type("text/event-stream");
-      if (calls === 1) {
-        const bytes = Buffer.from(
-          (
-            chunk({ reasoning_content: "café" }) +
-            chunk({}, "stop") +
-            "data: [DONE]\n\n"
-          ).replace(/\n/g, "\r\n"),
-        );
-        let i = 0;
-        const send = () => {
-          if (i === bytes.length) res.end();
-          else {
-            res.write(bytes.subarray(i, ++i));
-            setImmediate(send);
-          }
-        };
-        send();
-      } else
-        res.end(
-          chunk({ content: "Done" }) + chunk({}, "stop") + "data: [DONE]\n\n",
-        );
-    });
-    expect(await (await request()).text()).toContain("Done");
-    expect(calls).toBe(2);
-  });
-
-  it("caps buffering and passes through oversized prefixes", async () => {
-    const body =
-      chunk({ reasoning_content: "x".repeat(1024 * 1024) }) +
-      chunk({}, "stop") +
-      "data: [DONE]\n\n";
-    let calls = 0;
-    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
-      calls++;
-      res.type("text/event-stream").end(body);
-    });
-    expect(await (await request()).text()).toBe(body);
-    expect(calls).toBe(1);
-  });
-
-  it("passes through a truncated UTF-8 ending without retrying", async () => {
-    const body = Buffer.concat([Buffer.from(emptyStop), Buffer.from([0xc3])]);
-    let calls = 0;
-    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
-      calls++;
-      res.type("text/event-stream").end(body);
-    });
-    expect(Buffer.from(await (await request()).arrayBuffer())).toEqual(body);
-    expect(calls).toBe(1);
   });
 
   it.each(["disconnect", "revocation"])(
@@ -348,11 +195,13 @@ describe("Studio OpenCode credential bridge", () => {
       const ended = new Promise<void>((resolve) => {
         closed = resolve;
       });
-      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+      upstream.post("/v1/responses", (_req, res) => {
         calls++;
-        res
-          .type("text/event-stream")
-          .write(chunk({ reasoning_content: "Still working" }));
+        res.type("text/event-stream").write(
+          event("response.reasoning_summary_text.delta", {
+            delta: "Still working",
+          }),
+        );
         res.once("close", closed);
         began();
       });
@@ -373,56 +222,17 @@ describe("Studio OpenCode credential bridge", () => {
     },
   );
 
-  it.each([
-    chunk({ tool_calls: [{ index: 0, function: { arguments: "{" } }] }) +
-      chunk({}, "stop") +
-      "data: [DONE]\n\n",
-    chunk({ function_call: { arguments: "{" } }) +
-      chunk({}, "stop") +
-      "data: [DONE]\n\n",
-    chunk({ content: "Partial answer" }) +
-      chunk({}, "stop") +
-      "data: [DONE]\n\n",
-    chunk({ refusal: "Cannot do that" }) +
-      chunk({}, "stop") +
-      "data: [DONE]\n\n",
-    chunk({}, "length") + "data: [DONE]\n\n",
-    chunk({}, "stop"),
-    "data: malformed\n\n" + emptyStop,
-    'data: {"error":{"message":"upstream failed"}}\n\n' + emptyStop,
-    'data: {"choices":[null]}\n\n' + emptyStop,
-    chunk([]) + emptyStop,
-    chunk({ role: "tool" }) + emptyStop,
-    chunk({ reasoning_content: { text: "unknown" } }) + emptyStop,
-    chunk({ reasoning: 1 }) + emptyStop,
-    chunk({ reasoning_details: {} }) + emptyStop,
-    'data: {"choices":[{"index":0,"delta":{},"finish_reason":0}]}\n\n' +
-      emptyStop,
-    'data: {"choices":[{"index":1,"delta":{}}]}\n\n' + emptyStop,
-    emptyStop + 'data: {"choices":[]}\n\n',
-  ])(
-    "never retries a stream with output, an error, or an uncertain ending (%#)",
-    async (body) => {
-      let calls = 0;
-      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
-        calls++;
-        res.type("text/event-stream").end(body);
-      });
-      expect(await (await request()).text()).toBe(body);
-      expect(calls).toBe(1);
-    },
-  );
-
   it("injects the current Studio key and configured model without forwarding caller credentials", async () => {
-    upstream.post("/v2/openai/v1/chat/completions", (req, res) => {
-      expect(req.headers["x-sapiom-api-key"]).toBe("sk_private_studio");
-      expect(req.headers["x-sapiom-model"]).toBe("smart");
-      expect(req.body.model).toBe("smart");
+    upstream.post("/v1/responses", (req, res) => {
+      expect(req.headers["x-api-key"]).toBe("sk_private_studio");
+      expect(req.body.model).toBe("gpt-luna");
+      expect(req.body.store).toBe(false);
       for (const header of [
         "authorization",
         "cookie",
         "x-harness-token",
-        "x-api-key",
+        "x-sapiom-api-key",
+        "x-sapiom-model",
       ])
         expect(req.headers[header]).toBeUndefined();
       res.json({ ok: true });
@@ -444,7 +254,7 @@ describe("Studio OpenCode credential bridge", () => {
     const closed = new Promise<void>((resolve) => {
       disconnected = resolve;
     });
-    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+    upstream.post("/v1/responses", (_req, res) => {
       res.setHeader("Content-Type", "text/event-stream");
       res.write("data: first\n\n");
       finish = () => res.end("data: last\n\n");
@@ -471,22 +281,21 @@ describe("Studio OpenCode credential bridge", () => {
       ).status,
     ).toBe(401);
     expect(
-      (
-        await request(
-          "llm/v2/openai/v1/chat/completions?url=https://other.example",
-        )
-      ).status,
+      (await request("llm/v1/responses?url=https://other.example")).status,
     ).toBe(400);
     expect(
       (
-        await request("llm/v2/openai/v1/chat/completions", {
+        await request("llm/v1/responses", {
           method: "GET",
           body: undefined,
         })
       ).status,
     ).toBe(400);
     expect((await request("https://other.example")).status).toBe(404);
-    expect((await request("llm/v2/openai/v1/models")).status).toBe(404);
+    expect((await request("llm/v1/models")).status).toBe(404);
+    expect((await request("llm/v2/openai/v1/chat/completions")).status).toBe(
+      404,
+    );
   });
 
   it("retains MCP transport headers but replaces credentials at its fixed endpoint", async () => {
@@ -553,7 +362,9 @@ describe("Studio OpenCode credential bridge", () => {
       } else if (method === "tools/call") {
         calls++;
         callId = id;
-        res.type("text/event-stream").end("id: queued-start\nretry: 10\ndata:\n\n");
+        res
+          .type("text/event-stream")
+          .end("id: queued-start\nretry: 10\ndata:\n\n");
       } else res.status(202).end();
     });
     expect(
@@ -565,7 +376,11 @@ describe("Studio OpenCode credential bridge", () => {
     const client = new Client({ name: "replay-test", version: "1" });
     const transport = new StreamableHTTPClientTransport(
       new URL(`${origin}/opencode-runtime/${credential.id}/mcp`),
-      { requestInit: { headers: { Authorization: `Bearer ${credential.token}` } } },
+      {
+        requestInit: {
+          headers: { Authorization: `Bearer ${credential.token}` },
+        },
+      },
     );
     try {
       await client.connect(transport);
@@ -583,7 +398,7 @@ describe("Studio OpenCode credential bridge", () => {
   });
 
   it("never forwards upstream error bodies or follows redirects with credentials", async () => {
-    upstream.post("/v2/openai/v1/chat/completions", (_req, res) =>
+    upstream.post("/v1/responses", (_req, res) =>
       res.status(401).send("sk_private_studio"),
     );
     const response = await request();
@@ -668,7 +483,7 @@ describe("Studio OpenCode credential bridge", () => {
     "preserves and sanitizes upstream HTTP %i without model-response replay",
     async (status, type, code, message) => {
       let calls = 0;
-      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+      upstream.post("/v1/responses", (_req, res) => {
         calls++;
         res
           .status(status)
@@ -699,7 +514,7 @@ describe("Studio OpenCode credential bridge", () => {
   ] as const)(
     "for HTTP %i validates Retry-After %s before forwarding it",
     async (status, retryAfter, expected) => {
-      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+      upstream.post("/v1/responses", (_req, res) => {
         res.status(status).set("Retry-After", retryAfter).end();
       });
       const response = await request();
@@ -748,7 +563,7 @@ describe("Studio OpenCode credential bridge", () => {
     });
     try {
       const response = await fetch(
-        `http://127.0.0.1:${studio.port}/opencode-runtime/unknown/llm/v2/openai/v1/chat/completions`,
+        `http://127.0.0.1:${studio.port}/opencode-runtime/unknown/llm/v1/responses`,
         {
           method: "POST",
           headers: {
@@ -780,7 +595,7 @@ describe("Studio OpenCode credential bridge", () => {
   });
 
   it("revokes credentials and active streams on access loss, and permits a fresh login", async () => {
-    upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+    upstream.post("/v1/responses", (_req, res) => {
       res.setHeader("Content-Type", "text/event-stream");
       res.write("data: first\n\n");
     });
@@ -806,7 +621,7 @@ describe("Studio OpenCode credential bridge", () => {
     "rejects and revokes a credential after verified %s changes",
     async (field, value) => {
       let calls = 0;
-      upstream.post("/v2/openai/v1/chat/completions", (_req, res) => {
+      upstream.post("/v1/responses", (_req, res) => {
         calls++;
         res.json({ choices: [] });
       });
@@ -854,6 +669,6 @@ describe("Studio OpenCode credential bridge", () => {
         apiURL: "https://api.sapiom.ai",
         services: {},
       }).llm.href,
-    ).toBe("https://llm.services.sapiom.ai/v2/openai/v1/chat/completions");
+    ).toBe("https://router.sapiom.ai/v1/responses");
   });
 });

--- a/packages/harness/src/server/opencode-bridge.test.ts
+++ b/packages/harness/src/server/opencode-bridge.test.ts
@@ -92,6 +92,52 @@ function request(path = "llm/v1/responses", init: RequestInit = {}) {
 }
 
 describe("Studio OpenCode credential bridge", () => {
+  it("bounds failed authentication across model, MCP, and rotating credential IDs", async () => {
+    const forwarded = vi.fn();
+    upstream.use((_req, res) => {
+      forwarded();
+      res.json({ ok: true });
+    });
+    for (let attempt = 0; attempt < 120; attempt++) {
+      const path = attempt % 2 ? "mcp" : "llm/v1/responses";
+      const response = await fetch(
+        `${origin}/opencode-runtime/unknown-${attempt}/${path}`,
+        { method: "POST", headers: { Authorization: "Bearer invalid" } },
+      );
+      expect(response.status).toBe(401);
+      await response.arrayBuffer();
+    }
+    for (const path of ["mcp", "llm/v1/responses"]) {
+      const response = await request(path);
+      expect(response.status).toBe(429);
+      expect(Number(response.headers.get("Retry-After"))).toBeGreaterThan(0);
+      expect(response.headers.get("Cache-Control")).toBe("no-store");
+      expect(await response.json()).toEqual({
+        error: {
+          message:
+            "Too many failed Assistant authentication attempts. Try again shortly.",
+          type: "rate_limit_error",
+          code: "assistant_runtime_rate_limited",
+        },
+      });
+    }
+    expect(forwarded).not.toHaveBeenCalled();
+  });
+
+  it("does not spend the authentication budget on valid traffic or service failures", async () => {
+    let calls = 0;
+    upstream.use((_req, res) => {
+      calls++;
+      res.status(calls % 2 ? 200 : 503).json({ ok: calls % 2 === 1 });
+    });
+    for (let attempt = 0; attempt < 125; attempt++) {
+      const response = await request(attempt % 2 ? "mcp" : undefined);
+      expect(response.status).toBe(attempt % 2 ? 503 : 200);
+      await response.arrayBuffer();
+    }
+    expect(calls).toBe(125);
+  });
+
   const event = (type: string, fields: object = {}) =>
     `event: ${type}\ndata: ${JSON.stringify({ type, ...fields })}\n\n`;
   const completed = () =>

--- a/packages/harness/src/server/opencode-bridge.test.ts
+++ b/packages/harness/src/server/opencode-bridge.test.ts
@@ -138,6 +138,23 @@ describe("Studio OpenCode credential bridge", () => {
     expect(calls).toBe(125);
   });
 
+  it.each([401, 403])(
+    "does not spend the runtime authentication budget on upstream HTTP %i",
+    async (status) => {
+      let calls = 0;
+      upstream.use((_req, res) => {
+        calls++;
+        res.status(status).json({ error: "Upstream credential rejected" });
+      });
+      for (let attempt = 0; attempt < 125; attempt++) {
+        const response = await request(attempt % 2 ? "mcp" : undefined);
+        expect(response.status).toBe(status);
+        await response.arrayBuffer();
+      }
+      expect(calls).toBe(125);
+    },
+  );
+
   const event = (type: string, fields: object = {}) =>
     `event: ${type}\ndata: ${JSON.stringify({ type, ...fields })}\n\n`;
   const completed = () =>

--- a/packages/harness/src/server/opencode-bridge.ts
+++ b/packages/harness/src/server/opencode-bridge.ts
@@ -187,8 +187,8 @@ export class OpenCodeBridge {
       }
     });
     // Share the peer-IP budget across both routes so rotating runtime IDs cannot
-    // bypass it. Completed authorized requests and service outages do not spend
-    // the authentication budget, including long-lived MCP/model streams.
+    // bypass it. Count only local runtime credential rejection: upstream denials
+    // must still reach sign-in recovery, including on long-lived MCP streams.
     const authenticationRateLimit = rateLimit({
       windowMs: 60_000,
       max: 120,
@@ -197,7 +197,7 @@ export class OpenCodeBridge {
       legacyHeaders: false,
       skipSuccessfulRequests: true,
       requestWasSuccessful: (_req, res) =>
-        res.statusCode !== 401 && res.statusCode !== 403,
+        res.locals.assistantRuntimeAuthenticationFailed !== true,
       handler: (_req, res) => {
         sendBridgeError(res, 429, {
           message:
@@ -263,6 +263,7 @@ export class OpenCodeBridge {
       token.length > 256 ||
       !timingSafeEqual(entry.digest, digest(token))
     ) {
+      res.locals.assistantRuntimeAuthenticationFailed = true;
       sendBridgeError(res, 401, {
         message: "Invalid Assistant runtime credential.",
         type: "authentication_error",
@@ -272,6 +273,7 @@ export class OpenCodeBridge {
     }
     if (!grant || !sameAuthority(entry.grant, grant)) {
       this.revoke(req.params.id!);
+      res.locals.assistantRuntimeAuthenticationFailed = true;
       sendBridgeError(res, 403, {
         message: "Assistant access is unavailable.",
         type: "permission_error",

--- a/packages/harness/src/server/opencode-bridge.ts
+++ b/packages/harness/src/server/opencode-bridge.ts
@@ -138,7 +138,7 @@ export function assistantUpstreams(env: ResolvedEnvironment): {
   const configured =
     env.services.llm ??
     (env.name === "production" && env.apiURL === "https://api.sapiom.ai"
-      ? "https://llm.services.sapiom.ai"
+      ? "https://router.sapiom.ai"
       : undefined);
   if (!configured)
     throw new Error(
@@ -163,7 +163,7 @@ export function assistantUpstreams(env: ResolvedEnvironment): {
     return url;
   };
   return {
-    llm: new URL("/v2/openai/v1/chat/completions", root(configured)),
+    llm: new URL("/v1/responses", root(configured)),
     mcp: new URL("/v1/mcp", root(env.apiURL)),
   };
 }
@@ -176,7 +176,7 @@ export class OpenCodeBridge {
 
   constructor(
     private readonly access: Access,
-    readonly model = "smart",
+    readonly model = "gpt-luna",
   ) {
     this.unsubscribe = access.subscribe(() => {
       const grant = access.get();
@@ -185,13 +185,9 @@ export class OpenCodeBridge {
       }
     });
     const raw = express.raw({ type: () => true, limit: "4mb" });
-    this.router.all(
-      "/:id/llm/v2/openai/v1/chat/completions",
-      raw,
-      (req, res) => {
-        void this.forward(req, res, "llm");
-      },
-    );
+    this.router.all("/:id/llm/v1/responses", raw, (req, res) => {
+      void this.forward(req, res, "llm");
+    });
     this.router.all("/:id/mcp", raw, (req, res) => {
       void this.forward(req, res, "mcp");
     });
@@ -278,9 +274,7 @@ export class OpenCodeBridge {
         "Accept-Encoding": "identity",
         Accept: req.header("Accept") ?? "application/json",
         "Content-Type": "application/json",
-        ...(service === "llm"
-          ? { "x-sapiom-api-key": key, "x-sapiom-model": this.model }
-          : { "x-api-key": key }),
+        "x-api-key": key,
       });
       // Queued MCP tools close the POST stream and deliver results through
       // GET replay. Its cursor must survive the credential bridge.
@@ -315,7 +309,9 @@ export class OpenCodeBridge {
           });
           return;
         }
-        body = Buffer.from(JSON.stringify({ ...request, model: this.model }));
+        body = Buffer.from(
+          JSON.stringify({ ...request, model: this.model, store: false }),
+        );
         streamingModel = request.stream === true;
         completionToken = openCodeModelCompletionToken(request);
       }

--- a/packages/harness/src/server/opencode-bridge.ts
+++ b/packages/harness/src/server/opencode-bridge.ts
@@ -7,6 +7,7 @@ import {
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import express, { type Request, type Response, type Router } from "express";
+import rateLimit, { MemoryStore } from "express-rate-limit";
 import type { ResolvedEnvironment } from "@sapiom/mcp/auth";
 import type {
   AssistantAccess,
@@ -172,6 +173,7 @@ export function assistantUpstreams(env: ResolvedEnvironment): {
 export class OpenCodeBridge {
   readonly router: Router = express.Router();
   private registrations = new Map<string, Registration>();
+  private readonly authenticationAttempts = new MemoryStore();
   private unsubscribe: () => void;
 
   constructor(
@@ -184,11 +186,37 @@ export class OpenCodeBridge {
         if (!grant || !sameAuthority(entry.grant, grant)) this.revoke(id);
       }
     });
-    const raw = express.raw({ type: () => true, limit: "4mb" });
-    this.router.all("/:id/llm/v1/responses", raw, (req, res) => {
-      void this.forward(req, res, "llm");
+    // Share the peer-IP budget across both routes so rotating runtime IDs cannot
+    // bypass it. Completed authorized requests and service outages do not spend
+    // the authentication budget, including long-lived MCP/model streams.
+    const authenticationRateLimit = rateLimit({
+      windowMs: 60_000,
+      max: 120,
+      store: this.authenticationAttempts,
+      standardHeaders: true,
+      legacyHeaders: false,
+      skipSuccessfulRequests: true,
+      requestWasSuccessful: (_req, res) =>
+        res.statusCode !== 401 && res.statusCode !== 403,
+      handler: (_req, res) => {
+        sendBridgeError(res, 429, {
+          message:
+            "Too many failed Assistant authentication attempts. Try again shortly.",
+          type: "rate_limit_error",
+          code: "assistant_runtime_rate_limited",
+        });
+      },
     });
-    this.router.all("/:id/mcp", raw, (req, res) => {
+    const raw = express.raw({ type: () => true, limit: "4mb" });
+    this.router.all(
+      "/:id/llm/v1/responses",
+      authenticationRateLimit,
+      raw,
+      (req, res) => {
+        void this.forward(req, res, "llm");
+      },
+    );
+    this.router.all("/:id/mcp", authenticationRateLimit, raw, (req, res) => {
       void this.forward(req, res, "mcp");
     });
     this.router.use((_req, res) => {
@@ -213,6 +241,7 @@ export class OpenCodeBridge {
   close(): void {
     this.unsubscribe();
     for (const id of this.registrations.keys()) this.revoke(id);
+    this.authenticationAttempts.shutdown();
   }
 
   private revoke(id: string): void {

--- a/packages/harness/src/server/opencode-model-response.test.ts
+++ b/packages/harness/src/server/opencode-model-response.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it, vi } from "vitest";
+import { openCodeCompletionPrompt } from "../shared/opencode-completion.js";
+import {
+  fetchOpenCodeModelResponse,
+  openCodeModelCompletionToken,
+} from "./opencode-model-response.js";
+
+const event = (type: string, fields: object = {}) =>
+  `event: ${type}\ndata: ${JSON.stringify({ type, ...fields })}\n\n`;
+const completed = (output: unknown[] = []) =>
+  event("response.completed", {
+    response: {
+      status: "completed",
+      output,
+      error: null,
+      incomplete_details: null,
+    },
+  });
+const reasoning = event("response.reasoning_summary_text.delta", {
+  delta: "Working through the request.",
+});
+const empty = reasoning + completed([{ type: "reasoning", summary: [] }]);
+const text = (delta: string) => event("response.output_text.delta", { delta });
+const signal = () => new AbortController().signal;
+const stream = (body: BodyInit) =>
+  new Response(body, { headers: { "Content-Type": "text/event-stream" } });
+
+describe("Responses completion contract", () => {
+  it("reads instructions and system/developer input without adopting user or tool content", () => {
+    const { system } = openCodeCompletionPrompt();
+    const token = system.split("\n")[0]!.split(":")[1];
+    expect(openCodeModelCompletionToken({ instructions: system })).toBe(token);
+    for (const role of ["system", "developer"]) {
+      expect(
+        openCodeModelCompletionToken({ input: [{ role, content: system }] }),
+      ).toBe(token);
+      expect(
+        openCodeModelCompletionToken({
+          input: [
+            {
+              type: "message",
+              role,
+              content: [{ type: "input_text", text: system }],
+            },
+          ],
+        }),
+      ).toBe(token);
+    }
+    for (const role of ["user", "assistant", "tool"]) {
+      expect(
+        openCodeModelCompletionToken({ input: [{ role, content: system }] }),
+      ).toBeUndefined();
+    }
+    for (const input of [
+      system,
+      [{ type: "function_call_output", output: system }],
+      [{ role: "developer", content: [{ type: "image", text: system }] }],
+      [null],
+    ])
+      expect(openCodeModelCompletionToken({ input })).toBeUndefined();
+    expect(
+      openCodeModelCompletionToken({
+        instructions: system.replace("/v2:", "/v1:"),
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("Responses stream retry inspection", () => {
+  it("retries reasoning-only completion and forwards the first useful text before EOF", async () => {
+    let finish!: () => void;
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(text("Actual answer")));
+        finish = () => controller.close();
+      },
+    });
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(stream(empty))
+      .mockResolvedValueOnce(stream(source));
+    const response = await fetchOpenCodeModelResponse(request, signal());
+    const reader = response.body!.getReader();
+    expect(new TextDecoder().decode((await reader.read()).value)).toContain(
+      "Actual answer",
+    );
+    expect(request).toHaveBeenCalledTimes(2);
+    finish();
+    await reader.cancel();
+  });
+
+  it("bounds retries for clean empty and unmarked final responses", async () => {
+    const { system } = openCodeCompletionPrompt();
+    const token = openCodeModelCompletionToken({ instructions: system });
+    for (const body of [empty, text("I'll do it next.") + completed()]) {
+      const request = vi.fn(async () => stream(body));
+      expect(
+        await (
+          await fetchOpenCodeModelResponse(request, signal(), token)
+        ).text(),
+      ).toBe(body);
+      expect(request).toHaveBeenCalledTimes(3);
+    }
+  });
+
+  it("recognizes a marked answer split across events and does not require terminal EOF to stream", async () => {
+    const { system } = openCodeCompletionPrompt();
+    const token = openCodeModelCompletionToken({ instructions: system })!;
+    const answer = `<!-- studio-result:${token}:finished -->\nDone`;
+    let finish!: () => void;
+    const request = vi.fn(async () =>
+      stream(
+        new ReadableStream({
+          start(controller) {
+            for (const delta of [answer.slice(0, 20), answer.slice(20)])
+              controller.enqueue(new TextEncoder().encode(text(delta)));
+            finish = () => controller.close();
+          },
+        }),
+      ),
+    );
+    const response = await fetchOpenCodeModelResponse(request, signal(), token);
+    finish();
+    const body = await response.text();
+    expect(body).toContain(answer.slice(0, 20));
+    expect(body).toContain("Done");
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["function_call", { call_id: "call_one", name: "write", arguments: "" }],
+    ["custom_tool_call", { call_id: "call_one", name: "patch", input: "" }],
+    ["web_search_call", {}],
+    ["computer_call", {}],
+    ["future_tool_call", {}],
+  ])(
+    "commits the stream at the first %s before it can be executed",
+    async (type, fields) => {
+      let finish!: () => void;
+      const call = event("response.output_item.added", {
+        item: { type, ...fields },
+      });
+      const request = vi.fn(async () =>
+        stream(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode(reasoning + call));
+              finish = () => controller.close();
+            },
+          }),
+        ),
+      );
+      const response = await fetchOpenCodeModelResponse(request, signal());
+      finish();
+      expect(await response.text()).toBe(reasoning + call);
+      expect(request).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("passes through a tool or answer present only in the final output snapshot", async () => {
+    for (const item of [
+      {
+        type: "function_call",
+        call_id: "call_one",
+        name: "write",
+        arguments: "{}",
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "Done" }],
+      },
+      {
+        type: "message",
+        role: "assistant",
+        content: [{ type: "refusal", refusal: "Cannot comply" }],
+      },
+    ]) {
+      const body = completed([item]);
+      const request = vi.fn(async () => stream(body));
+      expect(
+        await (await fetchOpenCodeModelResponse(request, signal())).text(),
+      ).toBe(body);
+      expect(request).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it.each([
+    event("response.failed", {
+      response: { status: "failed", error: { code: "server_error" } },
+    }),
+    event("response.incomplete", {
+      response: {
+        status: "incomplete",
+        incomplete_details: { reason: "max_output_tokens" },
+      },
+    }),
+    event("error", { message: "Upstream failed" }),
+    event("response.output_text.delta", { delta: 1 }),
+    event("response.output_text.done", { text: 1 }),
+    event("response.content_part.added", {
+      part: { type: "refusal", refusal: "No" },
+    }),
+    event("response.output_item.added", {
+      item: { type: "reasoning", summary: "invalid" },
+    }),
+    event("response.output_item.done", {
+      item: { type: "message", role: "tool", content: [] },
+    }),
+    event("response.function_call_arguments.delta", { delta: "{" }),
+    event("response.future_event"),
+    event("response.completed", {
+      response: { status: "incomplete", output: [] },
+    }),
+    event("response.completed", {
+      response: {
+        status: "completed",
+        output: [],
+        error: { code: "server_error" },
+      },
+    }),
+    event("response.completed", {
+      response: { status: "completed", output: null },
+    }),
+    'data: {"choices":[]}\n\n',
+    "data: malformed\n\n",
+    "data: [DONE]\n\n",
+    empty +
+      event("response.in_progress", {
+        response: { status: "in_progress", output: [] },
+      }),
+  ])(
+    "does not retry errors, tools or uncertain Responses streams (%#)",
+    async (prefix) => {
+      const body = prefix + empty;
+      const request = vi.fn(async () => stream(body));
+      expect(
+        await (await fetchOpenCodeModelResponse(request, signal())).text(),
+      ).toBe(body);
+      expect(request).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("does not retry a truncated stream, trailing garbage, or oversized prefix", async () => {
+    for (const body of [
+      reasoning,
+      empty + "data: unfinished",
+      text("x".repeat(1024 * 1024)) + empty,
+    ]) {
+      const request = vi.fn(async () => stream(body));
+      expect(
+        await (await fetchOpenCodeModelResponse(request, signal())).text(),
+      ).toBe(body);
+      expect(request).toHaveBeenCalledTimes(1);
+    }
+    const body = Buffer.concat([Buffer.from(empty), Buffer.from([0xc3])]);
+    const request = vi.fn(async () => stream(body));
+    expect(
+      Buffer.from(
+        await (
+          await fetchOpenCodeModelResponse(request, signal())
+        ).arrayBuffer(),
+      ),
+    ).toEqual(body);
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it("recognizes a clean completion with byte-split UTF-8 and CRLF framing", async () => {
+    const body = Buffer.from(
+      (
+        event("response.reasoning_summary_text.delta", { delta: "café" }) +
+        completed()
+      ).replace(/\n/g, "\r\n"),
+    );
+    const request = vi
+      .fn()
+      .mockImplementationOnce(async () =>
+        stream(
+          new ReadableStream({
+            start(controller) {
+              for (let i = 0; i < body.length; i++)
+                controller.enqueue(body.subarray(i, i + 1));
+              controller.close();
+            },
+          }),
+        ),
+      )
+      .mockImplementationOnce(async () => stream(text("Done") + completed()));
+    expect(
+      await (await fetchOpenCodeModelResponse(request, signal())).text(),
+    ).toContain("Done");
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves non-stream and HTTP error handling to the credential bridge", async () => {
+    for (const response of [
+      new Response("{}"),
+      new Response("error", { status: 429 }),
+    ]) {
+      const request = vi.fn(async () => response);
+      expect(await fetchOpenCodeModelResponse(request, signal())).toBe(
+        response,
+      );
+      expect(request).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/packages/harness/src/server/opencode-model-response.ts
+++ b/packages/harness/src/server/opencode-model-response.ts
@@ -19,30 +19,36 @@ export async function fetchOpenCodeModelResponse(
   }
 }
 
-/** Native sends the current contract in system text, never user/tool history. */
+/** Responses carries the native contract in instructions or trusted input roles. */
 export function openCodeModelCompletionToken(request: Record<string, unknown>) {
-  if (!Array.isArray(request.messages)) return;
+  const texts: string[] = [];
+  if (typeof request.instructions === "string")
+    texts.push(request.instructions);
+  for (const message of Array.isArray(request.input) ? request.input : []) {
+    if (
+      !message ||
+      (message.type != null && message.type !== "message") ||
+      !["system", "developer"].includes(message.role)
+    )
+      continue;
+    if (typeof message.content === "string") texts.push(message.content);
+    else if (Array.isArray(message.content))
+      for (const part of message.content)
+        if (part?.type === "input_text" && typeof part.text === "string")
+          texts.push(part.text);
+  }
   let token: string | undefined;
-  for (const message of request.messages) {
-    if (!message || message.role !== "system") continue;
-    const content =
-      typeof message.content === "string"
-        ? message.content
-        : Array.isArray(message.content)
-          ? message.content
-              .filter(
-                (part: { type?: string; text?: unknown }) =>
-                  part?.type === "text" && typeof part.text === "string",
-              )
-              .map((part: { text: string }) => part.text)
-              .join("\n")
-          : "";
+  for (const content of texts) {
     for (const match of content.matchAll(
       /(?:^|\n)StudioAssistantResult\/v2:([a-f0-9-]{36})\n/g,
     ))
       token = match[1];
   }
   return token;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
 async function inspect(response: Response, completionToken?: string) {
@@ -58,8 +64,38 @@ async function inspect(response: Response, completionToken?: string) {
   let pending = "",
     content = "",
     size = 0,
-    stopped = false,
     ended = false;
+  // A marker commits streaming, not completion: native terminal state still
+  // rejects errors, absent answers, or simultaneous tools.
+  const commitsText = (text: string) =>
+    !!text.trim() &&
+    (!completionToken || !!parseOpenCodeCompletion(text, completionToken));
+  const canBufferPart = (part: unknown): boolean =>
+    record(part) &&
+    part.type === "output_text" &&
+    typeof part.text === "string" &&
+    !commitsText(part.text);
+  const canBufferItem = (item: unknown): boolean => {
+    if (!record(item)) return false;
+    if (item.type === "reasoning")
+      return (
+        Array.isArray(item.summary) &&
+        item.summary.every(
+          (part) =>
+            record(part) &&
+            part.type === "summary_text" &&
+            typeof part.text === "string",
+        )
+      );
+    // Every tool kind (including future ones) commits the stream before native
+    // can execute it. Refusals and unknown output also pass through unchanged.
+    return (
+      item.type === "message" &&
+      item.role === "assistant" &&
+      Array.isArray(item.content) &&
+      item.content.every(canBufferPart)
+    );
+  };
   const replay = (empty = false) => ({
     empty,
     response: new Response(
@@ -100,7 +136,7 @@ async function inspect(response: Response, completionToken?: string) {
         } catch {
           return replay();
         }
-        return replay(stopped && ended && !pending.trim());
+        return replay(ended && !pending.trim());
       }
       prefix.push(next.value);
       size += next.value.byteLength;
@@ -121,64 +157,68 @@ async function inspect(response: Response, completionToken?: string) {
         if (!lines.length) continue;
         const data = lines.map((line) => line.slice(5).trimStart()).join("\n");
         if (ended) return replay();
-        if (data === "[DONE]") {
-          ended = true;
-          continue;
-        }
         let value;
         try {
           value = JSON.parse(data);
         } catch {
           return replay();
         }
-        if (
-          !value ||
-          value.error ||
-          !Array.isArray(value.choices) ||
-          value.choices.length > 1
-        )
-          return replay();
-        for (const choice of value.choices) {
-          if (!choice || typeof choice !== "object" || choice.index !== 0)
+        if (!record(value) || value.error != null) return replay();
+        switch (value.type) {
+          case "response.created":
+          case "response.in_progress":
+          case "response.completed": {
+            const result = value.response;
+            if (
+              !record(result) ||
+              result.error != null ||
+              result.incomplete_details != null ||
+              !Array.isArray(result.output) ||
+              !result.output.every(canBufferItem)
+            )
+              return replay();
+            if (value.type === "response.completed") {
+              if (result.status !== "completed") return replay();
+              ended = true;
+            } else if (result.status !== "in_progress") return replay();
+            break;
+          }
+          case "response.output_item.added":
+          case "response.output_item.done":
+            if (!canBufferItem(value.item)) return replay();
+            break;
+          case "response.content_part.added":
+          case "response.content_part.done":
+            if (!canBufferPart(value.part)) return replay();
+            break;
+          case "response.output_text.delta":
+            if (typeof value.delta !== "string") return replay();
+            content += value.delta;
+            if (commitsText(content)) return replay();
+            break;
+          case "response.output_text.done":
+            if (typeof value.text !== "string" || commitsText(value.text))
+              return replay();
+            break;
+          case "response.reasoning_summary_text.delta":
+          case "response.reasoning_text.delta":
+            if (typeof value.delta !== "string") return replay();
+            break;
+          case "response.reasoning_summary_text.done":
+          case "response.reasoning_text.done":
+            if (typeof value.text !== "string") return replay();
+            break;
+          case "response.reasoning_summary_part.added":
+          case "response.reasoning_summary_part.done":
+            if (
+              !record(value.part) ||
+              value.part.type !== "summary_text" ||
+              typeof value.part.text !== "string"
+            )
+              return replay();
+            break;
+          default:
             return replay();
-          const delta = choice.delta;
-          if (!delta || typeof delta !== "object" || Array.isArray(delta))
-            return replay();
-          if (
-            (delta.role != null && delta.role !== "assistant") ||
-            [delta.reasoning_content, delta.reasoning].some(
-              (value) => value != null && typeof value !== "string",
-            ) ||
-            (delta.reasoning_details != null &&
-              !Array.isArray(delta.reasoning_details)) ||
-            (delta.content != null && typeof delta.content !== "string") ||
-            delta.tool_calls != null ||
-            delta.function_call != null ||
-            delta.refusal != null ||
-            Object.keys(delta).some(
-              (key) =>
-                ![
-                  "role",
-                  "content",
-                  "reasoning_content",
-                  "reasoning",
-                  "reasoning_details",
-                ].includes(key),
-            ) ||
-            (choice.finish_reason != null && choice.finish_reason !== "stop")
-          )
-            return replay();
-          content += delta.content ?? "";
-          // A marker commits streaming, not completion: native terminal state
-          // still rejects errors, absent answers, or simultaneous tools.
-          // Any tool fragment above also commits the stream before execution.
-          if (
-            content.trim() &&
-            (!completionToken ||
-              parseOpenCodeCompletion(content, completionToken))
-          )
-            return replay();
-          if (choice.finish_reason === "stop") stopped = true;
         }
       }
     }

--- a/packages/harness/src/server/opencode.test.ts
+++ b/packages/harness/src/server/opencode.test.ts
@@ -103,6 +103,7 @@ beforeEach(async () => {
       return fetch(`${nativeOrigin}${path}`, { ...init, headers });
     };
     hosts.set(id, {
+      model: { providerID: "sapiom", modelID: "gpt-luna" },
       harnessSessionId: id,
       cwd: root,
       stateRoot,
@@ -300,6 +301,7 @@ describe("Studio-scoped OpenCode transport", () => {
     )!;
     expect(native.body).toEqual({
       ...body,
+      model: { providerID: "sapiom", modelID: "gpt-luna" },
       system: expect.stringContaining("StudioAssistantResult/v2:"),
     });
     expect(native.body).not.toHaveProperty("format");

--- a/packages/harness/src/server/opencode.ts
+++ b/packages/harness/src/server/opencode.ts
@@ -135,6 +135,8 @@ export function createOpenCodeRouter(
               body: JSON.stringify({
                 ...req.body,
                 ...openCodeCompletionPrompt(),
+                // Saved conversations may still remember a retired model.
+                model: hosted.model,
               }),
             }
           : {}),
@@ -150,7 +152,7 @@ export function createOpenCodeRouter(
           openCodeTransportFailure(
             upstream.status === 404 && conversation
               ? "native_history_missing"
-            : "transport_unavailable",
+              : "transport_unavailable",
           ),
         );
         return;

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -13,7 +13,11 @@ await server.close();
 ```
 
 The bridge URL must be loopback. Only its revocable credential enters the model
-and remote MCP configuration. The runtime inherits an allowlist of platform
+and remote MCP configuration. The default model is `sapiom/gpt-luna`, using
+the bundled Responses provider at the bridge's `/llm/v1/responses` route.
+Low reasoning effort, encrypted reasoning history, and `store: false` keep
+reasoning and tool use compatible with the Sapiom router across turns.
+The runtime inherits an allowlist of platform
 environment variables; provider keys and the Electron esbuild pin are excluded
 from the runtime. A controlled native plugin removes the bridge configuration
 and runtime-admin credential from the runtime environment before tool execution,

--- a/packages/opencode/src/__fixtures__/server.mjs
+++ b/packages/opencode/src/__fixtures__/server.mjs
@@ -106,9 +106,7 @@ if (!config.startupExitWriter)
             configChecks: {
               model: config.model,
               modelBridge:
-                config.provider?.sapiom?.options?.baseURL?.endsWith(
-                  "/llm/v2/openai/v1",
-                ),
+                config.provider?.sapiom?.options?.baseURL?.endsWith("/llm/v1"),
               mcpBridge: config.mcp?.sapiom?.url?.endsWith("/mcp"),
             },
           }),

--- a/packages/opencode/src/config.ts
+++ b/packages/opencode/src/config.ts
@@ -21,7 +21,7 @@ export function createSapiomOpenCodeConfig(
     throw new Error("OpenCode requires a private loopback credential bridge");
   }
   const base = bridge.href.replace(/\/+$/, "");
-  const model = options.model ?? "smart";
+  const model = options.model ?? "gpt-luna";
   return {
     $schema: "https://opencode.ai/config.json",
     model: `sapiom/${model}`,
@@ -41,13 +41,26 @@ export function createSapiomOpenCodeConfig(
     },
     provider: {
       sapiom: {
-        npm: "@ai-sdk/openai-compatible",
+        npm: "@ai-sdk/openai",
         name: "Sapiom",
         options: {
           apiKey: options.runtimeToken,
-          baseURL: `${base}/llm/v2/openai/v1`,
+          baseURL: `${base}/llm/v1`,
         },
-        models: { [model]: { name: `Sapiom · ${model}` } },
+        models: {
+          [model]: {
+            name: `Sapiom · ${model}`,
+            limit: { context: 400_000, output: 128_000 },
+            options: {
+              reasoningEffort: "low",
+              reasoningSummary: "auto",
+              // Carry reasoning with the conversation through Studio's saved
+              // history; never depend on a vendor-side previous_response_id.
+              store: false,
+              include: ["reasoning.encrypted_content"],
+            },
+          },
+        },
       },
     },
     mcp: {

--- a/packages/opencode/src/server.native.test.ts
+++ b/packages/opencode/src/server.native.test.ts
@@ -46,6 +46,11 @@ async function readRequestBody(request: IncomingMessage): Promise<unknown> {
   return body ? (JSON.parse(body) as unknown) : undefined;
 }
 
+interface ModelRequest extends Record<string, unknown> {
+  tools?: Array<{ type: string; name: string }>;
+  input?: Array<{ type?: string; [key: string]: unknown }>;
+}
+
 async function startSyntheticBridge(token: string) {
   const state = {
     valid: true,
@@ -53,6 +58,8 @@ async function startSyntheticBridge(token: string) {
     mcpAuthorized: 0,
     rejected: 0,
     requests: [] as string[],
+    modelRequests: [] as ModelRequest[],
+    toolCalls: [] as unknown[],
   };
   bridge = createServer(async (request, response) => {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
@@ -81,7 +88,11 @@ async function startSyntheticBridge(token: string) {
       const message = (await readRequestBody(request)) as {
         id?: string | number;
         method?: string;
-        params?: { protocolVersion?: string };
+        params?: {
+          protocolVersion?: string;
+          name?: string;
+          arguments?: { a: number; b: number };
+        };
       };
       if (message.id === undefined) {
         response.writeHead(202).end();
@@ -95,44 +106,156 @@ async function startSyntheticBridge(token: string) {
               serverInfo: { name: "synthetic", version: "1" },
             }
           : message.method === "tools/list"
-            ? { tools: [] }
-            : {};
+            ? {
+                tools: [
+                  {
+                    name: "probe_add",
+                    description: "Add two integers",
+                    inputSchema: {
+                      type: "object",
+                      properties: {
+                        a: { type: "integer" },
+                        b: { type: "integer" },
+                      },
+                      required: ["a", "b"],
+                    },
+                  },
+                ],
+              }
+            : message.method === "tools/call"
+              ? {
+                  content: [
+                    {
+                      type: "text",
+                      text: String(
+                        (message.params?.arguments?.a ?? 0) +
+                          (message.params?.arguments?.b ?? 0),
+                      ),
+                    },
+                  ],
+                }
+              : {};
+      if (message.method === "tools/call") state.toolCalls.push(message.params);
       response.writeHead(200, { "Content-Type": "application/json" });
       response.end(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }));
       return;
     }
-    if (url.pathname.endsWith("/chat/completions")) {
+    if (url.pathname.endsWith("/responses")) {
       state.modelAuthorized++;
-      await readRequestBody(request);
+      const body = (await readRequestBody(request)) as ModelRequest;
+      state.modelRequests.push(body);
       response.writeHead(200, {
         "Content-Type": "text/event-stream",
         "Cache-Control": "no-cache",
       });
-      response.write(
-        `data: ${JSON.stringify({
-          id: "chatcmpl_synthetic",
-          object: "chat.completion.chunk",
-          created: 1,
-          model: "smart",
-          choices: [
+      const emit = (type: string, fields: object) =>
+        response.write(
+          `event: ${type}\ndata: ${JSON.stringify({ type, ...fields })}\n\n`,
+        );
+      const id = `resp_${state.modelAuthorized}`;
+      const reasonId = `rs_${state.modelAuthorized}`;
+      const reason = {
+        id: reasonId,
+        type: "reasoning",
+        summary: [{ type: "summary_text", text: "Synthetic reasoning" }],
+        encrypted_content: "encrypted-synthetic-reasoning",
+        status: "completed",
+      };
+      const base = { id, object: "response", created_at: 1, model: "gpt-luna" };
+      emit("response.created", {
+        response: { ...base, status: "in_progress", output: [] },
+      });
+      emit("response.output_item.added", {
+        output_index: 0,
+        item: { ...reason, status: "in_progress", summary: [] },
+      });
+      emit("response.reasoning_summary_part.added", {
+        item_id: reasonId,
+        output_index: 0,
+        summary_index: 0,
+        part: { type: "summary_text", text: "" },
+      });
+      emit("response.reasoning_summary_text.delta", {
+        item_id: reasonId,
+        output_index: 0,
+        summary_index: 0,
+        delta: "Synthetic reasoning",
+      });
+      emit("response.reasoning_summary_text.done", {
+        item_id: reasonId,
+        output_index: 0,
+        summary_index: 0,
+        text: "Synthetic reasoning",
+      });
+      emit("response.output_item.done", { output_index: 0, item: reason });
+      const tool = body.tools?.find(
+        (tool: { type: string; name: string }) =>
+          tool.type === "function" && tool.name === "execute",
+      );
+      const hasResult = body.input?.some(
+        (item: { type?: string }) => item.type === "function_call_output",
+      );
+      let output;
+      if (tool && !hasResult && body.tool_choice !== "none") {
+        output = {
+          id: "fc_once",
+          type: "function_call",
+          call_id: "call_once",
+          name: tool.name,
+          arguments: JSON.stringify({
+            code: "return await tools.sapiom.probe_add({a:2,b:3})",
+          }),
+          status: "completed",
+        };
+        emit("response.output_item.added", {
+          output_index: 1,
+          item: { ...output, arguments: "", status: "in_progress" },
+        });
+        emit("response.function_call_arguments.delta", {
+          item_id: output.id,
+          output_index: 1,
+          delta: output.arguments,
+        });
+        emit("response.function_call_arguments.done", {
+          item_id: output.id,
+          output_index: 1,
+          arguments: output.arguments,
+        });
+      } else {
+        output = {
+          id: `msg_${state.modelAuthorized}`,
+          type: "message",
+          role: "assistant",
+          content: [
             {
-              index: 0,
-              delta: { role: "assistant", content: "synthetic native reply" },
-              finish_reason: null,
+              type: "output_text",
+              text: "synthetic native reply",
+              annotations: [],
             },
           ],
-        })}\n\n`,
-      );
-      response.write(
-        `data: ${JSON.stringify({
-          id: "chatcmpl_synthetic",
-          object: "chat.completion.chunk",
-          created: 1,
-          model: "smart",
-          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
-        })}\n\n`,
-      );
-      response.end("data: [DONE]\n\n");
+          status: "completed",
+        };
+        emit("response.output_item.added", {
+          output_index: 1,
+          item: { ...output, content: [], status: "in_progress" },
+        });
+        emit("response.output_text.delta", {
+          item_id: output.id,
+          output_index: 1,
+          content_index: 0,
+          delta: "synthetic native reply",
+        });
+      }
+      emit("response.output_item.done", { output_index: 1, item: output });
+      emit("response.completed", {
+        response: {
+          ...base,
+          status: "completed",
+          output: [reason, output],
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        },
+      });
+      response.end();
       return;
     }
     response.writeHead(404).end();
@@ -317,7 +440,7 @@ describe("pinned OpenCode 1.18.29", () => {
     expect(nativeConfig.plugin?.[0]).toContain("credential-isolation.mjs");
   }, 60_000);
 
-  it("authenticates model and MCP requests and rejects a revoked runtime credential", async () => {
+  it("uses Luna Responses for a complete MCP tool round trip and rejects a revoked runtime credential", async () => {
     const token = "synthetic-bridge-grant";
     const synthetic = await startSyntheticBridge(token);
     runtime = await startOpenCodeServer({
@@ -358,6 +481,47 @@ describe("pinned OpenCode 1.18.29", () => {
       }),
     );
     expect(synthetic.state.modelAuthorized).toBeGreaterThan(0);
+    expect(
+      synthetic.state.toolCalls,
+      JSON.stringify(
+        synthetic.state.modelRequests.map((body) =>
+          body.tools?.map((tool) => tool.name),
+        ),
+      ),
+    ).toEqual([
+      expect.objectContaining({ name: "probe_add", arguments: { a: 2, b: 3 } }),
+    ]);
+    for (const body of synthetic.state.modelRequests) {
+      expect(body).toMatchObject({
+        model: "gpt-luna",
+        reasoning: { effort: "low", summary: "auto" },
+        store: false,
+        include: ["reasoning.encrypted_content"],
+      });
+      expect(body).not.toHaveProperty("previous_response_id");
+    }
+    const continued = synthetic.state.modelRequests.find((body) =>
+      body.input?.some(
+        (item: { type?: string }) => item.type === "function_call_output",
+      ),
+    );
+    expect(continued?.input).toContainEqual(
+      expect.objectContaining({
+        type: "function_call_output",
+        call_id: "call_once",
+      }),
+    );
+    expect(continued?.input).toContainEqual(
+      expect.objectContaining({
+        type: "reasoning",
+        encrypted_content: "encrypted-synthetic-reasoning",
+      }),
+    );
+    expect(
+      synthetic.state.requests.some((path) =>
+        path.endsWith("/chat/completions"),
+      ),
+    ).toBe(false);
 
     synthetic.state.valid = false;
     const disconnected = await runtime.fetch(`/mcp/sapiom/disconnect`, {

--- a/packages/opencode/src/server.test.ts
+++ b/packages/opencode/src/server.test.ts
@@ -101,6 +101,24 @@ describe("packaged OpenCode runtime", () => {
       bridgeUrl: "http://127.0.0.1:1234/opencode-runtime/runtime",
       runtimeToken: "scoped-token",
     });
+    expect(config.provider).toMatchObject({
+      sapiom: {
+        npm: "@ai-sdk/openai",
+        options: {
+          apiKey: "scoped-token",
+          baseURL: "http://127.0.0.1:1234/opencode-runtime/runtime/llm/v1",
+        },
+        models: {
+          "gpt-luna": {
+            options: {
+              store: false,
+              include: ["reasoning.encrypted_content"],
+              reasoningEffort: "low",
+            },
+          },
+        },
+      },
+    });
     server = await startOpenCodeServer({
       ...options(config),
       environment: {
@@ -135,7 +153,7 @@ describe("packaged OpenCode runtime", () => {
       expect([...inspected.keys, ...inspected.runtimeKeys]).not.toContain(key);
     expect(inspected.credentialValueInherited).toBe(false);
     expect(inspected.configChecks).toEqual({
-      model: "sapiom/smart",
+      model: "sapiom/gpt-luna",
       modelBridge: true,
       mcpBridge: true,
     });


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The Assistant still calls the retired gateway path and the abstract `smart` model. Move its model traffic to the rebuilt router and select Luna explicitly, including when continuing a saved conversation that remembers `smart`.

## Summary and scope

Send authenticated model requests to `https://router.sapiom.ai/v1/responses` with `model: gpt-luna`, using the signed-in account's host-held `x-api-key`. Configure the pinned native runtime's Responses provider with low reasoning effort, encrypted reasoning history, and `store: false`. Explicitly select Luna on ordinary and recovery prompts so saved conversations keep their history while changing models.

Adapt the existing bounded response inspection to Responses streaming events. Preserve the three-attempt limit, commit streaming before any tool call can execute, and pass through errors, refusals, incomplete responses, unknown events, truncated frames, and oversized buffered prefixes. Browser credentials remain separate from the runtime credential; account changes and revocation retain their existing boundaries.

Apply one peer-IP authentication-failure budget to the model and MCP bridge routes: 120 failed attempts per minute, shared across runtime IDs, with structured HTTP 429 and Retry-After. Completed requests with valid runtime credentials release their budget, including upstream 401/403 responses, preserving normal tool traffic and sign-in recovery. The bridge owns and closes its limiter store.

Split browser CI across two standard runners with two workers each, keep canvas checks on the first runner, and give each shard a separate failure report. Preserve the full suite and its existing per-test deadlines, retries, and 20-minute job cap. This is the same workflow correction included in #950; Playwright discovery there confirms all 681 cases are covered exactly once across the two shards.

The migration is separate from #950's marker-display and conversation-mount fixes. It preserves the current completion/recovery policy; the live limitations below still need the existing recovery follow-up.

Size: 1,300 changed lines across 19 files, measured as Git additions plus deletions against `origin/main`: 1,010 test/fixture lines and 290 implementation/documentation/changeset/workflow lines. `pnpm pr:size` is not defined in this repository. The provider, bridge routes, outgoing protocol, stream inspection, and saved-model selection must change together to keep the runtime usable.

## Related work

Related issue or discussion:
[Studio-owned Assistant credentials](https://linear.app/sapiom/issue/SAP-3289/auth-connect-opencode-through-studio-owned-sapiom-credentials).

Related delivery: #950. The known completion/duplicate-explanation findings belong to [Assistant recovery](https://linear.app/sapiom/issue/SAP-3295/ui-stop-assistant-work-and-recover-failed-operations).

## Validation

Final GitHub validation at `eff8fe0`: all checks pass, including Node 20/22, CodeQL, Devin review, desktop smoke, both browser shards (**336 + 335 passed; zero retries**), and all **15 canvas tests**. The browser jobs finish in about 10 minutes within the 20-minute cap. Devin explicitly confirmed that the upstream-authentication review finding is resolved.

```text
pnpm build — passed across the workspace
pnpm typecheck — passed across the workspace
pnpm lint — passed across the workspace (existing warnings, zero errors)
pnpm test — one existing Agent Core bundle-error permission-diagnostic test failed; the recursive command stopped before downstream packages
pnpm -r --no-bail --filter @sapiom/agent-studio --filter @sapiom/cli --filter @sapiom/harness --filter @sapiom/harness-desktop --filter @sapiom/mcp test — all five remaining package suites passed
pnpm terminology:check — passed (1,045 files)
pnpm provider-copy:check — passed (178 audited files)
pnpm --filter @sapiom/harness exec vitest run src/server/opencode-bridge.test.ts src/server/opencode-model-response.test.ts src/server/opencode.test.ts src/core/opencode-host.test.ts — 99 passed after the rate-limit correction and upstream-error review fix
pnpm --filter @sapiom/harness typecheck — passed after the rate-limit correction
pnpm --filter @sapiom/harness build:server — passed after the rate-limit correction
pnpm --filter @sapiom/harness exec eslint src/server/opencode-bridge.ts src/server/opencode-bridge.test.ts — passed
pnpm pr-ci-security:check — 3 security-contract checks and workflow formatting passed
git diff --check — passed
```

The new authentication regression failed before the correction (HTTP 200 instead of 429) and passed afterward. It verifies that rotating IDs and switching between model/MCP routes cannot reset the budget, blocked requests never reach upstream, and valid credentials with successful or service-error responses do not exhaust it. Two additional regressions first reproduced upstream HTTP 401/403 being replaced by local HTTP 429, then verified that 125 valid requests to each upstream denial still preserve the original status after explicitly tracking only local runtime authentication failures.

All 19 package test scripts were exercised. The root test run completed all 32 OpenCode tests successfully. Its only failure was `packages/agent-core/src/bundle-error.spec.ts`, the same local permission-error diagnostic mismatch observed before this migration; `packages/agent-core` has no diff from `origin/main`. The five downstream package suites then passed independently, including 4,014 harness tests (2 skipped), 10 performance checks, 190 MCP tests (3 skipped), 205 desktop tests, and 73 CLI tests. The pinned native runtime completed a synthetic MCP function round trip through Responses, carried the result and encrypted reasoning into the next request, and rejected revoked credentials. Four new Responses regressions failed against the previous parser before passing with this implementation.

The combined local checkout containing this commit and #950 passed the full Studio browser suite: **681 passed, zero failed**, including all 41 Assistant cases. This browser result includes #950 and is not presented as a run of this branch alone. The same combined build was exercised with a real authenticated account and captured in Chrome on macOS.

**Live completion limitation:** nine real-model scenarios confirmed Luna selection and working local/remote tools. Three reached Finished; six returned the requested information but ended Stopped because their completion IDs were wrong even after recovery. Seven displayed an additional recovery explanation. All five instrumented commands executed exactly once, original saved message hashes were preserved, and ordinary turns retained the same chat DOM node. This is not a claim that the overall Assistant completion experience is fixed. Remote MCP discovery returned 389 tools; local Agent Map authoring is still outside this Assistant configuration.

### Tests and documentation

Update bridge and host tests for the endpoint, authentication header, model selection and Responses request shape. Add a dedicated Responses stream-inspection suite covering bounded retries, text/marker detection, tool pass-through, terminal/error events, malformed framing, UTF-8 and buffer limits. Extend the real pinned-runtime test to cover a function call, its result, and encrypted reasoning history. Document the endpoint, explicit model, and custom-gateway compatibility in both package READMEs; add patch changesets for both published packages.

## Compatibility and release impact

- Breaking or externally visible changes: Existing Assistant conversations retain their messages and use Luna on their next prompt. Custom `services.llm` origins must now support `/v1/responses`. The existing internal Assistant access gate and remote MCP destination are preserved. Packaged macOS/Windows applications were not retested; the macOS check used the browser against the shared harness server.
- Changeset: Added `.changeset/assistant-router-luna.md` for `@sapiom/harness` and `@sapiom/opencode`, both patch releases.

Risk & rollout: Yash owns the existing internal Assistant rollout. Keep general access off and validate enabled internal accounts before expanding it; this PR does not remove or widen the gate. Enabled-account model/tool checks passed as described above, while existing disabled/revoked-access unit and browser checks remain covered. Gate removal stays outside this migration and depends on the Assistant project's acceptance criteria, including completion recovery.

Fix-forward: if the shared release regresses, stop the affected delivery and correct the Responses provider and bridge together in a focused PR to main. Preserve account isolation, saved history, and the boundary that prevents model-response inspection from replaying released tool calls; verify the resulting main SHA and deployed artifact.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex investigated the gateway contract, implemented the provider/bridge migration, and updated the tests and documentation. Verification included native-runtime integration, package/workspace checks, real account and tool requests, browser interaction and reconnect tests, and Mac browser screenshots. Live completion failures are disclosed above.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/951" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Assistant requests now use the `gpt-luna` model through the Responses API.
  - Streaming responses continue to support tool calls and assistant answers.
  - Reasoning summaries and encrypted reasoning history are supported, with response storage disabled.
  - Recovery requests preserve the active model configuration.
  - Account-scoped credentials are used for model and remote tool requests.

- **Documentation**
  - Updated setup guidance for production routing and custom environments.
  - Custom Assistant gateways must support the `/v1/responses` endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
