### PR TITLE
feat(harness): define authorized Assistant context [SAP-3328]

### DIFF
--- a/.changeset/studio-context-contract.md
+++ b/.changeset/studio-context-contract.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Add the internal Assistant context schema and prompt composer, with authorized agent selection, guidance provenance, profile fallback and recovery snapshot preservation.

--- a/packages/harness/docs/assistant-context.md
+++ b/packages/harness/docs/assistant-context.md
@@ -1,0 +1,61 @@
+# Assistant context contract
+
+Studio owns workspace authorization and contextual instructions. OpenCode owns
+the native conversation and execution. The internal Assistant uses a request
+snapshot; `.sapiom/harness-context.json` remains a Terminal integration and must
+not supply authoritative context to conversations sharing a directory.
+
+## Snapshot and selection
+
+`StudioAssistantContext` in `src/core/studio-assistant-context.ts` records:
+
+- Schema version and a SHA-256 revision of the serialized snapshot.
+- Studio session ID, canonical cwd, project identity and environment.
+- Separate selected and bound agents, plus authorized workspace inventory.
+- Capability availability and instruction provenance, revisions and load status.
+
+The browser can submit a selected agent path as intent. The host validates it
+against the authorized canonical cwd and registry; it does not accept arbitrary
+system prompts, workspace overrides or capability claims. Definition IDs are
+included only when the registry marks their cloud definition visible.
+
+Selection is sampled at Send. `available`, `none`, `not-provided` and `unavailable`
+are distinct states. Only an omitted selection falls back to the conversation's
+binding. An explicit empty or deleted target never selects another agent.
+Snapshot values are detached from mutable registries. A changed selection,
+binding, source or capability changes the revision of the next request.
+
+## Instructions and recovery
+
+`composeAssistantPrompt(context)` is the single normal prompt composer.
+It keeps `StudioAssistantResult/v2:<token>` first, then the versioned context
+policy and snapshot. A Studio profile is mandatory. Required guidance without
+available text or a managed source location fails before native dispatch.
+
+The profile uses the active environment's served guidance with a bundled
+fallback and records the actual source. Existing Terminal prompt fetching keeps
+its string-returning API. The project role carries generic writable authoring
+guidance without claiming that unconnected tools are available.
+
+`recoverAssistantPrompt(savedSystem)` creates fresh completion bookkeeping and
+preserves the admitted context verbatim. Native compaction controls are not new
+user intent: recovery traces them back to the accepted user message. Old history
+without a saved context stays readable, but cannot be automatically recovered
+using invented current context.
+
+## Loader boundary
+
+The server resolver supplies authorized identity to sibling loaders, which return
+`AssistantGuidance` records instead of writing a second native prompt:
+
+- Project rules: source, scope, revision and text; deeper applicable rules win,
+  with `AGENTS.md` preferred over a same-directory `CLAUDE.md` fallback.
+- Managed skills: version, availability and a host-prepared location.
+- Continue: one recorded brief for a new conversation, explicitly distinct from
+  resumed native history. Recovery preserves an accepted brief without duplicating it.
+- Capabilities: actual server connection/catalog facts, never a browser list.
+
+Missing optional sources are explicit. Required missing sources block dispatch.
+The foundation does not itself implement the project instruction loader, managed
+skill materializer, queue transitions, Resume/Continue UI or complete tool parity.
+Those integrations must preserve this contract and the existing access gate.

--- a/packages/harness/src/core/studio-assistant-context.test.ts
+++ b/packages/harness/src/core/studio-assistant-context.test.ts
@@ -1,0 +1,224 @@
+import { mkdtemp, mkdir, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import type { HostedOpenCode } from "./opencode-host.js";
+import {
+  composeAssistantPrompt,
+  recoverAssistantPrompt,
+  resolveStudioAssistantContext,
+  type AssistantGuidance,
+} from "./studio-assistant-context.js";
+
+let root: string;
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "studio-context-"));
+  await Promise.all(
+    ["project/cedar", "project/orchid", "unrelated"].map((path) =>
+      mkdir(join(root, path), { recursive: true }),
+    ),
+  );
+});
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+function fixture(id = "studio-a") {
+  const cwd = join(root, "project");
+  const hosted = {
+    harnessSessionId: id,
+    cwd,
+    isCurrent: () => true,
+    signal: new AbortController().signal,
+  } as HostedOpenCode;
+  return {
+    hosted,
+    session: {
+      id,
+      cwd,
+      projectId: "project-a",
+      boundAgentPath: join(cwd, "cedar"),
+    },
+    selectedAgentPath: join(cwd, "orchid"),
+    environment: "dev",
+    workflows: ["project/cedar", "project/orchid", "unrelated"].map((path) => ({
+      path: join(root, path),
+      name: path,
+      definitionId: 12,
+      definitionSlug: "unused",
+      source: "scan" as const,
+    })),
+    capabilities: [
+      { name: "sapiom-dev", status: "unavailable" as const, tools: [] },
+    ],
+    guidance: [
+      {
+        id: "studio",
+        kind: "profile" as const,
+        required: true,
+        source: "bundled",
+        revision: "1",
+        status: "available" as const,
+        text: "Fixture Studio profile",
+      },
+    ] as AssistantGuidance[],
+  };
+}
+it("resolves selected and bound agents separately and limits inventory to canonical workspace paths", async () => {
+  const input = fixture();
+  await symlink(join(root, "unrelated"), join(input.hosted.cwd, "escape"));
+  input.workflows.push({
+    ...input.workflows[0]!,
+    path: join(input.hosted.cwd, "escape"),
+  });
+  const context = await resolveStudioAssistantContext(input);
+  expect(context.agents).toHaveLength(2);
+  await symlink(input.hosted.cwd, join(root, "alias"));
+  expect(
+    (
+      await resolveStudioAssistantContext({
+        ...input,
+        selectedAgentPath: join(root, "alias", "orchid"),
+      })
+    ).selectedAgent,
+  ).toEqual(context.selectedAgent);
+  expect(context.selectedAgent).toMatchObject({
+    status: "available",
+    agent: { path: input.selectedAgentPath },
+  });
+  expect(context.boundAgent).toMatchObject({
+    status: "available",
+    agent: { path: input.session.boundAgentPath },
+  });
+  expect(context.session).toEqual({
+    id: "studio-a",
+    cwd: input.hosted.cwd,
+    projectId: "project-a",
+  });
+  await expect(
+    resolveStudioAssistantContext({
+      ...input,
+      selectedAgentPath: join(input.hosted.cwd, "escape"),
+    }),
+  ).rejects.toThrow("context");
+  await expect(
+    resolveStudioAssistantContext({
+      ...input,
+      selectedAgentPath: join(root, "unrelated"),
+    }),
+  ).rejects.toThrow("context");
+});
+it("rejects wrong-session, moved-workspace and revoked context resolution", async () => {
+  const input = fixture();
+  await expect(
+    resolveStudioAssistantContext({
+      ...input,
+      session: { ...input.session, id: "studio-b" },
+    }),
+  ).rejects.toThrow("context");
+  await expect(
+    resolveStudioAssistantContext({
+      ...input,
+      session: { ...input.session, cwd: root },
+    }),
+  ).rejects.toThrow("context");
+  input.hosted.isCurrent = () => false;
+  await expect(resolveStudioAssistantContext(input)).rejects.toThrow("context");
+});
+it("preserves absent, omitted and deleted targets without selecting a remaining agent", async () => {
+  const input = fixture();
+  expect(
+    (await resolveStudioAssistantContext({ ...input, selectedAgentPath: null }))
+      .selectedAgent,
+  ).toEqual({ status: "none" });
+  expect(
+    (
+      await resolveStudioAssistantContext({
+        ...input,
+        selectedAgentPath: undefined,
+      })
+    ).selectedAgent,
+  ).toEqual({ status: "not-provided" });
+  await rm(input.selectedAgentPath, { recursive: true });
+  const context = await resolveStudioAssistantContext(input);
+  expect(context.selectedAgent).toEqual({
+    status: "unavailable",
+    path: input.selectedAgentPath,
+  });
+  expect(context.agents).toHaveLength(1);
+});
+it("detaches snapshots and revises only when their actual input changes", async () => {
+  const input = fixture();
+  const before = await resolveStudioAssistantContext(input);
+  expect((await resolveStudioAssistantContext(input)).revision).toBe(
+    before.revision,
+  );
+  input.guidance[0]!.text = "Changed rules";
+  const after = await resolveStudioAssistantContext(input);
+  expect(after.revision).not.toBe(before.revision);
+  expect(before.guidance[0]!.text).toBe("Fixture Studio profile");
+  const other = await resolveStudioAssistantContext(fixture("studio-b"));
+  expect(other.revision).not.toBe(before.revision);
+  expect(before.session.id).toBe("studio-a");
+});
+it("composes provider sources once and recovers exactly the admitted snapshot", async () => {
+  const input = fixture();
+  input.guidance.push(
+    {
+      id: "rules",
+      kind: "project",
+      required: false,
+      source: "AGENTS.md",
+      revision: "2",
+      status: "available",
+      text: "PROJECT_RULE_MARKER",
+    },
+    {
+      id: "skill",
+      kind: "skill",
+      required: true,
+      source: "bundled",
+      revision: "3",
+      status: "available",
+      location: "/managed/skills/authoring/SKILL.md",
+    },
+    {
+      id: "brief",
+      kind: "continuation",
+      required: true,
+      source: "recorded:prior",
+      revision: "4",
+      status: "available",
+      text: "CONTINUE_BRIEF_MARKER",
+    },
+  );
+  const context = await resolveStudioAssistantContext(input);
+  const original = composeAssistantPrompt(context).system;
+  expect(original).toMatch(/^StudioAssistantResult\/v2:[a-f0-9-]{36}\n/);
+  const recovered = recoverAssistantPrompt(original).system;
+  const tail = (value: string) =>
+    value.slice(value.indexOf("\n\nStudioAssistantContext/v1\n"));
+  expect(tail(recovered)).toBe(tail(original));
+  expect(recovered).not.toBe(original);
+  expect(recovered.match(/CONTINUE_BRIEF_MARKER/g)).toHaveLength(1);
+  expect(recovered).toContain("PROJECT_RULE_MARKER");
+  expect(recovered).toContain("/managed/skills/authoring/SKILL.md");
+});
+it("fails explicitly for unavailable required guidance and pre-context recovery", async () => {
+  const context = await resolveStudioAssistantContext(fixture());
+  context.guidance.push({
+    id: "required-skill",
+    kind: "skill",
+    required: true,
+    source: "bundled",
+    revision: null,
+    status: "unavailable",
+  });
+  expect(() => composeAssistantPrompt(context)).toThrow("context");
+  context.guidance[1]!.required = false;
+  expect(composeAssistantPrompt(context).system).toContain(
+    '"status":"unavailable"',
+  );
+  context.guidance[0]!.text = "";
+  expect(() => composeAssistantPrompt(context)).toThrow("context");
+  expect(() => recoverAssistantPrompt(undefined)).toThrow("context");
+});

--- a/packages/harness/src/core/studio-assistant-context.ts
+++ b/packages/harness/src/core/studio-assistant-context.ts
@@ -1,0 +1,192 @@
+import { createHash } from "node:crypto";
+import { realpath } from "node:fs/promises";
+import { isAbsolute, relative, sep } from "node:path";
+import type { WorkflowInfo } from "../shared/types.js";
+import type { HostedOpenCode } from "./opencode-host.js";
+import { OpenCodeTransportError } from "./opencode-host.js";
+import { openCodeTransportFailure } from "../shared/opencode-errors.js";
+import { openCodeCompletionPrompt } from "../shared/opencode-completion.js";
+
+export interface AssistantContextAgent {
+  name: string;
+  path: string;
+  definitionId: number | null;
+}
+export type AssistantAgentContext =
+  | { status: "available"; agent: AssistantContextAgent }
+  | { status: "none" | "not-provided" }
+  | { status: "unavailable"; path: string };
+
+/** Providers return data; only this module composes native instructions. */
+export interface AssistantGuidance {
+  id: string;
+  kind: "profile" | "project" | "skill" | "continuation";
+  required: boolean;
+  source: string;
+  scope?: string;
+  revision: string | null;
+  status: "available" | "unavailable" | "not-configured";
+  text?: string;
+  location?: string;
+  reason?: string;
+}
+export interface AssistantCapability {
+  name: string;
+  status: "available" | "configured" | "unavailable";
+  tools: string[];
+}
+export interface StudioAssistantContext {
+  schemaVersion: 1;
+  revision: string;
+  session: { id: string; cwd: string; projectId: string | null };
+  environment: string;
+  selectedAgent: AssistantAgentContext;
+  boundAgent: AssistantAgentContext;
+  agents: AssistantContextAgent[];
+  capabilities: AssistantCapability[];
+  guidance: AssistantGuidance[];
+}
+export type ResolveAssistantContext = (
+  hosted: HostedOpenCode,
+  selectedAgentPath?: string | null,
+) => Promise<StudioAssistantContext>;
+
+export const assistantContextDigest = (value: string): string =>
+  createHash("sha256").update(value).digest("hex");
+export function assistantContextUnavailable(): OpenCodeTransportError {
+  return new OpenCodeTransportError(
+    openCodeTransportFailure("context_unavailable"),
+  );
+}
+
+const within = (root: string, path: string): boolean => {
+  const child = relative(root, path);
+  return child !== ".." && !child.startsWith(`..${sep}`) && !isAbsolute(child);
+};
+
+/** The workspace has already passed OpenCodeHost's identity/access boundary. */
+export async function resolveStudioAssistantContext(input: {
+  hosted: HostedOpenCode;
+  session: {
+    id: string;
+    cwd: string;
+    projectId: string | null;
+    boundAgentPath: string | null;
+  };
+  selectedAgentPath?: string | null;
+  workflows: readonly WorkflowInfo[];
+  environment: string;
+  capabilities: AssistantCapability[];
+  guidance: AssistantGuidance[];
+}): Promise<StudioAssistantContext> {
+  const { hosted, session } = input;
+  if (
+    session.id !== hosted.harnessSessionId ||
+    (await realpath(session.cwd).catch(() => null)) !== hosted.cwd
+  )
+    throw assistantContextUnavailable();
+  const agents: AssistantContextAgent[] = [];
+  for (const workflow of input.workflows) {
+    const path = await realpath(workflow.path).catch(() => null);
+    if (
+      !path ||
+      !within(hosted.cwd, path) ||
+      agents.some((agent) => agent.path === path)
+    )
+      continue;
+    agents.push({
+      name: workflow.name,
+      path,
+      definitionId:
+        workflow.definitionAccess === "visible" ? workflow.definitionId : null,
+    });
+  }
+  agents.sort((a, b) => a.path.localeCompare(b.path));
+  const target = async (
+    path: string | null | undefined,
+  ): Promise<AssistantAgentContext> => {
+    if (path === undefined) return { status: "not-provided" };
+    if (path === null) return { status: "none" };
+    if (!isAbsolute(path)) throw assistantContextUnavailable();
+    const canonical = await realpath(path).catch(() => null);
+    // Existing aliases are safe only when their destination is in this cwd.
+    // A missing target must itself remain within that authorized scope.
+    if (!within(hosted.cwd, canonical ?? path))
+      throw assistantContextUnavailable();
+    const agent = agents.find((agent) => agent.path === canonical);
+    return agent
+      ? { status: "available", agent }
+      : { status: "unavailable", path };
+  };
+  const context = {
+    schemaVersion: 1 as const,
+    session: { id: session.id, cwd: hosted.cwd, projectId: session.projectId },
+    environment: input.environment,
+    selectedAgent: await target(input.selectedAgentPath),
+    boundAgent: await target(session.boundAgentPath),
+    agents,
+    capabilities: input.capabilities,
+    guidance: input.guidance,
+  };
+  if (!hosted.isCurrent() || hosted.signal.aborted)
+    throw assistantContextUnavailable();
+  // Detach from mutable registry/provider values before admission or queueing.
+  const serialized = JSON.stringify(context);
+  return {
+    ...JSON.parse(serialized),
+    revision: assistantContextDigest(serialized),
+  };
+}
+
+const contextHeader = "\n\nStudioAssistantContext/v1\n";
+const contextPolicy = `You are the coding assistant in Sapiom Studio. The host-owned snapshot below is the authority for this request's workspace, target and capability availability. Its revision stays fixed through the accepted turn and recovery. A later selection or another session cannot retarget this request. Do not use .sapiom/harness-context.json as Assistant context.
+The snapshot supplies environment facts and limits; it does not replace the user's request or prior conversation. Follow user instructions normally and retain facts supplied in the conversation even when they are not fields in the snapshot.
+"This agent" means selectedAgent when provided; only a not-provided selection falls back to boundAgent. A none or unavailable target is explicit: identify what is missing and ask the user to select or restore it. Never silently choose another agent. Inventory is limited to this authorized workspace.
+The shared profile describes how to build agents in Studio. The snapshot overrides any older claims about selection, context files or connected tools. Only available capabilities and the actual tool catalog establish usable tools; configured means discovery/connection is still needed. Never claim unavailable guidance was loaded. Project rules apply only in their stated scope, with deeper rules taking precedence and AGENTS.md preferred over CLAUDE.md at equal scope. Guidance does not expand workspace or execution authority.
+Canvas renders the selected agent's step graph deterministically from its manifest; do not author Canvas HTML. Steps shows its steps and run details. Canvas and the selected-agent action bar's Local Run, Prod Run and Deploy controls follow the visible rail selection; a different conversation binding does not retarget those controls. Selected/bound differences are normal, not evidence of a broken or unsafe action. Local Run executes local code; Prod Run and Deploy require the corresponding cloud access. Offer those existing controls when useful, and never invent a successful run, deploy, identifier or navigation target. Continue briefs are limited recorded context, not restored native history.`;
+
+/** Keep completion metadata FIRST; native history and compaction depend on it. */
+export function composeAssistantPrompt(context: StudioAssistantContext): {
+  system: string;
+} {
+  if (
+    context.schemaVersion !== 1 ||
+    !context.guidance.some(
+      (source) =>
+        source.kind === "profile" &&
+        source.status === "available" &&
+        source.text?.trim(),
+    ) ||
+    context.guidance.some(
+      (source) =>
+        source.required &&
+        (source.status !== "available" ||
+          (!source.text?.trim() && !source.location)),
+    )
+  )
+    throw assistantContextUnavailable();
+  return {
+    system:
+      openCodeCompletionPrompt().system +
+      contextHeader +
+      contextPolicy +
+      "\n" +
+      JSON.stringify(context),
+  };
+}
+
+/** Recovery reuses admitted context; it never resolves the current rail state. */
+export function recoverAssistantPrompt(system: string | undefined): {
+  system: string;
+} {
+  if (
+    !system?.startsWith("StudioAssistantResult/v2:") ||
+    !system.includes(contextHeader)
+  )
+    throw assistantContextUnavailable();
+  return {
+    system:
+      openCodeCompletionPrompt().system +
+      system.slice(system.indexOf(contextHeader)),
+  };
+}

--- a/packages/harness/src/profiles/assistant.test.ts
+++ b/packages/harness/src/profiles/assistant.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, expect, it, vi } from "vitest";
+import type { ResolvedEnvironment } from "@sapiom/mcp/auth";
+import { assistantProfile, assistantProjectRole } from "./assistant.js";
+import { DEFAULT_SYSTEM_PROMPT } from "./default.js";
+
+const environment = {
+  name: "dev",
+  apiURL: "http://127.0.0.1:3000",
+  appURL: "http://127.0.0.1:2999",
+  services: {},
+  credentials: null,
+} as ResolvedEnvironment;
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+it("records the actual source and content revision, including the bundled offline fallback", async () => {
+  vi.stubEnv("SAPIOM_HARNESS_PROMPT_FETCH_DISABLED", "0");
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(new Response("Served Studio guidance")),
+  );
+  const served = await assistantProfile(environment);
+  expect(served.source).toBe("http://127.0.0.1:3000/v1/harness/system-prompt");
+  expect(served.text).toBe("Served Studio guidance");
+  vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+  const fallback = await assistantProfile(environment);
+  expect(fallback).toMatchObject({
+    source: "bundled:studio-profile",
+    text: DEFAULT_SYSTEM_PROMPT,
+    status: "available",
+    required: true,
+  });
+  expect(fallback.revision).not.toBe(served.revision);
+});
+
+it("uses the host's supplied profile and keeps an empty/failed override recoverable through the bundle", async () => {
+  expect(
+    (await assistantProfile(environment, async () => "Custom profile")).text,
+  ).toBe("Custom profile");
+  for (const load of [
+    async () => "",
+    async () => {
+      throw new Error("missing");
+    },
+  ])
+    expect((await assistantProfile(environment, load)).source).toBe(
+      "bundled:studio-profile",
+    );
+  const role = assistantProjectRole();
+  expect(role.text).toContain("ordinary writable coding agent");
+  expect(role.text).not.toContain("this project has sapiom");
+});

--- a/packages/harness/src/profiles/assistant.ts
+++ b/packages/harness/src/profiles/assistant.ts
@@ -1,0 +1,56 @@
+import type { ResolvedEnvironment } from "@sapiom/mcp/auth";
+import { isEnvFlagSet } from "../cli/consent.js";
+import {
+  assistantContextDigest,
+  type AssistantGuidance,
+} from "../core/studio-assistant-context.js";
+import { DEFAULT_SYSTEM_PROMPT, resolveKnownSystemPrompt } from "./default.js";
+import { PROJECT_AGENT_PROMPT_APPENDIX } from "./project-agent.js";
+import { fetchSystemPromptWithSource } from "./system-prompt-fetch.js";
+
+export async function assistantProfile(
+  environment: ResolvedEnvironment,
+  loadOverride?: () => Promise<string>,
+): Promise<AssistantGuidance> {
+  const fallback = {
+    text: DEFAULT_SYSTEM_PROMPT,
+    source: "bundled:studio-profile",
+  };
+  let loaded = fallback;
+  if (loadOverride) {
+    try {
+      const text = await loadOverride();
+      if (text.trim()) loaded = { text, source: "host:studio-profile" };
+    } catch {
+      /* The bundled teaching is the required offline fallback. */
+    }
+  } else if (!isEnvFlagSet(process.env.SAPIOM_HARNESS_PROMPT_FETCH_DISABLED)) {
+    loaded = await fetchSystemPromptWithSource(environment);
+  }
+  const text = resolveKnownSystemPrompt(loaded.text);
+  return {
+    id: "studio-profile",
+    kind: "profile",
+    required: true,
+    status: "available",
+    source: text === loaded.text ? loaded.source : "bundled:studio-profile",
+    revision: assistantContextDigest(text),
+    text,
+  };
+}
+
+/** Common writable project role; tool-specific guidance follows actual wiring. */
+export function assistantProjectRole(): AssistantGuidance {
+  const text =
+    PROJECT_AGENT_PROMPT_APPENDIX.split("\n\n")[0]! +
+    "\n</studio-project-agent>";
+  return {
+    id: "studio-project-role",
+    kind: "project",
+    required: true,
+    status: "available",
+    source: "bundled:project-agent-role",
+    revision: assistantContextDigest(text),
+    text,
+  };
+}

--- a/packages/harness/src/profiles/system-prompt-fetch.ts
+++ b/packages/harness/src/profiles/system-prompt-fetch.ts
@@ -19,7 +19,20 @@ const FETCH_TIMEOUT_MS = 5000;
  * Mirrors `fetchInstructions` in `@sapiom/mcp` (packages/mcp/src/instructions-fetch.ts),
  * deliberately: the two are the same mechanism on the two client surfaces.
  */
-export async function fetchSystemPrompt(env: ResolvedEnvironment): Promise<string> {
+export async function fetchSystemPrompt(
+  env: ResolvedEnvironment,
+): Promise<string> {
+  return (await fetchSystemPromptWithSource(env)).text;
+}
+
+/** Same fallback as Terminal, with provenance for Assistant's context revision. */
+export async function fetchSystemPromptWithSource(
+  env: ResolvedEnvironment,
+): Promise<{ text: string; source: string }> {
+  const fallback = {
+    text: DEFAULT_SYSTEM_PROMPT,
+    source: "bundled:studio-profile",
+  };
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
@@ -27,11 +40,13 @@ export async function fetchSystemPrompt(env: ResolvedEnvironment): Promise<strin
       headers: { Accept: "text/markdown, text/plain" },
       signal: controller.signal,
     });
-    if (!response.ok) return DEFAULT_SYSTEM_PROMPT;
+    if (!response.ok) return fallback;
     const body = (await response.text()).trim();
-    return body.length > 0 ? body : DEFAULT_SYSTEM_PROMPT;
+    return body.length > 0
+      ? { text: body, source: `${env.apiURL}/v1/harness/system-prompt` }
+      : fallback;
   } catch {
-    return DEFAULT_SYSTEM_PROMPT;
+    return fallback;
   } finally {
     clearTimeout(timeout);
   }

--- a/packages/harness/src/shared/opencode-errors.ts
+++ b/packages/harness/src/shared/opencode-errors.ts
@@ -5,6 +5,7 @@ export const openCodeTransportErrorCodes = [
   "runtime_start_failed",
   "runtime_exited",
   "native_history_missing",
+  "context_unavailable",
   "transport_unavailable",
 ] as const;
 export type OpenCodeTransportErrorCode =
@@ -80,6 +81,13 @@ const fixedFailures = {
     code: "transport_unavailable",
     message:
       "Assistant is temporarily unavailable. Reconnect before sending another message.",
+    retryable: true,
+    action: "reconnect",
+  },
+  context_unavailable: {
+    code: "context_unavailable",
+    message:
+      "Assistant context is unavailable. Select an agent in this session's project or restore its guidance, then reconnect and send a new message.",
     retryable: true,
     action: "reconnect",
   },


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Assistant needs a per-request representation of Studio context before the instruction, skill and lifecycle integrations can share it. The legacy context file represents a folder's binding and can be overwritten by another conversation in that folder.

## Summary and scope

Define the versioned context schema, canonical workspace/agent resolver and single prompt composer. Keep selected and bound agents distinct, preserve explicit missing targets, record guidance provenance and actual content revisions, and retain completion bookkeeping when recovering an accepted snapshot. Validate the detached serialized snapshot against its revision before composition. Recovery verifies the exact completion and context policy, UUID, JSON schema and digest before preserving the snapshot. Profiles, project rules and continuation briefs require actual text; managed skills retain their location seam. Add a served-profile provider with the existing bundled fallback.

This is the foundation layer. The next PR connects it to gated Assistant requests; project instruction loading, managed skill materialization and full lifecycle behavior remain separate tickets. The context contract and provider fixtures document their boundary.

## Related work

Related issue or discussion:
[SAP-3328](https://linear.app/sapiom/issue/SAP-3328), implementing the frozen [SAP-3327 context contract](https://linear.app/sapiom/issue/SAP-3327). First layer of the context delivery stack under [SAP-3398](https://linear.app/sapiom/issue/SAP-3398).

## Validation

```text
pnpm build — passed
pnpm typecheck — passed
pnpm lint — passed
pnpm --filter @sapiom/harness exec vitest run src/core/studio-assistant-context.test.ts src/profiles/assistant.test.ts src/profiles/system-prompt-fetch.test.ts — 23 passed
Original composer/recovery with the new regressions — failed as expected; restored implementation passed
pnpm test — stopped at the unchanged agent-core unreadable-directory bundle-error test (239 passed, 1 failed in that package)
pnpm pr:size — unavailable; actual base increment: 770 additions + 4 deletions = 774
git diff --check — passed
```

Includes main's packaged-runtime correction #986. Agent-core has no changes in this PR. Full current-head CI and the integrated packaged-native acceptance remain separate verification gates.

### Tests and documentation

Tests cover canonical containment and aliases, distinct selection/binding, missing targets, cross-session isolation, revision changes, immutable source snapshots, required-source failures, profile fallback and recovery composition. `packages/harness/docs/assistant-context.md` records the contract. Runtime, UI and live-model evidence for the integrated stack is tracked in SAP-3328; it is not a claim of full Epic 2 parity.

## Compatibility and release impact

- Breaking or externally visible changes: No public API removal. Terminal's prompt fetch still returns a string with the same fallback. This layer adds internal context helpers and a fixed transport error; request integration follows in the next layer.
- Changeset: Added `.changeset/studio-context-contract.md` for `@sapiom/harness`.

Owner: Yash. Delivery stays behind the existing internal Assistant eligibility gate, with Terminal as the default. Broader rollout remains subject to the epic's live parity checks. Fix-forward: correct the resolver/composer in a follow-up PR to main, preserving the saved context version and native history compatibility.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex implemented and reviewed the context contract, tests and documentation. Verification for this revision is recorded above; earlier live/native evidence remains in the related issue.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

