### PR TITLE
feat(harness): add native assistant state observer [SAP-3291]

### DIFF
--- a/.changeset/observe-native-assistant-state.md
+++ b/.changeset/observe-native-assistant-state.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Add a read-only native conversation observer that reconciles activity and pending-request counts across stream gaps for host integration.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -86,6 +86,8 @@ Assistant shows **Waiting for input** for current pending requests; failed reque
 reads retain last-known state while the status remains uncertain.
 Event transport scopes each frame to the authorized conversation and cancels
 its reader and status catch-up when the browser connection ends.
+The shared observer module derives activity and pending-request counts without
+storing transcript content or issuing execution commands.
 This first slice includes basic tool status; richer controls arrive separately.
 Studio actions reveal Terminal after a foreground CLI prompt is accepted; a
 rejected send shows its error and keeps the selected view. Unsent chat text is

--- a/packages/harness/src/core/opencode-observer.test.ts
+++ b/packages/harness/src/core/opencode-observer.test.ts
@@ -1,0 +1,371 @@
+import { afterEach, expect, it, vi } from "vitest";
+import type { HostedOpenCode } from "./opencode-host.js";
+import type { AssistantObservation } from "../shared/assistant-state.js";
+import { OpenCodeObserver } from "./opencode-observer.js";
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+const json = (value: unknown, status = 200) =>
+  new Response(JSON.stringify(value), { status });
+const wait = (check: () => void) =>
+  vi.waitFor(check, { interval: 10, timeout: 2500 });
+function fixture() {
+  const abort = new AbortController();
+  cleanups.push(() => abort.abort());
+  const data = new Map<string, unknown>([
+    ["/session/ses_a", { id: "ses_a" }],
+    ["/session/ses_b", { id: "ses_b" }],
+    ["/session/status", { ses_a: { type: "busy" }, ses_b: { type: "idle" } }],
+    ["/permission", []],
+    ["/question", []],
+  ]);
+  const streams: Array<{
+    send(value: unknown): void;
+    end(): void;
+    cancelled: boolean;
+  }> = [];
+  const queued = new Map<string, Array<Promise<Response>>>();
+  const fetch = vi.fn(async (path: string, _options?: RequestInit) => {
+    if (path === "/event") {
+      let controller!: ReadableStreamDefaultController<Uint8Array>;
+      const stream = {
+        cancelled: false,
+        send(value: unknown) {
+          controller.enqueue(
+            new TextEncoder().encode(`data: ${JSON.stringify(value)}\n\n`),
+          );
+        },
+        end() {
+          controller.close();
+        },
+      };
+      const body = new ReadableStream<Uint8Array>({
+        start(c) {
+          controller = c;
+        },
+        cancel() {
+          stream.cancelled = true;
+        },
+      });
+      streams.push(stream);
+      return new Response(body, {
+        headers: { "content-type": "text/event-stream" },
+      });
+    }
+    return queued.get(path)?.shift() ?? json(data.get(path));
+  });
+  let current = true;
+  const close = vi.fn();
+  const hosted = {
+    harnessSessionId: "studio-a",
+    cwd: "/same-folder",
+    signal: abort.signal,
+    isCurrent: () => current,
+    server: { fetch, close },
+  } as unknown as HostedOpenCode;
+  const updates: AssistantObservation[] = [];
+  const observer = new OpenCodeObserver(hosted, "ses_a", (state) =>
+    updates.push(state),
+  );
+  cleanups.push(observer.dispose);
+  return {
+    observer,
+    hosted,
+    fetch,
+    close,
+    data,
+    streams,
+    updates,
+    abort,
+    retire: () => {
+      current = false;
+    },
+    send(
+      type: string,
+      properties: Record<string, unknown> = {},
+      index = streams.length - 1,
+    ) {
+      streams[index]!.send({
+        type,
+        properties: { sessionID: "ses_a", ...properties },
+      });
+    },
+    hold(path: string) {
+      let resolve!: (value: Response) => void;
+      const promise = new Promise<Response>((done) => {
+        resolve = done;
+      });
+      queued.set(path, [...(queued.get(path) ?? []), promise]);
+      return resolve;
+    },
+    async start() {
+      observer.start();
+      await wait(() => expect(observer.getState().freshness).toBe("current"));
+    },
+  };
+}
+
+it("is lazy, observes only native reads, and coalesces duplicate starts and irrelevant events", async () => {
+  const f = fixture();
+  expect(f.observer.getState()).toEqual({
+    activity: "unknown",
+    pendingPermissions: null,
+    pendingQuestions: null,
+    freshness: "connecting",
+  });
+  expect(f.fetch).not.toHaveBeenCalled();
+  await f.start();
+  f.observer.start();
+  const before = f.updates.length;
+  f.send("server.heartbeat");
+  f.send("message.part.delta", {
+    messageID: "msg_a",
+    partID: "part_a",
+    delta: "private text",
+  });
+  f.send("session.status", { status: { type: "busy" } });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(f.updates).toHaveLength(before);
+  expect(f.fetch.mock.calls.map((call) => call[0]).sort()).toEqual([
+    "/event",
+    "/permission",
+    "/question",
+    "/session/ses_a",
+    "/session/status",
+  ]);
+  expect(f.fetch.mock.calls.every((call) => !call[1]?.method)).toBe(true);
+  expect(JSON.stringify(f.updates)).not.toContain("private text");
+  expect(f.close).not.toHaveBeenCalled();
+});
+
+it("lets newer status and request events win over in-flight snapshots", async () => {
+  const f = fixture();
+  const status = f.hold("/session/status");
+  const permission = f.hold("/permission");
+  const question = f.hold("/question");
+  f.observer.start();
+  await wait(() => expect(f.fetch).toHaveBeenCalledTimes(5));
+  f.send("session.idle");
+  f.send("permission.asked", { id: "new" });
+  f.send("permission.replied", { requestID: "old" });
+  f.send("question.asked", { id: "new-question" });
+  f.send("question.rejected", { requestID: "old-question" });
+  await wait(() => expect(f.observer.getState().activity).toBe("idle"));
+  status(json({ ses_a: { type: "busy" } }));
+  permission(
+    json([
+      { id: "old", sessionID: "ses_a" },
+      { id: "foreign", sessionID: "ses_b" },
+    ]),
+  );
+  question(json([{ id: "old-question", sessionID: "ses_a" }]));
+  await wait(() =>
+    expect(f.observer.getState()).toMatchObject({
+      activity: "idle",
+      pendingPermissions: 1,
+      pendingQuestions: 1,
+      freshness: "current",
+    }),
+  );
+  const before = f.updates.length;
+  f.send("permission.asked", { id: "new" });
+  f.send("question.asked", { id: "new-question" });
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(f.updates).toHaveLength(before);
+});
+
+it("keeps a newer native status current when the older status read fails", async () => {
+  const f = fixture();
+  const status = f.hold("/session/status");
+  f.observer.start();
+  await wait(() => expect(f.observer.getState().pendingQuestions).toBe(0));
+  f.send("session.idle");
+  await wait(() => expect(f.observer.getState().freshness).toBe("current"));
+  status(json({}, 500));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(f.observer.getState()).toMatchObject({
+    activity: "idle",
+    freshness: "current",
+  });
+});
+
+it("replaces stale pending sets after EOF and ignores late reads from the old connection", async () => {
+  const f = fixture();
+  f.data.set("/permission", [{ id: "old", sessionID: "ses_a" }]);
+  await f.start();
+  const oldStatus = f.hold("/session/status");
+  const oldPermission = f.hold("/permission");
+  f.streams[0]!.end();
+  await wait(() => expect(f.streams).toHaveLength(2));
+  await wait(() =>
+    expect(
+      f.fetch.mock.calls.filter((call) => call[0] === "/permission"),
+    ).toHaveLength(2),
+  );
+  expect(f.observer.getState()).toMatchObject({
+    pendingPermissions: 1,
+    freshness: "reconnecting",
+  });
+  f.data.set("/permission", []);
+  f.data.set("/session/status", {});
+  f.streams[1]!.end();
+  await wait(() => expect(f.streams).toHaveLength(3));
+  await wait(() =>
+    expect(f.observer.getState()).toMatchObject({
+      pendingPermissions: 0,
+      activity: "idle",
+      freshness: "current",
+    }),
+  );
+  oldStatus(json({ ses_a: { type: "busy" } }));
+  oldPermission(json([{ id: "old", sessionID: "ses_a" }]));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(f.observer.getState()).toMatchObject({
+    pendingPermissions: 0,
+    activity: "idle",
+    freshness: "current",
+  });
+  expect(f.close).not.toHaveBeenCalled();
+});
+
+it.each(["status", "permission", "question", "session"])(
+  "retries a malformed %s read without restarting a healthy stream",
+  async (resource) => {
+    const f = fixture();
+    const path =
+      resource === "session"
+        ? "/session/ses_a"
+        : resource === "status"
+          ? "/session/status"
+          : `/${resource}`;
+    f.hold(path)(json(null));
+    await f.start();
+    expect(f.streams).toHaveLength(1);
+    expect(f.fetch.mock.calls.filter((call) => call[0] === path)).toHaveLength(
+      2,
+    );
+    expect(f.updates.some((state) => state.freshness === "reconnecting")).toBe(
+      true,
+    );
+  },
+);
+
+it.each(["status", "permission"])(
+  "does not invent successful empty state after a failed %s read",
+  async (resource) => {
+    const f = fixture();
+    const path = resource === "status" ? "/session/status" : "/permission";
+    f.data.set("/permission", [{ id: "pending", sessionID: "ses_a" }]);
+    await f.start();
+    f.data.set(path, null);
+    f.streams[0]!.end();
+    await wait(() => expect(f.streams).toHaveLength(2));
+    await wait(() =>
+      expect(
+        f.fetch.mock.calls.filter((call) => call[0] === path).length,
+      ).toBeGreaterThanOrEqual(3),
+    );
+    expect(f.observer.getState()).toMatchObject({
+      activity: "busy",
+      pendingPermissions: 1,
+      freshness: "reconnecting",
+    });
+    f.observer.dispose();
+    const count = f.fetch.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(f.fetch).toHaveBeenCalledTimes(count);
+  },
+);
+
+it.each(["event", "missed-event"])(
+  "retains terminal missing state after deletion: %s",
+  async (source) => {
+    const f = fixture();
+    await f.start();
+    if (source === "event")
+      f.send("session.deleted", { info: { id: "ses_a" } });
+    else {
+      f.hold("/session/ses_a")(json({ private: "diagnostics" }, 404));
+      f.streams[0]!.end();
+    }
+    await wait(() =>
+      expect(f.observer.getState()).toMatchObject({
+        freshness: "unavailable",
+        failure: { code: "native_history_missing" },
+      }),
+    );
+    f.observer.start();
+    const count = f.fetch.mock.calls.length;
+    await new Promise((resolve) => setTimeout(resolve, 600));
+    expect(f.fetch).toHaveBeenCalledTimes(count);
+    expect(f.close).not.toHaveBeenCalled();
+    expect(JSON.stringify(f.updates)).not.toContain("diagnostics");
+  },
+);
+
+it("treats a global endpoint 404 as retryable observation loss", async () => {
+  const f = fixture();
+  f.hold("/permission")(json({}, 404));
+  await f.start();
+  expect(f.observer.getState().failure).toBeUndefined();
+  expect(f.streams).toHaveLength(1);
+});
+
+it("isolates two conversations in the same folder and sanitizes terminal authentication errors", async () => {
+  const f = fixture();
+  await f.start();
+  const b = new OpenCodeObserver(f.hosted, "ses_b", () => {});
+  cleanups.push(b.dispose);
+  b.start();
+  await wait(() => expect(b.getState().freshness).toBe("current"));
+  for (const stream of f.streams)
+    stream.send({
+      type: "permission.asked",
+      properties: { sessionID: "ses_a", id: "only-a" },
+    });
+  await wait(() => expect(f.observer.getState().pendingPermissions).toBe(1));
+  expect(b.getState()).toMatchObject({
+    activity: "idle",
+    pendingPermissions: 0,
+  });
+  f.send(
+    "session.error",
+    {
+      error: {
+        name: "ProviderAuthError",
+        data: { providerID: "sapiom", message: "secret" },
+      },
+    },
+    0,
+  );
+  await wait(() =>
+    expect(f.observer.getState().failure?.code).toBe("authentication_required"),
+  );
+  expect(JSON.stringify(f.updates)).not.toContain("secret");
+  expect(b.getState().freshness).toBe("current");
+});
+
+it.each(["dispose", "abort", "retire"])(
+  "fences pending reads and closes the observer connection on %s",
+  async (action) => {
+    const f = fixture();
+    const pending = f.hold("/permission");
+    f.observer.start();
+    await wait(() => expect(f.fetch).toHaveBeenCalledTimes(5));
+    if (action === "dispose") f.observer.dispose();
+    if (action === "abort") f.abort.abort();
+    if (action === "retire") {
+      f.retire();
+      f.send("server.heartbeat");
+    }
+    if (action !== "retire")
+      await wait(() => expect(f.streams[0]!.cancelled).toBe(true));
+    const before = f.updates.length;
+    pending(json([{ id: "late", sessionID: "ses_a" }]));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(f.updates).toHaveLength(before);
+    expect(f.close).not.toHaveBeenCalled();
+  },
+);

--- a/packages/harness/src/core/opencode-observer.ts
+++ b/packages/harness/src/core/opencode-observer.ts
@@ -1,0 +1,293 @@
+import { setTimeout as delay } from "node:timers/promises";
+import type { HostedOpenCode } from "./opencode-host.js";
+import { readOpenCodeEvents } from "../server/opencode-events.js";
+import type { AssistantObservation } from "../shared/assistant-state.js";
+import {
+  openCodeTransportFailure,
+  parseOpenCodeTransportFailure,
+  type OpenCodeTransportFailure,
+} from "../shared/opencode-errors.js";
+
+type Kind = "permission" | "question";
+type Resource = Kind | "status" | "session";
+interface Connection {
+  abort: AbortController;
+  current: Set<Resource>;
+  statusRevision: number;
+  updates: Record<Kind, Map<string, boolean> | null>;
+}
+const resources: Resource[] = ["session", "status", "permission", "question"];
+const record = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+const identifier = (value: unknown): value is string =>
+  typeof value === "string" && /^[A-Za-z0-9_-]{1,256}$/.test(value);
+const activity = (value: unknown): AssistantObservation["activity"] | null =>
+  value === "idle" || value === "busy" || value === "retry" ? value : null;
+
+/** Observe one authorized association. Construction and getters perform no I/O. */
+export class OpenCodeObserver {
+  private readonly lifetime = new AbortController();
+  private connection?: Connection;
+  private started = false;
+  private disposed = false;
+  private readonly pending = {
+    permission: new Set<string>(),
+    question: new Set<string>(),
+  };
+  private readonly known = { permission: false, question: false };
+  private value: AssistantObservation = {
+    activity: "unknown",
+    pendingPermissions: null,
+    pendingQuestions: null,
+    freshness: "connecting",
+  };
+  constructor(
+    private readonly hosted: HostedOpenCode,
+    private readonly id: string,
+    private readonly onUpdate: (state: AssistantObservation) => void,
+  ) {}
+
+  getState(): AssistantObservation {
+    return { ...this.value };
+  }
+  start(): void {
+    if (this.started || this.disposed) return;
+    this.started = true;
+    this.hosted.signal.addEventListener("abort", this.dispose, { once: true });
+    if (!this.live()) {
+      this.dispose();
+      return;
+    }
+    this.onUpdate(this.getState());
+    void this.run();
+  }
+  dispose = (): void => {
+    this.disposed = true;
+    this.hosted.signal.removeEventListener("abort", this.dispose);
+    this.lifetime.abort();
+    this.connection?.abort.abort();
+  };
+  private live(c?: Connection): boolean {
+    return (
+      !this.disposed &&
+      !this.hosted.signal.aborted &&
+      this.hosted.isCurrent() &&
+      (!c || (this.connection === c && !c.abort.signal.aborted))
+    );
+  }
+  private update(next: Partial<AssistantObservation>): void {
+    const value = { ...this.value, ...next };
+    if (JSON.stringify(value) === JSON.stringify(this.value)) return;
+    this.value = value;
+    this.onUpdate(this.getState());
+  }
+  private accepted(
+    c: Connection,
+    next: Partial<AssistantObservation> = {},
+  ): void {
+    if (!this.live(c)) return;
+    this.update({
+      ...next,
+      ...(c.current.size === resources.length
+        ? { freshness: "current", failure: undefined }
+        : {}),
+    });
+  }
+  private fail(failure: OpenCodeTransportFailure): void {
+    this.update({ freshness: "unavailable", failure });
+    this.dispose();
+  }
+  private counts(): Pick<
+    AssistantObservation,
+    "pendingPermissions" | "pendingQuestions"
+  > {
+    return {
+      pendingPermissions: this.known.permission
+        ? this.pending.permission.size
+        : null,
+      pendingQuestions: this.known.question ? this.pending.question.size : null,
+    };
+  }
+  private async run(): Promise<void> {
+    let backoff = 250;
+    while (this.live()) {
+      const c: Connection = {
+        abort: new AbortController(),
+        current: new Set(),
+        statusRevision: 0,
+        updates: { permission: null, question: null },
+      };
+      this.connection = c;
+      const signal = AbortSignal.any([this.lifetime.signal, c.abort.signal]);
+      const openedAt = Date.now();
+      try {
+        for await (const event of readOpenCodeEvents(
+          this.hosted,
+          this.id,
+          signal,
+          () => {
+            void this.reconcile(c).catch(() => {});
+          },
+        )) {
+          if (!this.live(c)) break;
+          this.event(c, event);
+        }
+      } catch {
+        /* Loss of observation is not execution failure. */
+      } finally {
+        c.abort.abort();
+        if (this.connection === c) this.connection = undefined;
+      }
+      if (!this.live()) return;
+      this.update({
+        freshness: "reconnecting",
+        failure: openCodeTransportFailure("transport_unavailable"),
+      });
+      if (Date.now() - openedAt >= 5000) backoff = 250;
+      await delay(backoff, undefined, {
+        signal: this.lifetime.signal,
+        ref: false,
+      }).catch(() => {});
+      backoff = Math.min(backoff * 2, 5000);
+    }
+  }
+  private async reconcile(c: Connection): Promise<void> {
+    let backoff = 250;
+    while (this.live(c) && c.current.size !== resources.length) {
+      await Promise.all(
+        resources
+          .filter((resource) => !c.current.has(resource))
+          .map((resource) =>
+            this.read(c, resource).catch(() => {
+              if (this.live(c) && !c.current.has(resource))
+                this.update({
+                  freshness: "reconnecting",
+                  failure: openCodeTransportFailure("transport_unavailable"),
+                });
+            }),
+          ),
+      );
+      if (!this.live(c) || c.current.size === resources.length) return;
+      await delay(backoff, undefined, { signal: c.abort.signal, ref: false });
+      backoff = Math.min(backoff * 2, 5000);
+    }
+  }
+  private async read(c: Connection, resource: Resource): Promise<void> {
+    const revision = c.statusRevision;
+    const updates = new Map<string, boolean>();
+    if (resource === "permission" || resource === "question")
+      c.updates[resource] = updates;
+    const signal = AbortSignal.any([
+      c.abort.signal,
+      this.lifetime.signal,
+      AbortSignal.timeout(3000),
+    ]);
+    try {
+      const path =
+        resource === "session"
+          ? `/session/${this.id}`
+          : resource === "status"
+            ? "/session/status"
+            : `/${resource}`;
+      const response = await this.hosted.server.fetch(path, { signal });
+      if (!response.ok) {
+        await response.body?.cancel();
+        if (this.live(c) && resource === "session" && response.status === 404)
+          this.fail(openCodeTransportFailure("native_history_missing"));
+        throw new Error("Assistant observation read failed");
+      }
+      if (!this.live(c) || signal.aborted) {
+        await response.body?.cancel().catch(() => {});
+        return;
+      }
+      const value: unknown = await response.json();
+      if (!this.live(c) || signal.aborted) return;
+      if (resource === "session") {
+        if (record(value)?.id !== this.id)
+          throw new Error("Invalid conversation metadata");
+      } else if (resource === "status") {
+        if (revision !== c.statusRevision) return;
+        const statuses = record(value);
+        if (!statuses) throw new Error("Invalid conversation status");
+        const next =
+          statuses[this.id] === undefined
+            ? "idle"
+            : activity(record(statuses[this.id])?.type);
+        if (!next) throw new Error("Invalid conversation status");
+        c.current.add(resource);
+        this.accepted(c, { activity: next });
+        return;
+      } else {
+        if (!Array.isArray(value)) throw new Error("Invalid pending requests");
+        const ids = new Set<string>();
+        const allIds = new Set<string>();
+        for (const entry of value) {
+          const request = record(entry);
+          if (
+            !request ||
+            !identifier(request.id) ||
+            !identifier(request.sessionID) ||
+            allIds.has(request.id)
+          )
+            throw new Error("Invalid pending request identity");
+          allIds.add(request.id);
+          if (request.sessionID === this.id) ids.add(request.id);
+        }
+        for (const [id, pending] of updates) {
+          if (pending) ids.add(id);
+          else ids.delete(id);
+        }
+        this.pending[resource] = ids;
+        this.known[resource] = true;
+      }
+      c.current.add(resource);
+      this.accepted(c, this.counts());
+    } finally {
+      if (
+        (resource === "permission" || resource === "question") &&
+        c.updates[resource] === updates
+      )
+        c.updates[resource] = null;
+    }
+  }
+  private event(c: Connection, event: Record<string, unknown>): void {
+    const properties = record(event.properties) ?? {};
+    if (event.type === "session.deleted") {
+      this.fail(openCodeTransportFailure("native_history_missing"));
+      return;
+    }
+    if (event.type === "studio.error") {
+      const failure = parseOpenCodeTransportFailure(properties);
+      if (failure) this.fail(failure);
+      return;
+    }
+    const next =
+      event.type === "session.idle"
+        ? "idle"
+        : event.type === "session.status"
+          ? activity(record(properties.status)?.type)
+          : null;
+    if (next) {
+      c.statusRevision++;
+      c.current.add("status");
+      this.accepted(c, { activity: next });
+    }
+    for (const kind of ["permission", "question"] as const) {
+      const asked = event.type === `${kind}.asked`;
+      if (
+        !asked &&
+        event.type !== `${kind}.replied` &&
+        !(kind === "question" && event.type === "question.rejected")
+      )
+        continue;
+      const id = asked ? properties.id : properties.requestID;
+      if (!identifier(id)) continue;
+      if (asked) this.pending[kind].add(id);
+      else this.pending[kind].delete(id);
+      c.updates[kind]?.set(id, asked);
+      this.accepted(c, this.counts());
+    }
+  }
+}

--- a/packages/harness/src/shared/assistant-state.ts
+++ b/packages/harness/src/shared/assistant-state.ts
@@ -1,0 +1,22 @@
+import type { OpenCodeTransportFailure } from "./opencode-errors.js";
+
+export interface AssistantSessionSummary {
+  harnessSessionId: string;
+  conversationId: string;
+  activity: "unknown" | "idle" | "busy" | "retry";
+  pendingPermissions: number | null;
+  pendingQuestions: number | null;
+  freshness: "connecting" | "current" | "reconnecting" | "unavailable";
+  failure?: OpenCodeTransportFailure;
+}
+export interface AssistantStateSnapshot {
+  hostInstanceId: string;
+  authorityRevision: string;
+  revision: number;
+  enabled: boolean;
+  sessions: readonly AssistantSessionSummary[];
+}
+export type AssistantObservation = Omit<
+  AssistantSessionSummary,
+  "harnessSessionId" | "conversationId"
+>;


### PR DESCRIPTION
<!--
Thank you for contributing to sapiom-js.
Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
-->

## Primary change type

<!-- Select exactly one primary type. -->

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Assistant activity currently has no host-side observer independent of the selected browser display. This module observes an already authorized native conversation and derives current activity and pending-request counts while retaining honest uncertainty through stream gaps.

## Summary and scope

Add `OpenCodeObserver` and the shared Assistant summary types. Its constructor/getter are synchronous and perform no I/O; explicit start consumes the shared scoped iterator. Reconcile independent metadata/status/permission/question reads with event ordering, bounded retries and connection/lifetime cancellation. Keep only activity and request identities, preserve last-known values through transport loss, and publish only changed facts.

A confirmed metadata 404 or native deletion leaves terminal `native_history_missing`, including deletion missed during a stream gap. Native authentication failures use the existing sanitized failure contract. No prompt, reply, recovery, abort or native-runtime-close commands are issued.

This 693-line all-file increment stacks on #961 for SAP-3291. Host ownership/router activation follows separately; the module is not yet attached to production host entries. REST/WebSocket projection and navigation indicators follow that activation.

## Related work

<!--
Link the issue or prior maintainer discussion when required by CONTRIBUTING.md.
Use N/A for a direct PR that does not need one.
-->

Related issue or discussion:
https://linear.app/sapiom/issue/SAP-3291

## Validation

```text
pnpm build — passed (root)
pnpm typecheck — passed (root)
pnpm lint — passed (root)
setpriv --inh-caps=-all --ambient-caps=-all env npm_config_workspace_concurrency=1 pnpm test — passed (root)
pnpm install --frozen-lockfile — passed
pnpm --filter @sapiom/harness exec vitest run src/core/opencode-observer.test.ts src/server/opencode-events.test.ts src/server/opencode.test.ts — 49 passed
pnpm --filter @sapiom/harness exec eslint src/core/opencode-observer.ts src/core/opencode-observer.test.ts src/shared/assistant-state.ts — passed
```

The root test wrapper drops this VM's ambient filesystem-permission bypass for the existing unreadable-directory fixture. `pnpm pr:size` is absent in this repository; all-file numstat enforces the 1,000-line hard maximum.

### Tests and documentation

17 new observer tests cover no-I/O construction/getters, one connection per start, ignored token/heartbeat events, read/event ordering, stale connection completions, independent malformed/failed reads, timer disposal, scoped counts, deletion received or missed during disconnect, global404 recovery, sanitized auth failure and same-folder conversation isolation. A regression reproduces an old failed status read downgrading newer native idle; superseded status failures now preserve current observation. Independent review reran all17 and found no further module defects. README and a harness patch Changeset describe the module. Actual native A/B background acceptance belongs to the later complete host/UI integration.

## Compatibility and release impact

- Breaking or externally visible changes: no production host activation or browser protocol change in this increment. Shared summary types establish the next integration contract.
- Changeset: Added `observe-native-assistant-state.md` for `@sapiom/harness`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex implemented and verified the observer and tests. An independent agent reviewed connection lifetime, ordering, missing-state handling and privacy.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

## Risk and rollout

This module becomes active only when wired by the following host ownership increment. The owner must bind before synchronous start, dispose on hosted retirement and preserve terminal missing-history bindings. Native idle is activity, not proof of task success. **Fix-forward:** correct observer ordering or lifecycle guards and extend the relevant race tests without adding execution dispatch.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/962" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->