### PR TITLE
feat(harness): deliver ordered Assistant summaries [SAP-3291]

### DIFF
--- a/.changeset/project-assistant-state.md
+++ b/.changeset/project-assistant-state.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Deliver bounded Assistant summaries through Studio's existing state and event transports, with socket and account ordering that preserves uncertainty through disconnects.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -15,6 +15,8 @@ with your coding agent (Claude Code or Codex) running in an embedded
 terminal — pre-wired with the Sapiom MCP servers and an agent-authoring
 system prompt, in whatever project directory you choose.
 
+Assistant summaries use the existing `/api/state` seed and `/ws/events` full snapshots. The browser preserves the last known state as uncertain until a validated current socket snapshot arrives; account changes clear it immediately. Summaries contain activity and pending counts only.
+
 ## What you get
 
 - **Terminal sessions** — your agent, your subscription, your machine; the

--- a/packages/harness/src/server/events-ws.test.ts
+++ b/packages/harness/src/server/events-ws.test.ts
@@ -23,12 +23,14 @@ function createFakeWs() {
 describe("createEventsWebSocketHandler", () => {
   it("rejects a connection with the wrong token", () => {
     const bus = new EventBus();
-    const handler = createEventsWebSocketHandler(bus, BOOT_TOKEN);
+    const getter = vi.fn();
+    const handler = createEventsWebSocketHandler(bus, BOOT_TOKEN, getter);
     const { ws } = createFakeWs();
 
     handler(ws, {} as IncomingMessage, new URLSearchParams({ token: "wrong" }));
 
     expect(ws.close).toHaveBeenCalledWith(4001, "unauthorized");
+    expect(getter).not.toHaveBeenCalled();
   });
 
   it("forwards a message published on the bus after a valid connection", () => {
@@ -65,4 +67,29 @@ describe("createEventsWebSocketHandler", () => {
 
     expect(sent).toEqual([]);
   });
+});
+
+// Access getters may synchronously revoke a grant and publish the reset.
+it("subscribes before the full snapshot and unsubscribes on socket error", () => {
+  const bus = new EventBus();
+  const snapshot = { hostInstanceId: "host", authorityRevision: "auth", revision: 2, enabled: false, sessions: [] };
+  const frame = { type: "assistant.state" as const, snapshot };
+  const getter = vi.fn(() => { bus.publish(frame); return snapshot; });
+  const { ws, emitter, sent } = createFakeWs();
+  createEventsWebSocketHandler(bus, BOOT_TOKEN, getter)(ws, {} as IncomingMessage, new URLSearchParams({ token: BOOT_TOKEN }));
+  expect(sent.map(data => JSON.parse(data))).toEqual([frame, frame]);
+  expect(getter).toHaveBeenCalledOnce();
+  emitter.emit("error", new Error("closed"));
+  bus.publish(frame);
+  expect(sent).toHaveLength(2);
+});
+
+it.each([true, false])("confirms current Assistant access after auth.changed with enabled=%s", enabled => {
+  const bus = new EventBus();
+  const state = { hostInstanceId: "host", authorityRevision: "auth", revision: 1, enabled, sessions: [] };
+  const { ws, sent } = createFakeWs();
+  createEventsWebSocketHandler(bus, BOOT_TOKEN, () => state)(ws, {} as IncomingMessage, new URLSearchParams({ token: BOOT_TOKEN }));
+  const auth = { type: "auth.changed" as const, authenticated: false, organizationName: null };
+  bus.publish(auth);
+  expect(sent.slice(1).map(data => JSON.parse(data))).toEqual([auth, { type: "assistant.state", snapshot: state }]);
 });

--- a/packages/harness/src/server/events-ws.ts
+++ b/packages/harness/src/server/events-ws.ts
@@ -5,6 +5,7 @@
  * feeding all of those into the bus from their respective sources.
  */
 
+import type { AssistantStateSnapshot } from "../shared/assistant-state.js";
 import type { IncomingMessage } from "node:http";
 import type { WebSocket } from "ws";
 
@@ -12,8 +13,16 @@ import type { EventBus } from "../core/event-bus.js";
 import type { BusMessage } from "../shared/types.js";
 import { timingSafeEqualString } from "./auth.js";
 
-export function createEventsWebSocketHandler(bus: EventBus, bootToken: string) {
-  return (ws: WebSocket, _req: IncomingMessage, params: URLSearchParams): void => {
+export function createEventsWebSocketHandler(
+  bus: EventBus,
+  bootToken: string,
+  getAssistantState?: () => AssistantStateSnapshot,
+) {
+  return (
+    ws: WebSocket,
+    _req: IncomingMessage,
+    params: URLSearchParams,
+  ): void => {
     const token = params.get("token") ?? "";
     if (!timingSafeEqualString(token, bootToken)) {
       ws.close(4001, "unauthorized");
@@ -24,9 +33,19 @@ export function createEventsWebSocketHandler(bus: EventBus, bootToken: string) {
       if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(message));
     };
 
-    const unsubscribe = bus.subscribe(send);
+    const snapshot = (): void => {
+      if (getAssistantState)
+        send({ type: "assistant.state", snapshot: getAssistantState() });
+    };
+    const unsubscribe = bus.subscribe((message) => {
+      send(message);
+      // Failed/cancelled sign-in can leave the same authority valid. Clear the
+      // browser first, then confirm the host's current grant and complete set.
+      if (message.type === "auth.changed") snapshot();
+    });
 
     ws.on("close", unsubscribe);
     ws.on("error", unsubscribe);
+    snapshot();
   };
 }

--- a/packages/harness/src/server/index.ts
+++ b/packages/harness/src/server/index.ts
@@ -3549,6 +3549,10 @@ export const startServer = async (
       return { harnessSessionId: id, cwd: session.cwd };
     },
   });
+  const getAssistantState = () => openCodeHost.getAssistantState();
+  const unsubscribeAssistant = openCodeHost.subscribeAssistantState(() =>
+    bus.publish({ type: "assistant.state", snapshot: getAssistantState() }),
+  );
   const app: Express = express();
   app.disable("x-powered-by");
   app.use("/opencode-runtime", openCodeBridge.router);
@@ -3578,6 +3582,7 @@ export const startServer = async (
   app.use(
     "/api",
     createRestRouter({
+      getAssistantState,
       sessionManager,
       adapters,
       version: readVersion(),
@@ -4253,7 +4258,7 @@ export const startServer = async (
     {
       path: "/ws/events",
       wss: eventsWss,
-      onConnection: createEventsWebSocketHandler(bus, options.bootToken),
+      onConnection: createEventsWebSocketHandler(bus, options.bootToken, getAssistantState),
     },
   ]);
 
@@ -4281,6 +4286,7 @@ export const startServer = async (
       unsubscribeCredentialChanges();
       assistantAccess.close();
       await settle(() => openCodeHost.close());
+      unsubscribeAssistant();
       openCodeBridge.close();
       await settle(() => sessionManager.beginShutdown());
       const bootstrapClosing = settle(() => projectBootstrap?.close());

--- a/packages/harness/src/server/rest.test.ts
+++ b/packages/harness/src/server/rest.test.ts
@@ -187,6 +187,22 @@ describe("createRestRouter", () => {
   });
 
   describe("GET /state", () => {
+    it("reads the Assistant projection after asynchronous inventory finishes", async () => {
+      let release!: () => void;
+      const inventory = new Promise<void>(resolve => { release = resolve; });
+      let entered!: () => void;
+      const started = new Promise<void>(resolve => { entered = resolve; });
+      let revision = 1;
+      const getAssistantState = vi.fn(() => ({ hostInstanceId: "host", authorityRevision: "auth", revision, enabled: false, sessions: [] }));
+      start({ getAssistantState, listWorkflows: async () => { entered(); await inventory; return []; } });
+      const response = fetch(`${baseUrl}/state`);
+      await started;
+      expect(getAssistantState).not.toHaveBeenCalled();
+      revision = 2;
+      release();
+      expect((await (await response).json() as { assistant: unknown }).assistant).toEqual(getAssistantState());
+    });
+
     it("reports unauthenticated with empty workflows/macros/sessions by default", async () => {
       start();
       const res = await fetch(`${baseUrl}/state`);

--- a/packages/harness/src/server/rest.ts
+++ b/packages/harness/src/server/rest.ts
@@ -1,3 +1,4 @@
+import type { AssistantStateSnapshot } from "../shared/assistant-state.js";
 /**
  * REST surface under /api — see src/shared/types.ts for the full contract
  * table. This router covers the session-lifecycle endpoints (W1); workflows,
@@ -193,6 +194,7 @@ async function agentHoldsConversation(
 }
 
 export interface RestRouterOptions {
+  getAssistantState?: () => AssistantStateSnapshot;
   sessionManager: SessionManager;
   adapters: Partial<Record<HarnessKind, HarnessAdapter>>;
   version: string;
@@ -388,6 +390,7 @@ export function createRestRouter(options: RestRouterOptions): Router {
           ? { agentsBaseUrl: options.agentsBaseUrl }
           : {}),
       };
+      if (options.getAssistantState) state.assistant = options.getAssistantState();
       res.json(state);
     } catch (err) {
       next(err);

--- a/packages/harness/src/shared/assistant-state.ts
+++ b/packages/harness/src/shared/assistant-state.ts
@@ -1,4 +1,7 @@
-import type { OpenCodeTransportFailure } from "./opencode-errors.js";
+import {
+  parseOpenCodeTransportFailure,
+  type OpenCodeTransportFailure,
+} from "./opencode-errors.js";
 
 export interface AssistantSessionSummary {
   harnessSessionId: string;
@@ -23,3 +26,95 @@ export type AssistantObservation = Omit<
 
 export const isConversationId = (id: unknown): id is string =>
   typeof id === "string" && /^ses_[A-Za-z0-9_-]{1,128}$/.test(id);
+
+const object = (
+  value: unknown,
+  keys: string[],
+): Record<string, unknown> | null =>
+  value !== null &&
+  typeof value === "object" &&
+  !Array.isArray(value) &&
+  Object.keys(value).every((key) => keys.includes(key))
+    ? (value as Record<string, unknown>)
+    : null;
+const id = (value: unknown): value is string =>
+  typeof value === "string" && /^[A-Za-z0-9_-]{1,256}$/.test(value);
+const count = (value: unknown): value is number | null =>
+  value === null ||
+  (typeof value === "number" && Number.isSafeInteger(value) && value >= 0);
+
+/** Decode the full public projection; no native diagnostics or extra fields cross it. */
+export function parseAssistantState(
+  value: unknown,
+): AssistantStateSnapshot | null {
+  const input = object(value, [
+    "hostInstanceId",
+    "authorityRevision",
+    "revision",
+    "enabled",
+    "sessions",
+  ]);
+  if (
+    !input ||
+    !id(input.hostInstanceId) ||
+    !id(input.authorityRevision) ||
+    typeof input.revision !== "number" ||
+    !Number.isSafeInteger(input.revision) ||
+    input.revision < 0 ||
+    typeof input.enabled !== "boolean" ||
+    !Array.isArray(input.sessions) ||
+    (!input.enabled && input.sessions.length)
+  )
+    return null;
+  const sessions: AssistantSessionSummary[] = [];
+  const seen = new Set<string>();
+  for (const raw of input.sessions) {
+    const row = object(raw, [
+      "harnessSessionId",
+      "conversationId",
+      "activity",
+      "pendingPermissions",
+      "pendingQuestions",
+      "freshness",
+      "failure",
+    ]);
+    if (
+      !row ||
+      !id(row.harnessSessionId) ||
+      !isConversationId(row.conversationId) ||
+      row.conversationId === row.harnessSessionId ||
+      seen.has(row.harnessSessionId) ||
+      typeof row.activity !== "string" ||
+      !["unknown", "idle", "busy", "retry"].includes(row.activity) ||
+      typeof row.freshness !== "string" ||
+      !["connecting", "current", "reconnecting", "unavailable"].includes(
+        row.freshness,
+      ) ||
+      !count(row.pendingPermissions) ||
+      !count(row.pendingQuestions)
+    )
+      return null;
+    const failure =
+      row.failure === undefined
+        ? undefined
+        : parseOpenCodeTransportFailure(row.failure);
+    if (failure === null) return null;
+    seen.add(row.harnessSessionId);
+    sessions.push({
+      harnessSessionId: row.harnessSessionId,
+      conversationId: row.conversationId,
+      activity: row.activity as AssistantSessionSummary["activity"],
+      pendingPermissions: row.pendingPermissions,
+      pendingQuestions: row.pendingQuestions,
+      freshness: row.freshness as AssistantSessionSummary["freshness"],
+      ...(failure ? { failure } : {}),
+    });
+  }
+  return {
+    hostInstanceId: input.hostInstanceId,
+    authorityRevision: input.authorityRevision,
+    revision: input.revision,
+    enabled: input.enabled,
+    sessions,
+  };
+}

--- a/packages/harness/src/shared/types.ts
+++ b/packages/harness/src/shared/types.ts
@@ -1,3 +1,4 @@
+import type { AssistantStateSnapshot } from "./assistant-state.js";
 /**
  * Sapiom Harness — shared interface contract.
  *
@@ -560,6 +561,7 @@ export type TerminalControlMessage = TerminalResizeMessage;
 // ---------------------------------------------------------------------------
 
 export type BusMessage =
+  | { type: "assistant.state"; snapshot: AssistantStateSnapshot }
   | { type: "session.status"; session: HarnessSession }
   /**
    * A prompt or completed turn is now durable in the local event store.
@@ -1276,6 +1278,7 @@ export interface HarnessWorkspaceContext {
 }
 
 export interface AppState {
+  assistant?: AssistantStateSnapshot;
   version: string;
   authenticated: boolean;
   userId: string | null;

--- a/packages/harness/vitest.config.ts
+++ b/packages/harness/vitest.config.ts
@@ -13,6 +13,9 @@ import { configDefaults, defineConfig } from "vitest/config";
 export default defineConfig({
   resolve: {
     alias: {
+      "@shared/assistant-state": fileURLToPath(
+        new URL("src/shared/assistant-state.ts", import.meta.url),
+      ),
       "@shared/initial-prompt": fileURLToPath(
         new URL("src/shared/initial-prompt.ts", import.meta.url),
       ),

--- a/packages/harness/web/src/lib/assistant-state.test.ts
+++ b/packages/harness/web/src/lib/assistant-state.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseAssistantState,
+  type AssistantStateSnapshot,
+} from "@shared/assistant-state";
+import { AssistantStateOrder } from "./assistant-state";
+
+const snapshot = (
+  revision = 1,
+  changes: Partial<AssistantStateSnapshot> = {},
+): AssistantStateSnapshot => ({
+  hostInstanceId: "host-a",
+  authorityRevision: "authority-a",
+  revision,
+  enabled: true,
+  sessions: [
+    {
+      harnessSessionId: "studio-a",
+      conversationId: "ses_a",
+      activity: "busy",
+      pendingPermissions: null,
+      pendingQuestions: 0,
+      freshness: "connecting",
+    },
+  ],
+  ...changes,
+});
+const open = (order: AssistantStateOrder, generation = 1) =>
+  order.transport({ generation, phase: "open" });
+
+describe("Assistant public payload", () => {
+  it("copies valid full snapshots and accepts disabled removal", () => {
+    const input = snapshot();
+    expect(parseAssistantState(input)).toEqual(input);
+    expect(parseAssistantState(input)?.sessions[0]).not.toBe(input.sessions[0]);
+    expect(
+      parseAssistantState(snapshot(2, { enabled: false, sessions: [] })),
+    ).not.toBeNull();
+  });
+  it.each([
+    { revision: -1 },
+    { revision: 1.5 },
+    { revision: Number.MAX_SAFE_INTEGER + 1 },
+    { hostInstanceId: "private/path" },
+    { authorityRevision: "" },
+    { enabled: "true" },
+    { sessions: null },
+    { enabled: false },
+    { credential: "private" },
+    { sessions: [snapshot().sessions[0], snapshot().sessions[0]] },
+  ])("rejects invalid full snapshot %j", (changes) => {
+    expect(parseAssistantState({ ...snapshot(), ...changes })).toBeNull();
+  });
+  it.each([
+    { activity: ["busy"] },
+    { freshness: ["current"] },
+    { activity: "success" },
+    { pendingPermissions: -1 },
+    { pendingQuestions: 1.5 },
+    { pendingQuestions: Number.MAX_SAFE_INTEGER + 1 },
+    { harnessSessionId: "ses_a" },
+    { conversationId: "not-native" },
+    { harnessSessionId: "x".repeat(257) },
+    { prompt: "private" },
+    { failure: { code: "runtime_exited", message: "raw native diagnostics" } },
+  ])("rejects invalid or private row %j", (changes) => {
+    expect(
+      parseAssistantState({
+        ...snapshot(),
+        sessions: [{ ...snapshot().sessions[0], ...changes }],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("Assistant snapshot ordering", () => {
+  it("seeds HTTP as uncertain and never lets it overwrite socket authority, even while disconnected", () => {
+    const order = new AssistantStateOrder();
+    const first = order.beginHttp();
+    expect(order.http(first, snapshot(1))).toEqual({
+      snapshot: snapshot(1),
+      current: false,
+    });
+    const late = order.beginHttp();
+    open(order);
+    order.socket(1, snapshot(2));
+    order.http(late, snapshot(50));
+    expect(order.current()).toEqual({ snapshot: snapshot(2), current: true });
+    order.transport({ generation: 1, phase: "closed" });
+    order.http(order.beginHttp(), snapshot(51));
+    expect(order.current()).toEqual({ snapshot: snapshot(2), current: false });
+  });
+  it("fences HTTP by request and auth generation", () => {
+    const order = new AssistantStateOrder();
+    const old = order.beginHttp();
+    const latest = order.beginHttp();
+    order.http(old, snapshot(2));
+    expect(order.current().snapshot).toBeNull();
+    order.authChanged();
+    order.http(latest, snapshot(3));
+    expect(order.current().snapshot).toBeNull();
+    order.http(order.beginHttp(), snapshot(4));
+    expect(order.current().snapshot?.revision).toBe(4);
+  });
+  it("requires a validated current-socket handshake; open and stale callbacks cannot restore freshness", () => {
+    const order = new AssistantStateOrder();
+    open(order);
+    order.socket(1, snapshot(5));
+    order.transport({ generation: 1, phase: "closed" });
+    order.socket(1, snapshot(6));
+    open(order, 2);
+    order.socket(1, snapshot(7));
+    order.transport({ generation: 1, phase: "open" });
+    order.socket(2, { ...snapshot(6), sessions: "bad" });
+    expect(order.current()).toEqual({ snapshot: snapshot(5), current: false });
+    order.socket(2, snapshot(4));
+    expect(order.current().current).toBe(false);
+    order.socket(2, snapshot(5));
+    expect(order.current().current).toBe(true);
+  });
+  it("adopts a new host with reset revisions only on a fresh socket", () => {
+    const order = new AssistantStateOrder();
+    open(order);
+    order.socket(1, snapshot(20));
+    order.socket(1, snapshot(1, { hostInstanceId: "host-b" }));
+    expect(order.current().snapshot?.hostInstanceId).toBe("host-a");
+    open(order, 2);
+    order.socket(2, { ...snapshot(), hostInstanceId: null });
+    order.socket(2, snapshot(0, { hostInstanceId: "host-b" }));
+    expect(order.current().snapshot?.hostInstanceId).toBe("host-b");
+    order.socket(1, snapshot(100));
+    order.socket(2, snapshot(100));
+    expect(order.current().snapshot?.hostInstanceId).toBe("host-b");
+  });
+  it("clears immediately on auth change and retains revision fences until the host reconfirms access", () => {
+    const order = new AssistantStateOrder();
+    open(order);
+    order.socket(1, snapshot(5));
+    order.authChanged();
+    expect(order.current()).toEqual({ snapshot: null, current: false });
+    order.socket(1, snapshot(4));
+    expect(order.current().snapshot).toBeNull();
+    order.socket(1, snapshot(6, { enabled: false, sessions: [] }));
+    expect(order.current().snapshot?.sessions).toEqual([]);
+    order.socket(1, snapshot(4, { authorityRevision: "authority-b" }));
+    expect(order.current().snapshot?.enabled).toBe(false);
+    order.socket(
+      1,
+      snapshot(7, { authorityRevision: "authority-b", sessions: [] }),
+    );
+    expect(order.current()).toEqual({
+      snapshot: snapshot(7, { authorityRevision: "authority-b", sessions: [] }),
+      current: true,
+    });
+  });
+  it("accepts unchanged authority after failed sign-in is reconfirmed by the host", () => {
+    const order = new AssistantStateOrder();
+    open(order);
+    order.socket(1, snapshot(5));
+    const oldHttp = order.beginHttp();
+    order.authChanged();
+    expect(order.current().snapshot).toBeNull();
+    order.http(oldHttp, snapshot(50));
+    expect(order.current().snapshot).toBeNull();
+    expect(order.socket(1, snapshot(5))).toEqual({
+      snapshot: snapshot(5),
+      current: true,
+    });
+  });
+  it("replaces complete sets and clears current presentation on malformed updates", () => {
+    const order = new AssistantStateOrder();
+    open(order);
+    order.socket(1, snapshot());
+    order.socket(1, snapshot(2, { sessions: [] }));
+    expect(order.current().snapshot?.sessions).toEqual([]);
+    order.socket(1, null);
+    expect(order.current()).toEqual({
+      snapshot: snapshot(2, { sessions: [] }),
+      current: false,
+    });
+  });
+});

--- a/packages/harness/web/src/lib/assistant-state.ts
+++ b/packages/harness/web/src/lib/assistant-state.ts
@@ -1,0 +1,81 @@
+import {
+  parseAssistantState,
+  type AssistantStateSnapshot,
+} from "@shared/assistant-state";
+
+export interface AssistantProjection {
+  snapshot: AssistantStateSnapshot | null;
+  current: boolean;
+}
+export interface EventConnection {
+  generation: number;
+  phase: "connecting" | "open" | "closed";
+}
+
+/** One ordering domain for boot reads, socket lifetimes and auth barriers. */
+export class AssistantStateOrder {
+  private value: AssistantProjection = { snapshot: null, current: false };
+  private last: AssistantStateSnapshot | null = null;
+  private connection: EventConnection = { generation: 0, phase: "closed" };
+  private initialized = false;
+  private socketAuthority = false;
+  private authGeneration = 0;
+  private request = 0;
+
+  current(): AssistantProjection {
+    return this.value;
+  }
+  beginHttp(): { auth: number; request: number } {
+    return { auth: this.authGeneration, request: ++this.request };
+  }
+  http(
+    token: ReturnType<AssistantStateOrder["beginHttp"]>,
+    raw: unknown,
+  ): AssistantProjection {
+    if (
+      this.socketAuthority ||
+      token.auth !== this.authGeneration ||
+      token.request !== this.request
+    )
+      return this.value;
+    const snapshot = parseAssistantState(raw);
+    if (!snapshot || !this.accepts(snapshot)) return this.value;
+    this.last = snapshot;
+    return (this.value = { snapshot, current: false });
+  }
+  transport(connection: EventConnection): AssistantProjection {
+    if (connection.generation < this.connection.generation) return this.value;
+    if (connection.generation !== this.connection.generation)
+      this.initialized = false;
+    this.connection = connection;
+    return (this.value = { ...this.value, current: false });
+  }
+  socket(generation: number | undefined, raw: unknown): AssistantProjection {
+    if (
+      generation !== this.connection.generation ||
+      this.connection.phase !== "open"
+    )
+      return this.value;
+    const snapshot = parseAssistantState(raw);
+    if (!snapshot) return (this.value = { ...this.value, current: false });
+    if (
+      (this.initialized &&
+        snapshot.hostInstanceId !== this.last?.hostInstanceId) ||
+      !this.accepts(snapshot)
+    )
+      return this.value;
+    this.initialized = this.socketAuthority = true;
+    this.last = snapshot;
+    return (this.value = { snapshot, current: true });
+  }
+  authChanged(): AssistantProjection {
+    this.authGeneration++;
+    return (this.value = { snapshot: null, current: false });
+  }
+  private accepts(snapshot: AssistantStateSnapshot): boolean {
+    return !(
+      this.last?.hostInstanceId === snapshot.hostInstanceId &&
+      snapshot.revision < this.last.revision
+    );
+  }
+}

--- a/packages/harness/web/src/lib/bus-message-type.ts
+++ b/packages/harness/web/src/lib/bus-message-type.ts
@@ -3,6 +3,7 @@ import type { BusMessage } from "@shared/types";
 // Keep the transport's supported discriminators exhaustive as the protocol
 // evolves. Removed or unknown events never reach mounted state subscribers.
 const supportedTypes: Record<BusMessage["type"], true> = {
+  "assistant.state": true,
   "session.status": true,
   "session.record.changed": true,
   "canvas.reload": true,

--- a/packages/harness/web/src/lib/events-connection.test.ts
+++ b/packages/harness/web/src/lib/events-connection.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, expect, it, vi } from "vitest";
+vi.mock("./api", () => ({
+  isMockMode: () => false,
+  getBootToken: () => "boot",
+}));
+import { subscribeEvents } from "./events";
+import { AssistantStateOrder } from "./assistant-state";
+
+class Socket {
+  static instances: Socket[] = [];
+  callbacks = new Map<string, ((event: { data?: string }) => void)[]>();
+  constructor(readonly url: URL) {
+    Socket.instances.push(this);
+  }
+  addEventListener(type: string, callback: (event: { data?: string }) => void) {
+    this.callbacks.set(type, [...(this.callbacks.get(type) ?? []), callback]);
+  }
+  emit(type: string, data?: unknown) {
+    for (const callback of this.callbacks.get(type) ?? [])
+      callback({ data: JSON.stringify(data) });
+  }
+  close() {
+    this.emit("close");
+  }
+}
+afterEach(() => {
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  Socket.instances = [];
+});
+
+it("fences old socket callbacks during retry and makes only validated snapshots current", () => {
+  vi.useFakeTimers();
+  vi.stubGlobal("window", { location: { href: "http://localhost:1234" } });
+  vi.stubGlobal("WebSocket", Socket);
+  const order = new AssistantStateOrder();
+  const messages = vi.fn((message, generation) =>
+    order.socket(generation, message.snapshot),
+  );
+  const reconnect = vi.fn();
+  const stop = subscribeEvents(messages, reconnect, (connection) =>
+    order.transport(connection),
+  );
+  const first = Socket.instances[0]!;
+  expect(first.url.searchParams.get("token")).toBe("boot");
+  first.emit("open");
+  expect(order.current().current).toBe(false);
+  const frame = {
+    type: "assistant.state",
+    snapshot: {
+      hostInstanceId: "host",
+      authorityRevision: "auth",
+      revision: 1,
+      enabled: true,
+      sessions: [],
+    },
+  };
+  first.emit("message", frame);
+  expect(order.current().current).toBe(true);
+  first.emit("close");
+  first.emit("open");
+  first.emit("message", frame);
+  first.emit("close");
+  expect(messages).toHaveBeenCalledTimes(1);
+  expect(reconnect).not.toHaveBeenCalled();
+  expect(order.current().current).toBe(false);
+  vi.advanceTimersByTime(2000);
+  expect(Socket.instances).toHaveLength(2);
+  const second = Socket.instances[1]!;
+  second.emit("open");
+  expect(reconnect).toHaveBeenCalledOnce();
+  expect(order.current().current).toBe(false);
+  first.emit("message", frame);
+  second.emit("message", frame);
+  expect(order.current().current).toBe(true);
+  const firstGeneration = messages.mock.calls[0]![1];
+  expect(messages.mock.calls[1]![1]).toBeGreaterThan(firstGeneration);
+  stop();
+  second.emit("open");
+  second.emit("message", frame);
+  second.emit("close");
+  vi.advanceTimersByTime(4000);
+  expect(messages).toHaveBeenCalledTimes(2);
+  expect(Socket.instances).toHaveLength(2);
+  expect(order.current().current).toBe(false);
+  const fresh = vi.fn();
+  const stopFresh = subscribeEvents(fresh);
+  Socket.instances[2]!.emit("open");
+  Socket.instances[2]!.emit("message", frame);
+  expect(fresh.mock.calls[0]![1]).toBeGreaterThan(messages.mock.calls[1]![1]);
+  Socket.instances[2]!.emit("close");
+  stopFresh();
+  vi.advanceTimersByTime(4000);
+  expect(Socket.instances).toHaveLength(3);
+});

--- a/packages/harness/web/src/lib/events.test.ts
+++ b/packages/harness/web/src/lib/events.test.ts
@@ -28,7 +28,7 @@ it("delivers supported events, ignores retired frames and removes its exact subs
       publishMockBusMessage({ type } as unknown as BusMessage);
     expect(listener).not.toHaveBeenCalled();
     publishMockBusMessage(message);
-    expect(listener).toHaveBeenCalledExactlyOnceWith(message);
+    expect(listener).toHaveBeenCalledExactlyOnceWith(message, expect.any(Number));
   } finally {
     unsubscribe();
   }

--- a/packages/harness/web/src/lib/events.ts
+++ b/packages/harness/web/src/lib/events.ts
@@ -3,6 +3,7 @@
  * ../../../src/shared/types.ts). No-op in mock mode — there's no server to
  * connect to, and the mock fixtures are static.
  */
+import type { EventConnection } from "./assistant-state";
 import type { BusMessage } from "@shared/types";
 
 import {
@@ -14,7 +15,8 @@ import {
 import { MOCK_ACTIVITY_SESSION_ID } from "./mock-data";
 import { hasKnownBusMessageType } from "./bus-message-type";
 
-export type BusListener = (message: BusMessage) => void;
+export type BusListener = (message: BusMessage, generation?: number) => void;
+let nextConnectionGeneration = 0;
 export type EventReconnectListener = () => void;
 
 const RECONNECT_DELAY_MS = 2000;
@@ -65,12 +67,17 @@ if (isMockMode() && typeof window !== "undefined") {
 export function subscribeEvents(
   onMessage: BusListener,
   onReconnect?: EventReconnectListener,
+  onConnection?: (connection: EventConnection) => void,
 ): () => void {
-  const deliver = (message: unknown): void => {
-    if (hasKnownBusMessageType(message)) onMessage(message as BusMessage);
+  const deliver = (message: unknown, generation: number): void => {
+    if (hasKnownBusMessageType(message))
+      onMessage(message as BusMessage, generation);
   };
   if (isMockMode()) {
-    mockListeners.add(deliver);
+    const generation = ++nextConnectionGeneration;
+    const receive = (message: BusMessage) => deliver(message, generation);
+    onConnection?.({ generation, phase: "open" });
+    mockListeners.add(receive);
     if (!mockActivitySimulated) {
       mockActivitySimulated = true;
       // Fixture nicety, not test infrastructure: shows the tab strip's busy
@@ -106,7 +113,10 @@ export function subscribeEvents(
         );
       }, DEMO_RUN_DELAY_MS);
     }
-    return () => mockListeners.delete(deliver);
+    return () => {
+      mockListeners.delete(receive);
+      onConnection?.({ generation, phase: "closed" });
+    };
   }
 
   const url = new URL("/ws/events", window.location.href);
@@ -118,21 +128,32 @@ export function subscribeEvents(
   let stopped = false;
   let opened = false;
 
+  let generation = 0;
   const connect = (): void => {
-    socket = new WebSocket(url);
-    socket.addEventListener("open", () => {
+    generation = ++nextConnectionGeneration;
+    const currentGeneration = generation;
+    onConnection?.({ generation, phase: "connecting" });
+    const current = new WebSocket(url);
+    socket = current;
+    const isCurrent = () => !stopped && socket === current;
+    current.addEventListener("open", () => {
+      if (!isCurrent()) return;
+      onConnection?.({ generation: currentGeneration, phase: "open" });
       if (opened) onReconnect?.();
       opened = true;
     });
-    socket.addEventListener("message", (event) => {
+    current.addEventListener("message", (event) => {
+      if (!isCurrent()) return;
       try {
-        deliver(JSON.parse(event.data as string));
+        deliver(JSON.parse(event.data as string), currentGeneration);
       } catch {
         // Ignore malformed frames rather than tearing down the socket.
       }
     });
-    socket.addEventListener("close", () => {
-      if (stopped) return;
+    current.addEventListener("close", () => {
+      if (!isCurrent()) return;
+      socket = null;
+      onConnection?.({ generation: currentGeneration, phase: "closed" });
       retryTimer = setTimeout(connect, RECONNECT_DELAY_MS);
     });
   };
@@ -142,5 +163,7 @@ export function subscribeEvents(
     stopped = true;
     if (retryTimer) clearTimeout(retryTimer);
     socket?.close();
+    socket = null;
+    onConnection?.({ generation, phase: "closed" });
   };
 }

--- a/packages/harness/web/src/lib/use-harness-state.ts
+++ b/packages/harness/web/src/lib/use-harness-state.ts
@@ -1,3 +1,4 @@
+import { AssistantStateOrder, type AssistantProjection } from "./assistant-state";
 import { parseAgentMapInitializationStatus, type AgentMapInitializationStatus } from "@shared/agent-map-initialization";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
@@ -135,6 +136,7 @@ export interface PendingWorkspace {
 }
 
 export interface HarnessStateHook {
+  assistant: AssistantProjection;
   authRevision: number;
   state: AppState | null;
   loading: boolean;
@@ -417,6 +419,8 @@ export interface HarnessStateHook {
 /** Central store for the SPA shell: fetches AppState + settings once, then keeps sessions/workflows fresh via the event bus. */
 export function useHarnessState(): HarnessStateHook {
   const [state, setState] = useState<AppState | null>(null);
+  const assistantOrder = useRef(new AssistantStateOrder()).current;
+  const [assistant, setAssistant] = useState(() => assistantOrder.current());
   useEffect(() => {
     if (!state) return;
     const projectIds = new Set(
@@ -1128,6 +1132,7 @@ export function useHarnessState(): HarnessStateHook {
   useEffect(() => {
     let cancelled = false;
     const workflowRequest = workflowProjectionOrder.begin();
+    const assistantRequest = assistantOrder.beginHttp();
     // A retry re-enters the loading state and clears the prior failure so the
     // shell shows "reconnecting", not a stale error, while the refetch runs.
     if (reloadSeq > 0) {
@@ -1149,7 +1154,9 @@ export function useHarnessState(): HarnessStateHook {
         const workflows = bootWorkflowsAccepted
           ? appState.workflows
           : [...(workflowProjectionOrder.current() ?? [])];
-        setState({ ...appState, workflows });
+        const { assistant: assistantSeed, ...shell } = appState;
+        setAssistant(assistantOrder.http(assistantRequest, assistantSeed));
+        setState({ ...shell, workflows });
         // Baseline the built-agents metric: everything present at load already
         // existed, so seed it into the seen-set and never count it as built.
         const seenAtLoad = (seenAgentPathsRef.current ??= new Set<string>());
@@ -1227,7 +1234,11 @@ export function useHarnessState(): HarnessStateHook {
 
   useEffect(() => {
     return subscribeEvents(
-      (message) => {
+      (message, generation) => {
+        if (message.type === "assistant.state") {
+          setAssistant(assistantOrder.socket(generation, message.snapshot));
+          return;
+        }
         // SessionRecord invalidations have a targeted listener below. Keeping
         // them out of the legacy last-message slot avoids repainting the entire
         // Studio for records no mounted transcript is watching.
@@ -1352,6 +1363,7 @@ export function useHarnessState(): HarnessStateHook {
             }, BUSY_WINDOW_MS),
           );
         } else if (message.type === "auth.changed") {
+          setAssistant(assistantOrder.authChanged());
           // Accept a barrier synchronously: merely issuing the refresh cannot
           // stop an older in-flight success from restoring another account.
           const workflows = (workflowProjectionOrder.current() ?? workflowsRef.current)
@@ -1382,8 +1394,9 @@ export function useHarnessState(): HarnessStateHook {
         eventReconnectListeners.current.forEach((listener) => listener());
         void refreshWorkflows().catch(() => undefined);
       },
+      connection => setAssistant(assistantOrder.transport(connection)),
     );
-  }, [refreshWorkflows, startRunPolling]);
+  }, [refreshWorkflows, startRunPolling, assistantOrder]);
 
   /**
    * Loads history for `cwds` and folds it into the store via `mergeHistory`,
@@ -2399,6 +2412,7 @@ export function useHarnessState(): HarnessStateHook {
   );
 
   return {
+    assistant,
     state,
     authRevision,
     loading,

--- a/packages/harness/web/tsconfig.json
+++ b/packages/harness/web/tsconfig.json
@@ -13,6 +13,7 @@
     "useDefineForClassFields": true,
     "types": ["vite/client", "node"],
     "paths": {
+      "@shared/assistant-state": ["../src/shared/assistant-state.ts"],
       "@shared/initial-prompt": ["../src/shared/initial-prompt.ts"],
       "@shared/types": ["../src/shared/types.ts"],
       "@shared/workspace-scope": ["../src/shared/workspace-scope.ts"],

--- a/packages/harness/web/vite.config.ts
+++ b/packages/harness/web/vite.config.ts
@@ -86,6 +86,9 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      "@shared/assistant-state": fileURLToPath(
+        new URL("../src/shared/assistant-state.ts", import.meta.url),
+      ),
       "@shared/initial-prompt": fileURLToPath(
         new URL("../src/shared/initial-prompt.ts", import.meta.url),
       ),


### PR DESCRIPTION
<!--
Thank you for contributing to sapiom-js.
Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
-->

## Primary change type

<!-- Select exactly one primary type. -->

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

Background Assistant state must reach Studio independently of the selected chat, and an old bootstrap response or socket must not replace a newer host/account view. Deliver one bounded full-snapshot projection through the existing state and event transports.

## Summary and scope

Add strict public snapshot parsing and a pure browser ordering store. REST reads the host projection after asynchronous inventory; authenticated event sockets subscribe before their initial snapshot and send another current snapshot after each auth event. Socket callbacks are fenced by connection identity/generation, HTTP seeds by request/auth generation, and accepted revisions by host instance. Disconnects preserve uncertain last-known state; a new socket can adopt a restarted host.

`useHarnessState` owns this projection separately from generic boot assignment. Account events clear it synchronously; unchanged valid access can be reconfirmed after failed/cancelled sign-in. No native history, credential, prompt or raw diagnostics enter the protocol.

This **622-line all-file increment** stacks on #966 for SAP-3291. Existing navigation indicators and full native/Studio acceptance follow.

## Related work

<!--
Link the issue or prior maintainer discussion when required by CONTRIBUTING.md.
Use N/A for a direct PR that does not need one.
-->

Related issue or discussion:
https://linear.app/sapiom/issue/SAP-3291

## Validation

```text
pnpm build — passed (root)
pnpm typecheck — passed (root)
pnpm lint — passed (root)
setpriv --inh-caps=-all --ambient-caps=-all env npm_config_workspace_concurrency=1 pnpm test — passed (root)
pnpm install --frozen-lockfile — passed
pnpm --filter @sapiom/harness exec vitest run web/src/lib/assistant-state.test.ts web/src/lib/events.test.ts web/src/lib/events-connection.test.ts src/server/events-ws.test.ts src/server/rest.test.ts — 149 passed
E2E_PORT=5397 pnpm --filter @sapiom/harness exec playwright test --config web/e2e/playwright.config.ts opencode-chat.spec.ts session-tabs.spec.ts --workers=1 — 45 passed
pnpm --filter @sapiom/harness exec eslint --no-inline-config --no-ignore --parser-options '{"project":"web/tsconfig.json"}' web/src/lib/assistant-state.ts web/src/lib/assistant-state.test.ts web/src/lib/events.ts web/src/lib/events-connection.test.ts web/src/lib/events.test.ts web/src/lib/use-harness-state.ts web/src/lib/bus-message-type.ts — passed with one existing unused-import warning
```

The root wrapper drops this VM's ambient permission bypass for an existing unreadable-directory fixture. Explicit browser lint disables inline rule directives because the parent hook already references an unavailable `react-hooks/exhaustive-deps` rule; the same error and unused-import warning were reproduced on the unchanged parent. Root lint remains unchanged and passes. `pnpm pr:size` is absent; explicit all-file numstat enforces the 1,000-line maximum.

### Tests and documentation

Parser tests reject malformed enum arrays, unsafe revisions/counts, duplicate IDs, private fields and arbitrary diagnostics. Ordering tests cover delayed HTTP, old socket callbacks, reconnect confirmation, host restart, account barriers and full removals. Real socket-seam tests cover retry/unsubscribe generations; server tests cover subscribe-before-getter reentrancy and post-auth confirmation. A held REST inventory proves the summary is read at response time.

Independent review found the initial permanent authority block broke failed sign-in recovery and caught missing browser aliases. Both are corrected; 148 independently rerun focused tests and same-authority probes pass. README and patch Changeset document the protocol.

## Compatibility and release impact

- Breaking or externally visible changes: optional `AppState.assistant` and additive `assistant.state` bus frames. Existing callers may omit the getter. Navigation does not consume summaries until the following increment.
- Changeset: Added `project-assistant-state.md` for `@sapiom/harness`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex implemented and verified the protocol, parser, ordering store and tests. An independent agent reviewed transport/auth ordering and validation.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

## Risk and rollout

The existing verified access gate determines the host projection. Full snapshots replace the complete set and idle does not imply success. **Fix-forward:** correct the relevant transport/auth ordering guard and extend its race test while retaining the existing native source of truth.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/sapiom/sapiom-js/pull/967" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->