### PR TITLE
fix(opencode): tolerate vanished Linux process entries [SAP-3291]

### DIFF
--- a/.changeset/vanished-native-process-entries.md
+++ b/.changeset/vanished-native-process-entries.md
@@ -1,0 +1,6 @@
+---
+"@sapiom/opencode": patch
+---
+
+Tolerate Linux processes exiting while their status is read during native shutdown,
+while preserving cleanup failures for unreadable or unverified tracked processes.

--- a/packages/opencode/README.md
+++ b/packages/opencode/README.md
@@ -43,6 +43,8 @@ cleanup proof. A missing proof fails closed so another runtime cannot write the
 same state. The proof remains outside the ephemeral launch directory until the
 runtime lock consumes it. Windows uses its native process-tree termination for
 normal close; installed-platform validation remains tracked by SAP-3297.
+Linux process scans tolerate entries that disappear during the read; unreadable
+entries still fail cleanup, and a missing tracked process cannot prove it stopped.
 Binary paths inside `app.asar` resolve to their unpacked counterparts; the
 generated supervisor needs no source loader and runs under Electron with
 `ELECTRON_RUN_AS_NODE` without forwarding that variable to native or tools.

--- a/packages/opencode/src/process-table.test.ts
+++ b/packages/opencode/src/process-table.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+import { evaluateTrackedClosure, readLinuxProcessTable } from "./server.js";
+
+const stat = (pid: string) =>
+  `${pid} (fixture (child)) ${["S", "4", "5", ...Array(16).fill("0"), "birth-" + pid].join(" ")}`;
+
+describe("Linux process enumeration during shutdown", () => {
+  it.each(["ENOENT", "ESRCH"])(
+    "continues around a vanished entry (%s)",
+    async (code) => {
+      const readStat = vi.fn(async (pid: string) => {
+        if (pid === "2")
+          throw Object.assign(new Error("process vanished"), { code });
+        return stat(pid);
+      });
+      const processes = await readLinuxProcessTable(
+        async () => ["self", "1", "2", "3"],
+        readStat,
+      );
+      expect([...processes.keys()]).toEqual([1, 3]);
+      expect(processes.get(3)).toEqual({
+        pid: 3,
+        ppid: 4,
+        pgid: 5,
+        state: "S",
+        birthId: "birth-3",
+      });
+      expect(readStat).toHaveBeenCalledTimes(3);
+      // A missing tracked descendant still cannot prove positive fencing.
+      expect(
+        evaluateTrackedClosure(
+          new Map([["2:birth-2", { pid: 2, birthId: "birth-2" }]]),
+          processes,
+        ),
+      ).toBe("uncertain");
+    },
+  );
+
+  it.each(["EACCES", "EPERM", "EIO", undefined])(
+    "rejects an unreadable entry (%s)",
+    async (code) => {
+      const error = Object.assign(new Error("cannot inspect process"), {
+        code,
+      });
+      await expect(
+        readLinuxProcessTable(
+          async () => ["1"],
+          async () => {
+            throw error;
+          },
+        ),
+      ).rejects.toBe(error);
+    },
+  );
+
+  it.each(["ENOENT", "ESRCH", "EACCES"])(
+    "does not hide failure to enumerate /proc (%s)",
+    async (code) => {
+      const error = Object.assign(new Error("cannot enumerate processes"), {
+        code,
+      });
+      const readStat = vi.fn(async () => stat("1"));
+      await expect(
+        readLinuxProcessTable(async () => {
+          throw error;
+        }, readStat),
+      ).rejects.toBe(error);
+      expect(readStat).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/packages/opencode/src/server.ts
+++ b/packages/opencode/src/server.ts
@@ -50,6 +50,38 @@ interface SupervisorProcessIdentity {
 }
 
 /** @internal Shared verbatim with the generated supervisor for deterministic tests. */
+export async function readLinuxProcessTable(
+  listEntries: () => Promise<readonly string[]>,
+  readStat: (entry: string) => Promise<string>,
+): Promise<
+  Map<number, SupervisorProcessIdentity & { ppid: number; pgid: number }>
+> {
+  const processes = new Map<
+    number,
+    SupervisorProcessIdentity & { ppid: number; pgid: number }
+  >();
+  for (const entry of await listEntries()) {
+    if (!/^\d+$/.test(entry)) continue;
+    try {
+      const stat = await readStat(entry);
+      const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
+      processes.set(Number(entry), {
+        pid: Number(entry),
+        ppid: Number(fields[1]),
+        pgid: Number(fields[2]),
+        state: fields[0],
+        birthId: fields[19],
+      });
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException)?.code;
+      // A process can vanish before opening its stat file or while reading it.
+      if (code !== "ENOENT" && code !== "ESRCH") throw error;
+    }
+  }
+  return processes;
+}
+
+/** @internal Shared verbatim with the generated supervisor for deterministic tests. */
 export function evaluateTrackedClosure(
   tracked: ReadonlyMap<
     string,
@@ -228,6 +260,7 @@ import { dirname } from "node:path";
 const cleanupPath = ${JSON.stringify(cleanupProof.path)};
 const cleanupToken = ${JSON.stringify(cleanupProof.token)};
 const shutdownTimeoutMs = ${JSON.stringify(shutdownTimeoutMs)};
+const readLinuxProcessTable = ${readLinuxProcessTable.toString()};
 const evaluateTrackedClosure = ${evaluateTrackedClosure.toString()};
 const evaluateWindowsCleanup = ${evaluateWindowsCleanup.toString()};
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -257,24 +290,10 @@ async function publishCleanupProof() {
   } finally { await rm(pending, { force: true }).catch(() => {}); }
 }
 async function linuxProcesses() {
-  const processes = new Map();
-  for (const entry of await readdir("/proc")) {
-    if (!/^\\d+$/.test(entry)) continue;
-    try {
-      const stat = await readFile("/proc/" + entry + "/stat", "utf8");
-      const fields = stat.slice(stat.lastIndexOf(")") + 2).split(" ");
-      processes.set(Number(entry), {
-        pid: Number(entry),
-        ppid: Number(fields[1]),
-        pgid: Number(fields[2]),
-        state: fields[0],
-        birthId: fields[19],
-      });
-    } catch (error) {
-      if (error?.code !== "ENOENT") throw error;
-    }
-  }
-  return processes;
+  return readLinuxProcessTable(
+    () => readdir("/proc"),
+    (entry) => readFile("/proc/" + entry + "/stat", "utf8"),
+  );
 }
 function darwinProcesses() {
   const result = spawnSync("ps", ["-axo", "pid=,ppid=,pgid=,stat=,lstart="], { encoding: "utf8" });


### PR DESCRIPTION
## Primary change type

- [x] Bug fix
- [ ] Documentation
- [ ] Feature
- [ ] Tests
- [ ] Dependency update
- [ ] Maintenance or refactor

## Problem and motivation

On Linux, a process can exit after its `/proc/<pid>/stat` file is opened but before it is read. That read can reject with `ESRCH`. The native supervisor only tolerated `ENOENT`, so an unrelated process exiting during enumeration could abort cleanup and prevent a successful cleanup proof.

## Summary and scope

Treat `ESRCH` like `ENOENT` only for individual process entries. Extract the existing Linux parser into an internal helper shared verbatim with the generated supervisor, following its existing closure-helper pattern, so the race has a deterministic regression. Enumeration failures, permission errors, other read errors, and missing tracked descendants retain their existing failure behavior.

This small follow-up was identified while investigating intermittent packaged-native cleanup failures during SAP-3291 validation. The Linux race is independently reproduced; the sanitized CI error does not establish that it caused every observed failure. Cleanup deadlines and ownership rules are unchanged. The increment is **134 all-file changed lines** (116 additions, 18 deletions across four files).

## Related work

Related issue or discussion:
[SAP-3291](https://linear.app/sapiom/issue/SAP-3291/ui-preserve-independent-assistant-sessions-and-background-work). Follows [#968](https://github.com/sapiom/sapiom-js/pull/968) in [the native stack](https://github.com/sapiom/sapiom-js/pull/957).

## Validation

```text
pnpm --filter @sapiom/opencode exec vitest run src/process-table.test.ts — 9 passed; ESRCH case fails before the fix (8 pass, 1 fail)
pnpm build — passed
pnpm typecheck — passed
pnpm lint — passed
setpriv --inh-caps=-all --ambient-caps=-all env npm_config_workspace_concurrency=1 pnpm test — passed; 41 packaged-native cases, 4,185 harness cases, and the other workspace suites
pnpm install --frozen-lockfile — passed
pnpm exec prettier --check packages/opencode/src/server.ts packages/opencode/src/process-table.test.ts packages/opencode/README.md .changeset/vanished-native-process-entries.md — passed
Packaged-native tests include the actual pinned runtime startup, credential scrubbing, and cleanup paths.
pnpm pr:size — unavailable in this repository; all-file git numstat and GitHub additions/deletions used to enforce the 1,000-line cap
git diff --check — passed
```

An independent review reconstructed the built helper from `.toString()` in an empty VM context and exercised real `/proc` data plus injected vanished-entry and permission errors. It has no dependency on outer runtime bindings. The combined checkout containing PRs #950/#951 and all eleven stack increments also passed fresh root build/typecheck/lint/test (4,206 harness and 41 packaged-native cases), frozen installation and terminology/provider checks. A fresh nonmock Studio acceptance run using two actual pinned 1.18.29 native processes passed all eleven behavior/cleanup assertions at 11:08:01–11:08:25 UTC on 2026-09-12, including zero-consumer background completion, 227ms reconnection, no prompt replay, same-folder isolation, Terminal-exit retention, reload and both processes reaped. Authority/model endpoints were synthetic loopback fixtures. This is Linux cloud acceptance; installed-platform validation remains separate.

### Tests and documentation

Nine regression cases cover vanished entries, numeric filtering, retained process identity, missing tracked-process uncertainty, unreadable entries, and enumeration failures. The package README explains the narrow behavior and retained cleanup guarantee.

## Compatibility and release impact

- Breaking or externally visible changes: No API change. Native shutdown tolerates an unrelated Linux process disappearing while its status is read. Fix-forward: if cleanup regresses, stop the affected delivery and submit a focused correction through the same review/check/merge process; retain the existing runtime lock when cleanup cannot be proved.
- Changeset: Added a patch Changeset for `@sapiom/opencode`.

## Security

- [x] I have not included secrets, credentials, private data, or unsanitized logs.
- [x] This pull request does not publicly disclose a suspected vulnerability. I
      will follow the
      [Security Policy](https://github.com/sapiom/sapiom-js/security/policy) for
      private reporting.

## AI assistance

- [ ] I did not use AI assistance for this change.
- [x] I used AI assistance and have described it below.

Codex implemented the narrow fix and regression tests, reproduced the original failure, and verified the generated runtime and workspace checks. A separate agent reviewed the helper and compiled serialization independently.

## Checklist

- [x] I read `CONTRIBUTING.md`, and this contribution follows the direct-PR or issue-first policy.
- [x] This pull request addresses one focused problem and contains no unrelated cleanup.
- [x] I added or updated tests, or explained above why tests are not applicable.
- [x] I ran the relevant build, typecheck, lint, and test commands, or explained
      any N/A checks above.
- [x] I updated documentation for user-facing changes, or marked it N/A above.
- [x] I added a Changeset for a published-package change, or explained why it is not applicable.
- [x] I can explain and maintain every submitted change, including any AI-assisted work.
