### PR TITLE
feat(harness): own native Assistant observation [SAP-3291]

### DIFF
--- a/.changeset/own-assistant-observation.md
+++ b/.changeset/own-assistant-observation.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Keep native Assistant observation owned by the authorized Studio runtime, independently of browser attachment, and retire its summaries synchronously with access or runtime changes.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -88,6 +88,8 @@ Event transport scopes each frame to the authorized conversation and cancels
 its reader and status catch-up when the browser connection ends.
 The shared observer module derives activity and pending-request counts without
 storing transcript content or issuing execution commands.
+Host observation starts after an authorized conversation attaches and ends with
+runtime retirement. Reading summaries never launches inactive conversations.
 This first slice includes basic tool status; richer controls arrive separately.
 Studio actions reveal Terminal after a foreground CLI prompt is accepted; a
 rejected send shows its error and keeps the selected view. Unsent chat text is

--- a/packages/harness/src/core/opencode-association.ts
+++ b/packages/harness/src/core/opencode-association.ts
@@ -8,8 +8,8 @@ import {
 import { openCodeTransportFailure } from "../shared/opencode-errors.js";
 import { DurableFileLock } from "./durable-file-lock.js";
 
-export const isConversationId = (id: unknown): id is string =>
-  typeof id === "string" && /^ses_[A-Za-z0-9_-]{1,128}$/.test(id);
+import { isConversationId } from "../shared/assistant-state.js";
+export { isConversationId } from "../shared/assistant-state.js";
 
 /** One native conversation per Studio session; the host holds the owner lock. */
 export class OpenCodeAssociations {

--- a/packages/harness/src/core/opencode-host.test.ts
+++ b/packages/harness/src/core/opencode-host.test.ts
@@ -11,9 +11,47 @@ import {
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 import { OpenCodeShutdownError } from "@sapiom/opencode";
+import type { HostedOpenCode } from "./opencode-host.js";
+import type { AssistantObservation } from "../shared/assistant-state.js";
+import { openCodeTransportFailure } from "../shared/opencode-errors.js";
 import type { AssistantGrant } from "./assistant-access.js";
 import { OpenCodeHost, OpenCodeTransportError } from "./opencode-host.js";
 
+const initial: AssistantObservation = {
+  activity: "unknown",
+  pendingPermissions: null,
+  pendingQuestions: null,
+  freshness: "connecting",
+};
+const observers: Array<{
+  hosted: HostedOpenCode;
+  id: string;
+  update: (state: AssistantObservation) => void;
+  dispose: ReturnType<typeof vi.fn>;
+  start: ReturnType<typeof vi.fn>;
+}> = [];
+const createObserver = vi.fn(
+  (
+    hosted: HostedOpenCode,
+    id: string,
+    update: (state: AssistantObservation) => void,
+  ) => {
+    const observer = {
+      hosted,
+      id,
+      update,
+      start: vi.fn(() => update(initial)),
+      dispose: vi.fn(),
+    };
+    observers.push(observer);
+    return observer;
+  },
+);
+let browserRevision: string;
+const getBrowserState = vi.fn(() => ({
+  enabled: !!grant,
+  authorityRevision: browserRevision,
+}));
 let root: string;
 let cwd: string;
 let host: OpenCodeHost;
@@ -32,6 +70,10 @@ const cleanupProofFor = (stateRoot: string, hex: string) => ({
 });
 beforeEach(async () => {
   expectShutdownFailure = false;
+  observers.length = 0;
+  createObserver.mockClear();
+  getBrowserState.mockClear();
+  browserRevision = "authority-a";
   root = await mkdtemp(join(tmpdir(), "studio-opencode-host-"));
   cwd = join(root, "project");
   await mkdir(cwd);
@@ -67,8 +109,10 @@ beforeEach(async () => {
     close,
   });
   host = new OpenCodeHost({
+    createObserver,
     access: {
       get: () => grant,
+      getBrowserState,
       getFailureCode: () =>
         grant ? "transport_unavailable" : "authentication_required",
       subscribe: (listener) => {
@@ -365,8 +409,8 @@ describe("Studio-owned OpenCode lifecycle", () => {
 
   it("waits for every runtime cleanup even when one shutdown fails", async () => {
     expectShutdownFailure = true;
-    await host.ensure("studio-one");
-    await host.ensure("studio-two");
+    host.observe(await host.ensure("studio-one"), "ses_one");
+    host.observe(await host.ensure("studio-two"), "ses_two");
     let finish!: () => void;
     close.mockRejectedValueOnce(new Error("still alive"));
     close.mockImplementationOnce(
@@ -379,6 +423,13 @@ describe("Studio-owned OpenCode lifecycle", () => {
     const shutdown = host.close().finally(() => {
       settled = true;
     });
+    expect(host.getAssistantState()).toMatchObject({
+      enabled: false,
+      sessions: [],
+    });
+    expect(
+      observers.every((observer) => observer.dispose.mock.calls.length === 1),
+    ).toBe(true);
     const rejected = expect(shutdown).rejects.toThrow("shutdown");
     await vi.waitFor(() => expect(close).toHaveBeenCalledTimes(2));
     expect(settled).toBe(false);
@@ -393,8 +444,11 @@ describe("Studio-owned OpenCode lifecycle", () => {
     });
     start.mockResolvedValueOnce({ pid: 123, exited, close });
     const first = await host.ensure("studio-one");
+    host.observe(first, "ses_one");
     exit();
     await vi.waitFor(() => expect(first.signal.aborted).toBe(true));
+    expect(host.getAssistantState().sessions).toEqual([]);
+    expect(observers[0]!.dispose).toHaveBeenCalledOnce();
     const restored = await host.ensure("studio-one");
     expect(restored.stateRoot).toBe(first.stateRoot);
     expect(start).toHaveBeenCalledTimes(2);
@@ -423,5 +477,241 @@ describe("Studio-owned OpenCode lifecycle", () => {
     await expect(host.ensure("studio-one")).rejects.toMatchObject({
       failure: { code: "authentication_required" },
     });
+  });
+});
+
+describe("host-owned Assistant observation", () => {
+  it("reads/subscribes without native startup and exposes only public identity", () => {
+    const listener = vi.fn();
+    const unsubscribe = host.subscribeAssistantState(listener);
+    const first = host.getAssistantState();
+    expect(host.getAssistantState()).toEqual(first);
+    expect(first).toMatchObject({
+      enabled: true,
+      authorityRevision: browserRevision,
+      revision: 0,
+      sessions: [],
+    });
+    expect(first.hostInstanceId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(start).not.toHaveBeenCalled();
+    expect(authorize).not.toHaveBeenCalled();
+    expect(createObserver).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+    expect(JSON.stringify(first)).not.toMatch(/sk_private|scoped|user|cwd/);
+    unsubscribe();
+  });
+
+  it("gives each host a fresh public instance identifier", async () => {
+    const other = new OpenCodeHost({
+      access: {
+        get: () => grant,
+        getFailureCode: () => "transport_unavailable",
+        getBrowserState,
+        subscribe: () => () => {},
+      },
+      bridge: { issue, model: "smart" },
+      origin: () => "http://127.0.0.1:1234",
+      stateRoot: root,
+      authorize,
+      start,
+      createObserver,
+    });
+    expect(other.getAssistantState().hostInstanceId).not.toBe(
+      host.getAssistantState().hostInstanceId,
+    );
+    await other.close();
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("binds before synchronous start and observes an exact association only once", async () => {
+    const hosted = await host.ensure("studio-a");
+    host.observe(hosted, "ses_a");
+    host.observe(hosted, "ses_a");
+    expect(createObserver).toHaveBeenCalledOnce();
+    expect(observers[0]!.start).toHaveBeenCalledOnce();
+    expect(host.getAssistantState().sessions).toEqual([
+      { harnessSessionId: "studio-a", conversationId: "ses_a", ...initial },
+    ]);
+    for (const invalid of ["ses_b", "../escape", "studio-a"])
+      expect(() => host.observe(hosted, invalid)).toThrow(
+        "saved Assistant conversation",
+      );
+    expect(() => host.observe({ ...hosted }, "ses_a")).toThrow(
+      "temporarily unavailable",
+    );
+    expect(createObserver).toHaveBeenCalledOnce();
+  });
+
+  it("keeps same-folder sessions independent and publishes only changed summaries", async () => {
+    const a = await host.ensure("studio-a");
+    const b = await host.ensure("studio-b");
+    host.observe(a, "ses_a");
+    host.observe(b, "ses_b");
+    const listener = vi.fn();
+    host.subscribeAssistantState(() => {
+      throw new Error("subscriber failure");
+    });
+    host.subscribeAssistantState(listener);
+    const busy: AssistantObservation = {
+      activity: "busy",
+      pendingPermissions: 1,
+      pendingQuestions: 0,
+      freshness: "current",
+    };
+    observers[0]!.update(busy);
+    observers[0]!.update(busy);
+    expect(listener).toHaveBeenCalledOnce();
+    expect(host.getAssistantState().sessions).toEqual([
+      { harnessSessionId: "studio-a", conversationId: "ses_a", ...busy },
+      { harnessSessionId: "studio-b", conversationId: "ses_b", ...initial },
+    ]);
+    expect(a.cwd).toBe(b.cwd);
+  });
+
+  it("removes a summary before disposal and before pending native cleanup", async () => {
+    const hosted = await host.ensure("studio-a");
+    host.observe(hosted, "ses_a");
+    let finish!: () => void;
+    close.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        }),
+    );
+    observers[0]!.dispose.mockImplementation(() => {
+      expect(host.getAssistantState().sessions).toEqual([]);
+      observers[0]!.update({ ...initial, activity: "busy" });
+    });
+    const before = host.getAssistantState().revision;
+    const retiring = host.retire("studio-a");
+    expect(host.getAssistantState()).toMatchObject({
+      revision: before + 1,
+      sessions: [],
+    });
+    expect(observers[0]!.dispose).toHaveBeenCalledOnce();
+    expect(hosted.signal.aborted).toBe(true);
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+    finish();
+    await retiring;
+  });
+
+  it("waits for native cleanup when a retirement listener closes the host", async () => {
+    host.observe(await host.ensure("studio-a"), "ses_a");
+    let release!: () => void;
+    close.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        }),
+    );
+    let shutdown!: Promise<void>;
+    let resolved = false;
+    const unsubscribe = host.subscribeAssistantState(() => {
+      unsubscribe();
+      shutdown = host.close().then(() => {
+        resolved = true;
+      });
+    });
+    const retiring = host.retire("studio-a");
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce());
+    await new Promise((resolve) => setImmediate(resolve));
+    try {
+      expect(resolved).toBe(false);
+    } finally {
+      release();
+      await retiring;
+      await shutdown;
+    }
+    expect(resolved).toBe(true);
+  });
+
+  it("rejects a late association and old callbacks after the same Studio session is replaced", async () => {
+    const old = await host.ensure("studio-a");
+    host.observe(old, "ses_a");
+    const oldObserver = observers[0]!;
+    await host.retire("studio-a");
+    const current = await host.ensure("studio-a");
+    host.observe(current, "ses_a");
+    const snapshot = host.getAssistantState();
+    expect(() => host.observe(old, "ses_a")).toThrow(OpenCodeTransportError);
+    oldObserver.update({ ...initial, activity: "busy" });
+    oldObserver.dispose();
+    expect(host.getAssistantState()).toEqual(snapshot);
+    expect(observers).toHaveLength(2);
+  });
+
+  it.each(["disable", "crossover"])(
+    "clears the authority-scoped set once before %s retirement",
+    async (mode) => {
+      host.observe(await host.ensure("studio-a"), "ses_a");
+      host.observe(await host.ensure("studio-b"), "ses_b");
+      const snapshots: ReturnType<OpenCodeHost["getAssistantState"]>[] = [];
+      host.subscribeAssistantState(() =>
+        snapshots.push(host.getAssistantState()),
+      );
+      const before = host.getAssistantState();
+      grant = mode === "disable" ? null : { ...grant!, userId: "other-user" };
+      browserRevision = "new-authority";
+      changed();
+      expect(snapshots).toHaveLength(1);
+      expect(snapshots[0]).toMatchObject({
+        hostInstanceId: before.hostInstanceId,
+        authorityRevision: "new-authority",
+        revision: before.revision + 1,
+        sessions: [],
+        enabled: mode !== "disable",
+      });
+      expect(
+        observers.every((observer) => observer.dispose.mock.calls.length === 1),
+      ).toBe(true);
+    },
+  );
+
+  it("advances empty authority and shutdown barriers without startup or duplicate revisions", async () => {
+    const initialState = host.getAssistantState();
+    browserRevision = "another-authority";
+    changed();
+    expect(host.getAssistantState().revision).toBe(initialState.revision + 1);
+    changed();
+    expect(host.getAssistantState().revision).toBe(initialState.revision + 1);
+    await host.close();
+    expect(host.getAssistantState()).toMatchObject({
+      enabled: false,
+      revision: initialState.revision + 2,
+      sessions: [],
+    });
+    expect(start).not.toHaveBeenCalled();
+  });
+
+  it("handles synchronous access revocation while a snapshot getter is running", async () => {
+    host.observe(await host.ensure("studio-a"), "ses_a");
+    getBrowserState.mockImplementationOnce(() => {
+      grant = null;
+      browserRevision = "revoked";
+      changed();
+      return { enabled: false, authorityRevision: browserRevision };
+    });
+    expect(host.getAssistantState()).toMatchObject({
+      enabled: false,
+      authorityRevision: "revoked",
+      sessions: [],
+    });
+    expect(observers[0]!.dispose).toHaveBeenCalledOnce();
+  });
+
+  it("retains an unavailable association after native history disappears", async () => {
+    const hosted = await host.ensure("studio-a");
+    host.observe(hosted, "ses_a");
+    const failure = openCodeTransportFailure("native_history_missing");
+    observers[0]!.update({ ...initial, freshness: "unavailable", failure });
+    expect(() => host.observe(hosted, "ses_a")).toThrow(failure.message);
+    expect(createObserver).toHaveBeenCalledOnce();
+    expect(host.getAssistantState().sessions[0]).toMatchObject({
+      conversationId: "ses_a",
+      freshness: "unavailable",
+      failure,
+    });
+    expect(hosted.signal.aborted).toBe(false);
+    expect(close).not.toHaveBeenCalled();
   });
 });

--- a/packages/harness/src/core/opencode-host.ts
+++ b/packages/harness/src/core/opencode-host.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { realpath } from "node:fs/promises";
 import { join } from "node:path";
 import {
@@ -11,6 +11,7 @@ import type {
   AssistantAccess,
   AssistantAccessFailureCode,
   AssistantGrant,
+  AssistantAccessProjection,
 } from "./assistant-access.js";
 import {
   openCodeStartupReasons,
@@ -27,6 +28,21 @@ import type {
   OpenCodeBridgeCredential,
 } from "../server/opencode-bridge.js";
 
+import type { OpenCodeObserver } from "./opencode-observer.js";
+import {
+  isConversationId,
+  type AssistantObservation,
+  type AssistantSessionSummary,
+  type AssistantStateSnapshot,
+} from "../shared/assistant-state.js";
+
+type ObserverHandle = Pick<OpenCodeObserver, "start" | "dispose">;
+interface ObservationBinding {
+  conversationId: string;
+  observer?: ObserverHandle;
+  failure?: OpenCodeTransportFailure;
+}
+
 export interface OpenCodeWorkspace {
   harnessSessionId: string;
   cwd: string;
@@ -42,17 +58,27 @@ interface Managed {
   authority: string;
   abort: AbortController;
   ready?: Promise<HostedOpenCode>;
+  hosted?: HostedOpenCode;
+  observation?: ObservationBinding;
   credential?: OpenCodeBridgeCredential;
   unlock?: DurableFileLockRelease;
   cleanupFailed?: boolean;
 }
 interface Options {
-  access: Pick<AssistantAccess, "get" | "getFailureCode" | "subscribe">;
+  access: Pick<
+    AssistantAccess,
+    "get" | "getFailureCode" | "getBrowserState" | "subscribe"
+  >;
   bridge: Pick<OpenCodeBridge, "issue" | "model">;
   origin: () => string;
   stateRoot: string;
   authorize: (id: string) => Promise<OpenCodeWorkspace | null>;
   start?: typeof startOpenCodeServer;
+  createObserver: (
+    hosted: HostedOpenCode,
+    id: string,
+    update: (state: AssistantObservation) => void,
+  ) => ObserverHandle;
 }
 export class OpenCodeTransportError extends Error {
   constructor(readonly failure: OpenCodeTransportFailure) {
@@ -85,6 +111,11 @@ const authority = (grant: AssistantGrant) =>
 
 /** Owned by startServer, not by React mounts or browser connections. */
 export class OpenCodeHost {
+  private readonly hostInstanceId = randomUUID();
+  private assistantRevision = 0;
+  private assistantAccess: AssistantAccessProjection;
+  private readonly summaries = new Map<string, AssistantSessionSummary>();
+  private readonly assistantListeners = new Set<() => void>();
   private entries = new Map<string, Managed>();
   private closing = new Set<Promise<void>>();
   private closed = false;
@@ -92,6 +123,7 @@ export class OpenCodeHost {
   private workspaceTimer: ReturnType<typeof setInterval>;
   private unsubscribe: () => void;
   constructor(private readonly options: Options) {
+    this.assistantAccess = options.access.getBrowserState();
     this.workspaceTimer = setInterval(() => {
       for (const [id, entry] of this.entries) {
         void this.workspace(id)
@@ -109,6 +141,7 @@ export class OpenCodeHost {
     this.workspaceTimer.unref?.();
     this.unsubscribe = options.access.subscribe(() => {
       const grant = options.access.get();
+      this.syncAssistantAccess();
       for (const [id, entry] of this.entries) {
         if (!grant || authority(grant) !== entry.authority)
           void this.retire(
@@ -119,6 +152,119 @@ export class OpenCodeHost {
           );
       }
     });
+  }
+
+  /** Read derived state only; never start or inspect an inactive native runtime. */
+  getAssistantState(): AssistantStateSnapshot {
+    this.syncAssistantAccess();
+    return {
+      hostInstanceId: this.hostInstanceId,
+      authorityRevision: this.assistantAccess.authorityRevision,
+      revision: this.assistantRevision,
+      enabled: this.assistantAccess.enabled,
+      sessions: [...this.summaries.values()].map((summary) => ({ ...summary })),
+    };
+  }
+  subscribeAssistantState(listener: () => void): () => void {
+    this.assistantListeners.add(listener);
+    return () => {
+      this.assistantListeners.delete(listener);
+    };
+  }
+  private assistantChanged(): void {
+    this.assistantRevision++;
+    for (const listener of this.assistantListeners) {
+      try {
+        listener();
+      } catch {
+        /* Isolate state subscribers from runtime ownership. */
+      }
+    }
+  }
+  private syncAssistantAccess(): void {
+    // getBrowserState can synchronously revoke access and reenter this owner.
+    const projection = this.options.access.getBrowserState();
+    const next = { ...projection, enabled: !this.closed && projection.enabled };
+    if (
+      next.enabled === this.assistantAccess.enabled &&
+      next.authorityRevision === this.assistantAccess.authorityRevision
+    )
+      return;
+    this.assistantAccess = next;
+    this.summaries.clear();
+    this.assistantChanged();
+  }
+  private removeSummary(id: string): void {
+    if (this.summaries.delete(id)) this.assistantChanged();
+  }
+  observe(hosted: HostedOpenCode, conversationId: string): void {
+    const id = hosted.harnessSessionId;
+    const entry = this.entries.get(id);
+    if (
+      !entry ||
+      entry.hosted !== hosted ||
+      entry.abort.signal !== hosted.signal ||
+      !hosted.isCurrent()
+    ) {
+      if (hosted.signal.reason instanceof OpenCodeTransportError)
+        throw hosted.signal.reason;
+      throw new OpenCodeTransportError(
+        openCodeTransportFailure("transport_unavailable"),
+      );
+    }
+    if (
+      !isConversationId(conversationId) ||
+      conversationId === id ||
+      (entry.observation && entry.observation.conversationId !== conversationId)
+    )
+      throw new OpenCodeTransportError(
+        openCodeTransportFailure("native_history_missing"),
+      );
+    if (entry.observation) {
+      if (entry.observation.failure)
+        throw new OpenCodeTransportError(entry.observation.failure);
+      return;
+    }
+    const binding: ObservationBinding = { conversationId };
+    entry.observation = binding;
+    try {
+      binding.observer = this.options.createObserver(
+        hosted,
+        conversationId,
+        (state) => {
+          if (
+            this.entries.get(id) !== entry ||
+            entry.hosted !== hosted ||
+            entry.observation !== binding ||
+            !hosted.isCurrent()
+          )
+            return;
+          binding.failure =
+            state.freshness === "unavailable" ? state.failure : undefined;
+          const summary: AssistantSessionSummary = {
+            harnessSessionId: id,
+            conversationId,
+            activity: state.activity,
+            pendingPermissions: state.pendingPermissions,
+            pendingQuestions: state.pendingQuestions,
+            freshness: state.freshness,
+            ...(state.failure ? { failure: state.failure } : {}),
+          };
+          if (
+            JSON.stringify(this.summaries.get(id)) === JSON.stringify(summary)
+          )
+            return;
+          this.summaries.set(id, summary);
+          this.assistantChanged();
+        },
+      );
+      binding.observer.start();
+    } catch (error) {
+      entry.observation = undefined;
+      this.removeSummary(id);
+      binding.observer?.dispose();
+      throw error;
+    }
   }
 
   async ensure(id: string): Promise<HostedOpenCode> {
@@ -178,8 +324,6 @@ export class OpenCodeHost {
     const entry = this.entries.get(id);
     if (!entry) return Promise.resolve();
     this.entries.delete(id);
-    entry.abort.abort(new OpenCodeTransportError(failure));
-    entry.credential?.revoke();
     const closing = (async () => {
       const hosted = await entry.ready?.catch(() => null);
       try {
@@ -193,11 +337,20 @@ export class OpenCodeHost {
     })();
     this.closing.add(closing);
     void closing.finally(() => this.closing.delete(closing)).catch(() => {});
+    // Own cleanup before removal notifies listeners that may reenter close().
+    // The first await above defers native cleanup until this retirement is fenced.
+    const binding = entry.observation;
+    entry.observation = undefined;
+    this.removeSummary(id);
+    binding?.observer?.dispose();
+    entry.abort.abort(new OpenCodeTransportError(failure));
+    entry.credential?.revoke();
     return closing;
   }
 
   async close(): Promise<void> {
     this.closed = true;
+    this.syncAssistantAccess();
     clearInterval(this.workspaceTimer);
     this.unsubscribe();
     for (const id of this.entries.keys()) void this.retire(id);
@@ -296,7 +449,7 @@ export class OpenCodeHost {
         })
         .catch(() => {});
       await this.validate(entry);
-      return {
+      const hosted: HostedOpenCode = {
         ...entry.workspace,
         stateRoot,
         server,
@@ -312,6 +465,8 @@ export class OpenCodeHost {
           );
         },
       };
+      entry.hosted = hosted;
+      return hosted;
     } catch (error) {
       if (this.entries.get(entry.workspace.harnessSessionId) === entry)
         this.entries.delete(entry.workspace.harnessSessionId);

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -197,6 +197,7 @@ import {
 import { IngestCredentialRegistry } from "../core/ingest-credentials.js";
 import { AssistantAccess } from "../core/assistant-access.js";
 import { OpenCodeHost } from "../core/opencode-host.js";
+import { OpenCodeObserver } from "../core/opencode-observer.js";
 import { OpenCodeBridge } from "./opencode-bridge.js";
 import { createStaticRouter } from "./static.js";
 import { createTerminalWebSocketHandler } from "./terminal-ws.js";
@@ -3533,6 +3534,8 @@ export const startServer = async (
 
   const openCodeHost = new OpenCodeHost({
     access: assistantAccess,
+    createObserver: (hosted, id, update) =>
+      new OpenCodeObserver(hosted, id, update),
     bridge: openCodeBridge,
     origin: () => `http://127.0.0.1:${actualPort}`,
     stateRoot: statePaths.root,

--- a/packages/harness/src/server/opencode.test.ts
+++ b/packages/harness/src/server/opencode.test.ts
@@ -29,6 +29,7 @@ const requests: {
   body: unknown;
 }[] = [];
 const ensure = vi.fn();
+const observe = vi.fn();
 const close = vi.fn();
 async function listen(app: express.Express): Promise<string> {
   const server = createServer(app);
@@ -45,6 +46,7 @@ beforeEach(async () => {
   hosts.clear();
   aborts.clear();
   close.mockReset();
+  observe.mockReset();
   const engine = express();
   engine.use(express.json());
   engine.use((req, _res, next) => {
@@ -126,7 +128,7 @@ beforeEach(async () => {
       throw new OpenCodeAccessError("unavailable");
     return hosts.get(id)!;
   });
-  router = createOpenCodeRouter({ ensure }, "boot-token");
+  router = createOpenCodeRouter({ ensure, observe }, "boot-token");
   const app = express();
   app.use("/opencode", (req, res, next) => router(req, res, next));
   origin = await listen(app);
@@ -235,6 +237,7 @@ describe("Studio-scoped OpenCode transport", () => {
       403,
     );
     expect(created).toBe(0);
+    expect(observe).not.toHaveBeenCalled();
   });
 
   it("coalesces attach and restores the same separate conversation after remount and host restart", async () => {
@@ -244,7 +247,7 @@ describe("Studio-scoped OpenCode transport", () => {
     expect(await attach("studio-b")).not.toBe(a);
     expect(created).toBe(2);
     hosts.set("studio-a", { ...hosts.get("studio-a")! });
-    router = createOpenCodeRouter({ ensure }, "boot-token");
+    router = createOpenCodeRouter({ ensure, observe }, "boot-token");
     expect(await attach()).toBe(a);
     expect(created).toBe(2);
   });
@@ -252,7 +255,9 @@ describe("Studio-scoped OpenCode transport", () => {
   it("rejects cross-session IDs and scope/configuration overrides before forwarding", async () => {
     const a = await attach();
     const b = await attach("studio-b");
+    observe.mockClear();
     expect((await request(`studio-a/session/${b}/message`)).status).toBe(403);
+    expect(observe).not.toHaveBeenCalled();
     for (const path of [
       "config",
       "provider",
@@ -376,7 +381,8 @@ describe("Studio-scoped OpenCode transport", () => {
   it("preserves a missing or corrupt association as a visible error instead of replacing history", async () => {
     const id = await attach();
     sessions.delete(id);
-    router = createOpenCodeRouter({ ensure }, "boot-token");
+    observe.mockClear();
+    router = createOpenCodeRouter({ ensure, observe }, "boot-token");
     const missing = await request("studio-a/attach", { method: "POST" });
     expect(missing.status).toBe(410);
     expect(await missing.json()).toEqual({
@@ -392,6 +398,7 @@ describe("Studio-scoped OpenCode transport", () => {
       error: openCodeTransportFailure("native_history_missing"),
     });
     expect(created).toBe(1);
+    expect(observe).not.toHaveBeenCalled();
   });
 
   it("returns exact typed access and startup failures without exposing diagnostics", async () => {
@@ -537,4 +544,28 @@ describe("Studio-scoped OpenCode transport", () => {
     expect(terminal).not.toContain("private");
     expect(await reader.read()).toEqual({ done: true, value: undefined });
   });
+});
+
+it("binds an authorized association even when its browser disconnects during attachment", async () => {
+  const abort = new AbortController();
+  let release!: (hosted: HostedOpenCode) => void;
+  ensure.mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        release = resolve;
+      }),
+  );
+  const pending = request("studio-a/attach", {
+    method: "POST",
+    signal: abort.signal,
+  });
+  const rejected = expect(pending).rejects.toThrow();
+  await vi.waitFor(() => expect(ensure).toHaveBeenCalledOnce());
+  abort.abort();
+  await rejected;
+  const hosted = hosts.get("studio-a")!;
+  release(hosted);
+  await vi.waitFor(() => expect(observe).toHaveBeenCalledWith(hosted, "ses_1"));
+  expect(hosted.signal.aborted).toBe(false);
+  expect(close).not.toHaveBeenCalled();
 });

--- a/packages/harness/src/server/opencode.ts
+++ b/packages/harness/src/server/opencode.ts
@@ -17,7 +17,7 @@ import { OpenCodeFinalResponse } from "../core/opencode-final-response.js";
 import { openCodeCompletionPrompt } from "../shared/opencode-completion.js";
 
 export function createOpenCodeRouter(
-  host: Pick<OpenCodeHost, "ensure">,
+  host: Pick<OpenCodeHost, "ensure" | "observe">,
   bootToken: string,
 ): Router {
   const router = express.Router();
@@ -95,14 +95,15 @@ export function createOpenCodeRouter(
     try {
       const hosted = await host.ensure(id);
       const nativeId = await associations.ensure(hosted);
-      const signal = AbortSignal.any([hosted.signal, disconnected.signal]);
-      signal.throwIfAborted();
       if (conversation && conversation[1] !== nativeId) {
         res.status(403).json({
           error: "Conversation does not belong to this Studio session",
         });
         return;
       }
+      host.observe(hosted, nativeId);
+      const signal = AbortSignal.any([hosted.signal, disconnected.signal]);
+      signal.throwIfAborted();
       if (attach) {
         res.json({ conversationId: nativeId });
         return;
@@ -150,7 +151,7 @@ export function createOpenCodeRouter(
           openCodeTransportFailure(
             upstream.status === 404 && conversation
               ? "native_history_missing"
-            : "transport_unavailable",
+              : "transport_unavailable",
           ),
         );
         return;

--- a/packages/harness/src/shared/assistant-state.ts
+++ b/packages/harness/src/shared/assistant-state.ts
@@ -20,3 +20,6 @@ export type AssistantObservation = Omit<
   AssistantSessionSummary,
   "harnessSessionId" | "conversationId"
 >;
+
+export const isConversationId = (id: unknown): id is string =>
+  typeof id === "string" && /^ses_[A-Za-z0-9_-]{1,128}$/.test(id);


### PR DESCRIPTION
<!--
Thank you for contributing to sapiom-js.
Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
-->

## Primary change type

<!-- Select exactly one primary type. -->

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

The native observer needs an owner independent of the selected browser. Bind observation to the exact authorized Studio/runtime/conversation association so background activity survives display detachment and old runtimes cannot publish into replacement sessions.

## Summary and scope

Wire `OpenCodeObserver` into `OpenCodeHost` and attach it once after verified conversation association. The host derives copied public summaries, a public instance ID and monotonic revisions; it coalesces unchanged facts and clears authority-scoped state synchronously before retiring native resources. Getters and subscription alone do not inspect workspaces or launch native processes.

Retirement removes summaries before observer disposal and native cleanup, and registers cleanup ownership before notifying listeners so reentrant shutdown waits correctly. Existing uncertain-cleanup lock retention remains in force. Terminal exit retains its Assistant association. A browser that disconnects during authorized attachment does not cancel host observation.

This focused increment stacks on #962. Summary transport and navigation indicators follow in the remaining SAP-3291 increments. All-file size: **522 additions plus deletions**.

## Related work

<!--
Link the issue or prior maintainer discussion when required by CONTRIBUTING.md.
Use N/A for a direct PR that does not need one.
-->

Related issue or discussion:
https://linear.app/sapiom/issue/SAP-3291

## Validation

```text
pnpm build — passed (root)
pnpm typecheck — passed (root)
pnpm lint — passed (root)
setpriv --inh-caps=-all --ambient-caps=-all env npm_config_workspace_concurrency=1 pnpm test — passed (root)
pnpm install --frozen-lockfile — passed
pnpm --filter @sapiom/harness exec vitest run src/core/opencode-host.test.ts src/server/opencode.test.ts — 41 passed
pnpm --filter @sapiom/harness exec eslint src/core/opencode-host.ts src/core/opencode-host.test.ts src/core/opencode-association.ts src/server/opencode.ts src/server/opencode.test.ts src/shared/assistant-state.ts — passed
```

The root wrapper drops this VM's ambient filesystem-permission bypass for the existing unreadable-directory fixture. `pnpm pr:size` is absent in this repository; explicit all-file numstat enforces the 1,000-line hard maximum.

### Tests and documentation

Host and real HTTP router regressions cover no-I/O getters, distinct host identities, exact binding coalescence/conflicts, independent same-folder sessions, stale callbacks after replacement, authority disable/crossover, zero-entry barriers, synchronous getter revocation, retained missing-history bindings and attachment after browser disconnection. Existing exit/failed-shutdown tests now assert immediate summary removal and observer disposal.

Independent review reproduced a reentrant-close cleanup race; the new regression failed before the fix and passes after cleanup registration moved ahead of synchronous notification. The independent recheck passed all three targeted lifecycle tests. README and a patch Changeset document host ownership.

## Compatibility and release impact

- Breaking or externally visible changes: one read-only native observer is active per authorized attached conversation; it survives browser detachment and is disposed with its host. No new browser protocol in this increment.
- Changeset: Added `own-assistant-observation.md` for `@sapiom/harness`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex implemented and verified host ownership and its tests. An independent agent reviewed lifecycle/reentrancy and verified the resulting fix.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

## Risk and rollout

The existing verified Assistant access gate controls activation. Background observation does not dispatch prompts, replies, recovery or abort commands. Native idle represents activity only. **Fix-forward:** correct host binding/retirement fences and extend the corresponding lifecycle regression without coupling ownership to a browser or Terminal exit.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->