### PR TITLE
refactor(harness): share scoped native event reading [SAP-3291]

### DIFF
--- a/.changeset/shared-assistant-event-reader.md
+++ b/.changeset/shared-assistant-event-reader.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Preserve native event scoping, browser backpressure and connection cleanup in a shared Assistant event reader.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -84,6 +84,8 @@ Disconnecting also cancels outstanding catch-up requests before reconnection.
 Attachment and reconnect also reconcile pending permissions and questions.
 Assistant shows **Waiting for input** for current pending requests; failed request
 reads retain last-known state while the status remains uncertain.
+Event transport scopes each frame to the authorized conversation and cancels
+its reader and status catch-up when the browser connection ends.
 This first slice includes basic tool status; richer controls arrive separately.
 Studio actions reveal Terminal after a foreground CLI prompt is accepted; a
 rejected send shows its error and keeps the selected view. Unsent chat text is

--- a/packages/harness/src/server/opencode-events.test.ts
+++ b/packages/harness/src/server/opencode-events.test.ts
@@ -1,0 +1,320 @@
+import { EventEmitter } from "node:events";
+import type { Response as ExpressResponse } from "express";
+import { afterEach, expect, it, vi } from "vitest";
+import type { HostedOpenCode } from "../core/opencode-host.js";
+import { readOpenCodeEvents, streamOpenCodeEvents } from "./opencode-events.js";
+
+const aborts: AbortController[] = [];
+afterEach(() => {
+  for (const abort of aborts.splice(0)) abort.abort();
+});
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes;
+    reject = no;
+  });
+  return { promise, resolve, reject };
+}
+const event = (type = "session.idle", sessionID = "ses_a") => ({
+  type,
+  properties: { sessionID },
+});
+const frame = (value: unknown) => `data: ${JSON.stringify(value)}\n\n`;
+function fixture() {
+  const abort = new AbortController();
+  aborts.push(abort);
+  let controller!: ReadableStreamDefaultController<Uint8Array>;
+  const cancel = vi.fn();
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      controller = c;
+    },
+    cancel,
+  });
+  const response = new Response(body, {
+    headers: { "content-type": "text/event-stream" },
+  });
+  const status = deferred<Record<string, unknown>>();
+  const fetch = vi.fn(async () => response);
+  const fetchJson = vi.fn(
+    (_path: string, _options?: RequestInit) => status.promise,
+  );
+  const close = vi.fn();
+  let current = true;
+  const hosted = {
+    cwd: "/workspace",
+    isCurrent: () => current,
+    signal: abort.signal,
+    server: { fetch, fetchJson, close },
+  } as unknown as HostedOpenCode;
+  const raw = (text: string) =>
+    controller.enqueue(new TextEncoder().encode(text));
+  return {
+    abort,
+    body,
+    response,
+    hosted,
+    fetch,
+    fetchJson,
+    close,
+    cancel,
+    status,
+    raw,
+    send: (value: unknown) => raw(frame(value)),
+    end: () => controller.close(),
+    bytes: (value: Uint8Array) => controller.enqueue(value),
+    retire: () => {
+      current = false;
+    },
+    read: (onOpen?: () => void) =>
+      readOpenCodeEvents(hosted, "ses_a", abort.signal, onOpen),
+  };
+}
+async function collect(iterator: AsyncIterable<Record<string, unknown>>) {
+  const values = [];
+  for await (const value of iterator) values.push(value);
+  return values;
+}
+function browser() {
+  const res = new EventEmitter();
+  const write = vi.fn((_chunk: string) => true);
+  const end = vi.fn();
+  Object.assign(res, {
+    write,
+    end,
+    setHeader: vi.fn(),
+    flushHeaders: vi.fn(),
+    destroyed: false,
+    writableEnded: false,
+  });
+  return { res: res as unknown as ExpressResponse, write, end };
+}
+
+it("opens lazily after successful response validation and never reads snapshots itself", async () => {
+  const f = fixture();
+  const opening = deferred<Response>();
+  f.fetch.mockReturnValueOnce(opening.promise);
+  const onOpen = vi.fn();
+  const iterator = f.read(onOpen);
+  expect(f.fetch).not.toHaveBeenCalled();
+  const first = iterator.next();
+  expect(onOpen).not.toHaveBeenCalled();
+  opening.resolve(f.response);
+  f.send({ type: "server.connected" });
+  expect(await first).toMatchObject({ value: { type: "server.connected" } });
+  expect(onOpen).toHaveBeenCalledOnce();
+  expect(f.fetch).toHaveBeenCalledWith(
+    "/event",
+    expect.objectContaining({ signal: f.abort.signal }),
+  );
+  expect(f.fetchJson).not.toHaveBeenCalled();
+  await iterator.return();
+  expect(f.cancel).toHaveBeenCalledOnce();
+  expect(f.body.locked).toBe(false);
+  expect(f.close).not.toHaveBeenCalled();
+  expect(f.abort.signal.aborted).toBe(false);
+});
+
+it.each(["status", "type", "body", "aborted"])(
+  "rejects invalid open: %s",
+  async (kind) => {
+    const f = fixture();
+    const onOpen = vi.fn();
+    if (kind === "status")
+      f.fetch.mockResolvedValueOnce(new Response(f.body, { status: 500 }));
+    if (kind === "type") f.fetch.mockResolvedValueOnce(new Response(f.body));
+    if (kind === "body") f.fetch.mockResolvedValueOnce(new Response(null));
+    if (kind === "aborted") f.abort.abort(new Error("already stopped"));
+    await expect(f.read(onOpen).next()).rejects.toThrow();
+    expect(onOpen).not.toHaveBeenCalled();
+    if (kind === "status" || kind === "type")
+      expect(f.cancel).toHaveBeenCalledOnce();
+    if (kind === "aborted") expect(f.fetch).not.toHaveBeenCalled();
+  },
+);
+
+it("decodes split UTF-8 and CRLF, multiline data, comments and ordered buffered frames", async () => {
+  const f = fixture();
+  const value = {
+    ...event(),
+    properties: { sessionID: "ses_a", title: "Hello 🌎" },
+  };
+  const bytes = new TextEncoder().encode(
+    `: heartbeat\r\n\r\n${frame(value).replace(/\n/g, "\r\n")}`,
+  );
+  const split = bytes.indexOf(0xf0) + 2;
+  f.bytes(bytes.slice(0, split));
+  f.bytes(bytes.slice(split, -1));
+  f.bytes(bytes.slice(-1));
+  f.raw(
+    JSON.stringify(event("session.status"), null, 2)
+      .split("\n")
+      .map((line) => `data: ${line}`)
+      .join("\n") + "\n\n",
+  );
+  f.end();
+  expect(await collect(f.read())).toEqual([value, event("session.status")]);
+  expect(f.body.locked).toBe(false);
+});
+
+it.each(["complete", "incomplete", "invalid-json"])(
+  "rejects a bounded malformed frame: %s",
+  async (kind) => {
+    const f = fixture();
+    f.raw(
+      kind === "invalid-json"
+        ? "data: nope\n\n"
+        : "data: " +
+            "x".repeat(2 * 1024 * 1024) +
+            (kind === "complete" ? "\n\n" : ""),
+    );
+    await expect(f.read().next()).rejects.toThrow(
+      kind === "invalid-json" ? undefined : "too large",
+    );
+    expect(f.cancel).toHaveBeenCalledOnce();
+    expect(f.body.locked).toBe(false);
+  },
+);
+
+it("discards an unterminated frame at EOF", async () => {
+  const f = fixture();
+  f.raw(frame(event()).trimEnd());
+  f.end();
+  expect(await collect(f.read())).toEqual([]);
+});
+
+it("scopes every buffered event and rechecks hosted authority after yield", async () => {
+  const f = fixture();
+  f.raw(
+    frame(event("session.idle", "ses_b")) +
+      frame(event()) +
+      frame(event("session.status")),
+  );
+  const iterator = f.read();
+  expect((await iterator.next()).value).toEqual(event());
+  f.retire();
+  f.end();
+  expect((await iterator.next()).done).toBe(true);
+});
+
+it("ends after one sanitized authentication event", async () => {
+  const f = fixture();
+  f.raw(
+    frame({
+      type: "session.error",
+      properties: {
+        sessionID: "ses_a",
+        error: {
+          name: "ProviderAuthError",
+          data: { providerID: "sapiom", message: "private" },
+        },
+      },
+    }) + frame(event()),
+  );
+  const result = await collect(f.read());
+  expect(result).toHaveLength(1);
+  expect(result[0]).toMatchObject({
+    type: "studio.error",
+    properties: { code: "authentication_required" },
+  });
+  expect(JSON.stringify(result)).not.toContain("private");
+  expect(f.cancel).toHaveBeenCalledOnce();
+});
+
+it.each(["read", "open-callback"])(
+  "cleans up a failed consumer lifetime: %s",
+  async (kind) => {
+    const f = fixture();
+    const failure = new Error("consumer stopped");
+    const next = f
+      .read(
+        kind === "open-callback"
+          ? () => {
+              throw failure;
+            }
+          : undefined,
+      )
+      .next();
+    const rejected = expect(next).rejects.toBe(failure);
+    if (kind === "read") {
+      await vi.waitFor(() => expect(f.body.locked).toBe(true));
+      f.abort.abort(failure);
+    }
+    await rejected;
+    expect(f.cancel).toHaveBeenCalledOnce();
+    expect(f.body.locked).toBe(false);
+    expect(f.close).not.toHaveBeenCalled();
+  },
+);
+
+it("paces browser writes until drain without consuming the next visible event", async () => {
+  const f = fixture();
+  const b = browser();
+  b.write.mockReturnValueOnce(false);
+  f.raw(frame(event()) + frame(event("session.status")));
+  f.end();
+  const task = streamOpenCodeEvents(f.hosted, "ses_a", b.res, f.abort.signal);
+  await vi.waitFor(() => expect(b.write).toHaveBeenCalledOnce());
+  b.res.emit("drain");
+  await task;
+  expect(
+    b.write.mock.calls.map((call) => JSON.parse(String(call[0]).slice(6))),
+  ).toEqual([event(), event("session.status")]);
+  expect(b.end).toHaveBeenCalledOnce();
+});
+
+it("aborts an outstanding browser drain and closes its reader", async () => {
+  const f = fixture();
+  const b = browser();
+  b.write.mockReturnValue(false);
+  f.send(event());
+  const task = streamOpenCodeEvents(f.hosted, "ses_a", b.res, f.abort.signal);
+  const rejected = expect(task).rejects.toThrow();
+  await vi.waitFor(() => expect(b.write).toHaveBeenCalledOnce());
+  f.abort.abort();
+  await rejected;
+  expect(f.cancel).toHaveBeenCalledOnce();
+  expect(f.body.locked).toBe(false);
+});
+
+it.each(["idle", "eof", "auth", "failure"])(
+  "fences the browser snapshot after %s",
+  async (kind) => {
+    const f = fixture();
+    const b = browser();
+    const task = streamOpenCodeEvents(f.hosted, "ses_a", b.res, f.abort.signal);
+    await vi.waitFor(() => expect(f.fetchJson).toHaveBeenCalledOnce());
+    if (kind === "idle") f.send(event());
+    if (kind === "auth")
+      f.send({
+        type: "session.error",
+        properties: {
+          sessionID: "ses_a",
+          error: {
+            name: "ProviderAuthError",
+            data: { providerID: "sapiom" },
+          },
+        },
+      });
+    if (kind === "idle" || kind === "auth")
+      await vi.waitFor(() => expect(b.write).toHaveBeenCalledOnce());
+    if (kind === "eof" || kind === "auth") {
+      if (kind === "eof") f.end();
+      await task;
+      const options = f.fetchJson.mock.calls[0]?.[1] as RequestInit;
+      expect(options.signal?.aborted).toBe(true);
+    }
+    if (kind === "failure") f.status.reject(new Error("read failed"));
+    else f.status.resolve({ ses_a: { type: "busy" } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (kind === "idle" || kind === "failure") {
+      f.end();
+      await task;
+    }
+    expect(b.write).toHaveBeenCalledTimes(
+      kind === "idle" || kind === "auth" ? 1 : 0,
+    );
+  },
+);

--- a/packages/harness/src/server/opencode-events.ts
+++ b/packages/harness/src/server/opencode-events.ts
@@ -63,64 +63,51 @@ export function scopedOpenCodeEvent(
     : null;
 }
 
-/** Buffer at most one incomplete frame; never collect the complete response. */
-export async function streamOpenCodeEvents(
+/** Read one connection lazily, yielding scoped events with consumer backpressure. */
+export async function* readOpenCodeEvents(
   hosted: HostedOpenCode,
   id: string,
-  res: Response,
   signal: AbortSignal,
-): Promise<void> {
+  onOpen?: () => void,
+): AsyncGenerator<Record<string, unknown>, void, unknown> {
+  signal.throwIfAborted();
   const upstream = await hosted.server.fetch("/event", {
     signal,
     headers: { Accept: "text/event-stream" },
   });
   if (
+    signal.aborted ||
     !upstream.ok ||
     !upstream.body ||
     !upstream.headers.get("content-type")?.includes("text/event-stream")
   ) {
-    await upstream.body?.cancel();
+    await upstream.body?.cancel().catch(() => {});
+    signal.throwIfAborted();
     throw new Error("Assistant event connection failed");
   }
-  res.setHeader("Content-Type", "text/event-stream");
-  res.setHeader("X-Accel-Buffering", "no");
-  res.flushHeaders();
-  const write = async (event: Record<string, unknown>) => {
-    signal.throwIfAborted();
-    if (!res.write(`data: ${JSON.stringify(event)}\n\n`))
-      await once(res, "drain", { signal });
-  };
-  let statusSeen = false;
-  // Start after subscribing; never overwrite a newer native status with this snapshot.
-  void hosted.server
-    .fetchJson<Record<string, unknown>>("/session/status", {
-      signal: AbortSignal.any([signal, AbortSignal.timeout(3000)]),
-    })
-    .then(async (statuses) => {
-      if (!statusSeen && !signal.aborted && !res.writableEnded)
-        await write({
-          type: "session.status",
-          properties: {
-            sessionID: id,
-            status: statuses[id] ?? { type: "idle" },
-          },
-        });
-    })
-    .catch(() => {});
   const reader = upstream.body.getReader();
+  const cancel = () => {
+    void reader.cancel().catch(() => {});
+  };
+  signal.addEventListener("abort", cancel, { once: true });
   const decoder = new TextDecoder();
   let pending = "";
+  // Decoded string units per frame, including an incomplete trailing frame.
   const maxFrame = 2 * 1024 * 1024;
   try {
+    signal.throwIfAborted();
+    onOpen?.();
     for (;;) {
       const { done, value } = await reader.read();
-      if (done) break;
+      signal.throwIfAborted();
+      if (done) return;
       pending = (pending + decoder.decode(value, { stream: true })).replace(
         /\r\n/g,
         "\n",
       );
       let boundary: number;
       while ((boundary = pending.indexOf("\n\n")) >= 0) {
+        signal.throwIfAborted();
         if (boundary > maxFrame)
           throw new Error("Assistant event is too large");
         const frame = pending.slice(0, boundary);
@@ -133,32 +120,88 @@ export async function streamOpenCodeEvents(
         if (!data) continue;
         const event = scopedOpenCodeEvent(JSON.parse(data), id, hosted);
         if (!event) continue;
-        if (event.type === "session.status" || event.type === "session.idle")
-          statusSeen = true;
-        await write(event);
-        if (event.type === "studio.error") {
-          res.end();
-          return;
-        }
+        yield event;
+        if (event.type === "studio.error") return;
       }
       if (pending.length > maxFrame)
         throw new Error("Assistant event is too large");
     }
-    if (
-      signal.reason instanceof OpenCodeTransportError &&
-      !res.destroyed &&
-      !res.writableEnded
-    ) {
-      res.write(
-        `data: ${JSON.stringify({
-          type: "studio.error",
-          properties: signal.reason.failure,
-        })}\n\n`,
-      );
+  } finally {
+    signal.removeEventListener("abort", cancel);
+    await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}
+
+/** Browser transport owns response framing and its one status catch-up read. */
+export async function streamOpenCodeEvents(
+  hosted: HostedOpenCode,
+  id: string,
+  res: Response,
+  signal: AbortSignal,
+): Promise<void> {
+  const lifetime = new AbortController();
+  const connection = AbortSignal.any([signal, lifetime.signal]);
+  let opened = false;
+  let finished = false;
+  let statusSeen = false;
+  let writeTail = Promise.resolve();
+  const write = (event: Record<string, unknown>, fallback = false) => {
+    const pending = writeTail.then(async () => {
+      if (finished || (fallback && statusSeen) || !hosted.isCurrent()) return;
+      connection.throwIfAborted();
+      if (!res.write(`data: ${JSON.stringify(event)}\n\n`))
+        await once(res, "drain", { signal: connection });
+    });
+    writeTail = pending.catch(() => {});
+    return pending;
+  };
+  const onOpen = () => {
+    opened = true;
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("X-Accel-Buffering", "no");
+    res.flushHeaders();
+    // A live status always wins, including while a fallback waits for drain.
+    void hosted.server
+      .fetchJson<Record<string, unknown>>("/session/status", {
+        signal: AbortSignal.any([connection, AbortSignal.timeout(3000)]),
+      })
+      .then((statuses) =>
+        write(
+          {
+            type: "session.status",
+            properties: {
+              sessionID: id,
+              status: statuses[id] ?? { type: "idle" },
+            },
+          },
+          true,
+        ),
+      )
+      .catch(() => {});
+  };
+  try {
+    for await (const event of readOpenCodeEvents(
+      hosted,
+      id,
+      connection,
+      onOpen,
+    )) {
+      if (
+        ["session.status", "session.idle", "studio.error"].includes(
+          String(event.type),
+        )
+      )
+        statusSeen = true;
+      await write(event);
+      if (event.type === "studio.error") break;
     }
+    finished = true;
     res.end();
   } catch (error) {
+    finished = true;
     if (
+      opened &&
       signal.reason instanceof OpenCodeTransportError &&
       !res.destroyed &&
       !res.writableEnded
@@ -174,6 +217,7 @@ export async function streamOpenCodeEvents(
     }
     throw error;
   } finally {
-    await reader.cancel().catch(() => {});
+    finished = true;
+    lifetime.abort();
   }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to sapiom-js.
Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
-->

## Primary change type

<!-- Select exactly one primary type. -->

- [ ] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [x] Maintenance or refactor

## Problem and motivation

The native event parser was coupled to an Express response, preventing a host-owned observer from consuming the same scoped stream safely. It now exposes one lazy async iterator while the existing browser wrapper retains response framing and status catch-up.

## Summary and scope

Extract `readOpenCodeEvents(hosted, conversationId, signal, onOpen)` without changing native event scoping. Preserve incremental decoding, the existing per-frame decoded-string limit, incomplete-EOF behavior and backpressure. Reader cleanup covers cancellation, parser failure, consumer return and callback failure. The browser wrapper serializes native/fallback writes and cancels its catch-up read when the connection ends.

This 471-line all-file increment stacks on #960 for SAP-3291. The iterator owns one connection and performs only the native event GET. The observer, reconnect policy, host ownership and summary delivery follow separately.

## Related work

<!--
Link the issue or prior maintainer discussion when required by CONTRIBUTING.md.
Use N/A for a direct PR that does not need one.
-->

Related issue or discussion:
https://linear.app/sapiom/issue/SAP-3291

## Validation

```text
pnpm build — passed (root)
pnpm typecheck — passed (root)
pnpm lint — passed (root)
setpriv --inh-caps=-all --ambient-caps=-all env npm_config_workspace_concurrency=1 pnpm test — passed (root)
pnpm install --frozen-lockfile — passed
pnpm --filter @sapiom/harness exec vitest run src/server/opencode-events.test.ts src/server/opencode.test.ts web/src/lib/opencode-tail.test.ts — 41 passed after carrying the parent's idle regression
pnpm --filter @sapiom/harness exec eslint src/server/opencode-events.ts src/server/opencode-events.test.ts — passed
```

The root test wrapper drops this VM's ambient filesystem-permission bypass for the existing unreadable-directory fixture. `pnpm pr:size` is absent in this repository; all-file numstat enforces the 1,000-line hard maximum.

### Tests and documentation

20 new direct tests cover lazy/failed opening, split UTF-8 and CRLF, multiline frames, malformed/oversized frames, incomplete EOF, per-yield scoping, terminal authentication, cancellation, reader cleanup, browser drain and stale/failed status reads. All 12 existing native HTTP route tests pass. A separate read-only review found no concrete introduced regression and ran an actual loopback HTTP probe confirming a pending read preserves the exact supplied abort error. Native A/B background acceptance is recorded with the complete later integration, not claimed for this extraction. README and a harness patch Changeset document transport cleanup.

## Compatibility and release impact

- Breaking or externally visible changes: no protocol or public package API change; browser transport retains its scoped SSE frames and backpressure.
- Changeset: Added `shared-assistant-event-reader.md` for `@sapiom/harness`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex implemented and verified the extraction and tests. An independent agent reviewed the transport and ran a real HTTP cancellation probe.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

## Risk and rollout

Ships through the existing Studio host transport. The existing bound remains decoded JavaScript string units per frame, not a whole-stream memory quota. A consumer aborts its signal to interrupt an outstanding iterator read. **Fix-forward:** correct shared parsing or cleanup and extend transport regressions while retaining authority and conversation scoping.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/961" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->