### PR TITLE
test(opencode): verify native context lifecycle [SAP-3399]

### DIFF
--- a/.github/workflows/harness.yml
+++ b/.github/workflows/harness.yml
@@ -62,11 +62,14 @@ jobs:
   # Playwright mock-mode tier — harness web/e2e specs (VITE_MOCK=1, chromium only).
   # The live/real-pty tiers (e2e:live, sim) are opt-in local only; nothing here
   # invokes them — they require real agent binaries and credentials not in CI.
-  playwright-mock:
+  playwright-shards:
     runs-on: ubuntu-latest
-    # The expanded mock suite has over 560 cases, followed by canvas checks.
-    # Keep the existing per-test deadlines; allow both suites to finish.
+    # Split the growing suite while preserving the per-job and per-test limits.
     timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     # Single Node version is enough — the mock tier tests browser behaviour,
     # not Node version compat; that's covered by the matrix job in test.yml.
     steps:
@@ -106,22 +109,34 @@ jobs:
         run: pnpm --filter @sapiom/harness exec playwright install-deps chromium
 
       - name: Run Playwright mock-mode suite
-        run: pnpm --filter @sapiom/harness test:ui
+        run: pnpm --filter @sapiom/harness test:ui --shard=${{ matrix.shard }}/2
 
       # The canvas suite renders the generated diagram documents in the same
       # chromium this job already installed. It was previously opt-in only, so
       # nothing verified in CI that a canvas the renderer produces actually
       # paints — a rendering regression could only be caught by hand.
       - name: Run Playwright canvas suite
-        run: pnpm --filter @sapiom/harness test:canvas
+        run: pnpm --filter @sapiom/harness test:canvas --shard=${{ matrix.shard }}/2
 
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: playwright-report
+          name: playwright-report-${{ matrix.shard }}
           path: packages/harness/web/e2e/playwright-report/
           retention-days: 7
+
+  # Preserve the existing required check and require every shard to succeed.
+  playwright-mock:
+    runs-on: ubuntu-latest
+    needs: playwright-shards
+    if: always()
+    timeout-minutes: 1
+    steps:
+      - name: Require all browser shards
+        env:
+          SHARD_RESULT: ${{ needs.playwright-shards.result }}
+        run: test "$SHARD_RESULT" = success
 
   # Desktop app: does the PACKAGED bundle still launch?
   #

--- a/packages/opencode/docs/context-probe.md
+++ b/packages/opencode/docs/context-probe.md
@@ -1,0 +1,78 @@
+# Native context assessment fixture
+
+This opt-in probe supplies the native evidence for [SAP-3399](https://linear.app/sapiom/issue/SAP-3399).
+It starts the real pinned OpenCode binary in temporary state, drives harmless tools against fixture files/MCP,
+and captures actual Responses request bodies and native history. Its local provider returns synthetic usage;
+those numbers are **not cache measurements**. No account credentials are required.
+
+## Run
+
+From an installed SDK checkout, with Node 20+ and the pinned pnpm:
+
+```sh
+pnpm install --frozen-lockfile
+pnpm --filter @sapiom/opencode build
+node --test scripts/assistant-context-projection.test.mjs
+packages/harness/node_modules/.bin/tsx scripts/assistant-context-probe.mjs . /tmp/context-probe.json
+```
+
+If install scripts were disabled, first run `node packages/opencode/node_modules/opencode-ai/postinstall.mjs`
+to materialize the pinned platform executable. The package's placeholder executable cannot run this probe.
+The output path must be outside the temporary runtime; the script removes its fixture workspace on exit.
+
+The first argument is the SDK checkout **under assessment**, which can differ from the checkout containing
+these scripts. When that checkout contains `studio-assistant-context.ts`, the probe imports its actual
+composer/recovery functions. Otherwise it constructs a clearly labeled fixture envelope for native-only
+checks on main. Missing dependencies inside an existing composer are errors, not a fallback condition.
+
+## Cases and limits
+
+The probe checks root discovery and nested file-read discovery separately. During the first model call it
+changes an explicit native instruction file and an already discovered skill body, then observes subsequent
+native tool steps. It changes nested rules before another read and changes Studio guidance/selection before
+a new user turn. It also exercises recovery, native summarization with synthetic continuation, restart with
+the same state, and an independent conversation in the same folder.
+
+The projection experiment moves profile guidance before changing completion metadata in the privileged
+system/developer request. It preserves old saved system records, the new saved v2 envelope, completion-token
+validation, and native continuation. The small helper recognizes this controlled envelope; downstream
+production integration must use validated host context and the full source/lifecycle contract.
+
+The host overwrites arbitrary `config.plugin` entries. The fixture therefore composes its test hook into the
+host-generated credential-isolation plugin via `beforeLaunch`, preserving its existing hooks. Native
+`experimental.chat.system.transform` requires mutating the original array with `splice`; assigning a new
+`output.system` array was tested and left the wire layout unchanged. This fixture does not install a product hook.
+
+Current-runtime expectations include behaviors that downstream implementation must correct: explicit
+instructions are reread during a turn, while nested instructions can load despite disabled project discovery.
+Update those expectations deliberately when changing the runtime; an upgraded pin needs fresh evidence.
+
+## Assessment candidate, 2026-09-12
+
+The issue's evidence bundle records source provenance, requests, history, and exact checksums. The candidate
+combines these SDK revisions in a disposable integration checkout:
+
+| Input                     | Commit                                     |
+| ------------------------- | ------------------------------------------ |
+| main                      | `76318848fd270bfc179315e99b7e2cce4049a5b1` |
+| #950 response visibility  | `9b40f11351bc86190482add78d16092ff31ce4c4` |
+| #951 Luna Responses route | `eff8fe067eec145a8db1043859a66900907c2a3b` |
+| #952 context types        | `963bb6b0cf5b4d772d7f3503b7f93fa3fea4994d` |
+| #953 context delivery     | `7c8eb92aaaa4a8aa495605367d7d6f7c41ce44c3` |
+| Local integration commit  | `7e83d40321e8a4ce21cff8a3eff1c43bf4bbc345` |
+| Integration tree          | `50d84dde1805a8e4006431f587eeffb2b566c5d0` |
+
+Runtime: OpenCode **1.18.29**, upstream commit `16747470f976aca3d362ad730bcd3fe82ecc2c9a`;
+Assistant UI adapter **0.2.22**. The native fixture explicitly selects the OpenAI Responses provider and
+`gpt-luna`, including when its SDK input is pre-Luna main.
+
+To reconstruct the integration tree, fetch the pinned #953 revision into a fresh detached checkout and apply
+the issue bundle's `candidate.patch` with `git apply --index candidate.patch`. `git write-tree` must equal the
+tree above. That patch incorporates #950/#951; overlapping normal/recovery requests retain #953 context
+admission and #951's `model: hosted.model`. The README retains both changes. The integration commits are
+assessment inputs, not changes delivered by this test PR.
+
+Install/build dependencies in that checkout, then pass its absolute path to this probe. The gateway probe
+in the next assessment PR additionally needs built MCP/workspace dependencies and the Luna/context candidate.
+The issue carries the complete lifecycle contract and actual gateway baseline; this fixture alone does not
+certify queued dispatch, live skill/MCP refresh, browser sign-in, or all Studio session controls.

--- a/scripts/assistant-context-probe.mjs
+++ b/scripts/assistant-context-probe.mjs
@@ -1,0 +1,534 @@
+// Run through the SDK's tsx: see packages/opencode/docs/context-probe.md.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { projectStudioSystem } from "./assistant-context-projection.mjs";
+
+const sdk = resolve(process.argv[2] ?? ".");
+const output = resolve(process.argv[3] ?? "context-probe.json");
+const source = (path) => import(pathToFileURL(join(sdk, path)).href);
+const { startOpenCodeServer } = await source("packages/opencode/src/server.ts");
+const { createSapiomOpenCodeConfig } = await source(
+  "packages/opencode/src/config.ts",
+);
+const {
+  openCodeCompletionPrompt,
+  openCodeCompletionTokens,
+  parseOpenCodeCompletion,
+} = await source("packages/harness/src/shared/opencode-completion.ts");
+const contextPath = "packages/harness/src/core/studio-assistant-context.ts";
+const hasDraft = await access(join(sdk, contextPath)).then(
+  () => true,
+  (error) => {
+    if (error.code !== "ENOENT") throw error;
+    return false;
+  },
+);
+const draft = hasDraft ? await source(contextPath) : null;
+const digest = (value) => createHash("sha256").update(value).digest("hex");
+const root = await mkdtemp(join(tmpdir(), "studio-context-assessment-"));
+const cwd = join(root, "project");
+const trusted = join(root, "trusted.md");
+const skillFile = join(root, "skills", "context-fixture", "SKILL.md");
+const rootRule = "ROOT_RULE_CANARY";
+const nestedRule = "NESTED_RULE_V1";
+const requests = [];
+const checks = {};
+let phase = "initial",
+  completed = false,
+  actions = [],
+  runtime,
+  projected = false;
+const nativeSystem = (body) =>
+  (body.input ?? [])
+    .filter((item) => ["system", "developer"].includes(item.role))
+    .flatMap((item) =>
+      typeof item.content === "string"
+        ? [item.content]
+        : item.content.map((part) => part.text ?? ""),
+    )
+    .join("\n");
+const mark = (name, condition) => {
+  checks[name] = !!condition;
+  assert.ok(condition, name);
+};
+const skill = (version) =>
+  `---\nname: context-fixture\ndescription: Controlled context fixture.\n---\nSKILL_BODY_${version}\n`;
+const context = (selected = "Cedar", version = "V1") => ({
+  schemaVersion: 1,
+  revision: version,
+  session: { id: "studio-fixture", cwd, projectId: "fixture" },
+  environment: "fixture",
+  selectedAgent: {
+    status: "available",
+    agent: { name: selected, path: join(cwd, selected), definitionId: null },
+  },
+  boundAgent: {
+    status: "available",
+    agent: { name: "Cedar", path: join(cwd, "Cedar"), definitionId: null },
+  },
+  agents: [],
+  capabilities: [{ name: "fixture", status: "available", tools: ["ping"] }],
+  guidance: [
+    {
+      id: "studio-profile",
+      kind: "profile",
+      required: true,
+      source: "fixture",
+      status: "available",
+      revision: version,
+      text: `PROFILE_${version}\n` + "Stable Studio guidance. ".repeat(300),
+    },
+  ],
+});
+const compose = (value) =>
+  draft?.composeAssistantPrompt(value) ?? {
+    system:
+      openCodeCompletionPrompt().system +
+      "\n\nStudioAssistantContext/v1\nFixture policy\n" +
+      JSON.stringify(value),
+  };
+const recover = (system) =>
+  draft?.recoverAssistantPrompt(system) ?? {
+    system:
+      openCodeCompletionPrompt().system +
+      system.slice(system.indexOf("\n\nStudioAssistantContext/v1\n")),
+  };
+
+const bridge = createServer(async (req, res) => {
+  try {
+    let raw = "";
+    for await (const chunk of req) raw += chunk;
+    const body = raw ? JSON.parse(raw) : {};
+    if (req.url.endsWith("/mcp")) {
+      if (req.method === "GET") return void res.writeHead(405).end();
+      if (body.id === undefined) return void res.writeHead(202).end();
+      const result =
+        body.method === "initialize"
+          ? {
+              protocolVersion: body.params.protocolVersion,
+              capabilities: { tools: {} },
+              serverInfo: { name: "fixture", version: "1" },
+              instructions: "MCP_INSTRUCTION_CANARY",
+            }
+          : body.method === "tools/list"
+            ? {
+                tools: [
+                  {
+                    name: "ping",
+                    description: "MCP_TOOL_CANARY",
+                    inputSchema: { type: "object", properties: {} },
+                  },
+                ],
+              }
+            : { content: [{ type: "text", text: "MCP_RESULT_CANARY" }] };
+      return void res
+        .writeHead(200, { "Content-Type": "application/json" })
+        .end(JSON.stringify({ jsonrpc: "2.0", id: body.id, result }));
+    }
+    if (!req.url.endsWith("/responses")) return void res.writeHead(404).end();
+    const work = !!body.tools?.length;
+    requests.push({ phase, projected, work, body });
+    const instruction = nativeSystem(body);
+    const token = [
+      ...instruction.matchAll(
+        /(?:^|\n)StudioAssistantResult\/v2:([a-f0-9-]{36})\n/g,
+      ),
+    ].at(-1)?.[1];
+    const action = work ? actions.shift() : undefined;
+    if (phase === "initial" && action?.name === "read") {
+      await writeFile(trusted, "EXPLICIT_GUIDE_V2");
+      await writeFile(skillFile, skill("V2"));
+    }
+    const id = `resp_${requests.length}`;
+    res.writeHead(200, { "Content-Type": "text/event-stream" });
+    const emit = (type, fields) =>
+      res.write(
+        `event: ${type}\ndata: ${JSON.stringify({ type, ...fields })}\n\n`,
+      );
+    const base = { id, object: "response", created_at: 1, model: "gpt-luna" };
+    emit("response.created", {
+      response: { ...base, status: "in_progress", output: [] },
+    });
+    const item = action
+      ? {
+          id: `fc_${id}`,
+          type: "function_call",
+          call_id: `call_${id}`,
+          name: action.name,
+          arguments: JSON.stringify(action.arguments),
+          status: "completed",
+        }
+      : {
+          id: `msg_${id}`,
+          type: "message",
+          role: "assistant",
+          content: [
+            {
+              type: "output_text",
+              text: work
+                ? `<!-- studio-result:${token}:finished -->\nFIXTURE_HISTORY_CANARY ${phase}`
+                : "Fixture summary: Cedar and Orchid; preserve the user's context and completed reads.",
+              annotations: [],
+            },
+          ],
+          status: "completed",
+        };
+    emit("response.output_item.added", {
+      output_index: 0,
+      item: {
+        ...item,
+        ...(action ? { arguments: "" } : { content: [] }),
+        status: "in_progress",
+      },
+    });
+    if (action)
+      emit("response.function_call_arguments.delta", {
+        output_index: 0,
+        item_id: item.id,
+        delta: item.arguments,
+      });
+    else
+      emit("response.output_text.delta", {
+        output_index: 0,
+        content_index: 0,
+        item_id: item.id,
+        delta: item.content[0].text,
+      });
+    emit("response.output_item.done", { output_index: 0, item });
+    emit("response.completed", {
+      response: {
+        ...base,
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 100, output_tokens: 20, total_tokens: 120 },
+      },
+    });
+    res.end();
+  } catch (error) {
+    res.writeHead(500).end(String(error));
+  }
+});
+
+const request = (path, body) =>
+  runtime.fetchJson(path, {
+    ...(body === undefined
+      ? {}
+      : {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        }),
+    signal: AbortSignal.timeout(90_000),
+  });
+const send = async (id, prompt, text) =>
+  request(`/session/${id}/message`, {
+    ...prompt,
+    model: { providerID: "sapiom", modelID: "gpt-luna" },
+    parts: [{ type: "text", text }],
+  });
+const workIn = (name) =>
+  requests.filter((item) => item.phase === name && item.work);
+let config, history;
+try {
+  await mkdir(join(cwd, "nested"), { recursive: true });
+  await mkdir(dirname(skillFile), { recursive: true });
+  await Promise.all([
+    writeFile(join(cwd, "AGENTS.md"), rootRule),
+    writeFile(join(cwd, "CLAUDE.md"), "ROOT_CLAUDE_CANARY"),
+    writeFile(join(cwd, "nested", "AGENTS.md"), nestedRule),
+    writeFile(join(cwd, "nested", "index.ts"), "export const value = 42;"),
+    writeFile(trusted, "EXPLICIT_GUIDE_V1"),
+    writeFile(skillFile, skill("V1")),
+  ]);
+  await new Promise((resolve) => bridge.listen(0, "127.0.0.1", resolve));
+  const origin = `http://127.0.0.1:${bridge.address().port}`;
+  config = createSapiomOpenCodeConfig({
+    bridgeUrl: origin,
+    runtimeToken: "fixture-only",
+    model: "gpt-luna",
+  });
+  config.provider.sapiom.npm = "@ai-sdk/openai";
+  config.provider.sapiom.options.baseURL = `${origin}/llm/v1`;
+  config.instructions = [trusted];
+  config.skills = { paths: [join(root, "skills")] };
+  const start = () =>
+    startOpenCodeServer({
+      cwd,
+      stateRoot: join(root, "native"),
+      config,
+      startupTimeoutMs: 30_000,
+      beforeLaunch: async () => {
+        if (!projected) return;
+        // Assessment seam: extend the generated host plugin, preserving isolation.
+        // Arbitrary config.plugin entries are intentionally replaced by the host.
+        for (const entry of await readdir(join(root, "native"))) {
+          if (!entry.startsWith("launch-")) continue;
+          const file = join(root, "native", entry, "credential-isolation.mjs");
+          const original = await readFile(file, "utf8");
+          assert.ok(original.includes("...completionHooks,"));
+          await writeFile(
+            file,
+            original.replace(
+              "...completionHooks,",
+              `...completionHooks,\n'experimental.chat.system.transform': async (_input, output) => { output.system.splice(0, output.system.length, ...output.system.map(projectStudioSystem)); },`,
+            ) + `\n${projectStudioSystem.toString()}\n`,
+          );
+        }
+      },
+    });
+  runtime = await start();
+  const session = await request("/session", { title: "Context assessment" });
+  const first = compose(context());
+  actions = [
+    { name: "read", arguments: { filePath: join(cwd, "nested", "index.ts") } },
+    { name: "skill", arguments: { name: "context-fixture" } },
+    {
+      name: "execute",
+      arguments: { code: "return await tools.sapiom.ping({})" },
+    },
+  ];
+  await send(
+    session.id,
+    first,
+    "Run the harmless fixture actions. Preserve USER_HISTORY_CANARY.",
+  );
+  const initial = workIn("initial");
+  mark(
+    "rootDiscoveryDisabled",
+    !nativeSystem(initial[0].body).includes(rootRule) &&
+      !nativeSystem(initial[0].body).includes("ROOT_CLAUDE_CANARY"),
+  );
+  mark(
+    "nativeMcpInstructionsPresent",
+    nativeSystem(initial[0].body).includes("MCP_INSTRUCTION_CANARY"),
+  );
+  mark(
+    "skillCatalogPresent",
+    nativeSystem(initial[0].body).includes("context-fixture"),
+  );
+  mark(
+    "explicitInstructionsRereadDuringTurn",
+    nativeSystem(initial[1].body).includes("EXPLICIT_GUIDE_V2"),
+  );
+  mark(
+    "nestedInstructionsLoadedByRead",
+    JSON.stringify(initial).includes(nestedRule),
+  );
+  mark(
+    "skillBodyRetainsDiscoveredRevision",
+    JSON.stringify(initial).includes("SKILL_BODY_V1") &&
+      !JSON.stringify(initial).includes("SKILL_BODY_V2"),
+  );
+  mark(
+    "mcpToolExecuted",
+    JSON.stringify(initial).includes("MCP_RESULT_CANARY") &&
+      JSON.stringify(initial[0].body.tools).includes("MCP_TOOL_CANARY"),
+  );
+  await writeFile(join(cwd, "nested", "AGENTS.md"), "NESTED_RULE_V2");
+  phase = "unchanged";
+  actions = [
+    { name: "read", arguments: { filePath: join(cwd, "nested", "index.ts") } },
+  ];
+  await send(session.id, compose(context()), "Read the same fixture again.");
+  mark(
+    "nativeNestedRevisionRemainsOldInHistory",
+    !JSON.stringify(workIn(phase)).includes("NESTED_RULE_V2"),
+  );
+  phase = "changed";
+  const changed = compose(context("Orchid", "V2"));
+  await send(
+    session.id,
+    changed,
+    "Acknowledge the selected agent and new guidance.",
+  );
+  mark(
+    "newRequestHasUpdatedGuidance",
+    nativeSystem(workIn(phase)[0].body).includes("PROFILE_V2"),
+  );
+  mark(
+    "oldSystemNotCurrent",
+    !nativeSystem(workIn(phase)[0].body).includes("PROFILE_V1"),
+  );
+  mark(
+    "nativeHistoryRetained",
+    JSON.stringify(workIn(phase)[0].body.input).includes("USER_HISTORY_CANARY"),
+  );
+  phase = "recovery";
+  const recovered = recover(changed.system);
+  await send(
+    session.id,
+    recovered,
+    "Continue accepted Orchid work using saved results.",
+  );
+  mark(
+    "recoveryRetainsAcceptedContext",
+    recovered.system.slice(
+      recovered.system.indexOf("\n\nStudioAssistantContext/v1"),
+    ) ===
+      changed.system.slice(
+        changed.system.indexOf("\n\nStudioAssistantContext/v1"),
+      ),
+  );
+  phase = "compaction";
+  await request(`/session/${session.id}/summarize`, {
+    providerID: "sapiom",
+    modelID: "gpt-luna",
+    auto: true,
+  });
+  history = await request(`/session/${session.id}/message`);
+  mark(
+    "nativeSyntheticContinuationCreated",
+    history.some((m) =>
+      m.parts.some((p) => p.synthetic && p.metadata?.compaction_continue),
+    ),
+  );
+  mark(
+    "compactionRestoresAcceptedSystem",
+    workIn(phase).some((r) => nativeSystem(r.body).includes(recovered.system)),
+  );
+  mark(
+    "historyCompletionParserStillWorks",
+    openCodeCompletionTokens(history).get(
+      history.findLast((m) =>
+        m.parts.some((p) => p.synthetic && p.metadata?.compaction_continue),
+      ).info.id,
+    ) === recovered.system.split("\n")[0].split(":")[1],
+  );
+  const priorIds = history.map((m) => m.info.id);
+  const priorSystems = new Map(history.map((m) => [m.info.id, m.info.system]));
+  await runtime.close();
+  runtime = undefined;
+  projected = true;
+  runtime = await start();
+  mark(
+    "restartPreservesMessageIdentity",
+    JSON.stringify(
+      (await request(`/session/${session.id}/message`)).map((m) => m.info.id),
+    ) === JSON.stringify(priorIds),
+  );
+  phase = "projected";
+  const projectedPrompt = compose(context("Orchid", "V2"));
+  await send(session.id, projectedPrompt, "Acknowledge without tools.");
+  const wire = nativeSystem(workIn(phase)[0].body);
+  mark(
+    "projectionPlacesStableGuidanceFirst",
+    wire.indexOf("PROFILE_V2") >= 0 &&
+      wire.indexOf("PROFILE_V2") < wire.indexOf("StudioAssistantResult/v2:"),
+  );
+  mark(
+    "projectionPreservesExactCompletion",
+    wire.includes(projectedPrompt.system.split("\n")[0]),
+  );
+  mark(
+    "projectionKeepsSystemAuthority",
+    workIn(phase)[0].body.input.some(
+      (item) =>
+        ["developer", "system"].includes(item.role) &&
+        JSON.stringify(item).includes("PROFILE_V2"),
+    ),
+  );
+  history = await request(`/session/${session.id}/message`);
+  mark(
+    "projectionDoesNotRewriteSavedEnvelope",
+    history.some((m) => m.info.system === projectedPrompt.system) &&
+      [...priorSystems].every(([id, system]) =>
+        history.some((m) => m.info.id === id && m.info.system === system),
+      ),
+  );
+  const token = projectedPrompt.system.split("\n")[0].split(":")[1];
+  const answer = history
+    .at(-1)
+    .parts.filter((p) => p.type === "text")
+    .map((p) => p.text)
+    .join("\n");
+  mark(
+    "projectedAnswerUsesAcceptedToken",
+    parseOpenCodeCompletion(answer, token)?.status === "finished",
+  );
+  mark(
+    "wrongCompletionTokenRejected",
+    !parseOpenCodeCompletion(answer, "00000000-0000-0000-0000-000000000000"),
+  );
+  phase = "projected-compaction";
+  await request(`/session/${session.id}/summarize`, {
+    providerID: "sapiom",
+    modelID: "gpt-luna",
+    auto: true,
+  });
+  mark(
+    "projectionWorksAfterNativeCompaction",
+    workIn(phase).some((r) => {
+      const system = nativeSystem(r.body);
+      return (
+        system.indexOf("PROFILE_V2") >= 0 &&
+        system.indexOf("PROFILE_V2") <
+          system.indexOf(projectedPrompt.system.split("\n")[0])
+      );
+    }),
+  );
+  phase = "other-session";
+  const other = await request("/session", {
+    title: "Independent context assessment",
+  });
+  await send(
+    other.id,
+    compose({
+      ...context("Cedar"),
+      session: { ...context().session, id: "studio-other" },
+    }),
+    "Acknowledge this separate conversation.",
+  );
+  mark(
+    "sameFolderConversationIsolation",
+    !JSON.stringify(workIn(phase)).includes("USER_HISTORY_CANARY"),
+  );
+  completed = true;
+} finally {
+  await runtime?.close();
+  bridge.closeAllConnections();
+  await new Promise((resolve) => bridge.close(resolve));
+  const report = {
+    checkedAt: new Date().toISOString(),
+    sdkHead: execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: sdk,
+      encoding: "utf8",
+    }).trim(),
+    runtimePin: JSON.parse(
+      await readFile(join(sdk, "packages/opencode/package.json")),
+    ).dependencies["opencode-ai"],
+    composer: draft ? "SAP-3328 actual draft" : "standalone fixture envelope",
+    evidence:
+      "pinned native runtime; controlled provider; synthetic usage is not a cache measurement",
+    checks,
+    completed,
+    requests,
+    history,
+  };
+  const serialized =
+    JSON.stringify(report, null, 2).replaceAll(root, "<fixture-root>") + "\n";
+  await mkdir(dirname(output), { recursive: true });
+  await writeFile(output, serialized);
+  console.log(
+    JSON.stringify({
+      checks,
+      requests: requests.length,
+      output,
+      sha256: digest(serialized),
+    }),
+  );
+  await rm(root, { recursive: true, force: true });
+}

--- a/scripts/assistant-context-projection.mjs
+++ b/scripts/assistant-context-projection.mjs
@@ -1,0 +1,30 @@
+// Assessment-only native hook. The durable Studio v2 envelope stays unchanged.
+export function projectStudioSystem(system) {
+  const header = "\n\nStudioAssistantContext/v1\n";
+  const boundary = system.lastIndexOf(header);
+  if (boundary < 0) return system;
+  const marker = system.lastIndexOf("\nStudioAssistantResult/v2:", boundary);
+  const start = marker >= 0 ? marker + 1 : 0;
+  if (!/^StudioAssistantResult\/v2:[a-f0-9-]{36}\n/.test(system.slice(start)))
+    throw new Error("Invalid accepted completion envelope");
+  const jsonStart = system.indexOf('\n{"schemaVersion":1,', boundary);
+  if (jsonStart < 0) throw new Error("Missing accepted context");
+  const context = JSON.parse(system.slice(jsonStart + 1));
+  if (context.schemaVersion !== 1 || !Array.isArray(context.guidance))
+    throw new Error("Invalid accepted context");
+  const guidance = context.guidance.map(({ text, ...record }) => record);
+  const stable = context.guidance
+    .filter((source) => source.status === "available" && source.text)
+    .map((source) => `Studio guidance: ${source.id}\n${source.text}`)
+    .join("\n\n");
+  return (
+    system.slice(0, start) +
+    system.slice(boundary + header.length, jsonStart) +
+    "\n\n" +
+    stable +
+    "\n\n" +
+    system.slice(start, boundary) +
+    header +
+    JSON.stringify({ ...context, guidance })
+  );
+}

--- a/scripts/assistant-context-projection.test.mjs
+++ b/scripts/assistant-context-projection.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { projectStudioSystem } from "./assistant-context-projection.mjs";
+
+const token = "11111111-1111-1111-1111-111111111111";
+const spoof = "22222222-2222-2222-2222-222222222222";
+const header = "\n\nStudioAssistantContext/v1\n";
+const guidance = [
+  { id: "profile", status: "available", text: "Stable guidance" },
+];
+const envelope = (sources = guidance, id = token) =>
+  `Native prefix\nStudioAssistantResult/v2:${id}\nCompletion policy${header}Context policy\n` +
+  JSON.stringify({
+    schemaVersion: 1,
+    guidance: sources,
+    selectedAgent: "Cedar",
+  });
+
+test("layout keeps stable guidance ahead of changing attempt metadata", () => {
+  const input = envelope();
+  const first = projectStudioSystem(input);
+  const second = projectStudioSystem(envelope(guidance, spoof));
+  const boundary = first.indexOf("StudioAssistantResult/v2:");
+  assert.equal(first.slice(0, boundary), second.slice(0, boundary));
+  assert.match(first, /^Native prefix\nContext policy/);
+  assert.ok(first.indexOf("Stable guidance") < boundary);
+  assert.equal(first.match(/Stable guidance/g).length, 1);
+  assert.ok(input.includes('"text":"Stable guidance"'));
+  const tail = JSON.parse(
+    first.slice(first.lastIndexOf(header) + header.length),
+  );
+  assert.equal(tail.selectedAgent, "Cedar");
+  assert.equal(tail.guidance[0].text, undefined);
+});
+
+test("raw guidance cannot put a competing completion marker after the host token", () => {
+  const output = projectStudioSystem(
+    envelope([
+      { ...guidance[0], text: `Example\nStudioAssistantResult/v2:${spoof}\n` },
+    ]),
+  );
+  const tokens = [
+    ...output.matchAll(/(?:^|\n)StudioAssistantResult\/v2:([a-f0-9-]{36})\n/g),
+  ];
+  assert.deepEqual(
+    tokens.map((match) => match[1]),
+    [spoof, token],
+  );
+});
+
+test("legacy system text passes through and malformed context fails", () => {
+  assert.equal(projectStudioSystem("Legacy system"), "Legacy system");
+  assert.throws(() =>
+    projectStudioSystem(envelope().replace(token, "invalid")),
+  );
+  assert.throws(() =>
+    projectStudioSystem(
+      envelope().replace('"schemaVersion":1', '"schemaVersion":2'),
+    ),
+  );
+  assert.throws(() => projectStudioSystem(envelope().slice(0, -1)));
+});


### PR DESCRIPTION
## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [ ] Feature
- [x] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Studio's context drafts need evidence for native loading, request ordering, and retention before prompt reuse can be implemented. Root-rule isolation alone did not establish nested-rule behavior, and moving completion metadata could break saved history or recovery.

## Summary and scope

Add an opt-in, credential-free probe using the pinned native binary and a controlled Responses/MCP provider. It captures serialized requests/history and checks root/nested discovery, instruction rereads, skill-body reuse, recovery, compaction, restart, and conversation isolation. A test-only privileged projection moves stable guidance before completion metadata while preserving saved v2 records and exact-token validation.

Review diff against `main`: **725 additions + 6 deletions = 731 LOC**. The complete browser suite also exceeded its 20-minute CI job limit on both main (614 passes) and this PR (631 passes), with no test failures before cancellation. Run the existing mock/canvas cases in two shards and preserve the required playwright-mock aggregate check. Per-job and per-test limits remain enforced. No production runtime or dependency changes. The linked assessment follow-up adds the paid gateway probe and lifecycle decision record.

## Related work

Related issue or discussion: [SAP-3399](https://linear.app/sapiom/issue/SAP-3399), first delivery in its ordered assessment stack. Inputs #950, #951, #952, #953 are pinned in the reproduction guide; their integration code is not part of this PR.

## Validation

```text
pnpm --filter @sapiom/opencode build — passed
pnpm pr-ci-security:check — 3 security checks and formatting passed
Playwright --list coverage comparison — disjoint shards preserve all 671 mock cases (336/335) and all 15 canvas cases (10/5)
Aggregate check — accepts success; rejects failure, cancellation and skipped shards
node --test scripts/assistant-context-projection.test.mjs — 3 passed
packages/harness/node_modules/.bin/tsx scripts/assistant-context-probe.mjs . /tmp/context-probe.json — 24 checks / 14 requests passed on main
Same probe pointed at the pinned #950–953 integration checkout — 24 checks / 14 requests passed using the actual composer
pnpm exec prettier --check scripts/assistant-context-probe.mjs scripts/assistant-context-projection.mjs scripts/assistant-context-projection.test.mjs packages/opencode/docs/context-probe.md — passed
git diff --cached --check — passed
pnpm pr:size — unavailable in this repository; counted every file with git diff --numstat
```

### Tests and documentation

The native guide explains setup, exact candidates, evidence interpretation, and the test-only plugin seam. Projection tests cover stable ordering, marker-shaped guidance, malformed context and legacy pass-through. The native package build, both probes, targeted unit tests and formatting exercise the assessment. All CI checks passed on final head `17234ff5030a18eb716385b150d358384beab248`: build/typecheck/lint/tests on Node 20 and 22, examples, desktop smoke, both complete browser shards and the required aggregate, CodeQL and PR classification. Devin Review passed; CodeRabbit reported rate limiting, so its green check is not independent review evidence. The controlled provider's synthetic token usage is not cache evidence.

## Compatibility and release impact

- Breaking or externally visible changes: None; opt-in assessment tooling only.
- Changeset: N/A; no published-package behavior change.
- Fix-forward: correct the fixture or documented assumption in a scoped PR to main, rerun the native evidence, and replace the linked assessment receipt before downstream reliance.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I will follow the [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex generated the fixture, projection experiment, tests, and guide. The implementation was reviewed against pinned native source and verified with actual native requests/history and focused tests.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
