### PR TITLE
feat(harness): show independent Assistant activity [SAP-3291]

### DIFF
--- a/.changeset/show-background-assistant-activity.md
+++ b/.changeset/show-background-assistant-activity.md
@@ -1,0 +1,5 @@
+---
+"@sapiom/harness": patch
+---
+
+Show independent Assistant activity and pending-input indicators in existing session tabs and retained-session rows, with explicit uncertainty through reconnects.

--- a/packages/harness/README.md
+++ b/packages/harness/README.md
@@ -17,6 +17,8 @@ system prompt, in whatever project directory you choose.
 
 Assistant summaries use the existing `/api/state` seed and `/ws/events` full snapshots. The browser preserves the last known state as uncertain until a validated current socket snapshot arrives; account changes clear it immediately. Summaries contain activity and pending counts only.
 
+Session tabs and retained-session rows show independent Assistant activity. Hover or use the accessible label for Working, Waiting for input, Checking status or Unavailable. Terminal output keeps its existing pulse; an idle Assistant has no success badge. See the [native acceptance record](docs/assistant-background-acceptance.md) for the combined integration checks.
+
 ## What you get
 
 - **Terminal sessions** — your agent, your subscription, your machine; the

--- a/packages/harness/docs/assistant-background-acceptance.md
+++ b/packages/harness/docs/assistant-background-acceptance.md
@@ -1,0 +1,34 @@
+# Assistant background-session acceptance
+
+Manual integration proof for SAP-3291, 2026-09-12. This exercises the combined SDK with PRs #950 and #951 and the SAP-3291 stack. It complements the committed observer, lifecycle, protocol, adapter and browser regressions.
+
+## Setup
+
+Real `startServer`, nonmock built Studio SPA, real browser boot authentication, `AssistantAccess`, durable credential refresh, `OpenCodeBridge`, `OpenCodeHost`, native observer, REST and event WebSocket. Two Studio sessions share one temporary folder and use distinct OpenCode state directories. Native version: 1.18.29.
+
+The authority and model endpoints are controlled loopback HTTP fixtures with synthetic credentials and Responses output. Terminal adapters launch idle local Node processes. Native MCP and automatic title generation are disabled; native tool permissions deny everything except a prompted read of the temporary README. Disabling title generation makes model-call counts correspond to the tested turns. The actual native startup supervisor and ownership protection remain active.
+
+This is a native/Studio integration check, not production OAuth, model quality, remote MCP, Electron packaging or a Mac-stack check.
+
+## Verified behavior
+
+- A streams while selected; switching to B removes A's browser stream while its one host observer remains.
+- A completes while B waits on a real native read permission. The real summary socket reports A idle/current and removes its Working indicator without claiming task success. B's draft stays intact.
+- Returning to A restores its complete answer once and retains its separate draft. The selected controller reports Finished using the native completion contract.
+- B's permission is acknowledged through native while A is selected. The observer clears B's pending count and observes its continuation finish in the background.
+- Review and new-session views unmount the selected display without stopping background work. Terminal/Assistant and A/B switches preserve separate in-memory drafts.
+- During a controlled event-stream outage, all native SSE consumers are absent. A still completes and persists its answer. The host reconnects, becomes current and reports idle; the selected display subsequently restores the complete answer.
+- Ending A's Terminal preserves its Assistant binding, completed history and unsent draft. The retained session remains accessible from history; a document reload restores the native messages. Unsent drafts intentionally remain memory-only.
+- Exactly three intentional user prompts are persisted: two for A and one for B. Four main model calls occur: A twice, and B's tool call plus its continuation. No prompt is replayed by observation, reconnection or navigation.
+
+The run records real `assistant.state` revisions, native event consumer counts, synthetic model requests, screenshots and a browser trace. The maximum observed consumers per runtime is two: one host observer and one selected display. Background sessions retain one observer. Shutdown verifies both native PIDs have exited, no event consumers remain, and temporary state is removed.
+
+## Verification record
+
+The final run passed at **2026-09-12 10:11:25–10:11:47 UTC** (22.65 seconds). Native `/global/health` confirmed both processes were version 1.18.29. Observation recovered 230 ms after restoring the event transport. All eleven behavioral/cleanup assertions passed, with no browser page errors or blocked external requests. Optional account-plan/template requests received controlled loopback 404 responses.
+
+The combined checkout used main `76318848`, PR #950 `9b40f113`, PR #951 `eff8fe06`, and the SAP-3291 increments #955, #956, #958, #959, #960, #961, #962, #966, #967 plus this navigation change. The fixture disables telemetry, configures loopback authority/model destinations, and blocks nonloopback browser/server fetches. This does not audit every possible native-child network destination.
+
+The complete fixture is retained with this workspace's SAP-3291 execution evidence. It imports the combined source, wraps only environment/credential discovery and native fixture configuration, and runs as one explicitly selected Vitest test. It does not mock host summaries or intercept the Studio state/WS/native browser routes.
+
+The focused browser suites also cover malformed/older projections, authority clearing, unavailable/uncertain/input precedence, unknown summaries creating no tabs, Terminal-exited header/history rows and hovered-tooltip updates/removal. Earlier commits carry the stream/history/pending-read ordering regressions.

--- a/packages/harness/web/e2e/assistant-activity.spec.ts
+++ b/packages/harness/web/e2e/assistant-activity.spec.ts
@@ -1,0 +1,228 @@
+import { expect, test, type Page } from "@playwright/test";
+import type {
+  AssistantSessionSummary,
+  AssistantStateSnapshot,
+} from "../../src/shared/assistant-state";
+
+const row = (
+  harnessSessionId: string,
+  changes: Partial<AssistantSessionSummary> = {},
+): AssistantSessionSummary => ({
+  harnessSessionId,
+  conversationId: `ses_${harnessSessionId.replaceAll("-", "_")}`,
+  activity: "busy",
+  pendingPermissions: 0,
+  pendingQuestions: 0,
+  freshness: "current",
+  ...changes,
+});
+const publish = (
+  page: Page,
+  revision: number,
+  sessions: AssistantSessionSummary[],
+  changes: Partial<AssistantStateSnapshot> = {},
+) =>
+  page.evaluate(
+    (snapshot) => {
+      (
+        window as unknown as {
+          __HARNESS_TEST__: { publish: (message: unknown) => void };
+        }
+      ).__HARNESS_TEST__.publish({ type: "assistant.state", snapshot });
+    },
+    {
+      hostInstanceId: "host-a",
+      authorityRevision: "authority-a",
+      revision,
+      enabled: true,
+      sessions,
+      ...changes,
+    },
+  );
+const indicator = (page: Page, id = "sess-boot") =>
+  page.getByTestId(`assistant-activity-${id}`);
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/?seed=0");
+  await expect(page.locator(".harness-terminal")).toBeVisible();
+});
+
+test("keeps independent Assistant and Terminal activity on existing same-folder tabs", async ({
+  page,
+}) => {
+  const tabs = page.getByRole("tablist", { name: "Sessions" }).getByRole("tab");
+  const count = await tabs.count();
+  await publish(page, 1, [
+    row("sess-boot"),
+    row("sess-leasing-2", { pendingQuestions: 1 }),
+    row("unknown-session"),
+  ]);
+  await expect(indicator(page)).toHaveAttribute(
+    "aria-label",
+    "Assistant: Working",
+  );
+  await expect(indicator(page, "sess-leasing-2")).toHaveAttribute(
+    "aria-label",
+    "Assistant: Waiting for input",
+  );
+  await expect(tabs).toHaveCount(count);
+  await expect(indicator(page, "unknown-session")).toHaveCount(0);
+  await page.evaluate(() =>
+    (window as any).__HARNESS_TEST__.publish({
+      type: "session.activity",
+      harnessSessionId: "sess-boot",
+      at: new Date().toISOString(),
+    }),
+  );
+  await expect(page.getByTestId("session-tab-busy-sess-boot")).toBeVisible();
+  await tabs.nth(1).click();
+  await expect(indicator(page)).toHaveAttribute(
+    "aria-label",
+    "Assistant: Working",
+  );
+  await publish(page, 2, [
+    row("sess-boot", { activity: "idle" }),
+    row("sess-leasing-2", { activity: "retry" }),
+  ]);
+  await expect(indicator(page)).toHaveCount(0);
+  await expect(indicator(page, "sess-leasing-2")).toHaveAttribute(
+    "aria-label",
+    "Assistant: Working",
+  );
+  await expect(
+    page.getByRole("img", { name: /Assistant: (Finished|Success)/ }),
+  ).toHaveCount(0);
+  await page.screenshot({
+    path: test.info().outputPath("independent-assistant-tabs.png"),
+  });
+});
+
+test("prioritizes uncertainty, validates payloads, and replaces the complete authority-scoped set", async ({
+  page,
+}) => {
+  await publish(page, 1, [
+    row("sess-boot", { pendingPermissions: 1, freshness: "reconnecting" }),
+  ]);
+  await expect(indicator(page)).toHaveAttribute(
+    "aria-label",
+    "Assistant: Checking status",
+  );
+  await publish(page, 2, [row("sess-boot", { pendingPermissions: 1 })]);
+  await expect(indicator(page)).toHaveAttribute(
+    "aria-label",
+    "Assistant: Waiting for input",
+  );
+  await publish(page, 3, [row("sess-boot", { pendingQuestions: null })]);
+  await expect(indicator(page)).toHaveAttribute(
+    "aria-label",
+    "Assistant: Checking status",
+  );
+  await publish(page, 4, [row("sess-boot", { freshness: "unavailable" })]);
+  await expect(indicator(page)).toHaveAttribute(
+    "aria-label",
+    "Assistant: Unavailable",
+  );
+  await publish(page, 3, [row("sess-boot")]);
+  await expect(indicator(page)).toHaveAttribute(
+    "aria-label",
+    "Assistant: Unavailable",
+  );
+  await publish(page, 5, [row("sess-boot", { pendingQuestions: -1 })]);
+  await expect(indicator(page)).toHaveAttribute(
+    "aria-label",
+    "Assistant: Checking status",
+  );
+  await publish(page, 5, [], { authorityRevision: "authority-b" });
+  await expect(indicator(page)).toHaveCount(0);
+  await publish(page, 6, [row("sess-boot")], {
+    authorityRevision: "authority-b",
+  });
+  await expect(indicator(page)).toBeVisible();
+  await publish(page, 7, [], {
+    enabled: false,
+    authorityRevision: "authority-c",
+  });
+  await expect(indicator(page)).toHaveCount(0);
+});
+
+test("clears on auth change and accepts the host's unchanged authorized confirmation", async ({
+  page,
+}) => {
+  await publish(page, 1, [row("sess-boot")]);
+  await expect(indicator(page)).toBeVisible();
+  await page.evaluate(() =>
+    (window as any).__HARNESS_TEST__.publish({
+      type: "auth.changed",
+      authenticated: false,
+      organizationName: null,
+    }),
+  );
+  await expect(indicator(page)).toHaveCount(0);
+  await publish(page, 1, [row("sess-boot")]);
+  await expect(indicator(page)).toHaveAttribute(
+    "aria-label",
+    "Assistant: Working",
+  );
+});
+
+test("retains Assistant activity in the exited-session header and history row", async ({
+  page,
+}) => {
+  await publish(page, 1, [row("sess-boot", { pendingPermissions: 1 })]);
+  await page.evaluate(() =>
+    (window as any).__HARNESS_TEST__.publish({
+      type: "session.status",
+      session: {
+        id: "sess-boot",
+        agentSessionId: null,
+        boundWorkflowPath: "/Users/demo/acme-app/leasing",
+        harness: "claude-code",
+        cwd: "/Users/demo/acme-app",
+        title: "acme-app",
+        status: "exited",
+        ready: false,
+        exitCode: 0,
+        createdAt: new Date().toISOString(),
+        lastActiveAt: new Date().toISOString(),
+      },
+    }),
+  );
+  await expect(page.getByTestId("dead-session-pane")).toBeVisible();
+  await expect(page.getByTestId("session-tab-sess-boot")).toHaveCount(0);
+  await expect(
+    page
+      .locator(".session-current")
+      .getByRole("img", { name: "Assistant: Waiting for input" }),
+  ).toBeVisible();
+  await page.getByTestId("history-trigger").click();
+  await page.getByTestId("past-sessions-trigger").hover();
+  await expect(
+    page
+      .getByTestId("exited-session-sess-boot")
+      .getByRole("img", { name: "Assistant: Waiting for input" }),
+  ).toBeVisible();
+  await page.screenshot({
+    path: test.info().outputPath("retained-assistant-session.png"),
+  });
+});
+
+test("refreshes hovered Assistant text and removes it at the auth barrier", async ({
+  page,
+}) => {
+  await publish(page, 1, [row("sess-boot")]);
+  await indicator(page).hover();
+  const tooltip = page.locator('.app-tooltip[data-show="true"]');
+  await expect(tooltip).toHaveText("Assistant: Working");
+  await publish(page, 2, [row("sess-boot", { pendingQuestions: 1 })]);
+  await expect(tooltip).toHaveText("Assistant: Waiting for input");
+  await page.evaluate(() =>
+    (window as any).__HARNESS_TEST__.publish({
+      type: "auth.changed",
+      authenticated: false,
+      organizationName: null,
+    }),
+  );
+  await expect(indicator(page)).toHaveCount(0);
+  // Removing the child can transfer hover to the titled session button.
+  await expect(page.locator(".app-tooltip")).not.toContainText("Assistant:");
+});

--- a/packages/harness/web/e2e/workflow-deployment.spec.ts
+++ b/packages/harness/web/e2e/workflow-deployment.spec.ts
@@ -31,7 +31,10 @@ test("list outages silently retain the cloud badge and background refreshes reco
   await expect(cloud).toHaveAttribute("data-deployment-unavailable", "false");
   await patch(page, { failure: "list" });
   await expect(cloud).toHaveAttribute("data-deployed", "false");
-  await expect(cloud).toHaveAttribute("title", "Draft. Not deployed to Sapiom yet.");
+  // Hover consumes the native title; assert the text the user still sees.
+  await expect(page.locator('.app-tooltip[data-show="true"]')).toHaveText(
+    "Draft. Not deployed to Sapiom yet.",
+  );
 });
 
 test("auth invalidation clears evidence before replacement lookup and rejects an old success", async ({

--- a/packages/harness/web/src/App.tsx
+++ b/packages/harness/web/src/App.tsx
@@ -2900,6 +2900,7 @@ export const App = (): JSX.Element => {
           }
         >
           <WorkflowsRail
+            assistant={harness.assistant}
             projectRoot={projectRoot || null}
             onSaveProjectRoot={saveProjectRoot}
             width={widths.rail}
@@ -3174,6 +3175,7 @@ export const App = (): JSX.Element => {
 
           <div className="center-pane">
             <SessionBar
+              assistant={harness.assistant}
               openedAgentName={
                 showAgentEmpty ? (focusedWorkflow?.name ?? null) : null
               }

--- a/packages/harness/web/src/components/AssistantActivity.tsx
+++ b/packages/harness/web/src/components/AssistantActivity.tsx
@@ -1,0 +1,64 @@
+import type { JSX } from "react";
+import type { AssistantProjection } from "../lib/assistant-state";
+import { Icon } from "./Icon";
+
+/** Only decorate an existing Studio session; summaries never create navigation. */
+export function AssistantActivity({
+  assistant,
+  sessionId,
+}: {
+  assistant?: AssistantProjection;
+  sessionId: string;
+}): JSX.Element | null {
+  const summary = assistant?.snapshot?.enabled
+    ? assistant.snapshot.sessions.find(
+        (row) => row.harnessSessionId === sessionId,
+      )
+    : undefined;
+  if (!summary) return null;
+  const state = !assistant?.current
+    ? "checking"
+    : summary.freshness === "unavailable"
+      ? "unavailable"
+      : summary.freshness !== "current" ||
+          summary.activity === "unknown" ||
+          summary.pendingPermissions === null ||
+          summary.pendingQuestions === null
+        ? "checking"
+        : summary.pendingPermissions > 0 || summary.pendingQuestions > 0
+          ? "waiting"
+          : summary.activity === "busy" || summary.activity === "retry"
+            ? "working"
+            : null;
+  if (!state) return null;
+  const label = {
+    checking: "Assistant: Checking status",
+    unavailable: "Assistant: Unavailable",
+    waiting: "Assistant: Waiting for input",
+    working: "Assistant: Working",
+  }[state];
+  return (
+    <span
+      className="assistant-activity"
+      data-state={state}
+      data-testid={`assistant-activity-${sessionId}`}
+      role="img"
+      aria-label={label}
+      title={label}
+      data-tooltip={label}
+    >
+      <Icon
+        name={
+          state === "waiting"
+            ? "MessageSquare"
+            : state === "unavailable"
+              ? "TriangleAlert"
+              : state === "checking"
+                ? "CloudOff"
+                : "Loader"
+        }
+        size={12}
+      />
+    </span>
+  );
+}

--- a/packages/harness/web/src/components/SessionBar.tsx
+++ b/packages/harness/web/src/components/SessionBar.tsx
@@ -1,3 +1,5 @@
+import { AssistantActivity } from "./AssistantActivity";
+import type { AssistantProjection } from "../lib/assistant-state";
 import { useEffect, useRef, useState } from "react";
 import type { JSX, ReactNode, RefObject } from "react";
 import type { HarnessSession } from "@shared/types";
@@ -20,6 +22,7 @@ function workspaceLabelOf(path: string): string {
 const EMPTY_BUSY_SESSION_IDS: ReadonlySet<string> = new Set();
 
 interface SessionBarProps {
+  assistant?: AssistantProjection;
   /** The main panel is showing the Overview/intro, not a session. */
   overviewMode?: boolean;
   /** Set while an agent is open whose workspace has no live session. */
@@ -83,6 +86,7 @@ interface SessionBarProps {
  * its caret, while agent actions remain right-anchored on the same row.
  */
 export function SessionBar({
+  assistant,
   overviewMode = false,
   openedAgentName = null,
   reviewTitle = null,
@@ -220,6 +224,7 @@ export function SessionBar({
           onNewSession &&
           labelOf ? (
           <SessionTabs
+            assistant={assistant}
             sessions={sessions}
             activeSessionId={activeSession?.id ?? null}
             busySessionIds={busySessionIds}
@@ -296,6 +301,7 @@ export function SessionBar({
                     ? labelOf(activeSession)
                     : (sessionName ?? activeSession.title)}
                 </span>
+                <AssistantActivity assistant={assistant} sessionId={activeSession.id} />
                 <Icon name="ChevronDown" size={13} />
               </button>
             )}

--- a/packages/harness/web/src/components/SessionTabs.tsx
+++ b/packages/harness/web/src/components/SessionTabs.tsx
@@ -1,3 +1,5 @@
+import { AssistantActivity } from "./AssistantActivity";
+import type { AssistantProjection } from "../lib/assistant-state";
 import { useEffect, useRef } from "react";
 import type { JSX, RefObject } from "react";
 import type { HarnessSession } from "@shared/types";
@@ -7,6 +9,7 @@ import { HARNESS_LABELS } from "../lib/history-meta";
 import { Icon } from "./Icon";
 
 interface SessionTabsProps {
+  assistant?: AssistantProjection;
   sessions: HarnessSession[];
   activeSessionId: string | null;
   busySessionIds: ReadonlySet<string>;
@@ -34,6 +37,7 @@ interface SessionTabsProps {
  * the active tab's options menu rather than becoming per-tab close buttons.
  */
 export function SessionTabs({
+  assistant,
   sessions,
   activeSessionId,
   busySessionIds,
@@ -169,6 +173,7 @@ export function SessionTabs({
                   >
                     {label}
                   </span>
+                  <AssistantActivity assistant={assistant} sessionId={session.id} />
                 </button>
               )}
 

--- a/packages/harness/web/src/components/TooltipLayer.tsx
+++ b/packages/harness/web/src/components/TooltipLayer.tsx
@@ -18,6 +18,7 @@ export function TooltipLayer(): JSX.Element {
     let anchor: Element | null = null;
 
     const hide = (): void => {
+      changes.disconnect();
       anchor = null;
       tip.dataset.show = "false";
       // Empty when hidden — stale text must never linger in the DOM.
@@ -36,6 +37,10 @@ export function TooltipLayer(): JSX.Element {
       const text = titled.dataset.tooltip || titled.dataset.tipStash;
       if (!text) return;
       anchor = el;
+      changes.observe(document.body, {
+        childList: true, subtree: true, attributes: true,
+        attributeFilter: ["data-tooltip", "title"],
+      });
       tip.textContent = text;
       tip.dataset.show = "true";
       const rect = el.getBoundingClientRect();
@@ -57,6 +62,18 @@ export function TooltipLayer(): JSX.Element {
       tip.style.transform = `translate(${Math.round(x)}px, ${Math.round(y)}px)`;
     };
 
+    // Observe only while a tooltip is visible. State changes and removed
+    // anchors need no pointer movement to refresh or clear their old text.
+    const changes = new MutationObserver(() => {
+      if (!anchor?.isConnected) return hide();
+      const current = anchor as HTMLElement;
+      const text = current.dataset.tooltip || current.title || current.dataset.tipStash;
+      if (text === tip.textContent) return;
+      anchor = null;
+      hide();
+      show(current);
+    });
+
     const onOver = (e: Event): void => show(e.target as Element);
     const onOut = (e: Event): void => {
       if (anchor && !anchor.contains((e as PointerEvent).relatedTarget as Node)) hide();
@@ -68,6 +85,7 @@ export function TooltipLayer(): JSX.Element {
     document.addEventListener("scroll", hide, true);
     window.addEventListener("blur", hide);
     return () => {
+      changes.disconnect();
       document.removeEventListener("pointerover", onOver, true);
       document.removeEventListener("pointerout", onOut, true);
       document.removeEventListener("pointerdown", hide, true);

--- a/packages/harness/web/src/components/WorkflowsRail.tsx
+++ b/packages/harness/web/src/components/WorkflowsRail.tsx
@@ -1,3 +1,5 @@
+import { AssistantActivity } from "./AssistantActivity";
+import type { AssistantProjection } from "../lib/assistant-state";
 import {
   useCallback,
   useEffect,
@@ -101,6 +103,7 @@ import { trackingAttrs } from "../lib/analytics/tracking-attrs";
 const api = createApi();
 
 interface WorkflowsRailProps {
+  assistant?: AssistantProjection;
   /** Resizable width (px) — the rail can shrink to minWidth under pressure. */
   width: number;
   minWidth: number;
@@ -401,6 +404,8 @@ function ProjectRowMenu({
  * `=== "true"` checks that silently miss the unknown state.
  */
 function PastSessionRow({
+  assistant,
+  sessionId,
   testid,
   harness,
   title,
@@ -410,6 +415,8 @@ function PastSessionRow({
   isSelected,
   onOpen,
 }: {
+  assistant?: AssistantProjection;
+  sessionId?: string;
   testid: string;
   harness: HarnessKind;
   title: string;
@@ -443,6 +450,7 @@ function PastSessionRow({
         <span className="session-item-title">{title}</span>
         <span className="session-item-meta">{meta}</span>
       </span>
+      {sessionId && <AssistantActivity assistant={assistant} sessionId={sessionId} />}
     </button>
   );
 }
@@ -454,6 +462,7 @@ function PastSessionRow({
  * keyed to the focused agent.
  */
 export function WorkflowsRail({
+  assistant,
   width,
   minWidth,
   workflows,
@@ -1186,6 +1195,8 @@ export function WorkflowsRail({
                             : summary?.resumeMode;
                         return (
                           <PastSessionRow
+                            assistant={assistant}
+                            sessionId={row.session.id}
                             key={row.session.id}
                             testid={`exited-session-${row.session.id}`}
                             harness={row.session.harness}

--- a/packages/harness/web/src/styles.css
+++ b/packages/harness/web/src/styles.css
@@ -2705,6 +2705,20 @@ button.rail-footer-card:hover {
 }
 
 
+/* Native Assistant state is separate from the Terminal output pulse. */
+.assistant-activity {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--text-dim);
+}
+.assistant-activity[data-state="waiting"],
+.assistant-activity[data-state="unavailable"] {
+  color: var(--text-warning);
+}
+.assistant-activity[data-state="working"] {
+  color: var(--accent);
+}
+
 /* Subtle pulse — the active session produced output in roughly the last 3s. */
 .session-busy {
   width: 6px;


### PR DESCRIPTION
<!--
Thank you for contributing to sapiom-js.
Read CONTRIBUTING.md before submitting, and keep the pull request focused on one problem.
Do not disclose suspected vulnerabilities here; follow SECURITY.md instead.
-->

## Primary change type

- [ ] Bug fix
- [ ] Documentation
- [x] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

A user working in session B needs to see whether Assistant A is still working or needs input. The host now observes both independently, but existing session navigation does not display that state. Decorate the existing live tabs and retained-session rows with the validated Assistant projection.

## Summary and scope

Add one accessible activity component for Working, Waiting for input, Checking status and Unavailable. Uncertain observations take precedence over cached activity/input counts. Idle removes the indicator; it does not claim task success. Session summaries only decorate existing navigation, and Terminal's output pulse remains independent.

Pass the projection through App, SessionBar, SessionTabs and retained WorkflowsRail rows, including the Terminal-exited header. Refresh the shared tooltip when its hovered label changes, and disconnect its observer when hidden or unmounted so an auth-cleared icon cannot leave stale Assistant text.

This final **394-line all-file increment** stacks on #967 in the ten-part SAP-3291 delivery. The native acceptance record documents the combined stack with the still-open #950 and #951. Full End/Resume/Continue and interactive permission/question reply controls remain their separately planned tickets.

## Related work

Related issue or discussion:
https://linear.app/sapiom/issue/SAP-3291

## Validation

```text
pnpm build — passed (root)
pnpm typecheck — passed (root)
pnpm lint — passed (root)
setpriv --inh-caps=-all --ambient-caps=-all env npm_config_workspace_concurrency=1 pnpm test — passed (root)
pnpm install --frozen-lockfile — passed
pnpm --filter @sapiom/harness exec tsc --noEmit -p web/tsconfig.json — passed
pnpm --filter @sapiom/harness exec eslint --no-inline-config --no-ignore --parser-options '{"project":"web/tsconfig.json"}' web/src/components/AssistantActivity.tsx web/src/components/SessionBar.tsx web/src/components/SessionTabs.tsx web/src/components/WorkflowsRail.tsx web/src/components/TooltipLayer.tsx web/src/App.tsx — passed, four existing WorkflowsRail unused-name warnings
E2E_PORT=5408 pnpm --filter @sapiom/harness exec playwright test --config web/e2e/playwright.config.ts assistant-activity.spec.ts --workers=1 — 5 passed
pnpm --filter @sapiom/harness exec playwright test --config web/e2e/playwright.config.ts assistant-activity.spec.ts opencode-chat.spec.ts session-tabs.spec.ts --workers=1 — 49 passed; new hover case exposed an overly strict test oracle; corrected and all 5 indicator cases subsequently passed
VITE_MOCK=0 pnpm --filter @sapiom/harness exec vite build --config web/vite.config.ts --outDir <isolated-web-dir> — passed
E2E_PORT=5412 pnpm --filter @sapiom/harness exec playwright test --config web/e2e/playwright.config.ts assistant-activity.spec.ts workflow-deployment.spec.ts --workers=1 — 7 passed
node scripts/agent-studio-terminology-check.mjs — passed
node scripts/provider-neutral-copy-check.mjs — passed
```

The root test wrapper drops this VM's ambient permission bypass for an existing unreadable-directory fixture. An unchanged native cleanup-deadline test failed during concurrent validation; the full root retry passed without changing assertions/timeouts. Root lint omits web files, so explicit browser lint also ran. `--no-inline-config` avoids the unchanged parent's missing inline `react-hooks/exhaustive-deps` rule configuration. `pnpm pr:size` is absent; all-file numstat is **394**, including tests, docs and Changeset.

**Combined checkout:** root `pnpm build`, `pnpm typecheck`, `pnpm lint` and the complete wrapped `pnpm test` all passed with #950, #951 and the full SAP-3291 stack applied.

**Combined acceptance:** real `startServer`, built nonmock SPA, browser boot authentication, access verification, bridge, host observer, real native 1.18.29 runtimes and REST/WebSocket transport. Loopback fixtures supply synthetic credentials/model output; MCP is disabled and the one prompted tool only reads a temporary README. A completes while B waits for input, B settles off-screen, review/new-session/Terminal switches preserve work and separate drafts, and A completes with zero event consumers. Reconnection recovers in 230 ms without replaying any prompt. Terminal exit retains Assistant; reload restores native history. Both native PIDs exit during cleanup. The evidence records exactly three user prompts and four main model calls (B includes one tool continuation).

### Tests and documentation

Five browser regressions cover independent activity, uncertain/current/unavailable precedence, malformed and older snapshots, full-set replacement, auth barriers, retained exited rows and tooltip updates/removal. The first indicator assertion failed against the parent; the tooltip update failed before its fix. Independent review verified observer cleanup and absence of feedback loops. After auth removal, the hovered parent tab may legitimately show its own tooltip; the corrected test forbids stale Assistant text.

Full browser CI also exposed an older deployment test that expected `title` after hover. The shared tooltip intentionally consumes that attribute. Its assertion now verifies the visible tooltip changes from deployed to draft. This stronger check fails on the parent with the stale deployed tooltip and passes with this PR; all seven Assistant/deployment cases pass. This CI correction changes only the test.

README, patch Changeset and `docs/assistant-background-acceptance.md` describe behavior and the actual native check's scope. Production OAuth, real model quality, remote MCP and installed-app lifecycle certification are outside this local fixture.

### Visual evidence

Before and after use the same deterministic Studio fixture with working A and pending B. The video is reconstructed at its original timing from screenshots recorded by the passing native Playwright trace; it is not a synthetic animation.

| Before | After |
| --- | --- |
| ![Before: no Assistant activity in tabs](https://raw.githubusercontent.com/sapiom/sapiom-js/718ada5166790fc1d182482576e598969e3bbfde/media/assistant-background-20260912/navigation-before.png) | ![After: independent working and input-needed indicators](https://raw.githubusercontent.com/sapiom/sapiom-js/718ada5166790fc1d182482576e598969e3bbfde/media/assistant-background-20260912/navigation-after.png) |

[Native A/B, navigation, reconnection and retained Terminal-exit recording](https://raw.githubusercontent.com/sapiom/sapiom-js/718ada5166790fc1d182482576e598969e3bbfde/media/assistant-background-20260912/native-navigation.webm)

![Native B waits while A has completed in the background](https://raw.githubusercontent.com/sapiom/sapiom-js/718ada5166790fc1d182482576e598969e3bbfde/media/assistant-background-20260912/b-waiting-a-idle.png)

![Assistant history and draft retained after Terminal exit](https://raw.githubusercontent.com/sapiom/sapiom-js/718ada5166790fc1d182482576e598969e3bbfde/media/assistant-background-20260912/terminal-exited-assistant-retained.png)

## Compatibility and release impact

- Breaking or externally visible changes: additive activity icons on existing Studio session navigation; no API or dependency changes in this increment.
- Changeset: Added `show-background-assistant-activity.md` for `@sapiom/harness`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex implemented and verified the indicators, tooltip correction, regression tests and native fixture. An independent agent reviewed the UI and tooltip lifecycle; focused browser tests and the real native run verified the corrections.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.

## Risk and rollout

The existing access gate and validated projection control visibility. Native idle only removes activity; selected-chat completion still uses its own native contract. **Fix-forward:** correct the narrow label/projection mapping or tooltip lifecycle and extend the corresponding browser regression while preserving native session ownership and prompt counts.
